### PR TITLE
Qualify absolute rerun-diagnostic wording in Stripe test retry-budget comment

### DIFF
--- a/spec/support/stripe_rate_limit_retries.rb
+++ b/spec/support/stripe_rate_limit_retries.rb
@@ -64,8 +64,9 @@ module StripeTestRateLimitRetries
   # Test Slow out to 50 shards and Test Fast to 18, all against the same
   # Stripe test account, and several PRs build concurrently — so contention
   # scales with how busy the queue is, not with anything a spec does. A build
-  # that goes red from budget exhaustion alone always goes green on a re-run
-  # with no code change, which is the tell that the budget was too small.
+  # that goes red from budget exhaustion alone usually goes green on a re-run
+  # with no code change — that's the tell — though it can redden again if the
+  # same contention is still there.
   #
   # It is kept OFF Stripe's global configuration on purpose. Raising
   # Stripe.max_network_retries would also widen the gem's own retries for


### PR DESCRIPTION
## What
Qualifies the rerun diagnostic in the `MAX_RETRIES` comment (`spec/support/stripe_rate_limit_retries.rb`): a rerun going green is now described as the usual signal of budget exhaustion, not an absolute guarantee.

## Why
Greptile P2 on #7076 (with a Ruby harness proving a rerun can exhaust the same 12-retry budget again under persistent contention): the old wording said a clean rerun "always" happens, which is false when shared-account contention hasn't cleared.

Premerge review: exempt (docs-only comment wording, no code touched)

## Test Results
`ruby -c spec/support/stripe_rate_limit_retries.rb` → Syntax OK. Comment-only change.

## QA steps
Docs-only; read the diff.

## Status
- [x] Scope — comment wording only
- [x] Design — "usually" instead of "always", keep the durable invariant
- [x] Build — pushed to `fix/qualify-stripe-rerun-diagnostic`
- [x] QA — docs-only, `ruby -c` clean
- [x] Shipped — docs-only, merges on sight
- [x] Market — n/a
- [x] Sell — n/a

---
AI disclosure: built by Hermes Agent (Claude) running autonomously as gumclaw, addressing a Greptile finding on #7076.
