### PR TITLE
Show a bundle's own reviews on its page, not a merge with its contents'

### DIFF
--- a/app/modules/product/review_stat.rb
+++ b/app/modules/product/review_stat.rb
@@ -11,40 +11,6 @@ module Product::ReviewStat
     }
   end
 
-  # A bundle's product page shows one combined rating summary: the bundle's own
-  # reviews (buyers can review the bundle itself) plus the reviews earned by the
-  # products inside it. Merging both means a new bundle review visibly updates
-  # the page's star summary and histogram, while the bundle still benefits from
-  # the social proof its contents have earned on their own pages. The per-star
-  # counts are summed, so the math is a review-count-weighted average.
-  # Display-layer only: the bundle's own review stat row is never written to by
-  # this method (it accumulates normally as bundle reviews come in).
-  def bundle_rating_stats
-    return rating_stats unless is_bundle
-
-    counts = Hash.new(0)
-    rating_counts.each { |rating, count| counts[rating] += count.to_i }
-    bundle_products.alive.includes(product: :product_review_stat).each do |bundle_product|
-      product = bundle_product.product
-      next unless product.display_product_reviews?
-      product.rating_counts.each { |rating, count| counts[rating] += count.to_i }
-    end
-
-    # Build an unsaved stat row from the summed per-star counts so we can reuse
-    # ProductReviewStat's percentage math (largest-remainder rounding to 100%).
-    aggregate = ProductReviewStat.new
-    counts.each { |rating, count| aggregate[ProductReviewStat::RATING_COLUMN_MAP[rating]] = count }
-    total = counts.values.sum
-    aggregate.reviews_count = total
-    aggregate.average_rating = total.zero? ? 0 : (counts.sum { |rating, count| rating * count }.to_f / total).round(1)
-
-    {
-      count: aggregate.reviews_count,
-      average: aggregate.average_rating,
-      percentages: aggregate.rating_percentages.values,
-    }
-  end
-
   def update_review_stat_via_rating_change(old_rating, new_rating)
     if product_review_stat.nil?
       # First-row creation must not go through a plain INSERT: on a duplicate key it takes a

--- a/app/modules/user/reputation_summary.rb
+++ b/app/modules/user/reputation_summary.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-# Seller-level rating rollup over per-product review stats, computed on read
-# (same maths as Link#bundle_rating_stats: sum the per-star counters, weight by
-# review count). Everything here is gated on the :seller_reputation_summary
-# Flipper flag via reputation_summary_enabled?.
+# Seller-level rating rollup over per-product review stats, computed on read:
+# sum the per-star counters, weight by review count. Everything here is gated on
+# the :seller_reputation_summary Flipper flag via reputation_summary_enabled?.
 module User::ReputationSummary
   # Below these the rollup reads as noise, not signal (gumroad-private#1669).
   # Product-owned numbers: change them in one line, not by redesign.

--- a/app/presenters/product_presenter/product_props.rb
+++ b/app/presenters/product_presenter/product_props.rb
@@ -33,7 +33,7 @@ class ProductPresenter::ProductProps
         quantity_remaining: product.remaining_for_sale_count,
         long_url: product.long_url,
         is_sales_limited: product.max_purchase_count?,
-        ratings: product.display_product_reviews? ? product.bundle_rating_stats : nil,
+        ratings: product.display_product_reviews? ? product.rating_stats : nil,
         # Excludes this product so its own reviews never inflate the seller
         # rollup shown on its page (gumroad-private#1669).
         **(seller.reputation_summary_enabled? ? { seller_reputation: seller.seller_reputation_summary(exclude_product: product) } : {}),

--- a/app/services/pages/interpolator.rb
+++ b/app/services/pages/interpolator.rb
@@ -14,9 +14,7 @@ class Pages::Interpolator
     "description" => ->(product) { ActionView::Base.full_sanitizer.sanitize(product.description.to_s) },
   }.freeze
 
