### PR TITLE
Fanout-aware branch spec selection with enforced full-suite escalation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -870,14 +870,27 @@ jobs:
         id: specs
         run: |
           git fetch --no-tags --quiet origin main
+          set +e
           SPECS=$(ruby bin/branch-specs)
-          COUNT=$(echo "$SPECS" | grep -c . || true)
-          # An empty list would make Knapsack fall back to its full-suite
-          # pattern; fail loudly instead. The smoke set makes this
-          # unreachable unless those specs are deleted.
-          if [ "$COUNT" -eq 0 ]; then
-            echo "bin/branch-specs returned no specs — refusing to run"
+          STATUS=$?
+          set -e
+          # Exit 3 = the selector refused to certify a trimmed run (dependency/
+          # config/migration/factory change, mapping gap, or oversized
+          # selection). The full suite is required: add the run-all-specs label.
+          if [ "$STATUS" -eq 3 ]; then
+            echo "::error::bin/branch-specs escalated — this diff needs the full suite. Add the run-all-specs label to this PR and re-run."
             exit 1
+          elif [ "$STATUS" -ne 0 ]; then
+            echo "bin/branch-specs failed with status $STATUS"
+            exit "$STATUS"
+          fi
+          COUNT=$(echo "$SPECS" | grep -c . || true)
+          # An empty list here means the diff touched nothing rspec-affecting
+          # (selector escalates on app-code diffs that map to nothing).
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No rspec-affecting changes; running the schema smoke spec as a floor."
+            SPECS="spec/models/user_spec.rb"
+            COUNT=1
           fi
           echo "Running $COUNT spec file(s):"
           echo "$SPECS" | sed 's/^/  /'

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -172,30 +172,34 @@ def spec_candidates(path)
   end
 end
 
-specs = changed
-  .flat_map { |path| spec_candidates(path) }
-  .uniq
+specs = Set.new
+unattributed = []
 
-# Fanout expansion: registry hits add whole flow directories.
-fanout_dirs = changed.flat_map do |path|
-  FANOUT.select { |re, _| re.match?(path) }.values.flatten
-end.uniq
-specs |= fanout_dirs.select { |dir| Dir.exist?(dir) }
+changed.each do |path|
+  candidates = spec_candidates(path).select { |s| File.exist?(s) }
+  fanout_hits = FANOUT.select { |re, _| re.match?(path) }.values.flatten.select { |dir| Dir.exist?(dir) }
+  contributed = candidates + fanout_hits
 
-specs = specs.select { |spec| File.exist?(spec) || Dir.exist?(spec) }
+  if contributed.any?
+    specs.merge(contributed)
+  else
+    unattributed << path
+  end
+end
+
+# Any changed path that contributed no specs of its own is a mapping gap, not
+# a clean bill — even when OTHER paths in the same diff selected specs. This
+# catches both a lone boot/test-infrastructure change (Rakefile, bin/rspec,
+# .rspec, config.ru) and one hiding alongside a mapped file, where the old
+# specs.empty? guard was fooled into thinking the diff was fully covered.
+if unattributed.any?
+  escalate!("diff touches #{unattributed.first(5).join(', ')} but no specs were selected for it (mapping gap)")
+end
 
 # Knapsack consumes a plain file list, so directories expand to their spec files.
 specs = specs.flat_map { |s| Dir.exist?(s) ? Dir.glob("#{s}/**/*_spec.rb") : [s] }.uniq
 
 specs |= SMOKE_SPECS.select { |spec| File.exist?(spec) } if smoke
-
-# Any non-ignored change that selected nothing is a mapping gap, not a clean
-# bill — this also catches boot/test-infrastructure paths (Rakefile, bin/rspec,
-# .rspec, config.ru) that aren't under app/, lib/, or spec/ but can still
-# change what the suite runs or how it boots.
-if specs.empty? && changed.any?
-  escalate!("diff touches #{changed.first(5).join(', ')} but no specs were selected (mapping gap)")
-end
 
 escalate!("selection of #{specs.size} spec files exceeds #{MAX_SELECTED_FILES}") if specs.size > MAX_SELECTED_FILES
 

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -2,30 +2,27 @@
 # frozen_string_literal: true
 
 # Prints the spec files a branch needs for confidence, instead of the whole
