### PR TITLE
Trim dated incident specifics from Stripe test retry-budget comment

### DIFF
--- a/spec/support/stripe_rate_limit_retries.rb
+++ b/spec/support/stripe_rate_limit_retries.rb
@@ -60,14 +60,12 @@ module StripeTestRateLimitRetries
   # request-rate bucket. A budget short enough to expire inside that window
   # would fail the build for the reason this file exists to prevent.
   #
-  # Eight retries (63.5s) was that budget, and it was not enough: on 2026-08-03
-  # nine open PRs went red at once, every failure a checkout or subscription spec
-  # whose log ended in "still rate limited after 8 retries". Test Slow alone
-  # fans out to 50 shards and Test Fast to 18, every one of them against the same
-  # Stripe test account, and several PRs build concurrently — so the contention
-  # scales with how busy the queue is, not with anything a spec does. Re-running
-  # the identical commit turned #6901 from 11 failures to 0, which is what a
-  # too-small budget looks like from the outside.
+  # Eight retries (63.5s) was that budget, and it was not enough: CI fans
+  # Test Slow out to 50 shards and Test Fast to 18, all against the same
+  # Stripe test account, and several PRs build concurrently — so contention
+  # scales with how busy the queue is, not with anything a spec does. A build
+  # that goes red from budget exhaustion alone always goes green on a re-run
+  # with no code change, which is the tell that the budget was too small.
   #
   # It is kept OFF Stripe's global configuration on purpose. Raising
   # Stripe.max_network_retries would also widen the gem's own retries for


### PR DESCRIPTION
## What
Trims the dated incident specifics (2026-08-03, #6901, "nine open PRs") out of the `MAX_RETRIES` comment in `spec/support/stripe_rate_limit_retries.rb`, keeping only the durable invariant: shared Stripe test account, contention scales with shard count/queue depth.

## Why
Greptile P2 on merged #6956: those specifics will go stale and obscure the lasting reason for the wider budget.

Premerge review: exempt (docs-only comment trim, no code touched)

## Test Results
`ruby -c spec/support/stripe_rate_limit_retries.rb` → Syntax OK. Comment-only change, no code touched.

## QA steps
Docs-only; read the diff.

## Status
- [x] Scope — comment-only trim of one paragraph
- [x] Design — keep the durable invariant, drop dated specifics
- [x] Build — pushed to `fix/trim-stripe-retry-incident-history`
- [x] QA — docs-only, `ruby -c` clean
- [x] Shipped — docs-only, merges on sight
- [x] Market — n/a, internal test-infra comment
- [x] Sell — n/a

---
AI disclosure: built by Hermes Agent (Claude) running autonomously as gumclaw, addressing a Greptile finding on merged PR #6956.
