### PR TITLE
Fix deterministic disputable_spec.rb:842 failure on main: align replay-safety example with #7073's window_open? gate

### DIFF
--- a/spec/models/concerns/charge/disputable_spec.rb
+++ b/spec/models/concerns/charge/disputable_spec.rb
@@ -824,10 +824,10 @@ describe Charge::Disputable, :vcr do
           end
         end
 
-        # The old gate tested `elapsed < 72.hours` exactly while every other consumer — including
-        # the notice's own body — asks the rounded hours_left_to_submit_evidence. Between 71.5h and
-        # 72h the two disagreed, so the gate called the window open and the email it sent read "in
-        # the next 0 hours". One predicate now answers for both.
+        # Between 71.5h and 72h the window is open by exact arithmetic while the rounded hour
+        # count reads 0. The gate here asks window_open? and sends; the mailer recomputes hours at
+        # render and drops the evidence ask (see contacting_creator_mailer_spec), so the seller
+        # still learns of the dispute without ever being quoted "0 hours".
         context "when rounding has taken the window to its last half hour" do
           let(:boundary_stamp) { (DisputeEvidence::SUBMIT_EVIDENCE_WINDOW_DURATION_IN_HOURS - 0.4).hours.ago }
 
@@ -839,13 +839,13 @@ describe Charge::Disputable, :vcr do
             end
           end
 
-          it "does not send a notice that would quote zero hours" do
-            expect(ContactingCreatorMailer).not_to receive(:chargeback_notice)
-
-            Purchase.handle_charge_event(event)
+          it "still sends the notice, leaving the zero-hours copy to the mailer's render-time gate" do
+            expect { Purchase.handle_charge_event(event) }
+              .to have_enqueued_mail(ContactingCreatorMailer, :chargeback_notice)
 
             evidence = purchase.reload.dispute.dispute_evidence
-            # Still inside the window by exact arithmetic, which is what made this band send.
+            # Open by exact arithmetic even though the rounded hour count reads 0 — the band where
+            # a rounded gate here would have silenced the notice entirely.
             expect(Time.current - evidence.seller_contacted_at)
               .to be < DisputeEvidence::SUBMIT_EVIDENCE_WINDOW_DURATION_IN_HOURS.hours
             expect(evidence.hours_left_to_submit_evidence).to eq(0)


### PR DESCRIPTION
Fixes the deterministic failure on main:

```
rspec ./spec/models/concerns/charge/disputable_spec.rb:842
# Charge::Disputable ... webhook replay safety when rounding has taken the window
# to its last half hour does not send a notice that would quote zero hours
```

It reddens `ci/green` on every main run (e.g. Test Fast 17 in run 30996231385).

## Bisect finding

- **Breaking commit: `0c79b6adf` — "Fix three Greptile P1s on dispute-evidence hold-until-deadline (#6918)" (#7073).** Verified by running the single spec at `b93543fa7` (parent, **green**) and at `0c79b6adf` (**red**). The commit title mentions the postPurchaseCartSave test in some trackers, but the actual diff is the dispute-evidence Greptile P1 follow-up; `git log -S notice_worth_sending` also pins this as the only commit touching the gate.
- #7073 changed `DisputeEvidence.notice_worth_sending?` / `.accepting_evidence?` from the **rounded** `hours_left_in_window(...).positive?` to the **exact** `window_open?` (`Time.current < seller_contacted_at + 72.hours`), deliberately: the rounded gate was closing the window up to ~29 minutes early (that was one of the Greptile P1s). #7073 updated `spec/models/dispute_evidence_spec.rb` to the new contract but missed this example in `disputable_spec.rb`, which still asserted the old rounded-gate behavior (notice suppressed at 71.6h elapsed).

## Root cause: spec drift, not a production bug

The question the spec poses — "would production email a seller a notice quoting **0 hours**?" — is **no**, even with the notice now sent in the 71.5–72h band:

- `ContactingCreatorMailer#chargeback_notice` recomputes `hours_left_to_submit_evidence` **at render time** and gates the evidence ask with `accepting_evidence? && hours_left&.positive?` (app/mailers/contacting_creator_mailer.rb). In this band it sends the **plain dispute notice** ("We fight every dispute.") with no deadline copy and no submit button — covered by `spec/mailers/contacting_creator_mailer_spec.rb` ("drops the request for evidence rather than quoting a deadline that has passed", which uses the exact same 71.6h stamp).
- Suppressing the notice entirely here would be worse: the seller would never learn their sale was disputed just because the webhook landed in the window's last half hour.

So the gate in `disputable.rb:457` is correct post-#7073; the spec's fixture asserted a contract #7073 intentionally retired.

## Fix (spec-only)

Updated the example to the new contract: the notice **is** enqueued in the last rounded half hour (window open by exact arithmetic), and the zero-hours protection is documented as living in the mailer's render-time gate. Kept the assertions that the band is exactly the rounded-to-zero-but-open one (`hours_left == 0`, elapsed < 72h) so the example still pins the boundary.

No production code changed.

## Verification

- `rspec spec/models/concerns/charge/disputable_spec.rb:842` — red on main, green with this change.
- Full `spec/models/concerns/charge/disputable_spec.rb` — 155 examples, 0 failures locally (the only local reds were `Vite Ruby can't find entrypoints/email.ts` env noise from a worktree without built test assets; green once assets present, and these examples are green on main's CI).
- Consistency: `dispute_evidence_spec.rb` ("keeps sending inside the last rounded hour") and `contacting_creator_mailer_spec.rb` (zero-hours render gate) already assert the behavior this example now matches.

Premerge review: clean @ 6586e5693c3bacdf4a2e8ac287d61f06082b4b15

## QA steps

Spec-only change, no rendered surface — the diff and the local/CI spec runs are the reviewable artifact:
1. `bundle exec rspec spec/models/concerns/charge/disputable_spec.rb:842` — red on main, green on this branch.
2. `bundle exec rspec spec/models/concerns/charge/disputable_spec.rb` — 155 examples, 0 failures on this branch.

---

AI disclosure: built by Gumclaw (Hermes agent, Claude/fable-5) with a codex/gpt-5.6 pre-merge QA audit; prompts: bisect the deterministic disputable_spec.rb:842 failure on main, decide code-vs-spec, fix, verify.
