### PR TITLE
Cap grouped receipts and claim the send once per recipient + set

### DIFF
--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -9,6 +9,17 @@ class CustomerMailer < ApplicationMailer
 
   layout "layouts/email", except: :send_to_kindle
 
+  # A buyer's full history can run to hundreds of purchases (gumroad-private#1869: 752),
+  # and rendering a receipt for each produced a multi-hundred-page email whose SMTP upload
+  # timed out AFTER the relay accepted it — so every MailDeliveryJob retry delivered
+  # another copy. Newest receipts are the ones a "resend my receipts" caller is after.
+  GROUPED_RECEIPT_MAX_CHARGEABLES = 20
+
+  # One send per recipient + receipt set within this window. The claim is taken at render,
+  # so a retry of a send that failed before SMTP handoff is also suppressed — acceptable,
+  # because every caller of this mailer is a self-serve flow the buyer can re-trigger.
+  GROUPED_RECEIPT_SEND_CLAIM_TTL = 24.hours
+
   def grouped_receipt(purchase_ids)
     # Callers can pass ids of purchases in any state (e.g. the email-reassignment flow
     # moves failed purchases too). A failed purchase that belongs to a Charge resolves
@@ -17,12 +28,16 @@ class CustomerMailer < ApplicationMailer
     # Only successful purchases get receipts, so filter here.
     @chargeables = Purchase.where(id: purchase_ids)
       .all_success_states_including_test
+      .order(id: :desc)
       .includes(charge: [:order, :seller])
       .map { Charge::Chargeable.find_by_purchase_or_charge!(purchase: _1) }
       .uniq
+      .first(GROUPED_RECEIPT_MAX_CHARGEABLES)
+      .reverse
     return if @chargeables.empty?
 
     last_chargeable = @chargeables.last
