### PR TITLE
Fix 3 unreplied Greptile P1s on #6918 (dispute evidence hold-until-deadline)

### DIFF
--- a/app/controllers/purchases/dispute_evidence_controller.rb
+++ b/app/controllers/purchases/dispute_evidence_controller.rb
@@ -38,28 +38,34 @@ class Purchases::DisputeEvidenceController < ApplicationController
 
   def update
     input_blobs = customer_communication_file_blobs
-    # Only what the seller actually filled in this time. A revision is additive per field: the
-    # form always posts all three, so assigning them wholesale would let a seller who returns to
-    # attach a file blank the statement they wrote yesterday. Same reason the attachment below is
-    # left alone when no new file arrives.
-    @dispute_evidence.assign_attributes(
-      dispute_evidence_params.slice(:cancellation_rebuttal, :reason_for_winning, :refund_refusal_explanation)
-                             .compact_blank
-    )
+    # A revision is additive per field: the form always posts all three, so assigning them
+    # wholesale would let a seller who returns to attach a file blank the statement they wrote
+    # yesterday. But `compact_blank` also drops a field the seller explicitly cleared — an empty
+    # string submitted on purpose must still overwrite the saved value, not be treated as absent.
+    text_field_updates = dispute_evidence_params.slice(:cancellation_rebuttal, :reason_for_winning, :refund_refusal_explanation)
+                                                 .reject { |_, value| value.nil? }
+    @dispute_evidence.assign_attributes(text_field_updates)
 
-    if input_blobs.one?
-      attached_blob = covert_and_optimize_blob_if_needed(input_blobs.first)
-      @dispute_evidence.customer_communication_file.attach(attached_blob)
-    elsif input_blobs.many?
-      # Stripe accepts a single file for this evidence field, so multiple uploads are merged
-      # into one PDF before attaching. The merge stays inline: FightDisputeJob can fire the
-      # moment the window closes, and an async merge would let it forward the evidence before
-      # the merged file exists.
-      merged_blob = DisputeEvidence::MergeCustomerCommunicationFilesService.perform(
-        blobs: input_blobs,
-        max_size: @dispute_evidence.customer_communication_file_max_size
-      )
-      @dispute_evidence.customer_communication_file.attach(merged_blob)
+    if input_blobs.present?
+      # has_one_attached REPLACES rather than adds: attaching a new blob without folding in
+      # whatever is already saved would silently drop a file from an earlier revision before it
+      # ever reaches Stripe.
+      existing_blob = @dispute_evidence.customer_communication_file.blob if @dispute_evidence.customer_communication_file.attached?
+
+      if existing_blob.nil? && input_blobs.one?
+        attached_blob = covert_and_optimize_blob_if_needed(input_blobs.first)
+        @dispute_evidence.customer_communication_file.attach(attached_blob)
+      else
+        # Stripe accepts a single file for this evidence field, so multiple uploads — and any
+        # already-attached file — are merged into one PDF before attaching. The merge stays
+        # inline: FightDisputeJob can fire the moment the window closes, and an async merge
+        # would let it forward the evidence before the merged file exists.
+        merged_blob = DisputeEvidence::MergeCustomerCommunicationFilesService.perform(
+          blobs: existing_blob ? [existing_blob, *input_blobs] : input_blobs,
+          max_size: @dispute_evidence.customer_communication_file_max_size
+        )
+        @dispute_evidence.customer_communication_file.attach(merged_blob)
+      end
     end
     @dispute_evidence.update_as_seller_submitted!
     # Only once the submission is persisted: a validation failure below has to leave the

--- a/app/models/dispute_evidence.rb
+++ b/app/models/dispute_evidence.rb
@@ -83,14 +83,23 @@ class DisputeEvidence < ApplicationRecord
     errors.add(:base, "Invalid file type.")
   end
 
-  # Hours the seller has left, from a stamp. Every consumer must ask through here: the number the
-  # notice quotes and the number the gates test have to be the same one, or a window reads open to
-  # one caller while the email it triggers says "0 hours". Rounded, so callers that hold a raw
-  # timestamp cannot reintroduce a second arithmetic.
+  # Hours the seller has left, from a stamp, for DISPLAY COPY only (the UI/email hour count).
+  # Rounded, so it can report the window closed up to ~29 minutes before seller_response_due_at
+  # actually arrives — gating decisions must not use this. See window_open? below.
   def self.hours_left_in_window(seller_contacted_at)
     return 0 if seller_contacted_at.nil?
 
     (SUBMIT_EVIDENCE_WINDOW_DURATION_IN_HOURS - (Time.current - seller_contacted_at) / 1.hour).round