-  # Both fields read the aggregate that interpolate computes at most once per render — for a
-  # bundle it loads every content product's stat row, so recomputing per marker scales the
-  # query count with how often the page repeats the markers.
+  # Both fields read the summary that interpolate computes at most once per render.
   REVIEW_FIELDS = {
     # Trailing ".0" is stripped because the native page renders the rating as a JSON number,
     # where 4.0 prints as "4".
@@ -24,13 +22,10 @@ class Pages::Interpolator
     "review-count" => ->(summary) { summary.fetch(:count).to_s },
   }.freeze
 
-  # bundle_rating_stats, not rating_stats: the native page merges a bundle's contents' reviews
-  # into one summary (ProductPresenter::ProductProps), so the plain row would disagree with the
-  # page this markup replaces.
   def self.review_summary(product)
     return unless product.display_product_reviews?
 
-    stats = product.bundle_rating_stats
+    stats = product.rating_stats
     return if stats[:count].zero?
 
     stats

--- a/app/views/help_center/articles/contents/_339-product-bundles.html.erb
+++ b/app/views/help_center/articles/contents/_339-product-bundles.html.erb
@@ -49,7 +49,7 @@
   <h3 id="Checkout-DUhSH">Checkout</h3>
   <p>Customers who purchase your bundle will see a list of the individual products included within. On the product page, the price will show the cumulative value of every product in the bundle crossed out with the new price shown next to it.</p>
   <p><i>Note:</i> If your bundle has versions of its own, the crossed-out price only shows on a version that does not add anything to the bundle's price. The cumulative value is fixed by the product variants you picked when you built the bundle, so it does not describe what a customer gets on a version that costs extra. On those versions no crossed-out price is shown.</p>
-  <p><i>Note:</i> Customers can <a href="222-product-ratings-on-gumroad">rate and review</a> the bundle itself as well as the individual products inside it. The bundle's product page shows one combined rating summary: the bundle's own reviews plus the reviews of the products it contains. Products with ratings hidden are not included in this combined summary.</p>
+  <p><i>Note:</i> Customers can <a href="222-product-ratings-on-gumroad">rate and review</a> the bundle itself as well as the individual products inside it. The bundle's product page shows the bundle's own rating; each product listed inside the bundle shows its own rating on its card.</p>
   <p>On the checkout page, customers will once again find a list of everything they will receive inside the bundle.</p>
   <figure><%= image_tag "https://d33v4339jhl8k0.cloudfront.net/docs/assets/5c4657ad2c7d3a66e32d763f/images/6589a58bdcdba22513abb141/file-jsLiTIsQef.png" %></figure>
   <h3 id="Customer-drawer-Lijr-">Customer drawer</h3>

--- a/spec/modules/product/review_stat_spec.rb
+++ b/spec/modules/product/review_stat_spec.rb
@@ -252,78 +252,30 @@ describe Product::ReviewStat do
     end
   end
 
-  describe "#bundle_rating_stats" do
-    it "returns the product's own rating_stats for a non-bundle product" do
-      purchase = create(:purchase, link: @product)
-      create(:product_review, purchase:, rating: 4)
-
-      expect(@product.reload.bundle_rating_stats).to eq(@product.rating_stats)
-      expect(@product.bundle_rating_stats[:count]).to eq(1)
+  describe "#rating_stats for a bundle" do
+    before do
+      @bundle = create(:product, :bundle)
+      @first_bundled_product, @second_bundled_product = @bundle.bundle_products.map(&:product)
     end
 
-    context "when the product is a bundle" do
-      before do
-        @bundle = create(:product, :bundle)
-        @first_bundled_product, @second_bundled_product = @bundle.bundle_products.map(&:product)
-      end
+    it "counts only the bundle's own reviews, not its contents'" do
+      create(:product_review, purchase: create(:purchase, link: @first_bundled_product), rating: 5)
+      create(:product_review, purchase: create(:purchase, link: @second_bundled_product), rating: 1)
+      create(:product_review, purchase: create(:purchase, link: @bundle, is_bundle_purchase: true), rating: 3)
 