-# suite: specs mapped from changed files (same rules as bin/rspec-changed)
-# plus an always-on smoke set covering the core money paths end to end.
+# suite: specs mapped from changed files, expanded through a fanout registry
+# for files whose behavior many end-to-end specs depend on.
 #
 # Branch CI runs exactly this list (see .github/workflows/tests.yml
-# test_relevant); main still runs everything before a deploy.
+# test_relevant); main still runs everything before a deploy, and a PR can
+# opt into the full suite with the run-all-specs label.
+#
+# Exits 3 (ESCALATE) when the diff cannot be mapped safely — dependency,
+# config, migration, factory, or unmapped-helper changes, or a selection so
+# large the full suite is cheaper. CI turns that into "add run-all-specs".
 #
 # Usage:
 #   bin/branch-specs                 # print the list, one per line
 #   bin/branch-specs --base main     # diff against a different base ref
-#   bin/branch-specs --no-smoke      # mapped specs only
+#   bin/branch-specs --smoke         # include the legacy smoke set
 #   bin/rspec $(bin/branch-specs)    # run it locally
-#
-# Mapping rules:
-#   spec/**/*_spec.rb                    -> itself
-#   app/controllers/**/foo_controller.rb -> spec/controllers + spec/requests/**/foo_spec.rb
-#   app/<dir>/**/foo.rb                  -> spec/<dir>/**/foo_spec.rb
-#   lib/**/foo.rb                        -> spec/lib/**/foo_spec.rb
-#   app/models|services/**/foo.rb        -> spec/requests/**/foo*_spec.rb (E2E coverage)
 
 require "set"
 
-# Core end-to-end flows that run on every branch regardless of the diff:
-# a change that breaks buying, receipts, login, or the balance page must
-# not reach main on a trimmed run.
+# Legacy always-on smoke set, now opt-in (--smoke): money-path smoke coverage
+# on every branch moved to the run-all-specs label + main's full suite.
 SMOKE_SPECS = %w[
   spec/requests/checkout/payment_spec.rb
   spec/requests/checkout/form_spec.rb
@@ -35,6 +32,64 @@ SMOKE_SPECS = %w[
   spec/requests/balance_pages_spec.rb
 ].freeze
 
+# Fanout registry: files whose change puts whole flows at risk, mapped to the
+# spec directories that exercise those flows end to end. Reviewed like code —
+# additions come from post-merge misses (see ledger note in tests.yml).
+# #7070 lesson: the checkout presenter and payment JS gate which Stripe
+# surface EVERY checkout browser spec mounts; their unit specs alone prove
+# nothing about the flows.
+CHECKOUT_FLOW_SPECS = %w[
+  spec/requests/checkout
+  spec/requests/purchases
+  spec/requests/subscription
+].freeze
+
+FANOUT = {
+  %r{\Aapp/presenters/checkout/} => CHECKOUT_FLOW_SPECS,
+  %r{\Aapp/javascript/components/Checkout/} => CHECKOUT_FLOW_SPECS,
+  %r{\Aapp/javascript/data/(purchase|order|payment)} => CHECKOUT_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/Checkout/} => CHECKOUT_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/Subscriptions/} => CHECKOUT_FLOW_SPECS,
+  %r{\Aapp/services/order/} => CHECKOUT_FLOW_SPECS,
+  %r{\Aapp/services/charge/} => CHECKOUT_FLOW_SPECS,
+  %r{\Aapp/controllers/orders_controller\.rb\z} => CHECKOUT_FLOW_SPECS,
+  %r{\Aapp/controllers/stripe/} => CHECKOUT_FLOW_SPECS,
+  %r{\Aspec/support/checkout_helpers\.rb\z} => CHECKOUT_FLOW_SPECS,
+  %r{\Aspec/support/stripe_.*\.rb\z} => CHECKOUT_FLOW_SPECS,
+}.freeze
+
+# Support files with mappings; any OTHER spec/support change escalates.
+MAPPED_SUPPORT = FANOUT.keys.select { |re| re.source.start_with?('\Aspec/support') }.freeze
+
+# Paths that cannot be attributed to specs by filename: run the full suite.
+ESCALATE_PATTERNS = [
+  %r{\AGemfile},
+  %r{\Aconfig/},
+  %r{\Adb/},
+  %r{\Apackage\.json\z},
+  %r{\A(pnpm-lock\.yaml|yarn\.lock|package-lock\.json)\z},
+  %r{\Atsconfig},
+  %r{\Aspec/factories/},
+  %r{\Aspec/spec_helper\.rb\z},
+  %r{\Aspec/rails_helper\.rb\z},
+  %r{\Avite\.config},
+  %r{\A\.github/workflows/tests\.yml\z},
+].freeze
+
+# Paths that never affect the rspec suite.
+IGNORED_PATTERNS = [
+  %r{\Aqa-media/},
+  %r{\Adocs?/},
+  %r{\.md\z},
+  %r{\A\.agents/},
+  %r{\A\.claude/},
+].freeze
+
+# Above this many selected files the full suite's parallelism wins anyway.
+MAX_SELECTED_FILES = 120
+
+ESCALATE_EXIT = 3
+
 def git(*args)
   out = IO.popen(["git", *args], err: File::NULL, &:read)
   $?.success? ? out.split("\n") : []
