### PR TITLE
Advertise subscribe-preview card dimensions in profile og:image meta tags

### DIFF
--- a/app/controllers/concerns/page_meta/user.rb
+++ b/app/controllers/concerns/page_meta/user.rb
@@ -23,6 +23,12 @@ module PageMeta::User
 
       if user.subscribe_preview_url.present?
         set_meta_tag(property: "og:image", content: user.subscribe_preview_url)
+        # Dimensions + type let Facebook's crawler render the card on the FIRST
+        # share after a scrape; without them it processes the image async and the
+        # first preview goes out imageless (which sellers report as "blank circle").
+        set_meta_tag(property: "og:image:type", content: "image/png")
+        set_meta_tag(property: "og:image:width", content: SubscribePreviewGeneratorService::OUTPUT_WIDTH.to_s)
+        set_meta_tag(property: "og:image:height", content: SubscribePreviewGeneratorService::OUTPUT_HEIGHT.to_s)
         set_meta_tag(property: "og:image:alt", content: user.name_or_username)
         set_meta_tag(property: "twitter:card", content: "summary_large_image")
         set_meta_tag(property: "twitter:image", content: user.subscribe_preview_url)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -307,6 +307,12 @@ class UsersController < ApplicationController
       share_image_tags = [%(<meta property="og:image" content="#{escaped_share_image}">),
                           %(<meta property="og:image:alt" content="#{alt}">)]
       if preview_url
+        # Dimensions + type mirror PageMeta::User: they let Facebook's crawler
+        # render the card on the FIRST share after a scrape instead of an
+        # imageless preview while it processes the image asynchronously.
+        share_image_tags << %(<meta property="og:image:type" content="image/png">)
+        share_image_tags << %(<meta property="og:image:width" content="#{SubscribePreviewGeneratorService::OUTPUT_WIDTH}">)
+        share_image_tags << %(<meta property="og:image:height" content="#{SubscribePreviewGeneratorService::OUTPUT_HEIGHT}">)
         share_image_tags << %(<meta property="twitter:card" content="summary_large_image">)
         share_image_tags << %(<meta property="twitter:image" content="#{escaped_share_image}">)
         share_image_tags << %(<meta property="twitter:image:alt" content="#{alt}">)

--- a/app/services/subscribe_preview_generator_service.rb
+++ b/app/services/subscribe_preview_generator_service.rb
@@ -6,6 +6,12 @@ class SubscribePreviewGeneratorService
   ASPECT_RATIO = 128/67r
   WIDTH = 512
   HEIGHT = WIDTH / ASPECT_RATIO
