### PR TITLE
Close branch-specs mapping gaps that escalated four PRs this week

### DIFF
--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -44,6 +44,20 @@ CHECKOUT_FLOW_SPECS = %w[
   spec/requests/subscription
 ].freeze
 
+# Unauthenticated charge/license lookup surfaces (PublicController).
+PUBLIC_LOOKUP_SPECS = %w[
+  spec/controllers/public_controller_spec.rb
+  spec/requests/license_key_lookup_spec.rb
+  spec/requests/products/show/license_key_lookup_form_spec.rb
+].freeze
+
+# Creator storefront/profile pages.
+PROFILE_FLOW_SPECS = %w[
+  spec/requests/user
+  spec/requests/profile_analytics_spec.rb
+  spec/requests/profile_custom_html_spec.rb
+].freeze
+
 FANOUT = {
   %r{\Aapp/presenters/checkout/} => CHECKOUT_FLOW_SPECS,
   %r{\Aapp/javascript/components/Checkout/} => CHECKOUT_FLOW_SPECS,
@@ -56,6 +70,26 @@ FANOUT = {
   %r{\Aapp/controllers/stripe/} => CHECKOUT_FLOW_SPECS,
   %r{\Aspec/support/checkout_helpers\.rb\z} => CHECKOUT_FLOW_SPECS,
   %r{\Aspec/support/stripe_.*\.rb\z} => CHECKOUT_FLOW_SPECS,
+  # #7101 gap: the unauthenticated charge/license lookup forms and their data
+  # layer render through PublicController; these specs are their e2e coverage.
+  %r{\Aapp/javascript/components/Public/} => PUBLIC_LOOKUP_SPECS,
+  %r{\Aapp/javascript/pages/Public/} => PUBLIC_LOOKUP_SPECS,
+  %r{\Aapp/javascript/data/(charge|license)} => PUBLIC_LOOKUP_SPECS,
+  # fix-profile-header-mobile-gap gap: profile components mount on the
+  # storefront pages exercised by the user/profile request specs.
+  %r{\Aapp/javascript/components/Profile/} => PROFILE_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/Profile/} => PROFILE_FLOW_SPECS,
+  # Help-center article partials render through the help_center request specs;
+  # the per-article view glob finds nothing because specs aren't per-article.
+  %r{\Aapp/views/help_center/} => %w[spec/requests/help_center_spec.rb spec/requests/help_center],
+}.freeze
+
+# Config files with dedicated request coverage. Everything else under
+# config/ still escalates via ESCALATE_PATTERNS; entries here are reviewed
+# like FANOUT — a file belongs only when a spec exists whose entire purpose
+# is exercising it.
+CONFIG_SPEC_MAP = {
+  "config/initializers/rack_attack.rb" => %w[spec/requests/rack_attack_spec.rb],
 }.freeze
 
 # Support files with mappings; any OTHER spec/support change escalates.
@@ -138,13 +172,26 @@ def escalate!(reason)
   exit ESCALATE_EXIT
 end
 
-unmappable = changed.select { |path| ESCALATE_PATTERNS.any? { |re| re.match?(path) } }
+unmappable = changed.select do |path|
+  ESCALATE_PATTERNS.any? { |re| re.match?(path) } && !CONFIG_SPEC_MAP.key?(path)
+end
 escalate!("cannot attribute specs to: #{unmappable.first(5).join(', ')}") if unmappable.any?
 
 unmapped_support = changed.select do |path|
   path.start_with?("spec/support/") && MAPPED_SUPPORT.none? { |re| re.match?(path) }
 end
 escalate!("unmapped spec/support change: #{unmapped_support.first(3).join(', ')}") if unmapped_support.any?
+
+# Content attribution fallback for Ruby files whose spec lives under a
+# different name. Camelizes the basename (colombia_id_number →
+# ColombiaIdNumber) and greps specs for either form. Word-boundary anchored
+# so short names don't false-positive.
+def specs_mentioning(basename)
+  camel = basename.split("_").map(&:capitalize).join
+  pattern = "\\b(#{Regexp.escape(basename)}|#{Regexp.escape(camel)})\\b"
+  out = IO.popen(["grep", "-rlE", pattern, "spec/", "--include=*_spec.rb"], err: File::NULL, &:read)
+  $?.success? ? out.split("\n") : []
+end
 
 def spec_candidates(path)
   case path