-      it "aggregates the bundled products' review stats weighted by review count" do
-        2.times { create(:product_review, purchase: create(:purchase, link: @first_bundled_product), rating: 5) }
-        create(:product_review, purchase: create(:purchase, link: @first_bundled_product), rating: 4)
-        create(:product_review, purchase: create(:purchase, link: @second_bundled_product), rating: 1)
+      stats = @bundle.reload.rating_stats
+      expect(stats[:count]).to eq(1)
+      expect(stats[:average]).to eq(3.0)
+      expect(stats[:percentages]).to eq([0, 0, 100, 0, 0])
+    end
 
-        stats = @bundle.reload.bundle_rating_stats
-        expect(stats[:count]).to eq(4)
-        expect(stats[:average]).to eq(3.8) # (5 + 5 + 4 + 1) / 4 = 3.75 rounded
-        expect(stats[:percentages]).to eq([25, 0, 0, 25, 50])
-        expect(stats[:percentages].sum).to eq(100)
-      end
+    it "returns zeroed stats when only the bundled products have reviews" do
+      create(:product_review, purchase: create(:purchase, link: @first_bundled_product), rating: 5)
 
-      it "includes reviews of the bundle itself alongside the bundled products' reviews" do
-        create(:product_review, purchase: create(:purchase, link: @first_bundled_product), rating: 5)
-        create(:product_review, purchase: create(:purchase, link: @second_bundled_product), rating: 1)
-        create(:product_review, purchase: create(:purchase, link: @bundle, is_bundle_purchase: true), rating: 3)
-
-        stats = @bundle.reload.bundle_rating_stats
-        expect(stats[:count]).to eq(3)
-        expect(stats[:average]).to eq(3.0) # (5 + 1 + 3) / 3
-        expect(stats[:percentages]).to eq([33, 0, 33, 0, 34])
-        expect(stats[:percentages].sum).to eq(100)
-      end
-
-      it "excludes bundled products that hide reviews" do
-        create(:product_review, purchase: create(:purchase, link: @first_bundled_product), rating: 5)
-        create(:product_review, purchase: create(:purchase, link: @second_bundled_product), rating: 1)
-        @second_bundled_product.update!(display_product_reviews: false)
-
-        stats = @bundle.reload.bundle_rating_stats
-        expect(stats[:count]).to eq(1)
-        expect(stats[:average]).to eq(5.0)
-      end
-
-      it "excludes deleted bundle products" do
-        create(:product_review, purchase: create(:purchase, link: @first_bundled_product), rating: 5)
-        create(:product_review, purchase: create(:purchase, link: @second_bundled_product), rating: 1)
-        @bundle.bundle_products.find_by(product: @second_bundled_product).mark_deleted!
-
-        stats = @bundle.reload.bundle_rating_stats
-        expect(stats[:count]).to eq(1)
-        expect(stats[:average]).to eq(5.0)
-      end
-
-      it "returns zeroed stats when no bundled product has reviews" do
-        stats = @bundle.bundle_rating_stats
-        expect(stats[:count]).to eq(0)
-        expect(stats[:average]).to eq(0)
-        expect(stats[:percentages]).to eq([0, 0, 0, 0, 0])
-      end
-
-      it "does not persist anything on the bundle's own review stat" do
-        create(:product_review, purchase: create(:purchase, link: @first_bundled_product), rating: 5)
-
-        expect { @bundle.reload.bundle_rating_stats }.not_to change { ProductReviewStat.count }
-        expect(@bundle.product_review_stat).to be_nil
-      end
+      stats = @bundle.reload.rating_stats
+      expect(stats[:count]).to eq(0)
+      expect(stats[:average]).to eq(0)
+      expect(stats[:percentages]).to eq([0, 0, 0, 0, 0])
     end
   end
 end

--- a/spec/presenters/product_presenter/product_props_spec.rb
+++ b/spec/presenters/product_presenter/product_props_spec.rb
@@ -540,19 +540,30 @@ describe ProductPresenter::ProductProps do
         )
       end
 
