### PR TITLE
Clear stale inferred taxonomy attributes on taxonomy move and empty backfill

### DIFF
--- a/app/services/discover/taxonomy_attribute_classifier.rb
+++ b/app/services/discover/taxonomy_attribute_classifier.rb
@@ -15,7 +15,7 @@ module Discover
 
     def self.classify!(link)
       classifier = classifier_for(link)
-      return false if classifier.nil?
+      return clear_inferred_values(link) if classifier.nil?
 
       classifier.new(link).classify!
     end
@@ -34,6 +34,12 @@ module Discover
       return nil if taxonomy.nil?
 
       CLASSIFIERS[taxonomy.ancestry_path.join("/")]
+    end
+
+    # A product moved off a classified taxonomy (or has none) must not keep a prior
+    # classifier's inferred values — nothing re-runs classify! for it again to clear them.
+    def self.clear_inferred_values(link)
+      link.inferred_taxonomy_attribute_values.present? ? link.save_inferred_taxonomy_attribute_values({}) : false
     end
   end
 end

--- a/app/services/onetime/backfill_taxonomy_attribute_classification.rb
+++ b/app/services/onetime/backfill_taxonomy_attribute_classification.rb
@@ -52,7 +52,11 @@ module Onetime
 
       def backfill(link)
         inferred = Discover::TaxonomyAttributeClassifier.inferred_values_for(link)
-        return tick(:skipped_no_signal) if inferred.empty?
+
+        if inferred.empty?
+          return tick(:skipped_no_signal) if @dry_run || link.inferred_taxonomy_attribute_values.blank?
+          return link.save_inferred_taxonomy_attribute_values({}) ? tick(:cleared) : tick(:save_failed)
+        end
 
         inferred.each { |name, value| @value_distribution[name][value.to_s] += 1 }
         return tick(:would_infer) if @dry_run

--- a/spec/services/discover/taxonomy_attribute_classifier_spec.rb
+++ b/spec/services/discover/taxonomy_attribute_classifier_spec.rb
@@ -31,6 +31,17 @@ describe Discover::TaxonomyAttributeClassifier do
 
       expect(described_class.classify!(product)).to eq(false)
     end
+
+    it "clears a stale inferred value when the product moves to an unregistered taxonomy" do
+      product = create(:product, taxonomy: fonts_taxonomy)
+      create(:product_file, link: product, url: "#{S3_BASE_URL}specs/font.otf")
+      described_class.classify!(product)
+      expect(product.reload.inferred_taxonomy_attribute_values).to eq("format" => "OTF")
+
+      product.update!(taxonomy: other_taxonomy)
+
+      expect(product.reload.inferred_taxonomy_attribute_values).to eq({})
+    end
   end
 
   describe ".inferred_values_for" do

--- a/spec/services/onetime/backfill_taxonomy_attribute_classification_spec.rb
+++ b/spec/services/onetime/backfill_taxonomy_attribute_classification_spec.rb
@@ -56,4 +56,24 @@ describe Onetime::BackfillTaxonomyAttributeClassification do
 
     expect(result[:stats]).to eq(dry_run: false)
   end
+
+  it "clears a stale inferred value on a real run when the classifier no longer returns one" do
+    product = create(:product, taxonomy: fonts_taxonomy)
+    product.update_column(:json_data, { "inferred_taxonomy_attribute_values" => { "format" => "OTF" } })
+
+    result = described_class.process(dry_run: false)
+
+    expect(product.reload.inferred_taxonomy_attribute_values).to eq({})
+    expect(product.taxonomy_attribute_filter_tokens).to eq([])
+    expect(result[:stats][:cleared]).to eq(1)
+  end
+
+  it "does not clear a stale inferred value on a dry run" do
+    product = create(:product, taxonomy: fonts_taxonomy)
+    product.update_column(:json_data, { "inferred_taxonomy_attribute_values" => { "format" => "OTF" } })
+
+    described_class.process(dry_run: true)
+
+    expect(product.reload.inferred_taxonomy_attribute_values).to eq("format" => "OTF")
+  end
 end


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [x] QA — 12 examples/0 failures + independent mutation-verified review (see below); `Premerge review: clean @ 96d329d0630557c4f7c4f21be01fb27988b1451e`
- [x] Ship — CI green, ready to merge
- [ ] Market
- [ ] Sell

## What

Follow-up to #6967: fix the two P1s Greptile found post-merge in `Discover::TaxonomyAttributeClassifier` and `Onetime::BackfillTaxonomyAttributeClassification` — stale `inferred_taxonomy_attribute_values` were never cleared when a product left a classified taxonomy, or when a real backfill run's classifier stopped returning any value.

## Why

Both bugs left obsolete automatic attribute values (and their derived Discover filter tokens) on a product after the signal that produced them went away — a moved-taxonomy product or a re-run backfill would keep advertising a stale format/style that no longer applies.

## Design

- `TaxonomyAttributeClassifier.classify!` now calls a new `clear_inferred_values(link)` when there is no registered classifier for the current taxonomy, instead of silently returning `false`. It only writes when a value is actually present, so the common "never had one" case stays a no-op.
- `BackfillTaxonomyAttributeClassification#backfill` no longer treats an empty classifier result as unconditionally skippable: on a real run (`dry_run: false`), if the link already has an inferred value and the classifier now returns none, it persists the empty map (tallied as `:cleared`). Dry runs keep the old skip-and-report behavior — nothing is ever written on a dry run.

## Test Results

Ran in a lane-borrowed env (`lane_alloc.sh env 0`, `RACK_ATTACK_REDIS_HOST`/`RPUSH_REDIS_HOST` set to the lane redis):

- `spec/services/discover/taxonomy_attribute_classifier_spec.rb`, `spec/services/onetime/backfill_taxonomy_attribute_classification_spec.rb` — 12 examples, 0 failures.
- Mutation check: reverted each fix individually (back to `return false`, back to the unconditional `return tick(:skipped_no_signal)`) and re-ran the corresponding new spec — both failed as expected, confirming the guards are load-bearing. Restored and re-verified green.
- `ruby -c` clean on both changed files.

## QA steps

- Classified a Fonts product with a single `.otf` (`inferred_taxonomy_attribute_values` → `{"format"=>"OTF"}`), moved it to an unregistered taxonomy, reloaded: inferred values now `{}`.
- Seeded a product's `json_data` with a stale inferred value, ran the backfill with `dry_run: false`: value cleared and `taxonomy_attribute_filter_tokens` empty, stats counter `:cleared` incremented.
- Same seed, `dry_run: true`: stale value untouched.

---
AI disclosure: built autonomously by gumclaw (claude-sonnet-5) in response to Greptile review findings on #6967.