@@ -177,11 +224,25 @@ unattributed = []
 
 changed.each do |path|
   candidates = spec_candidates(path).select { |s| File.exist?(s) }
-  fanout_hits = FANOUT.select { |re, _| re.match?(path) }.values.flatten.select { |dir| Dir.exist?(dir) }
-  contributed = candidates + fanout_hits
+  fanout_hits = FANOUT.select { |re, _| re.match?(path) }.values.flatten.select { |dir| Dir.exist?(dir) || File.exist?(dir) }
+  config_hits = (CONFIG_SPEC_MAP[path] || []).select { |s| File.exist?(s) }
+  contributed = candidates + fanout_hits + config_hits
 
   if contributed.any?
     specs.merge(contributed)
+  elsif path.match?(%r{\Aapp/javascript/.*\.test\.(ts|tsx)\z}) ||
+        (path.match?(%r{\Aapp/javascript/.*\.(ts|tsx)\z}) &&
+         File.exist?(path.sub(/\.(ts|tsx)\z/, '.test.\1')))
+    # Covered by vitest, which lint_js runs on every PR (npm test). A
+    # co-located .test file is that module's suite; neither needs rspec.
+    next
+  elsif path.match?(%r{\A(lib|app)/.*\.rb\z}) &&
+        (by_content = specs_mentioning(File.basename(path, ".rb"))).any?
+    # Name-based mapping missed (spec lives under another name, e.g.
+    # lib/utilities/compliance/colombia_id_number.rb tested via
+    # update_user_compliance_info_spec.rb). Content attribution: any spec
+    # that mentions the file's basename exercises it.
+    specs.merge(by_content)
   else
     unattributed << path
   end

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -1,0 +1,183 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Tests for bin/branch-specs' mapping layers, pinned to the four real
+# escalations from 2026-08-05/06 that each cost a red CI round-trip:
+#
+#   #7101  app/javascript/components/Public/, app/javascript/data/charge.ts
+#   #7098  app/javascript/components/Profile/Layout.tsx
+#   #7099  config/initializers/rack_attack.rb
+#   #7097  co-located vitest module + lib/ file with a differently-named spec
+#          + help_center article partial
+#
+# Same shape as check_migration_versions_test.rb: throwaway git repos, no
+# Rails. The selector runs from the repo root of the throwaway repo, so each
+# scenario lays down the spec files its mapping should find.
+#
+#   ruby spec/bin/branch_specs_test.rb
+
+require "tmpdir"
+require "fileutils"
+require "open3"
+
+SELECTOR = File.expand_path("../../bin/branch-specs", __dir__)
+
+$failures = []
+$count = 0
+
+def build_repo(dir, base_files:, head_files:)
+  Dir.chdir(dir) do
+    system("git init -q -b main .", exception: true)
+    system("git config user.email t@t.t", exception: true)
+    system("git config user.name t", exception: true)
+    system("git config commit.gpgsign false", exception: true)
+
+    write = lambda do |files|
+      files.each do |path, content|
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, content || "# noop\n")
+      end
+      system("git add -A", exception: true)
+      system("git commit -q -m x --allow-empty", exception: true)
+    end
+
+    write.call(base_files)
+    system("git branch -f base HEAD", exception: true)
+    write.call(head_files)
+  end
+end
+
+def check(name, base_files:, head_files:, expect_specs: nil, expect_escalate: false)
+  $count += 1
+  Dir.mktmpdir do |dir|
+    build_repo(dir, base_files:, head_files:)
+    stdout, stderr, status = Open3.capture3("ruby", SELECTOR, "--base", "base", chdir: dir)
+
+    if expect_escalate
+      unless status.exitstatus == 3
+        $failures << "#{name}: expected escalate (exit 3), got #{status.exitstatus}\nstdout: #{stdout}\nstderr: #{stderr}"
+      end
+    else
+      unless status.success?
+        $failures << "#{name}: expected success, got #{status.exitstatus}\nstderr: #{stderr}"
+        return
+      end
+      got = stdout.split("\n").sort
+      missing = (expect_specs || []) - got
+      if missing.any?
+        $failures << "#{name}: missing expected specs #{missing.inspect}\ngot: #{got.inspect}"
+      end
+    end
+  end
+end
+
+SPEC_STUB = "# frozen_string_literal: true\n"
+
+# --- #7101: Public lookup components + data layer -> PublicController coverage
+check(
+  "Public lookup component maps to public_controller + license lookup specs",
+  base_files: {
+    "spec/controllers/public_controller_spec.rb" => SPEC_STUB,
+    "spec/requests/license_key_lookup_spec.rb" => SPEC_STUB,
+    "app/javascript/components/Public/LookupLayout.tsx" => "old",
+    "app/javascript/data/charge.ts" => "old",
+  },
+  head_files: {
+    "app/javascript/components/Public/LookupLayout.tsx" => "new",
+    "app/javascript/data/charge.ts" => "new",
+  },
+  expect_specs: %w[
+    spec/controllers/public_controller_spec.rb
+    spec/requests/license_key_lookup_spec.rb
+  ],
+)
+
+# --- #7098: Profile component -> storefront request specs
+check(
+  "Profile component fans out to user/profile request specs",
+  base_files: {
+    "spec/requests/user/profile_spec.rb" => SPEC_STUB,
+    "app/javascript/components/Profile/Layout.tsx" => "old",
+  },
+  head_files: { "app/javascript/components/Profile/Layout.tsx" => "new" },
+  expect_specs: %w[spec/requests/user/profile_spec.rb],
+)
+
+# --- #7099: rack_attack initializer -> its dedicated request spec
+check(
+  "rack_attack initializer maps to rack_attack_spec instead of escalating",
+  base_files: {
+    "spec/requests/rack_attack_spec.rb" => SPEC_STUB,
+    "config/initializers/rack_attack.rb" => "old",
+  },
+  head_files: { "config/initializers/rack_attack.rb" => "new" },
+  expect_specs: %w[spec/requests/rack_attack_spec.rb],
+)
+
+# Other config files must still escalate — the map is per-file, not per-dir.
+check(
+  "unmapped config file still escalates",
+  base_files: { "config/initializers/other.rb" => "old" },
+  head_files: { "config/initializers/other.rb" => "new" },
+  expect_escalate: true,
+)
+
+# --- #7097 (a): co-located vitest module is not a mapping gap
+check(
+  "TS module with co-located .test.ts does not escalate",
+  base_files: {
+    "app/javascript/utils/colombiaIdNumbers.ts" => "old",
+    "app/javascript/utils/colombiaIdNumbers.test.ts" => "old",
+    # something else in the diff must select a spec or the run is empty; the
+    # escalate we're guarding against is the mapping-gap one.
+    "app/models/widget.rb" => "old",
+    "spec/models/widget_spec.rb" => SPEC_STUB,
+  },
+  head_files: {
+    "app/javascript/utils/colombiaIdNumbers.ts" => "new",
+    "app/javascript/utils/colombiaIdNumbers.test.ts" => "new",
+    "app/models/widget.rb" => "new",
+  },
+  expect_specs: %w[spec/models/widget_spec.rb],
+)
+
+# --- #7097 (b): lib file with differently-named spec found by content
+check(
+  "lib file resolves via content attribution when name mapping misses",
+  base_files: {
+    "lib/utilities/compliance/colombia_id_number.rb" => "old",
+    "spec/services/update_user_compliance_info_spec.rb" =>
+      "#{SPEC_STUB}describe \"x\" do\n  it { ColombiaIdNumber.valid?(\"1\") }\nend\n",
+  },
+  head_files: { "lib/utilities/compliance/colombia_id_number.rb" => "new" },
+  expect_specs: %w[spec/services/update_user_compliance_info_spec.rb],
+)
+
+# --- #7097 (c): help_center article partial -> help_center request specs
+check(
+  "help_center article partial maps to help_center request specs",
+  base_files: {
+    "spec/requests/help_center_spec.rb" => SPEC_STUB,
+    "app/views/help_center/articles/contents/_260-your-payout-settings-page.html.erb" => "old",
+  },
+  head_files: {
+    "app/views/help_center/articles/contents/_260-your-payout-settings-page.html.erb" => "new",
+  },
+  expect_specs: %w[spec/requests/help_center_spec.rb],
+)
+
+# A genuinely unmapped app file must still escalate (the guard this whole
+# selector exists for).
+check(
+  "unmapped app file still escalates",
+  base_files: { "app/javascript/components/Novel/Thing.tsx" => "old" },
+  head_files: { "app/javascript/components/Novel/Thing.tsx" => "new" },
+  expect_escalate: true,
+)
+
+if $failures.empty?
+  puts "#{$count} checks passed"
+else
+  $failures.each { |f| puts "FAIL: #{f}\n\n" }
+  abort "#{$failures.size}/#{$count} checks failed"
+end

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -1,14 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Tests for bin/branch-specs' mapping layers, pinned to the four real
-# escalations from 2026-08-05/06 that each cost a red CI round-trip:
-#
-#   #7101  app/javascript/components/Public/, app/javascript/data/charge.ts
-#   #7098  app/javascript/components/Profile/Layout.tsx
-#   #7099  config/initializers/rack_attack.rb
-#   #7097  co-located vitest module + lib/ file with a differently-named spec
-#          + help_center article partial
+# Tests for bin/branch-specs' mapping layers: Public/Profile component
+# fanout, a per-file config/ exception list, vitest co-location, lib/app
+# content-attribution fallback, and help_center view mapping.
 #
 # Same shape as check_migration_versions_test.rb: throwaway git repos, no
 # Rails. The selector runs from the repo root of the throwaway repo, so each
