### PR TITLE
Fix creator rating icon to render a star row matching the average

### DIFF
--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -1039,7 +1039,7 @@ const SellerReputationSection = ({
   <section className="grid gap-2 p-6 not-first:border-t" aria-label="Creator rating">
     {!hasOwnReviews ? <div>This product has no reviews yet.</div> : null}
     <div className="flex flex-wrap items-center gap-1">
-      <Star pack="filled" className="size-5" />
+      <RatingStars rating={reputation.average} />
       <span>
         Creator rating: {reputation.average} from{" "}
         {seller ? (


### PR DESCRIPTION
## What
Renders the "Creator rating" star icon using `RatingStars` (a 5-star row reflecting `reputation.average`), replacing the hardcoded single filled star.

## Why
`SellerReputationSection` always rendered one `<Star pack="filled">` regardless of the seller's actual average rating, so a 5-star seller's product page showed what looked like a 1-star rating next to the correct text "Creator rating: 5 from 17 verified reviews...". Reported via a seller Helper ticket with a screenshot showing exactly this. `RatingsSummary` two lines below already solves this correctly for the product's own rating with `RatingStars`.

## Before / After
Reusing `RatingStars`'s own star-count logic (`Math.round`, half-star, empty-star fill) against the ticket's real value:

| reputation.average | Before (icon shown) | After (icon shown) |
|---|---|---|
| 5 | 1 filled star (hardcoded, always) | 5 filled stars |
| 3.5 | 1 filled star (hardcoded, always) | 4 filled + 1 empty star |
| 1 | 1 filled star (hardcoded, always) | 1 filled + 4 empty stars |

## Test Results
- `git diff --stat`: 1 file changed, 1 insertion, 1 deletion — swaps the hardcoded `<Star>` for the existing `RatingStars` component already imported in this file (used by `RatingsSummary`).
- CI green at head: Lint JS/TS, Typecheck TS, Test Minitest/Relevant, Greptile Review — all passed.
- No spec exists for `SellerReputationSection` today (none added/removed by this change; grepped `*.test.tsx` for `SellerReputationSection`/`Creator rating`/`seller_reputation` — zero hits).
- Premerge review: clean @ 58b1bcc20e366aa4c7c01f108606ad658a8373a3

## QA steps
Diff-level QA: `RatingStars` is the identical component already rendering the product's own rating row (`RatingsSummary`, two lines below this change) — same import, same call shape, only the `rating` value differs. No new component, no new prop shape, no server-side change.

## Status
- [x] Scope — verified live at origin/main: single hardcoded `<Star pack="filled">`, confirmed by reading `app/javascript/components/Product/index.tsx`
- [x] Design — reuse `RatingStars`, the sibling component already used two lines below for `RatingsSummary`
- [x] Build — one-line swap, pushed
- [x] QA — premerge review clean, CI green at head
- [ ] Shipped
- [ ] Market — n/a (cosmetic bugfix)
- [ ] Sell — n/a

---
AI disclosure: this PR was authored autonomously by an AI agent (Hermes Agent, claude-sonnet-5) per antiwork/gumroad-private#1881, which the same agent filed from a Helper ticket screenshot.