+  # The PNG's real pixel dimensions (the screenshot is taken at retina scale).
+  # Meta tags advertise these so Facebook's crawler can render the card on the
+  # very first share of a freshly-scraped URL instead of a blank preview while
+  # it processes the image asynchronously.
+  OUTPUT_WIDTH = WIDTH * RETINA_PIXEL_RATIO
+  OUTPUT_HEIGHT = (HEIGHT * RETINA_PIXEL_RATIO).to_i
   CHROME_ARGS = [
     "force-device-scale-factor=#{RETINA_PIXEL_RATIO}",
     "headless",

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -425,6 +425,17 @@ describe UsersController do
           expect(meta_content("twitter:image:alt")).to eq(preview_seller.name_or_username)
         end
 
+        # Without explicit dimensions Facebook's crawler processes the image
+        # asynchronously and the first share after a scrape goes out imageless.
+        it "advertises the card's pixel dimensions and type" do
+          @request.host = preview_seller.subdomain
+          get :show, params: { username: preview_seller.username }
+
+          expect(meta_content("og:image:type")).to eq("image/png")
+          expect(meta_content("og:image:width")).to eq(SubscribePreviewGeneratorService::OUTPUT_WIDTH.to_s)
+          expect(meta_content("og:image:height")).to eq(SubscribePreviewGeneratorService::OUTPUT_HEIGHT.to_s)
+        end
+
         # With only a preview attached either precedence order passes, so this is the
         # example that actually pins the card ahead of the avatar.
         it "prefers the card over an uploaded avatar when the seller has both" do
@@ -451,6 +462,10 @@ describe UsersController do
           expect(avatar_seller.avatar).to be_attached
           expect(meta_content("og:image")).to eq(avatar_seller.avatar_url)
           expect(meta_content("og:image:alt")).to eq("#{avatar_seller.name_or_username}'s profile picture")
+          # The card's dimensions describe the generated PNG, not an arbitrary
+          # avatar upload — advertising them here would lie to the crawler.
+          expect(meta_content("og:image:width")).to be_empty
+          expect(meta_content("og:image:height")).to be_empty
         end
 
         # avatar_url falls back to the default avatar, so a presence check here would

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -82,6 +82,9 @@ describe "Profile custom HTML rendering", type: :request do
       expect(response.body).to include(%(<meta property="twitter:image" content="#{ERB::Util.h(seller.subscribe_preview_url)}">))
       expect(response.body).to include(%(<meta property="twitter:card" content="summary_large_image">))
       expect(response.body).to include(%(<meta property="og:image:alt" content="Jane Doe">))
+      expect(response.body).to include(%(<meta property="og:image:type" content="image/png">))
+      expect(response.body).to include(%(<meta property="og:image:width" content="#{SubscribePreviewGeneratorService::OUTPUT_WIDTH}">))
+      expect(response.body).to include(%(<meta property="og:image:height" content="#{SubscribePreviewGeneratorService::OUTPUT_HEIGHT}">))
     end
 
     it "falls back to an uploaded avatar with no twitter card" do
@@ -98,6 +101,8 @@ describe "Profile custom HTML rendering", type: :request do
       expect(response.body).to include(%(<meta property="og:image:alt" content="Jane Doe's profile picture">))
       expect(response.body).not_to include(%(property="twitter:image"))
       expect(response.body).not_to include(%(property="twitter:card"))
+      # Dimensions describe the generated card PNG only, never an avatar upload.
+      expect(response.body).not_to include(%(property="og:image:width"))
     end
 
     # The common case for an established seller, and the one that pins the chain's


### PR DESCRIPTION
## Why

CSAT escalation (Helper `d3bab00ac55c260d2ea8203bda7871fe`, seller Zoe Rios / `zoerios`): her profile picture doesn't render in social share-card previews (iMessage/WhatsApp/Facebook) even after the subscribe-preview card was regenerated with her photo and support told her twice it was fixed.

Live reproduction as a crawler (facebookexternalhit UA, no cookies):
- `https://zoerios.gumroad.com/` serves `og:image` → `https://public-files.gumroad.com/trhs7i8y4diw86mjubgss87l7oel`
- That URL fetches clean: **200, image/png, 1024×536, no redirects, no auth, `cache-control: public, max-age=31536000`**, and visually contains her photo.

So the asset and tags are correct — the remaining server-side gap is that we advertise **no `og:image:width`/`og:image:height`/`og:image:type`**. Facebook documents that without explicit dimensions its crawler processes the image asynchronously and the *first* share after a scrape renders an imageless card — exactly the "blank circle on share, photo fine on click-through" symptom, compounded by each platform then caching that imageless preview.

## What

- `SubscribePreviewGeneratorService`: expose `OUTPUT_WIDTH`/`OUTPUT_HEIGHT` (1024×536 — the card PNG's real retina pixel size, verified against the live asset).
- `PageMeta::User` (standard profile) and the custom-HTML wrapper `<head>` in `UsersController`: emit `og:image:type`, `og:image:width`, `og:image:height` **only on the subscribe-preview branch** — avatar uploads have arbitrary dimensions, so advertising the card's numbers there would lie to the crawler.

## What this does NOT fix

Crawler-side caches that already stored the blank preview (Apple/Meta) still need a re-scrape (Facebook Sharing Debugger "Scrape Again") or their own TTL expiry. That's the follow-up on the support ticket, not a code change.

## QA steps

1. `curl -sL -A "facebookexternalhit/1.1" https://zoerios.gumroad.com/ | grep -oE '<meta[^>]*og:image[^>]*>'` — after deploy, expect `og:image:width content="1024"`, `og:image:height content="536"`, `og:image:type content="image/png"` alongside the existing `og:image`.
2. Same check on a custom-HTML profile (wrapper document surface).
3. Avatar-only seller profile: no width/height tags (spec-pinned).

## Test results

- `spec/controllers/users_controller_spec.rb -e "share card meta tags"` — 6 examples, 0 failures
- `spec/requests/profile_custom_html_spec.rb -e "share card"` — 4 examples, 0 failures
- rubocop clean on all 5 touched files

## AI disclosure

Authored by Hermes Agent (claude-fable-5) as part of a support-escalation root-cause investigation.


Premerge review: clean @ 1dec1b8a7375e91959d72ed38af851bed68c6ef8