@@ -42,7 +97,7 @@ end
 
 base = "origin/main"
 base_given = false
-smoke = true
+smoke = false
 
 argv = ARGV.dup
 until argv.empty?
@@ -50,7 +105,8 @@ until argv.empty?
   when "--base"
     base = argv.shift or abort("--base requires a ref")
     base_given = true
-  when "--no-smoke" then smoke = false
+  when "--smoke" then smoke = true
+  when "--no-smoke" then smoke = false # kept for compatibility
   when "-h", "--help"
     doc = File.read(__FILE__).lines
       .drop_while { |line| line.start_with?("#!") || line.include?("frozen_string_literal") || line.strip.empty? }
@@ -74,6 +130,22 @@ changed.merge(git("diff", "--name-only", "--diff-filter=d", "#{merge_base}..HEAD
 changed.merge(git("diff", "--name-only", "--diff-filter=d", "HEAD"))
 changed.merge(git("ls-files", "--others", "--exclude-standard"))
 
+changed.reject! { |path| IGNORED_PATTERNS.any? { |re| re.match?(path) } }
+
+def escalate!(reason)
+  warn "bin/branch-specs: ESCALATE — #{reason}"
+  warn "Run the full suite instead: add the run-all-specs label to the PR."
+  exit ESCALATE_EXIT
+end
+
+unmappable = changed.select { |path| ESCALATE_PATTERNS.any? { |re| re.match?(path) } }
+escalate!("cannot attribute specs to: #{unmappable.first(5).join(', ')}") if unmappable.any?
+
+unmapped_support = changed.select do |path|
+  path.start_with?("spec/support/") && MAPPED_SUPPORT.none? { |re| re.match?(path) }
+end
+escalate!("unmapped spec/support change: #{unmapped_support.first(3).join(', ')}") if unmapped_support.any?
+
 def spec_candidates(path)
   case path
   when %r{\Aspec/.*_spec\.rb\z}
@@ -89,6 +161,8 @@ def spec_candidates(path)
       Dir.glob("spec/#{$1}/#{$2}#{$3}/**/*_spec.rb")
     e2e = Dir.glob("spec/requests/**/#{$3}*_spec.rb")
     unit + e2e
+  when %r{\Aapp/views/(.*)/[^/]+\z}
+    Dir.glob("spec/requests/#{$1}*_spec.rb") + Dir.glob("spec/views/#{$1}/**/*_spec.rb")
   when %r{\Aapp/([^/]+)/(.*)\.rb\z}
     ["spec/#{$1}/#{$2}_spec.rb"]
   when %r{\Alib/(.*)\.rb\z}
@@ -101,8 +175,26 @@ end
 specs = changed
   .flat_map { |path| spec_candidates(path) }
   .uniq
-  .select { |spec| File.exist?(spec) }
+
+# Fanout expansion: registry hits add whole flow directories.
+fanout_dirs = changed.flat_map do |path|
+  FANOUT.select { |re, _| re.match?(path) }.values.flatten
+end.uniq
+specs |= fanout_dirs.select { |dir| Dir.exist?(dir) }
+
+specs = specs.select { |spec| File.exist?(spec) || Dir.exist?(spec) }
+
+# Knapsack consumes a plain file list, so directories expand to their spec files.
+specs = specs.flat_map { |s| Dir.exist?(s) ? Dir.glob("#{s}/**/*_spec.rb") : [s] }.uniq
 
 specs |= SMOKE_SPECS.select { |spec| File.exist?(spec) } if smoke
+
+# Rails-affecting changes that selected nothing are a mapping gap, not a
+# clean bill: refuse to certify silence.
+if specs.empty? && changed.any? { |p| p.start_with?("app/", "lib/", "spec/") }
+  escalate!("diff touches app code but no specs were selected (mapping gap)")
+end
+
+escalate!("selection of #{specs.size} spec files exceeds #{MAX_SELECTED_FILES}") if specs.size > MAX_SELECTED_FILES
 
 puts specs.sort

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -189,10 +189,12 @@ specs = specs.flat_map { |s| Dir.exist?(s) ? Dir.glob("#{s}/**/*_spec.rb") : [s]
 
 specs |= SMOKE_SPECS.select { |spec| File.exist?(spec) } if smoke
 
-# Rails-affecting changes that selected nothing are a mapping gap, not a
-# clean bill: refuse to certify silence.
-if specs.empty? && changed.any? { |p| p.start_with?("app/", "lib/", "spec/") }
-  escalate!("diff touches app code but no specs were selected (mapping gap)")
+# Any non-ignored change that selected nothing is a mapping gap, not a clean
+# bill — this also catches boot/test-infrastructure paths (Rakefile, bin/rspec,
+# .rspec, config.ru) that aren't under app/, lib/, or spec/ but can still
+# change what the suite runs or how it boots.
+if specs.empty? && changed.any?
+  escalate!("diff touches #{changed.first(5).join(', ')} but no specs were selected (mapping gap)")
 end
 
 escalate!("selection of #{specs.size} spec files exceeds #{MAX_SELECTED_FILES}") if specs.size > MAX_SELECTED_FILES


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

## What

`bin/branch-specs` v2: selection expands through a **fanout registry** (files whose behavior whole flows depend on → the flow spec directories), and diffs that can't be attributed by filename **escalate to the full suite** (exit 3 → CI fails with an explicit "add run-all-specs" instruction). The always-on smoke set becomes opt-in `--smoke`.

## Why

#7070 was branch-green then failed 15 Test Slow shards on main, forcing revert #7079 and hours of blocked deploys. Measured cause: its diff (payment.ts, PaymentForm.tsx, checkout_helpers.rb, presenter) selected **9 spec files, none of the 15+ that failed** — app/javascript and spec/support had no mapping rules, and the 6-file smoke set masked the gap.

## Selection changes (verified by running each scenario)

| Diff | Before | After |
|---|---|---|
| `payment.ts` | 0 mapped + smoke | 73 files (checkout/purchases/subscription flows) |
| `checkout_helpers.rb` | 0 mapped | 73 files |
| checkout presenter | unit spec only | 74 files |
| `app/models/comment.rb` | unit + name-matched | unchanged (1 file) |
| `Gemfile.lock`, `config/`, `db/`, factories, tsconfig, lockfiles | 0 mapped, smoke-only run certified | **escalate: full suite required** |
| unmapped `spec/support/*` | 0 mapped | **escalate** |
| app-code diff mapping to nothing | smoke-only | **escalate (mapping gap ≠ clean bill)** |
| >120 selected files | ran anyway | **escalate (full suite's parallelism wins)** |

## Design record

Two-model panel (fable-5 + gpt-5.6-sol xhigh), converged: fanout registry + enforced escalation is the core fix; no vitest output into this script (feeds `KNAPSACK_PRO_TEST_FILE_LIST`); AI-in-the-loop rejected for the no-secrets job; selection-vs-outcome ledger recommended as follow-up for data-driven registry updates.

## QA steps

- `echo // >> app/javascript/components/Checkout/payment.ts && ruby bin/branch-specs` → 73 files
- `echo x >> Gemfile.lock && ruby bin/branch-specs; echo $?` → exit 3 with escalation message
- workflow YAML validates; escalation path fails the job with the label instruction

This PR carries `run-all-specs` itself (it touches tests.yml — its own selector would escalate it, which is the system working).

## AI disclosure
claude-fable-5 via Hermes (gumclaw).

## Update (3295a530)

Fixed a Greptile P1: the empty-selection escalation guard only fired for changes under `app/`, `lib/`, `spec/`, so a boot/test-infra-only diff (e.g. `Rakefile`) selected nothing and the workflow fallback silently ran just `spec/models/user_spec.rb`. Guard now escalates on ANY unmapped diff. Verified: `Rakefile`-only and `bin/rspec`-only now exit 3; `payment.ts` still selects 73 files.

Premerge review: clean @ 3295a530492e02d046005fb3f9a8264318076dd4

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
