### PR TITLE
Include deleted paths in branch-specs escalation checks

### DIFF
--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -126,8 +126,8 @@ end
 merge_base = git("merge-base", base, "HEAD").first
 
 changed = Set.new
-changed.merge(git("diff", "--name-only", "--diff-filter=d", "#{merge_base}..HEAD")) if merge_base
-changed.merge(git("diff", "--name-only", "--diff-filter=d", "HEAD"))
+changed.merge(git("diff", "--name-only", "#{merge_base}..HEAD")) if merge_base
+changed.merge(git("diff", "--name-only", "HEAD"))
 changed.merge(git("ls-files", "--others", "--exclude-standard"))
 
 changed.reject! { |path| IGNORED_PATTERNS.any? { |re| re.match?(path) } }


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

## What

Fix a Greptile P1 on merged #7086: `bin/branch-specs` used `--diff-filter=d` on both diff queries, which excludes deletions from git's output entirely — so a deleted file never reached the unmapped-support or unattributed-path escalation checks. A deletion-only diff (or a deletion mixed with a mapped modification) could select zero specs, or select only the mapped file's specs while masking the gap the deletion caused.

## Why

Fixes on antiwork/gumroad#7086 (merged 0d28ecd0e). Deleted boot/test-infrastructure or unmapped `spec/support/` files should escalate exactly like modified ones do — that's the whole point of the fail-closed design #7086 introduced.

## Fix

Removed `--diff-filter=d` from both `git diff --name-only` invocations so deleted paths flow into `changed` and hit the same `ESCALATE_PATTERNS` / unmapped-support / unattributed checks as modifications and additions.

## Before/After

| Diff | Before | After |
|---|---|---|
| Delete unmapped `spec/support/aria_extensions.rb` (deletion-only) | exit 0, no specs selected | exit 3, ESCALATE |
| Delete unmapped `spec/support/aria_extensions.rb` + modify `app/models/comment.rb` | exit 0, only comment specs (masked the deletion) | exit 3, ESCALATE |
| `payment.ts` modify only (regression check) | 73 files, exit 0 | 73 files, exit 0 (unchanged) |

## Test Results

- `bundle exec rubocop bin/branch-specs` — 1 file inspected, no offenses.
- Ran `bin/branch-specs` directly against three live worktree fixtures in `~/work/gp7086-diff-filter-fix` (table above); each command and exit code captured directly, not predicted.

## QA steps

```
git rm spec/support/aria_extensions.rb && ruby bin/branch-specs; echo $?   # => 3, ESCALATE
git checkout -- spec/support/aria_extensions.rb
echo x >> app/javascript/components/Checkout/payment.ts && ruby bin/branch-specs --base HEAD | wc -l   # => 73
```

## AI disclosure
claude-sonnet-5 via Hermes (gumclaw).

## QA audit

Code: single-flag removal, read line-by-line against the escalation logic it feeds — no other call site depends on `--diff-filter=d`'s exclusion behavior. Specs: none added (no rspec/jest harness for this CLI script); behavior proven instead via the three live fixtures above, which match Greptile's T-Rex artifact scenarios byte-for-byte. Comments: untouched. Evidence: no rendered surface — this is a CLI selector script with no UI.

## Before/After (media exemption)

Backend-only, one-off CLI selector script (`bin/branch-specs`) — no route, no view, nothing to screenshot. Same exemption basis as other backend-only PRs in this repo (no rendered surface to capture). Confirmed the hosted preview (`fix-branch-specs-deletion-escala.apps.staging.gumroad.org`) boots successfully at the current head (`x-revision: 39c1cc7aee46`) as a sanity check that the branch's code loads without error; the actual verification is the QA steps table above (exit codes on real fixtures), not a click path.

Premerge review: exempt (empty CI-retrigger commit only since the last reviewed head 8e829f6c19f — no code diff, review verdict at that head still applies; see 39c1cc7aee46 commit message "Retrigger CI with run-all-specs label")

