### PR TITLE
Classify unfetchable private-bucket moderation URLs as permanent, not transient

### DIFF
--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -39,6 +39,12 @@ class ContentModeration::Strategies::ClassifierStrategy
   # static, so "try again later" can never come true.
   UNSUPPORTED = :unsupported
   PERMANENT_REJECTION_CODES = %w[invalid_data_url invalid_image_format file_too_large].freeze
+  # The raw (unsigned) private-bucket prefix — what `gumroad-cli files upload`
+  # and other API::V2::FilesController writes hand back. OpenAI 400s fetching
+  # it with `image_url_unavailable` every time (403, not a signed-URL expiry),
+  # so unlike the same code on a product/post's expired signed URL, a retry
+  # here can never succeed.
+  UNFETCHABLE_PRIVATE_BUCKET_URL_PREFIX = S3_BASE_URL
   UNAVAILABLE_REASON = "We cannot moderate the content at this time, please try again later or update the content."
   # Not "inline": `file_too_large` reaches here for a remote URL OpenAI
   # downloaded and refused, not only for a `data:` payload we refused locally.
@@ -323,6 +329,8 @@ class ContentModeration::Strategies::ClassifierStrategy
         # perform) reproduces on every save of the same content, so it must not
         # be reported as a passing failure.
         code = body.is_a?(Hash) ? body.dig("error", "code") : nil
+        return UNSUPPORTED if code == "image_url_unavailable" && skip_url.to_s.start_with?(UNFETCHABLE_PRIVATE_BUCKET_URL_PREFIX)
+
         PERMANENT_REJECTION_CODES.include?(code) ? UNSUPPORTED : nil
       end
     end

--- a/app/services/content_moderation/strategies/classifier_strategy.rb
+++ b/app/services/content_moderation/strategies/classifier_strategy.rb
@@ -39,10 +39,8 @@ class ContentModeration::Strategies::ClassifierStrategy
   # static, so "try again later" can never come true.
   UNSUPPORTED = :unsupported
   PERMANENT_REJECTION_CODES = %w[invalid_data_url invalid_image_format file_too_large].freeze
-  # The raw (unsigned) private-bucket prefix — what `gumroad-cli files upload`
-  # and other API::V2::FilesController writes hand back. OpenAI 400s fetching
-  # it with `image_url_unavailable` every time (403, not a signed-URL expiry),
-  # so unlike the same code on a product/post's expired signed URL, a retry
+  # Private-bucket URLs 403 to OpenAI unconditionally (not a signed-URL
+  # expiry), so unlike the same error code on a product/post URL, retrying
   # here can never succeed.
   UNFETCHABLE_PRIVATE_BUCKET_URL_PREFIX = S3_BASE_URL
   UNAVAILABLE_REASON = "We cannot moderate the content at this time, please try again later or update the content."

--- a/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
+++ b/spec/services/content_moderation/strategies/classifier_strategy_spec.rb
@@ -211,6 +211,21 @@ RSpec.describe ContentModeration::Strategies::ClassifierStrategy, :vcr do
     expect(result.reasoning).to eq([described_class::UNAVAILABLE_REASON])
   end
 
+  it "reports a permanent rejection, not a retry-later one, for a private S3 bucket URL OpenAI can never fetch" do
+    image_urls = ["#{S3_BASE_URL}attachments/123/original/photo.png"]
+    bad_response = instance_double(Faraday::Response, status: 400, body: "", headers: {})
+    unfetchable_error = Faraday::BadRequestError.new(
+      { status: 400, body: { "error" => { "code" => "image_url_unavailable" } } },
+      bad_response
+    )
+    allow(client).to receive(:moderations).and_raise(unfetchable_error)
+
+    result = described_class.new(text: "", image_urls:, max_images: :all).perform
+
+    expect(result.status).to eq("flagged")
+    expect(result.reasoning).to eq([described_class::UNSUPPORTED_IMAGE_REASON])
+  end
+
   it "never logs an inline image payload verbatim" do
     inline = "data:image/png;base64,#{"A" * 400}"
     bad_response = instance_double(Faraday::Response, status: 400, body: "", headers: {})


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [x] Ship (draft, awaiting merge)
- [ ] Market
- [ ] Sell

## What

Classifies an unfetchable **private-bucket** attachment URL (the shape `gumroad-cli files upload`
hands back) as a permanent `UNSUPPORTED` rejection instead of the generic transient
`UNAVAILABLE_REASON`, so a seller stops being told to retry something that can never succeed.

## Why

`ContentModeration::Strategies::ClassifierStrategy` sends page image URLs to OpenAI's moderation
endpoint for it to fetch. A `gumroad files upload` image lives in the private `S3_BUCKET`
(`s3_base_url`), not the public/CDN bucket — OpenAI 403s fetching it every time
(`image_url_unavailable`), and no retry changes that. The strategy previously treated that error
code identically for every URL (including a genuinely-transient expired signed URL on a
product/post), so the seller got "try again in a few minutes" in a loop that could never resolve.

This ships option 2 from gp#1888 (the copy/classification fix). Option 1 — a new `gumroad media
upload` CLI command hitting `POST /v2/media` so a seller has a page-legal upload path at all — is
the real fix for the underlying gap and is a separate, larger change not attempted here.

## Before / After

Before: private-bucket URL → `image_url_unavailable` → `UNAVAILABLE_REASON` ("try again later").
After: private-bucket URL → `image_url_unavailable` → `UNSUPPORTED_IMAGE_REASON` ("this file can't
be reviewed"). Any other URL hitting the same error code (e.g. an expired signed attachment URL)
is unaffected — still `UNAVAILABLE_REASON`, since a retry there can help.

## Test Results

`bundle exec rspec spec/services/content_moderation/strategies/classifier_strategy_spec.rb` — 44
examples, 0 failures (ran locally, DISABLE_SPRING=1). New example: "reports a permanent rejection,
not a retry-later one, for a private S3 bucket URL OpenAI can never fetch". Mutation-verified: with
the new `return UNSUPPORTED if ...` guard removed, that example fails (red), confirming it pins the
new behavior rather than being vacuous.

## QA steps

Backend-only classifier-level change, no rendered surface — confirmed there is genuinely no UI/page
to screenshot; the spec run above is the evidence.

---

Premerge review: clean @ 032116af6048387bf70a6fdef585c2f7bbbdcc8b

AI disclosure: Written by an autonomous Hermes Agent session (model: claude-sonnet-5) per gp#1888.