+  end
+
+  # Exact comparison against seller_response_due_at. Anything deciding whether the window is
+  # STILL OPEN — accepting_evidence?, the hourly forward-to-Stripe jobs — must ask through here,
+  # never through hours_left_in_window: rounding it can close the window, or forward evidence to
+  # Stripe, up to ~29 minutes before the real deadline.
+  def self.window_open?(seller_contacted_at)
+    return false if seller_contacted_at.nil?
+
+    Time.current < seller_response_due_at(seller_contacted_at)
   end
 
   # Hours the seller has left to keep working on their statement. A saved statement does not close
@@ -142,7 +151,7 @@ class DisputeEvidence < ApplicationRecord
   def self.accepting_evidence?(seller_contacted_at:, resolved_at:)
     return false if evidence_submission_closed?(resolved_at:)
 
-    seller_contacted_at.present? && hours_left_in_window(seller_contacted_at).positive?
+    seller_contacted_at.present? && window_open?(seller_contacted_at)
   end
 
   # Is the notice itself still worth sending, whether or not we may ask for evidence? A dispute with

--- a/app/sidekiq/create_missing_dispute_evidence_job.rb
+++ b/app/sidekiq/create_missing_dispute_evidence_job.rb
@@ -139,9 +139,10 @@ class CreateMissingDisputeEvidenceJob
       # left the window stamped with nobody told about it, and a stamped window no longer matches
       # the sweep that would have retried. Nothing here can raise now.
       #
-      # Ask through hours_left_in_window rather than the record: update_all left this object stale,
-      # so it reports no window at all, and the gate has to be the same arithmetic the notice quotes.
-      unless DisputeEvidence.hours_left_in_window(window_start).positive?
+      # Ask through window_open? rather than the record: update_all left this object stale, so
+      # it reports no window at all, and the gate must use the same exact comparison
+      # accepting_evidence? does — hours_left_in_window would close this up to ~29 minutes early.
+      unless DisputeEvidence.window_open?(window_start)
         # The backdated window has already elapsed, so the seller has no time to say anything and
         # there is nothing to notify them about. Submit now rather than wait for FightDisputesJob's
         # next tick, which can cost an hour of a cutoff measured in hours — but the window IS

--- a/app/sidekiq/fight_dispute_job.rb
+++ b/app/sidekiq/fight_dispute_job.rb
@@ -11,7 +11,7 @@ class FightDisputeJob
     # Raw arithmetic, not hours_left_to_submit_evidence, so this reads the window and nothing else.
     # Nothing is forwarded before the window closes even when the seller has already saved a
     # statement: they keep the whole 72 hours to revise it, and Stripe accepts one submission.
-    return if DisputeEvidence.hours_left_in_window(dispute_evidence.seller_contacted_at).positive?
+    return if DisputeEvidence.window_open?(dispute_evidence.seller_contacted_at)
 
     disputable = dispute.disputable
     if disputable.charge_processor_transaction_id.blank?

--- a/app/sidekiq/fight_disputes_job.rb
+++ b/app/sidekiq/fight_disputes_job.rb
@@ -16,7 +16,7 @@ class FightDisputesJob
     # ready and got forwarded a second time. The scope is filtered on seller_contacted, so a NULL
     # stamp (owned by CreateMissingDisputeEvidenceJob) never reaches the arithmetic.
     DisputeEvidence.seller_contacted.not_resolved.includes(:dispute).find_each do |dispute_evidence|
-      next if DisputeEvidence.hours_left_in_window(dispute_evidence.seller_contacted_at).positive?
+      next if DisputeEvidence.window_open?(dispute_evidence.seller_contacted_at)
       next if TERMINAL_DISPUTE_STATES.include?(dispute_evidence.dispute.state)
       FightDisputeJob.perform_async(dispute_evidence.dispute.id)
     end

--- a/spec/controllers/purchases/dispute_evidence_controller_spec.rb
+++ b/spec/controllers/purchases/dispute_evidence_controller_spec.rb
@@ -168,9 +168,32 @@ describe Purchases::DisputeEvidenceController, type: :controller, inertia: true 
       expect(FightDisputeJob.jobs.size).to eq(0)
     end
 
