### PR TITLE
Strengthen postPurchaseCartSave regression test against conditional/inserted-statement mutants

### DIFF
--- a/app/javascript/pages/Checkout/postPurchaseCartSave.test.ts
+++ b/app/javascript/pages/Checkout/postPurchaseCartSave.test.ts
@@ -27,6 +27,7 @@ describe("post-purchase cart save cancellation", () => {
     for (const match of resets) {
       const before = source
         .slice(0, match.index)
+        .replace(/\/\*[\s\S]*?\*\//gu, "")
         .replace(/\/\/[^\n]*\n\s*/gu, "")
         .trimEnd();
       expect(before.endsWith("debouncedSaveCartState.cancel();")).toBe(true);

--- a/app/javascript/pages/Checkout/postPurchaseCartSave.test.ts
+++ b/app/javascript/pages/Checkout/postPurchaseCartSave.test.ts
@@ -20,9 +20,16 @@ describe("post-purchase cart save cancellation", () => {
     // The success path (items: failedItems) and the PaymentConfirmedError path (items: []).
     expect(resets.length).toBeGreaterThanOrEqual(2);
 
+    // Requiring the reset to be the very next statement (only whitespace/comments between) is what
+    // catches a conditional cancel — an `if (x) { …cancel(); }` puts a `}` right before the reset,
+    // not the cancel call — and an inserted statement between the two, both of which the old
+    // "somewhere in the preceding 400 chars" check let through.
     for (const match of resets) {
-      const preceding = source.slice(Math.max(0, match.index - 400), match.index);
-      expect(preceding).toContain("debouncedSaveCartState.cancel()");
+      const before = source
+        .slice(0, match.index)
+        .replace(/\/\/[^\n]*\n\s*/gu, "")
+        .trimEnd();
+      expect(before.endsWith("debouncedSaveCartState.cancel();")).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## Status

- [x] Scope
- [x] Design
- [x] Build
- [x] QA — mutation proof against a temporarily-mutated, then restored, `Show.tsx`
- [ ] Shipped
- N/A Market
- N/A Sell

## What

Strengthens the `postPurchaseCartSave` regression test added in #6942 so it pins ordering, not just proximity: each post-purchase cart reset must be immediately preceded by `debouncedSaveCartState.cancel()` (only whitespace/comments allowed between), not merely have the cancel call somewhere in the preceding 400 characters.

## Why

Greptile flagged #6942's test on gumroad-private#1793's fix (comment on #6942): a future edit that wraps the cancel in a conditional, or inserts a statement between the cancel and the reset, would still pass the old "somewhere nearby" check — silently reopening the duplicate-charge bug the test exists to catch.

Greptile's review on this PR itself then flagged a follow-on gap in the same normalizer: it stripped `//` line comments but not `/* ... */` block comments, so a documentation-only block comment inserted between `cancel()` and the reset made the test fail on correctly-ordered code (a false positive, not the false negative the test exists to prevent, but still worth fixing before merge since it would break on any future block comment there).

## Before/After

No runtime behavior change — test-only diff on `app/javascript/pages/Checkout/postPurchaseCartSave.test.ts`.

## Test Results

- `npx vitest run app/javascript/pages/Checkout/postPurchaseCartSave.test.ts` — 1 passed
- Mutation proof (manual, on the real `Show.tsx`, restored after each):
  - Wrapped the success-path `cancel()` in a no-op `if` — test FAILS (old test would have passed)
  - Inserted a `console.log(...)` statement between `cancel()` and the reset — test FAILS (old test would have passed)
  - Inserted a `/* documentation-only block comment */` between `cancel()` and the reset (Greptile's finding) — test PASSES after adding block-comment stripping (would have FAILED before this round's fix)
  - Restored `Show.tsx` after each mutation — `git diff` empty, `npx vitest run` green again
- `npx eslint app/javascript/pages/Checkout/postPurchaseCartSave.test.ts` — clean
- `npx prettier --check` — clean

## QA steps

1. Read the diff: the assertion now strips both `/* ... */` block comments and `//` line comments before checking `before.endsWith("debouncedSaveCartState.cancel();")`.
2. `npx vitest run app/javascript/pages/Checkout/postPurchaseCartSave.test.ts`.

Not in this PR: no code change to `Show.tsx` — the cancellation logic itself is already correct and unchanged.

---

## AI disclosure

Written by Hermes Agent (claude-sonnet-5) autonomously, on behalf of @gumclaw, responding to Greptile's review findings on #6942 and on this PR.


Premerge review: clean @ 8325cbbf3cbfeb604b85e4ad4a58a7e9fc310f7f