-      it "aggregates the bundled products' ratings for the bundle's own ratings prop" do
+      it "shows only the bundle's own reviews in its ratings prop" do
         first_bundled_product = bundle.bundle_products.in_order.first.product
         second_bundled_product = bundle.bundle_products.in_order.second.product
         create(:product_review, purchase: create(:purchase, link: first_bundled_product), rating: 5)
         create(:product_review, purchase: create(:purchase, link: second_bundled_product), rating: 3)
+        create(:product_review, purchase: create(:purchase, link: bundle, is_bundle_purchase: true), rating: 4)
         bundle.reload
 
         props = described_class.new(product: bundle).props(seller_custom_domain_url: nil, request:, pundit_user: nil)
         expect(props[:product][:ratings]).to eq(
-          count: 2,
+          count: 1,
           average: 4.0,
-          percentages: [0, 0, 50, 0, 50],
+          percentages: [0, 0, 0, 100, 0],
         )
+      end
+
+      it "keeps per-product ratings on the bundle contents cards" do
+        first_bundled_product = bundle.bundle_products.in_order.first.product
+        create(:product_review, purchase: create(:purchase, link: first_bundled_product), rating: 5)
+        bundle.reload
+
+        props = described_class.new(product: bundle).props(seller_custom_domain_url: nil, request:, pundit_user: nil)
+        card = props[:product][:bundle_products].find { _1[:id] == first_bundled_product.external_id }
+        expect(card[:ratings]).to eq(count: 1, average: 5.0)
       end
 
       it "does not issue per-row queries for bundle product card associations" do

--- a/spec/services/pages/interpolator_spec.rb
+++ b/spec/services/pages/interpolator_spec.rb
@@ -76,11 +76,9 @@ describe Pages::Interpolator do
         expect(result).to include(%(<span data-gumroad-field="rating">4</span>))
       end
 
-      # For a bundle each aggregation loads every content product's stat row, so per-marker
-      # recomputation would scale the query count with how often the page repeats the markers.
       it "computes the review summary once even when the markers repeat" do
         product = reviewed.reload
-        expect(product).to receive(:bundle_rating_stats).once.and_call_original
+        expect(product).to receive(:rating_stats).once.and_call_original
         html = %(<span data-gumroad-field="rating">x</span><span data-gumroad-field="review-count">x</span>) * 2
 
         result = described_class.interpolate(html, product:)
@@ -89,9 +87,9 @@ describe Pages::Interpolator do
         expect(result.scan(%(<span data-gumroad-field="review-count">4</span>)).size).to eq(2)
       end
 
-      # The native bundle page merges its contents' reviews in, so a bundle's own row alone
-      # would disagree with the page this markup replaces.
-      it "uses the combined bundle summary for a bundle" do
+      # Bundles carry their own reviews now (#6078), so the page shows the bundle's row alone
+      # rather than merging in what its contents earned on their own pages.
+      it "uses only the bundle's own reviews for a bundle" do
         bundle = create(:product, :bundle, name: "Bundle")
         inner = create(:product, user: bundle.user)
         3.times { review!(inner, 5) }
@@ -100,7 +98,7 @@ describe Pages::Interpolator do
 
         result = described_class.interpolate(%(<span data-gumroad-field="review-count">x</span>), product: bundle.reload)
 
-        expect(result).to include(%(<span data-gumroad-field="review-count">4</span>))
+        expect(result).to include(%(<span data-gumroad-field="review-count">1</span>))
       end
     end
 


### PR DESCRIPTION
Removes the combined bundle rating summary. A bundle's product page now shows the bundle's **own** `ProductReviewStat` only; the products listed inside it keep showing their individual ratings on their cards.

## Why now

