### PR TITLE
State the $100 threshold on the Agent nav row for ineligible sellers

### DIFF
--- a/app/javascript/components/LoggedInUser.ts
+++ b/app/javascript/components/LoggedInUser.ts
@@ -95,6 +95,11 @@ export type LoggedInUser = {
    * not in the core set renders under "Everything else" until they use it.
    */
   promotedNavItems: string[];
+  /**
+   * Threshold copy for the Agent nav row when this seller is under the earned-access bar (see
+   * AgentPresenter::LOCKED_NAV_BADGE), null once eligible.
+   */
+  agentNavBadge: string | null;
   isGumroadAdmin: boolean;
   isImpersonating: boolean;
   /**
@@ -117,6 +122,7 @@ export const parseLoggedInUser = (data: unknown): LoggedInUser | null => {
     has_payout_setup_to_port: boolean;
     policies: Policies;
     promoted_nav_items: string[];
+    agent_nav_badge: string | null;
     confirmed: boolean;
     is_gumroad_admin: boolean;
     is_impersonating: boolean;
@@ -134,6 +140,7 @@ export const parseLoggedInUser = (data: unknown): LoggedInUser | null => {
     hasPayoutSetupToPort: parsed.has_payout_setup_to_port,
     policies: parsed.policies,
     promotedNavItems: parsed.promoted_nav_items,
+    agentNavBadge: parsed.agent_nav_badge,
     isGumroadAdmin: parsed.is_gumroad_admin,
     isImpersonating: parsed.is_impersonating,
     lazyLoadOffscreenDiscoverImages: parsed.lazy_load_offscreen_discover_images,

--- a/app/javascript/components/client-components/Nav/index.test.tsx
+++ b/app/javascript/components/client-components/Nav/index.test.tsx
@@ -109,6 +109,7 @@ const buildUser = (promotedNavItems: string[]): LoggedInUser => ({
   canCreateBrandAccount: false,
   hasPayoutSetupToPort: false,
   promotedNavItems,
+  agentNavBadge: null,
   isGumroadAdmin: false,
   isImpersonating: false,
   lazyLoadOffscreenDiscoverImages: false,
@@ -277,5 +278,26 @@ describe("dashboard nav progressive disclosure", () => {
     // A promoted row sits at the top level, where prefetching costs nothing: promoting an
     // already-recorded destination is a no-op.
     expect(linkPropsByText.get("Products")?.prefetch).not.toBe(false);
+  });
+});
+
+describe("agent nav badge (gumroad-private#1773)", () => {
+  it("states the threshold on the Agent row for a seller under the earned-access bar", () => {
+    renderNav({
+      withUser: (user) => {
+        user.agentNavBadge = "$100 to unlock";
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Everything else" }));
+    expect(within(navScrollRegion()).getByRole("link", { name: /Agent.*\$100 to unlock/u })).toBeTruthy();
+  });
+
+  it("shows no badge once the seller is eligible", () => {
+    renderNav();
+
+    fireEvent.click(screen.getByRole("button", { name: "Everything else" }));
+    const agentLink = within(navScrollRegion()).getByRole("link", { name: "Agent" });
+    expect(agentLink.textContent.trim()).toBe("Agent");
   });
 });

--- a/app/javascript/components/client-components/Nav/index.tsx
+++ b/app/javascript/components/client-components/Nav/index.tsx
@@ -39,6 +39,7 @@ import { useCurrentSeller } from "$app/components/CurrentSeller";
 import { useAppDomain, useDiscoverUrl } from "$app/components/DomainSettings";
 import { useLoggedInUser } from "$app/components/LoggedInUser";
 import { Nav as NavFramework, NavSection } from "$app/components/Nav";
+import { Pill } from "$app/components/ui/Pill";
 import { useRunOnce } from "$app/components/useRunOnce";
 
 type Props = {
@@ -123,6 +124,7 @@ type NavItem = {
   additionalPatterns?: string[];
   text: string;
   icon: React.ReactNode;
+  badge?: React.ReactNode;
   onClick?: (event: React.MouseEvent) => void;
 };
 
@@ -178,6 +180,14 @@ export const Nav = (props: Props) => {
       visible: !!loggedInUser?.policies.user.view_store_agent,
       text: "Agent",
       icon: <MessageBubbleDots pack="filled" className="size-5" />,
+      // The row itself states the bar so a seller who never opens the tab still learns why it
+      // isn't pinned yet (gumroad-private#1773) — isPinned below keeps it out of the core list
+      // until they've earned it or used it once.
+      badge: loggedInUser?.agentNavBadge ? (
+        <Pill size="small" className="shrink-0 text-xs">
+          {loggedInUser.agentNavBadge}
+        </Pill>
+      ) : undefined,
       href: Routes.agent_url(routeParams),
       exactHrefMatch: true,
     },

--- a/app/presenters/agent_presenter.rb
+++ b/app/presenters/agent_presenter.rb
@@ -22,6 +22,10 @@ class AgentPresenter
                        "have #{MoneyFormatter.format(User::MIN_SALES_CENTS_VALUE_FOR_STORE_AGENT, :usd, no_cents_if_whole: true, symbol: true)} " \
                        "in sales and your first payout has completed. Nothing to apply for — it appears here on its own."
 
+  # Short form of the same threshold for the nav row badge (gumroad-private#1773), where the full
+  # LOCKED_EXPLANATION sentence has no room.
+  LOCKED_NAV_BADGE = "#{MoneyFormatter.format(User::MIN_SALES_CENTS_VALUE_FOR_STORE_AGENT, :usd, no_cents_if_whole: true, symbol: true)} to unlock"
+
   def initialize(pundit_user:)
     @pundit_user = pundit_user
     @seller = pundit_user.seller

--- a/app/presenters/rendering_extension.rb
+++ b/app/presenters/rendering_extension.rb
@@ -57,6 +57,10 @@ module RenderingExtension
           user.payment_address.present?,
         policies: policies_props(pundit_user),
         promoted_nav_items: user.promoted_nav_item_keys,
+        # Nil once eligible so the badge disappears the moment access is earned. Only meaningful
+        # alongside view_store_agent (gumroad-private#1773): a role that can't see the tab at all
+        # has nothing to unlock.
+        agent_nav_badge: pundit_user.seller.eligible_for_store_agent? ? nil : AgentPresenter::LOCKED_NAV_BADGE,
         is_gumroad_admin: user.is_team_member?,
         is_impersonating:,
         lazy_load_offscreen_discover_images: Feature.active?(:lazy_load_offscreen_discover_images, user),

--- a/spec/presenters/rendering_extension_spec.rb
+++ b/spec/presenters/rendering_extension_spec.rb
@@ -158,6 +158,7 @@ describe "RenderingExtension" do
                 is_gumroad_admin: false,
                 is_impersonating: true,
                 promoted_nav_items: [],
+                agent_nav_badge: nil,
                 lazy_load_offscreen_discover_images: false,
               },
               current_seller: UserPresenter.new(user: seller).as_current_seller,
@@ -194,6 +195,24 @@ describe "RenderingExtension" do
           create(:ach_account, user:)
 
           expect(custom_context[:logged_in_user][:has_payout_setup_to_port]).to eq(true)
+        end
+      end
+
+      describe "agent_nav_badge" do
+        let(:seller) { create(:named_seller) }
+        let(:user) { seller }
+        let(:pundit_user) { SellerContext.new(user:, seller:) }
+
+        it "states the threshold for a seller under the earned-access bar (gumroad-private#1773)" do
+          allow(seller).to receive(:eligible_for_store_agent?).and_return(false)
+
+          expect(custom_context[:logged_in_user][:agent_nav_badge]).to eq(AgentPresenter::LOCKED_NAV_BADGE)
+        end
+
+        it "is nil once the seller is eligible" do
+          allow(seller).to receive(:eligible_for_store_agent?).and_return(true)
+
+          expect(custom_context[:logged_in_user][:agent_nav_badge]).to be_nil
         end
       end
     end


### PR DESCRIPTION
## What

The Agent nav row now carries a small badge stating the earned-access threshold ("$100 to unlock") for a seller who hasn't earned it yet, and no badge once they're eligible.

## Why

Follow-up direction from Sahil on gumroad-private#1773: the tab should sit in the sidebar under "Everything else" for a seller who hasn't used it, with a message right there stating the $100-in-sales bar — rather than relying on the seller to open the tab to learn why it's locked (the state #6934 shipped).

The nav's existing progressive-disclosure logic (`DashboardNav` / `isPinned`) already keeps an unused destination out of the pinned rows and under "Everything else" until the seller visits it or it's promoted, so the row placement Sahil described was already correct. The gap was the message: nothing on the row itself told an ineligible seller why it wasn't pinned or what unlocks it.

`AgentPresenter::LOCKED_NAV_BADGE` reuses the same sales threshold already piped into `LOCKED_EXPLANATION` from #6934 (`User::MIN_SALES_CENTS_VALUE_FOR_STORE_AGENT`), so the two copy surfaces can't drift independently. `RenderingExtension` serves it as `agent_nav_badge` (nil once `eligible_for_store_agent?`), and the client nav renders it as a `Pill` in the existing `badge` slot every other nav row already supports.

## Before / After

| | Before | After |
|---|---|---|
| Agent row, ineligible seller, under "Everything else" | "Agent" | "Agent" + `$100 to unlock` pill |
| Agent row, eligible seller | "Agent" | "Agent" (no badge) |
| Row placement | Already correct (progressive disclosure) | Unchanged |

## Test Results

- `bundle exec rspec spec/presenters/rendering_extension_spec.rb spec/presenters/agent_presenter_spec.rb` — 11 examples, 0 failures.
- `bundle exec rubocop app/presenters/agent_presenter.rb app/presenters/rendering_extension.rb spec/presenters/rendering_extension_spec.rb` — no offenses.
- `npx vitest run app/javascript/components/client-components/Nav/index.test.tsx` — 11 tests passed (9 pre-existing + 2 new for the badge).
- `npx eslint` / `npx prettier --check` on the touched JS/TS files — clean.

## QA steps

Rendered the two new vitest assertions directly against the real `Nav` component: an ineligible seller's "Everything else" list shows an "Agent" link whose accessible name includes "$100 to unlock"; an eligible seller's "Agent" link has no badge text.

---

🤖 Generated by [Hermes Agent](https://github.com/NousResearch/hermes-agent) (`claude-sonnet-5`) as gumclaw, from the GitHub webhook lane.



Premerge review: clean @ 7353bc0decaea3b0f59a27a8d2044c28437aeb48