-    # The form posts all three fields every time, so assigning them wholesale would let a seller who
-    # returns only to add a file blank the statement they wrote yesterday.
-    it "keeps fields the seller left blank on a later revision" do
+    # The form always posts all three fields, so assigning them wholesale would let a seller who
+    # returns only to add a file blank the statement they wrote yesterday — but a field genuinely
+    # OMITTED from this request (an older client, or a partial API call) is different from one the
+    # seller submitted as an explicit empty string, which is a request to clear it.
+    it "keeps fields omitted from a later revision's params" do
+      put :update, params: {
+        purchase_id: purchase.external_id,
+        dispute_evidence: {
+          reason_for_winning: "First answer",
+          cancellation_rebuttal: "First rebuttal",
+          refund_refusal_explanation: "First refusal"
+        }
+      }
+
+      put :update, params: {
+        purchase_id: purchase.external_id,
+        dispute_evidence: { reason_for_winning: "Revised answer" }
+      }
+
+      dispute_evidence.reload
+      expect(dispute_evidence.reason_for_winning).to eq("Revised answer")
+      expect(dispute_evidence.cancellation_rebuttal).to eq("First rebuttal")
+      expect(dispute_evidence.refund_refusal_explanation).to eq("First refusal")
+    end
+
+    it "clears fields the seller explicitly submits as blank on a later revision" do
       put :update, params: {
         purchase_id: purchase.external_id,
         dispute_evidence: {
@@ -191,8 +214,8 @@ describe Purchases::DisputeEvidenceController, type: :controller, inertia: true 
 
       dispute_evidence.reload
       expect(dispute_evidence.reason_for_winning).to eq("Revised answer")
-      expect(dispute_evidence.cancellation_rebuttal).to eq("First rebuttal")
-      expect(dispute_evidence.refund_refusal_explanation).to eq("First refusal")
+      expect(dispute_evidence.cancellation_rebuttal).to be_nil
+      expect(dispute_evidence.refund_refusal_explanation).to be_nil
     end
 
     context "when a signed_id for a PNG file is provided" do
@@ -228,6 +251,32 @@ describe Purchases::DisputeEvidenceController, type: :controller, inertia: true 
         expect(dispute_evidence.customer_communication_file.content_type).to eq("application/pdf")
 
         expect(response).to redirect_to(success_purchase_dispute_evidence_path(purchase.external_id))
+      end
+    end
+
+    context "when a second revision uploads another file" do
+      before do
+        # Purging in test ENV returns Aws::S3::Errors::AccessDenied
+        allow_any_instance_of(ActiveStorage::Blob).to receive(:purge).and_return(nil)
+      end
+
+      # has_one_attached REPLACES the prior blob on a bare #attach, which would silently drop the
+      # first file the seller saved before it ever reaches Stripe.
+      it "merges the new file with the one already attached instead of replacing it" do
+        first_blob = ActiveStorage::Blob.create_and_upload!(io: fixture_file_upload("test.pdf"), filename: "first.pdf", content_type: "application/pdf")
+        put :update, params: { purchase_id: purchase.external_id, dispute_evidence: { customer_communication_file_signed_blob_id: first_blob.signed_id } }
+        expect(dispute_evidence.reload.customer_communication_file.filename.to_s).to eq("first.pdf")
+
+        second_blob = ActiveStorage::Blob.create_and_upload!(io: fixture_file_upload("smilie.png"), filename: "second.png", content_type: "image/png")
+        put :update, params: { purchase_id: purchase.external_id, dispute_evidence: { customer_communication_file_signed_blob_id: second_blob.signed_id } }
+
+        dispute_evidence.reload
+        expect(dispute_evidence.customer_communication_file.attached?).to be(true)
+        expect(dispute_evidence.customer_communication_file.filename.to_s).to eq("customer_communication.pdf")
+        expect(dispute_evidence.customer_communication_file.content_type).to eq("application/pdf")
+
+        pages = PDF::Reader.new(StringIO.new(dispute_evidence.customer_communication_file.download)).pages
+        expect(pages.size).to eq(2)
       end
     end
 

--- a/spec/models/dispute_evidence_spec.rb
+++ b/spec/models/dispute_evidence_spec.rb
@@ -311,10 +311,8 @@ describe DisputeEvidence do
         .to eq(dispute_evidence.hours_left_to_submit_evidence)
     end
 
-    # The band where the old exact `elapsed < 72.hours` test in Charge::Disputable disagreed with
-    # this rounded one: it called the window open while the notice's own body would have read
-    # "in the next 0 hours". One predicate now answers for both, so the band cannot reopen.
-    it "reports no hours left once rounding takes the window to zero, where an exact test would not" do
+    # Display copy only — gates use .window_open? below instead, which is exact.
+    it "reports no hours left once rounding takes the window to zero, even with real time still on the clock" do
       elapsed = (DisputeEvidence::SUBMIT_EVIDENCE_WINDOW_DURATION_IN_HOURS - 0.4).hours
 
       expect(described_class.hours_left_in_window(elapsed.ago)).to eq(0)
@@ -323,6 +321,23 @@ describe DisputeEvidence do
 
     it "goes negative past the window rather than flooring" do
       expect(described_class.hours_left_in_window((DisputeEvidence::SUBMIT_EVIDENCE_WINDOW_DURATION_IN_HOURS + 1).hours.ago)).to eq(-1)
+    end
+  end
+
+  describe ".window_open?" do
+    it "is false without a stamp" do
+      expect(described_class.window_open?(nil)).to be(false)
+    end
+
+    it "is open right up to the exact deadline, not up to ~29 minutes early the way the rounded helper would read" do
+      elapsed = (DisputeEvidence::SUBMIT_EVIDENCE_WINDOW_DURATION_IN_HOURS - 0.4).hours
+
+      expect(described_class.window_open?(elapsed.ago)).to be(true)
+      expect(described_class.hours_left_in_window(elapsed.ago)).to eq(0)
+    end
+
+    it "closes exactly at the deadline" do
+      expect(described_class.window_open?(DisputeEvidence::SUBMIT_EVIDENCE_WINDOW_DURATION_IN_HOURS.hours.ago)).to be(false)
     end
   end
 
@@ -349,13 +364,17 @@ describe DisputeEvidence do
       expect(dispute_evidence.accepting_evidence?).to be(true)
     end
 
-    it "declines an elapsed window" do
-      expect(accepting?(seller_contacted_at: (DisputeEvidence::SUBMIT_EVIDENCE_WINDOW_DURATION_IN_HOURS - 0.4).hours.ago)).to be(false)
+    it "declines once the exact deadline has passed" do
+      expect(accepting?(seller_contacted_at: (DisputeEvidence::SUBMIT_EVIDENCE_WINDOW_DURATION_IN_HOURS + 0.01).hours.ago)).to be(false)
     end
 
-    it "still quotes the last whole hour rather than declining early" do
-      expect(accepting?(seller_contacted_at: (DisputeEvidence::SUBMIT_EVIDENCE_WINDOW_DURATION_IN_HOURS - 1.4).hours.ago)).to be(true)
-      expect(described_class.hours_left_in_window((DisputeEvidence::SUBMIT_EVIDENCE_WINDOW_DURATION_IN_HOURS - 1.4).hours.ago)).to eq(1)
+    # Regression for the rounded-hours gate: 71h36m elapsed (0.4h left) used to round to 0 hours
+    # left and close the window ~24 minutes before the real seller_response_due_at.
+    it "keeps accepting right up to the exact deadline, where the rounded helper would already read 0 hours left" do
+      elapsed = (DisputeEvidence::SUBMIT_EVIDENCE_WINDOW_DURATION_IN_HOURS - 0.4).hours
+
+      expect(accepting?(seller_contacted_at: elapsed.ago)).to be(true)
+      expect(described_class.hours_left_in_window(elapsed.ago)).to eq(0)
     end
 
     # The controller bounces an unstamped row too ("You are not allowed to perform this action"), so


### PR DESCRIPTION
# Fix 3 unreplied Greptile P1s on #6918 (dispute evidence hold-until-deadline)

> Draft status: code complete for all 3 findings, specs added/updated, running local checks now.

## What

Three targeted fixes to the dispute-evidence hold-until-deadline feature shipped in #6918, each addressing an unreplied Greptile P1 (comments 3703321237/3705499336, 3703394700, 3704260421/3705499330):

1. **Can't-clear-a-field bug** (`Purchases::DisputeEvidenceController#update`): `compact_blank` on the params slice dropped an explicitly-submitted empty string the same way it dropped an omitted key, so a seller who cleared a previously-saved field never actually cleared it — the old text survived and would have been forwarded to Stripe. Now only `nil` (omitted) is treated as "leave unchanged"; an explicit `""` overwrites.
2. **File-loss-on-revision bug** (same controller, `#update`): `customer_communication_file.attach(...)` on a `has_one_attached` column REPLACES the prior blob. A seller who saved one file, came back, and added another would silently lose the first file. Now a later revision merges the new upload(s) with whatever is already attached via `DisputeEvidence::MergeCustomerCommunicationFilesService`, same as the existing multi-file merge path.
3. **Early-close/early-forward bug** (`DisputeEvidence.hours_left_in_window`): the rounded hours-remaining helper drove both `accepting_evidence?` (can the seller still save?) and the hourly `FightDisputesJob`/`FightDisputeJob` decision to forward evidence to Stripe. Rounding closes the window up to ~29 minutes before the real `seller_response_due_at`. Added `DisputeEvidence.window_open?`, an exact timestamp comparison, and routed every GATING call site (`accepting_evidence?`, `FightDisputesJob`, `FightDisputeJob`, `CreateMissingDisputeEvidenceJob`'s immediate-submit check) through it. `hours_left_in_window` / `hours_left_to_submit_evidence` are kept, unchanged, for DISPLAY copy only (UI + email hour counts).

## Why

All three are money-path defects on the chargeback evidence flow: #1 and #2 can cause incomplete or stale evidence to reach Stripe, and #3 can close the seller's window or force-submit evidence up to ~29 minutes before the real 72-hour deadline. All three were flagged twice independently by Greptile on #6918 and never replied to or fixed before merge.

## Before / after

- **Before (#1):** seller saves `cancellation_rebuttal: "text"`, later saves the form with that field submitted as `""` → DB still has `"text"`.
- **After (#1):** the same flow now correctly stores `nil`/blank.
- **Before (#2):** seller attaches file A, saves; later attaches file B, saves → `customer_communication_file` is file B only, file A is gone.
- **After (#2):** the saved file is a merged PDF containing both A and B, same merge path used for a same-request multi-file upload.
- **Before (#3):** at 71h36m elapsed (0.4h left), `hours_left_in_window` already rounds to `0` → `accepting_evidence?` is `false` and the hourly job forwards early.
- **After (#3):** `window_open?` compares directly against `seller_response_due_at`; the window stays open and nothing is forwarded until the real deadline.

## Checklist

- [x] Scope — exactly the 3 flagged findings in `dispute_evidence_controller.rb`, `dispute_evidence.rb`, `fight_disputes_job.rb`, `fight_dispute_job.rb`, `create_missing_dispute_evidence_job.rb`. No unrelated changes.
- [x] Design — `window_open?` added as a new exact-comparison class method rather than changing `hours_left_in_window`'s signature/rounding, so every existing DISPLAY caller (mailer, presenter) is untouched.
- [x] Build — single commit on `fix-6918-greptile-p1s`, pushed.
- [ ] QA — pending local spec run + pre-merge audit (see Test Results below once populated).
- [ ] Shipped — draft; will mark ready after QA audit.
- [x] Market — n/a, internal bugfix.
- [x] Sell — n/a, internal bugfix.

## Tests

```text
(populated once bundle install / local spec run completes)
```

## QA

Backend-only fix, no rendered surface. Verifying via:
- `spec/controllers/purchases/dispute_evidence_controller_spec.rb` (new specs for clear-vs-omit and merge-on-revision)
- `spec/models/dispute_evidence_spec.rb` (new `.window_open?` coverage, updated `.accepting_evidence?` boundary specs)
- `spec/sidekiq/fight_disputes_job_spec.rb`, `spec/sidekiq/fight_dispute_job_spec.rb`, `spec/sidekiq/create_missing_dispute_evidence_job_spec.rb` (existing specs re-run against the new gate)

---

AI disclosure: claude-sonnet-5 (Anthropic), operating as a Hermes subagent. Instructions: fix the 3 unreplied Greptile P1 findings on #6918 per the parent task description, minimal targeted diff, add/adjust specs, open draft PR, reply on all 5 original review-comment threads, route to slavingia with `awaiting-human` (no auto-merge — chargeback/Stripe money path).
