### PR TITLE
Remove orphaned AggregateRating microdata that fails Google's Rich Results Test

### DIFF
--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -971,10 +971,11 @@ const Reviews = ({
           {`${formatOrderOfMagnitude(ratings.count, 1)} ${ratings.count === 1 ? "rating" : "ratings"}`})
         </div>
       </header>
-      <div itemProp="aggregateRating" itemType="https://schema.org/AggregateRating" itemScope className="hidden">
-        <div itemProp="reviewCount">{ratings.count}</div>
-        <div itemProp="ratingValue">{ratings.average}</div>
-      </div>
+      {/* Rating markup lives in the page's JSON-LD (Product::StructuredData), where the
+          AggregateRating nests under the Product. Do not re-add microdata here: this section
+          has no itemscope Product ancestor, so an itemscope block becomes a standalone
+          top-level AggregateRating that Google's Rich Results Test flags as
+          "Missing field itemReviewed" (gumroad-private#1875). */}
       <section className="grid grid-cols-[auto_1fr_auto] gap-3" aria-label="Ratings histogram">
         {([4, 3, 2, 1, 0] as const).map((rating) => (
           <RatingsHistogramRow rating={rating + 1} percentage={ratings.percentages[rating]} key={rating} />

--- a/spec/requests/products/show/reviews_spec.rb
+++ b/spec/requests/products/show/reviews_spec.rb
@@ -46,6 +46,25 @@ describe("Product page reviews", js: true, type: :system) do
     expect(page).not_to have_text("0 ratings")
   end
 
+  it "emits rating markup only as JSON-LD, never as standalone microdata" do
+    visit product.long_url
+
+    expect(page).to have_text("Ratings")
+    # A microdata AggregateRating here has no itemscope Product ancestor, so Google reads it
+    # as a standalone unnamed item and flags "Missing field itemReviewed"
+    # (gumroad-private#1875). The JSON-LD block is the one source of rating markup.
+    expect(page).not_to have_selector("[itemprop='aggregateRating']", visible: :all)
+
+    structured_data = JSON.parse(page.find("script[type='application/ld+json']", visible: :all, match: :first).text(:all))
+    expect(structured_data["aggregateRating"]).to eq(
+      "@type" => "AggregateRating",
+      "ratingValue" => 2.8,
+      "reviewCount" => 6,
+      "bestRating" => 5,
+      "worstRating" => 1
+    )
+  end
+
   it "allows user to provide rating if already bought and displays the rating regardless of display_product_reviews being enabled for that product" do
     purchaser = create(:user)
     purchase = create(:purchase, link: product, purchaser:)


### PR DESCRIPTION
## What

Removes the hidden `AggregateRating` **microdata** block from the product page's ratings section. The page's JSON-LD (`Product::StructuredData`) remains the single source of rating structured data.

## Why

External SEO tester report (Helper ticket → gumroad-private#1875, Sahil: "You do it"): Google's Rich Results Test flags **"Missing field itemReviewed"** on every Gumroad product page that has reviews — the AggregateRating shows up as an "unnamed AggregateRating item" in the detected-items tree.

Root cause: the page emits rating markup **twice**, in two different syntaxes:

1. **JSON-LD** (`Product::StructuredData#build_product_structured_data`) — `aggregateRating` correctly nested inside the `Product` object. Per Google's review-snippet docs, `itemReviewed` must be omitted in this shape. ✅ compliant.
2. **Microdata** (`Product/index.tsx` ratings section) — a `hidden` `<div itemProp="aggregateRating" itemType="https://schema.org/AggregateRating" itemScope>` with **no `itemscope` Product ancestor anywhere in the DOM**. `itemProp` without an enclosing scope does not attach to anything, so parsers treat the block as a standalone top-level `AggregateRating` item — which *does* require `itemReviewed`, hence the error. ❌ this is what the validator flags.

The nearby `itemProp="name"` (h1) and `itemProp="offers"` (PriceTag / ConfigurationSelector) fragments are equally orphaned — the Offer/AggregateOffer ones are standalone typed items too — but none of them has a required field Google flags the way a standalone AggregateRating requires `itemReviewed`, so only this block trips the validator.

## Before/After

Verified against the live reported page (`tylerstump.gumroad.com/l/tncww`, curled 2026-08-05):

| | JSON-LD Product w/ nested aggregateRating | Standalone microdata AggregateRating | Rich Results verdict |
|---|---|---|---|
| Before | ✅ present (compliant) | ❌ present, orphaned (no Product ancestor) | "Missing field itemReviewed" on the unnamed AggregateRating |
| After | ✅ present (unchanged) | removed | only the compliant JSON-LD item remains |

The removed block was `className="hidden"` — zero rendered pixels change. Reporter's own control case confirms the mechanism: a 0-review product (no `aggregateRating` emitted anywhere) shows no error.

## Test Results

- New system spec in `spec/requests/products/show/reviews_spec.rb`: `"emits rating markup only as JSON-LD, never as standalone microdata"` — asserts no `[itemprop='aggregateRating']` element exists (visible or hidden) AND that the page's `ld+json` block carries the exact nested AggregateRating (ratingValue 2.8 / reviewCount 6 from the fixtures), so the negative assertion cannot pass vacuously on a page that lost rating markup entirely.
- `ruby -c` clean; `prettier --write` run on the `.tsx` (unchanged).
- Local run owed: lane pool refused at load 41 (`lane_alloc: load 41 > 35`) and this is a `type: :system, js: true` spec that requires a lane's dedicated MySQL/Chrome — the Tests workflow run on this PR is the authoritative spec run.

## QA steps

1. Open any product page with reviews on the branch preview; view source.
2. Confirm exactly one source of rating markup: the `application/ld+json` script with `aggregateRating` nested in the Product; no `itemprop="aggregateRating"` element in the DOM.
3. Rich Results Test on the preview URL: Product detected, no "Missing field itemReviewed".
4. Visual: ratings header/histogram unchanged (removed block was `hidden`).

## Not in this PR

The remaining orphaned `itemprop` fragments (`name`, `offers` in PriceTag/ConfigurationSelector) — inert in the validator today; removing them is a follow-up sweep if we want the DOM microdata-free.

Premerge review: clean @ ca2bc51a3c6a2de2eca9fb36726ce96caa1b260c

---
**AI disclosure:** Generated with claude-sonnet-5. Root-caused from the reporter's Rich Results screenshots + live page source, traced to the orphaned microdata block, fixed by deletion with a spec pinning JSON-LD as the sole rating markup source.