+    return unless claim_grouped_receipt_send(last_chargeable.orderable.email)
 
     mail(
       to: last_chargeable.orderable.email,
@@ -380,6 +395,19 @@ class CustomerMailer < ApplicationMailer
   end
 
   private
+    # True when this render owns the send for this recipient + receipt set. NX so a
+    # MailDeliveryJob retry that re-renders after a successful SMTP handoff (the
+    # gumroad-private#1869 loop: the relay accepted the message but the final response
+    # timed out) cannot deliver another copy. Fails open — losing a receipt to a Redis
+    # blip is worse than a rare duplicate.
+    def claim_grouped_receipt_send(email)
+      digest = Digest::SHA256.hexdigest(@chargeables.map { _1.external_id }.sort.join(","))
+      $redis.set(RedisKey.grouped_receipt_send_claim(email, digest), Time.current.to_i, nx: true, ex: GROUPED_RECEIPT_SEND_CLAIM_TTL.to_i)
+    rescue => e
+      ErrorNotifier.notify(e)
+      true
+    end
+
     def receipt_for_gift_receiver?(chargeable)
       chargeable.orderable.receipt_for_gift_receiver?
     rescue NotImplementedError

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -35,6 +35,7 @@ class RedisKey
     def sales_related_products_internal_limit = "sales_related_products_internal_limit"
     def recommended_products_associated_product_ids_limit = "recommended_products_associated_product_ids_limit"
     def blast_recipients_slice_size = "blast:recipients_slice_size"
+    def grouped_receipt_send_claim(email, digest) = "grouped_receipt_send_claim:#{Digest::SHA256.hexdigest(email.to_s.downcase)}:#{digest}"
     def blast_sent_emails(blast_id) = "blast:#{blast_id}:sent_emails"
     def blast_audience_snapshot(blast_id) = "blast:#{blast_id}:audience_snapshot"
     def blast_non_opener_emails(blast_id) = "blast:#{blast_id}:non_opener_emails"

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -1401,6 +1401,58 @@ describe CustomerMailer do
       expect(charge_queries.size).to be <= 2
       expect(order_queries.size).to be <= 2
     end
+
+    it "caps the number of rendered receipts, keeping the newest purchases" do
+      stub_const("CustomerMailer::GROUPED_RECEIPT_MAX_CHARGEABLES", 2)
+      many = create_list(:purchase, 4, link: product, seller:)
+
+      body = CustomerMailer.grouped_receipt(many.map(&:id)).message.decoded
+
+      expect(body.scan("Order ID").size).to eq(2)
+      expect(body).to include(many[2].external_id_for_invoice)
+      expect(body).to include(many[3].external_id_for_invoice)
+      expect(body).not_to include(many[0].external_id_for_invoice)
+      expect(body).not_to include(many[1].external_id_for_invoice)
+    end
+
+    it "sends only once for the same recipient and receipt set (retry after successful SMTP handoff must not re-deliver)" do
+      first = CustomerMailer.grouped_receipt(purchases.map(&:id))
+      expect(first.to).to eq([purchases.last.email])
+
+      second = CustomerMailer.grouped_receipt(purchases.map(&:id))
+      expect(second.message).to be_a(ActionMailer::Base::NullMail)
+    end
+
+    it "still sends when the send-once store is unavailable" do
+      allow($redis).to receive(:set).and_raise(Redis::CannotConnectError)
+      allow(ErrorNotifier).to receive(:notify)
+
+      mail = CustomerMailer.grouped_receipt(purchases.map(&:id))
+      expect(mail.to).to eq([purchases.last.email])
+      expect(ErrorNotifier).to have_received(:notify)
+    end
+
+    it "allows a different receipt set for the same recipient" do
+      CustomerMailer.grouped_receipt(purchases.map(&:id))
+
+      other_purchase = create(:purchase, link: product, seller:, email: purchases.last.email)
+      mail = CustomerMailer.grouped_receipt(purchases.map(&:id) + [other_purchase.id])
+      expect(mail.to).to eq([other_purchase.email])
+    end
+
+    it "renders the same receipt selection for repeated identical calls" do
+      stub_const("CustomerMailer::GROUPED_RECEIPT_MAX_CHARGEABLES", 2)
+      many = create_list(:purchase, 4, link: product, seller:)
+
+      selections = 2.times.map do
+        $redis.flushdb
+        body = CustomerMailer.grouped_receipt(many.map(&:id).shuffle).message.decoded
+        many.select { body.include?(_1.external_id_for_invoice) }.map(&:id)
+      end
+
+      expect(selections.uniq.size).to eq(1)
+      expect(selections.first.size).to eq(2)
+    end
   end
 
   describe "#refund" do


### PR DESCRIPTION
Fixes the runaway growing-receipt email loop reported in gumroad-private#1869 (Sahil: "Fix ASAP").

## What happened
The unauthenticated "resend my receipts" / "why was I charged" flows (`PublicController#charge_data` / `#license_key_lookup_data`) enqueue `CustomerMailer.grouped_receipt(purchases.ids)` with **every** successful purchase for the email. One buyer with 752 $0 purchases produced a ~455-page email (752 full receipts, each with its own "also bought" recommendations block). The SMTP upload of that message died with `Net::ReadTimeout` **after** the relay had accepted the body, so ActiveJob's `MailDeliveryJob` retry (default retry 25) re-rendered and re-delivered a fresh copy on every attempt — 13+ real sends with distinct Message-IDs over an hour. 61 such stuck retry jobs across ≥32 distinct buyers were in the prod retry set (retry counts 9–22, all `Net::ReadTimeout`); they've been deleted via the audited console path.

Each re-run of the flow by the buyer also snapshots the now-larger purchase set (free downloads keep adding rows) and the recommendations model is re-sampled per render, which is why successive emails kept growing.

## Fix
- **Cap**: render at most `GROUPED_RECEIPT_MAX_CHARGEABLES` (20) receipts, newest first, deterministically ordered — the email stays a deliverable size and repeated renders of the same set produce the same selection.
- **Retry-safe send**: take a Redis `NX` claim keyed on recipient + receipt-set digest (24h TTL) before mailing. A `MailDeliveryJob` retry that re-renders after a successful SMTP handoff now yields `NullMail` instead of another delivery. Fails open if Redis is unreadable (a lost receipt is worse than a rare duplicate, and every caller is a self-serve flow the buyer can re-trigger).

## Specs
- caps rendered receipts at N, keeping the newest purchases
- repeated identical calls render the identical selection (idempotent render)
- second call for the same recipient + set is suppressed (retry cannot re-deliver)
- different receipt set for the same recipient still sends
- unreadable claim store still sends and notifies

`spec/mailers/customer_mailer_spec.rb -e '#grouped_receipt'`: 9 examples, 0 failures. Also green: `public_controller_spec`, `reassign_by_email_service_spec`, `mail_delivery_job_spec`, admin `purchases_controller_spec`, `handle_customer_email_info_spec` (247 examples total). Rubocop clean.


Premerge review: clean @ ee227cb577ce82174465bab91586a2b6eee4c197