The merge (#6074) was a stopgap for a structural gap: bundle purchases were excluded from reviews entirely, so a bundle page had no social proof of its own and borrowed what its contents had earned on their own pages. #6078 removed that exclusion on 2026-07-22 and shipped to production the same day.

Two weeks later, bundles are accumulating their own reviews — measured on the read replica (`replica_lag=0-2s`, audited console request `20260805T141542Z-4cd4fada` / `20260805T141633Z-99fdea43`):

| Measurement | Value |
|---|---|
| Reviews on bundle products since 2026-07-22 | **87** |
| Distinct bundles reviewed | **68** |
| Bundles with a nonzero `ProductReviewStat.reviews_count` | **68** |
| Trend (reviews/day) | 1-2/day in week 1 → 6-18/day in week 2 |

Daily accumulation: `Jul 23:1, 24:2, 25:2, 26:3, 27:4, 28:2, 29:11, 30:6, 31:11, Aug 1:8, 2:6, 3:18, 4:8, 5:5`.

So the merge is now actively wrong rather than merely redundant: a visitor reads a star average and a histogram built largely from reviews that are not about the bundle they are looking at. Sample bundle stat rows confirm real own-reviews (`link_id 7407003 → 175 reviews @ 4.9`; `12454032 → 9 @ 5.0`).

## What changed

- **`Product::ReviewStat#bundle_rating_stats` deleted.** It summed the bundle's own per-star counters with every alive content product's, built an unsaved `ProductReviewStat` to reuse the largest-remainder percentage math, and returned that.
- **`ProductPresenter::ProductProps`** — the product page's `ratings` prop now reads `product.rating_stats`.
- **`Pages::Interpolator.review_summary`** — custom pages' `rating` / `review-count` markers read `product.rating_stats`, so a custom bundle page agrees with the native one again (both now show the bundle's own number).
- **Per-product ratings on bundle-contents cards are untouched** — `bundle_product_props` already reads each content product's own `reviews_count` / `average_rating`, and a new spec pins that.
- **Help center article 339** — the note added by #6103 and rewritten by #6128 described the combined summary; it now says the bundle page shows the bundle's own rating and each listed product shows its own.
- **`User::ReputationSummary`** — comment referenced the deleted method; the maths description stays.

`BundlePresenter` already used `bundle.rating_stats` (seller-side editor), so it needed no change.

## What this does not cover

- No backfill or data change: `bundle_rating_stats` never wrote anything, and bundles' own stat rows have been accumulating normally since #6078. Bundle pages whose contents carry many reviews will show a visibly lower count/average after deploy — that is the intended correction, not a regression.
- Bundles with zero own reviews now render no rating summary (the `count.zero?` paths already handled this), matching every other product with no reviews. 42 of the ~110 bundles reviewed pre-#6078 fall in this class on any given day; they get the standard no-reviews treatment.
- Rating-hiding (`display_product_reviews`) semantics for content products are unchanged — that check only existed inside the merge, and each card still respects its own product's setting.

## Specs

- `spec/modules/product/review_stat_spec.rb` — the six `#bundle_rating_stats` examples from #6074/#6078 (aggregation weighting, bundle-own-review inclusion, hidden-reviews exclusion, deleted-bundle-product exclusion, zeroed stats, no-persistence) are replaced by two `#rating_stats` examples pinning that a bundle counts only its own reviews and reads zero when only its contents have reviews.
- `spec/presenters/product_presenter/product_props_spec.rb` — the aggregation example becomes "shows only the bundle's own reviews in its ratings prop" (bundle rated 4, contents rated 5 and 3 → `count: 1, average: 4.0`), plus a new example pinning per-product ratings on the contents cards.
- `spec/services/pages/interpolator_spec.rb` — the combined-summary example now asserts the bundle's own count (1, not the merged 4); the memoization example targets `rating_stats`.

Run locally at this head:

```
spec/modules/product/review_stat_spec.rb
spec/presenters/product_presenter/product_props_spec.rb   61 examples, 0 failures
spec/services/pages/interpolator_spec.rb                  38 examples, 0 failures
```

## Rendered surface

The change is a single number and histogram on the product page, driven entirely by the `ratings` prop — no markup or component change, so there is no new UI to screenshot. The prop values are pinned by the presenter specs above.

Closes the code-fix half of the bundle-rating soak plan (gumroad#6129 — that issue is unreachable now that issues are disabled on this repo; this PR body carries the reasoning).

Premerge review: clean @ 414f59040413b62886e7135427ab854a78cceebc (Round 1 — CI green: 19 checks pass; residual-reference grep clean, frontend zero-count paths verified, N+1 guard intact)