@@ -73,7 +68,7 @@ end
 
 SPEC_STUB = "# frozen_string_literal: true\n"
 
-# --- #7101: Public lookup components + data layer -> PublicController coverage
+# Public lookup components + data layer -> PublicController coverage
 check(
   "Public lookup component maps to public_controller + license lookup specs",
   base_files: {
@@ -92,7 +87,7 @@ check(
   ],
 )
 
-# --- #7098: Profile component -> storefront request specs
+# Profile component -> storefront request specs
 check(
   "Profile component fans out to user/profile request specs",
   base_files: {
@@ -103,7 +98,7 @@ check(
   expect_specs: %w[spec/requests/user/profile_spec.rb],
 )
 
-# --- #7099: rack_attack initializer -> its dedicated request spec
+# rack_attack initializer -> its dedicated request spec
 check(
   "rack_attack initializer maps to rack_attack_spec instead of escalating",
   base_files: {
@@ -122,7 +117,7 @@ check(
   expect_escalate: true,
 )
 
-# --- #7097 (a): co-located vitest module is not a mapping gap
+# Co-located vitest module is not a mapping gap
 check(
   "TS module with co-located .test.ts does not escalate",
   base_files: {
@@ -141,7 +136,7 @@ check(
   expect_specs: %w[spec/models/widget_spec.rb],
 )
 
-# --- #7097 (b): lib file with differently-named spec found by content
+# lib file resolves via content attribution when name mapping misses
 check(
   "lib file resolves via content attribution when name mapping misses",
   base_files: {
@@ -153,7 +148,7 @@ check(
   expect_specs: %w[spec/services/update_user_compliance_info_spec.rb],
 )
 
-# --- #7097 (c): help_center article partial -> help_center request specs
+# help_center article partial -> help_center request specs
 check(
   "help_center article partial maps to help_center request specs",
   base_files: {


### PR DESCRIPTION
## What

Closes four `bin/branch-specs` mapping gaps found live this week, each of
which forced a real PR to escalate to `run-all-specs` and cost a red
"Compute relevant specs" CI round-trip:

| PR | Diff that escalated | Reason |
|---|---|---|
| #7101 | `app/javascript/components/Public/`, `app/javascript/data/charge.ts` | no FANOUT entry for the public charge/license lookup forms |
| #7098 | `app/javascript/components/Profile/Layout.tsx` | no FANOUT entry for Profile components |
| #7099 | `config/initializers/rack_attack.rb` | `config/` is a blanket ESCALATE pattern with no per-file exception |
| #7097 | co-located vitest module + `lib/` file with a differently-named spec + help_center article partial | three separate gaps in one diff |

## Fixes

- `PUBLIC_LOOKUP_SPECS` / `PROFILE_FLOW_SPECS` fanout entries for the Public
  lookup and Profile component trees.
- `CONFIG_SPEC_MAP`: a reviewed per-file exception list under `config/`
  (currently just `rack_attack.rb -> rack_attack_spec.rb`). Everything else
  under `config/` still escalates via the existing blanket pattern — this is
  additive, not a loosening of the guard.
- A vitest co-location rule: a `.ts`/`.tsx` file with a sibling `.test.ts(x)`
  is already covered by `npm test`, which `lint_js` runs on every PR, so
  neither file is a mapping gap.
- A content-attribution fallback for `lib/`/`app/` Ruby files whose spec
  lives under a different name (e.g. `colombia_id_number.rb` tested via
  `update_user_compliance_info_spec.rb`) — greps specs for the file's
  snake_case or CamelCase name before giving up and escalating.
- `app/views/help_center/` -> the help_center request specs (per-article
  view globs find nothing because there's no per-article spec).

## Test Results

New `spec/bin/branch_specs_test.rb`, same throwaway-git-repo shape as the
existing `spec/bin/check_migration_versions_test.rb` (no Rails, no DB — this
selector runs in a job with no secrets before Rails even boots, so a real
rspec spec can't exercise it). Pins:

- Each of the four real escalations above, asserting the expected spec set.
- Two escalate-preserving negatives: an unmapped `config/` file and an
  unmapped `app/` file must still escalate. The fix must not blanket-loosen
  the guard.

```
$ ruby spec/bin/branch_specs_test.rb
8 checks passed
```

Also re-ran the updated selector against worktrees checked out at the exact
head commits of #7101, #7098, #7099, and #7097 — each now returns a concrete
spec list instead of escalating:

```
== 7101 lookup-year-scoping
   spec/controllers/public_controller_spec.rb
   spec/requests/license_key_lookup_spec.rb
   spec/requests/products/show/license_key_lookup_form_spec.rb
== 7098 profile-header-mobile-gap
   spec/requests/profile_analytics_spec.rb
   spec/requests/profile_custom_html_spec.rb
   spec/requests/user/... (14 files)
== 7099 mobile-throttle-method-restrict
   spec/requests/rack_attack_spec.rb
== 7097 colombia-id-floor-six
   spec/business/payments/merchant_registration/stripe/stripe_beneficial_owners_manager_spec.rb
   spec/requests/help_center/contacts_spec.rb
   spec/requests/help_center_spec.rb
   spec/requests/settings/payments_spec.rb
   spec/services/update_user_compliance_info_spec.rb
```

`ruby -c bin/branch-specs` — Syntax OK.

## QA steps

1. `ruby spec/bin/branch_specs_test.rb` locally — 8/8.
2. On this PR's own CI, the diff (`bin/branch-specs`, `spec/bin/branch_specs_test.rb`)
   still correctly escalates (workflow-adjacent Ruby with no dedicated spec
   mapping) — confirms the fix didn't accidentally make itself invisible to
   its own guard.

## Status

- [x] Scope — close the four live mapping gaps from #7101/#7098/#7099/#7097
- [x] Build — pushed at `1a25a1e0d`
- [x] Test — `spec/bin/branch_specs_test.rb` 8/8, verified against real PR head commits
- [ ] Premerge QA audit
- [ ] Shipped

Premerge review: clean @ 194e09c4b5a23ae86c07acdb0527e7d8ed1048fd

---

AI disclosure: authored by Hermes Agent (claude-sonnet-5) as gumclaw, per Sahil's request to resolve branch-specs mapping gaps found across recent PRs so they merge faster without lowering the quality bar.

