### PR TITLE
Add AutoTopUpNegativeDestinationBalancesJob: automate the top-up leg of gp#1903

### DIFF
--- a/app/business/payments/transfers/stripe/stripe_transfer_internally_to_creator.rb
+++ b/app/business/payments/transfers/stripe/stripe_transfer_internally_to_creator.rb
@@ -10,17 +10,21 @@ module StripeTransferInternallyToCreator
   # Public: Creates a Stripe transfer that may or may not be attached to a charge.
   # Logs the transfer to the #payments chat room.
   # Returns the Stripe::Transfer object that was created.
-  def self.transfer_funds_to_account(message_why:, stripe_account_id:, currency:, amount_cents:, related_charge_id: nil, metadata: nil)
+  def self.transfer_funds_to_account(message_why:, stripe_account_id:, currency:, amount_cents:, related_charge_id: nil, metadata: nil, idempotency_key: nil)
     description = message_why
     description += " Related Charge ID: #{related_charge_id}." if related_charge_id
 
     transfer = Stripe::Transfer.create(
-      destination: stripe_account_id,
-      currency:,
-      description:,
-      amount: amount_cents,
-      metadata:,
-      expand: %w[balance_transaction])
+      {
+        destination: stripe_account_id,
+        currency:,
+        description:,
+        amount: amount_cents,
+        metadata:,
+        expand: %w[balance_transaction],
+      },
+      idempotency_key ? { idempotency_key: } : {},
+    )
 
     transfer
   end

--- a/app/business/payments/transfers/stripe/stripe_transfer_internally_to_creator.rb
+++ b/app/business/payments/transfers/stripe/stripe_transfer_internally_to_creator.rb
@@ -14,17 +14,18 @@ module StripeTransferInternallyToCreator
     description = message_why
     description += " Related Charge ID: #{related_charge_id}." if related_charge_id
 
-    transfer = Stripe::Transfer.create(
-      {
-        destination: stripe_account_id,
-        currency:,
-        description:,
-        amount: amount_cents,
-        metadata:,
-        expand: %w[balance_transaction],
-      },
-      idempotency_key ? { idempotency_key: } : {},
-    )
+    params = {
+      destination: stripe_account_id,
+      currency:,
+      description:,
+      amount: amount_cents,
+      metadata:,
+      expand: %w[balance_transaction],
+    }
+    # Keep the kwargs call shape when there is no idempotency key: the payout processor's
+    # doubles capture positionally, so moving every caller's params into the first positional
+    # hash changes what they observe.
+    transfer = idempotency_key ? Stripe::Transfer.create(params, { idempotency_key: }) : Stripe::Transfer.create(**params)
 
     transfer
   end

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -24,6 +24,7 @@ class RedisKey
     def api_v2_sales_page_key_query_timeout = "api_v2_sales_page_key_query_timeout"
     def free_purchases_watch_hours = "free_purchases_watch_hours"
     def max_allowed_free_purchases_of_same_product = "max_allowed_free_purchases_of_same_product"
+    def auto_topup_negative_destination_balance_last_amount(merchant_account_id) = "auto_topup_negative_destination_balance:#{merchant_account_id}:last_amount_cents"
     def ai_request_throttle(user_id) = "ai_request_throttle:#{user_id}"
     def agent_request_throttle(user_id) = "agent_request_throttle:#{user_id}"
     def agent_turn_status(user_id, client_turn_id) = "agent_turn_status:#{user_id}:#{client_turn_id}"

--- a/app/sidekiq/alert_on_negative_destination_balances_job.rb
+++ b/app/sidekiq/alert_on_negative_destination_balances_job.rb
@@ -177,6 +177,11 @@ class AlertOnNegativeDestinationBalancesJob
           set_total:,
           full_total:,
           row_count: set.count,
+          # Fingerprints the specific rows behind full_total, so a consumer (the auto top-up job)
+          # can tell "this candidate's underlying balances are unchanged" from "leg two reconciled
+          # the old rows and a new, independent shortfall landed on the same account" — the two
+          # look identical if you only compare amounts.
+          balance_ids: full_set.order(:id).pluck(:id),
           retired: !merchant_account.alive?,
           unpaid_usd_cents:,
           post_cutoff: !in_cycle,

--- a/app/sidekiq/alert_on_negative_destination_balances_job.rb
+++ b/app/sidekiq/alert_on_negative_destination_balances_job.rb
@@ -40,6 +40,13 @@ class AlertOnNegativeDestinationBalancesJob
     new.send(:scan_for_negative_destinations)
   end
 
+  # Reused by AutoTopUpNegativeDestinationBalancesJob so its live re-read applies the same
+  # in-cycle-vs-whole-ledger window `resolve_entry`'s full_total used, instead of always summing
+  # the whole ledger and drifting from the scan's own payability verdict.
+  def self.payout_cutoff_date
+    new.send(:payout_cutoff_date)
+  end
+
   private
     # Sellers whose Stripe-held balance set nets negative AND who are payable now, so the next payout
     # run reaches them. `truncated` means the candidate window was cut short, so the counts are floors.

--- a/app/sidekiq/alert_on_negative_destination_balances_job.rb
+++ b/app/sidekiq/alert_on_negative_destination_balances_job.rb
@@ -34,6 +34,12 @@ class AlertOnNegativeDestinationBalancesJob
     InternalNotificationWorker.perform_async("payouts", "Negative destination balances", message_for(scan))
   end
 
+  # Reused by AutoTopUpNegativeDestinationBalancesJob (gumroad-private#1903) so the top-up leg
+  # scans the SAME candidate set this report describes, rather than re-deriving it and drifting.
+  def self.scan
+    new.send(:scan_for_negative_destinations)
+  end
+
   private
     # Sellers whose Stripe-held balance set nets negative AND who are payable now, so the next payout
     # run reaches them. `truncated` means the candidate window was cut short, so the counts are floors.

--- a/app/sidekiq/alert_on_negative_destination_balances_job.rb
+++ b/app/sidekiq/alert_on_negative_destination_balances_job.rb
@@ -81,7 +81,11 @@ class AlertOnNegativeDestinationBalancesJob
           tripped = tripped_window(full_set)
           if tripped
             not_payable += 1
-            unreconciled_not_payable << { merchant_account:, balance_ids: tripped.first.order(:id).pluck(:id) }
+            # The funded-TTL refresher intersects stored funded IDs against this list. It must
+            # carry the account's FULL unpaid set, not the tripped window's: when the cycle
+            # window trips, a funded row past the cutoff would be absent, its credit would
+            # expire, and a later payable scan would transfer the full shortfall again.
+            unreconciled_not_payable << { merchant_account:, balance_ids: full_set.order(:id).pluck(:id) }
           end
         end
       end

--- a/app/sidekiq/alert_on_negative_destination_balances_job.rb
+++ b/app/sidekiq/alert_on_negative_destination_balances_job.rb
@@ -50,6 +50,11 @@ class AlertOnNegativeDestinationBalancesJob
 
       payable = []
       not_payable = 0
+      # Balance-id fingerprints for tripped-but-below-minimum accounts, so a consumer tracking
+      # funded credit against specific rows (AutoTopUpNegativeDestinationBalancesJob) can still
+      # refresh that credit's TTL while an account is temporarily unpayable — otherwise credit for
+      # a still-unreconciled row silently expires off-scan and a later top-up double-funds it.
+      unreconciled_not_payable = []
 
       candidates.each do |user_id, merchant_account_id|
         merchant_account = MerchantAccount.find_by(id: merchant_account_id)
@@ -73,11 +78,15 @@ class AlertOnNegativeDestinationBalancesJob
         if entry
           payable << entry
         else
-          not_payable += 1 if tripped_window(full_set)
+          tripped = tripped_window(full_set)
+          if tripped
+            not_payable += 1
+            unreconciled_not_payable << { merchant_account:, balance_ids: tripped.first.order(:id).pluck(:id) }
+          end
         end
       end
 
-      { payable: report_order(payable), not_payable:, truncated: }
+      { payable: report_order(payable), not_payable:, unreconciled_not_payable:, truncated: }
     end
 
     # One entry per (seller, merchant account) whose Stripe-held set nets negative on EITHER window —

--- a/app/sidekiq/alert_on_negative_destination_balances_job.rb
+++ b/app/sidekiq/alert_on_negative_destination_balances_job.rb
@@ -171,6 +171,11 @@ class AlertOnNegativeDestinationBalancesJob
         # cycle total stays the honest figure — that credit is not available to the tripping run.
         full_total = in_cycle ? [full_set.sum(:holding_amount_cents), set_total].min : set_total
 
+        # One pluck for both id ordering and per-row amounts — the auto top-up job needs the
+        # per-row breakdown (not just the aggregate) to credit only the rows that actually
+        # survive between runs, rather than treating a partially-reconciled set as all-or-nothing.
+        row_pairs = full_set.order(:id).pluck(:id, :holding_amount_cents)
+
         return {
           user:,
           merchant_account:,
@@ -181,7 +186,8 @@ class AlertOnNegativeDestinationBalancesJob
           # can tell "this candidate's underlying balances are unchanged" from "leg two reconciled
           # the old rows and a new, independent shortfall landed on the same account" — the two
           # look identical if you only compare amounts.
-          balance_ids: full_set.order(:id).pluck(:id),
+          balance_ids: row_pairs.map(&:first),
+          balance_amounts: row_pairs.to_h,
           retired: !merchant_account.alive?,
           unpaid_usd_cents:,
           post_cutoff: !in_cycle,

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -141,13 +141,25 @@ class AutoTopUpNegativeDestinationBalancesJob
       # is still negative — re-reading the whole ledger here would silently skip or underfund
       # exactly the gap the scan flagged. A post-cutoff-only candidate never reaches here (the
       # branch above escalates it), so only the in-cycle window needs the live re-read at all.
-      current_total_cents =
+      # current_window_ids is the row set that current_total_cents was actually summed over —
+      # whole ledger for a post-cutoff-only trip, otherwise whichever of whole-ledger/in-cycle
+      # was more negative. Credit below must be tracked against this SAME set: storing (and later
+      # re-summing) funded rows from the whole ledger while current_total_cents is windowed to the
+      # cycle let a post-cutoff credit row inflate funded_signed beyond what the window's total
+      # ever accounted for, so an unrelated later change (e.g. a masking row clearing) computed a
+      # bogus delta and resent part of the original shortfall.
+      current_window_ids, current_total_cents =
         if entry[:post_cutoff]
-          whole_ledger_cents
+          [current_balance_ids, whole_ledger_cents]
         else
           cutoff = AlertOnNegativeDestinationBalancesJob.payout_cutoff_date
-          in_cycle_cents = current_balance_pairs.sum { |_id, cents, date| date <= cutoff ? cents : 0 }
-          [whole_ledger_cents, in_cycle_cents].min
+          in_cycle_pairs = current_balance_pairs.select { |_id, _cents, date| date <= cutoff }
+          in_cycle_cents = in_cycle_pairs.sum { |_id, cents, _date| cents }
+          if in_cycle_cents <= whole_ledger_cents
+            [in_cycle_pairs.map(&:first), in_cycle_cents]
+          else
+            [current_balance_ids, whole_ledger_cents]
+          end
         end
       return { entry:, verdict: :noop, reason: "reconciled since scan — nothing left to transfer" } unless current_total_cents.negative?
 
@@ -157,14 +169,15 @@ class AutoTopUpNegativeDestinationBalancesJob
       # reconciled set (some funded rows gone, others still outstanding, maybe a brand-new row
       # added) would otherwise either re-transfer already-funded rows (crediting nothing) or, worse,
       # suppress a genuinely new shortfall because the stale aggregate still "covered" the current
-      # total. Only the funded rows still present in the current unpaid set count as credit.
+      # total. Only the funded rows still present in the current WINDOW count as credit — not just
+      # still-unpaid, but still inside the same window current_total_cents was computed from.
       #
       # Summed SIGNED (not per-row abs): full_total is a signed net, and a funded set can mix
       # signs (a positive residue row alongside a larger negative one). Summing magnitudes
       # overstates credit whenever that happens — it double-counts what full_total already nets
       # out — so credit must live on the same signed basis as full_total for the comparison below
       # to mean anything.
-      surviving_funded_ids = funded_ids & current_balance_ids
+      surviving_funded_ids = funded_ids & current_window_ids
       funded_signed = surviving_funded_ids.any? ? surviving_funded_ids.sum { |id| current_balance_amounts.fetch(id, 0) } : nil
 
       # An earlier ambiguous Stripe outcome for this account (below) means we don't know whether
@@ -229,7 +242,11 @@ class AutoTopUpNegativeDestinationBalancesJob
       # only safe to drop because a human clears it explicitly as part of the leg-two reconciliation
       # pass (same convention as the ambiguous-error rescue below).
       $redis.persist(transfer_key)
-      $redis.set(dedupe_key, "#{current_total_cents.abs}:#{current_balance_ids.join("-")}", ex: DEDUPE_TTL)
+      # Store the WINDOW's row ids, not the whole current_balance_ids set: a post-cutoff row
+      # excluded from an in-cycle window's total must not become "funded" credit either, or a
+      # later run intersecting funded_ids against a different window could count it and resend
+      # part of the original shortfall (the bug this window/credit split exists to close).
+      $redis.set(dedupe_key, "#{current_total_cents.abs}:#{current_window_ids.join("-")}", ex: DEDUPE_TTL)
       $redis.del(unresolved_key)
       { entry:, verdict: :topped_up, reason: nil, amount_cents: to_transfer_cents, currency: entry[:merchant_account].currency }
     rescue Stripe::InvalidRequestError, Stripe::RateLimitError => e

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -33,6 +33,7 @@ class AutoTopUpNegativeDestinationBalancesJob
     return if scan[:payable].empty?
 
     live = Feature.active?(:auto_topup_negative_destination_balances)
+    refresh_funded_state_ttls(scan[:payable])
     candidates = scan[:payable].first(MAX_TOPUPS_PER_RUN)
     outcomes = candidates.map { |entry| topup(entry, live:) }
 
@@ -42,6 +43,20 @@ class AutoTopUpNegativeDestinationBalancesJob
   end
 
   private
+    # Only `topup` (called on the first MAX_TOPUPS_PER_RUN candidates) refreshes an account's
+    # funded-state TTL — an account outside that cap would otherwise have its 7-day dedupe lapse
+    # while genuinely still unreconciled, letting a later re-fund of a surviving row collide with
+    # a since-added new row's delta (the changed-fingerprint transfer_key can't tell the two
+    # apart once the TTL is gone). Runs for every payable candidate, capped or not.
+    def refresh_funded_state_ttls(payable)
+      payable.each do |entry|
+        dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(entry[:merchant_account].id)
+        _funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)
+        funded_ids = funded_ids_str.to_s.split("-").map(&:to_i)
+        $redis.expire(dedupe_key, DEDUPE_TTL) if (funded_ids & entry[:balance_ids]).any?
+      end
+    end
+
     # A RETIRED merchant account cannot receive a Stripe transfer (the connected account is
     # closed); a post-cutoff-only trip means the whole-ledger gap is smaller than the
     # cycle-window figure would suggest; and an amount we already transferred for this account
@@ -133,6 +148,14 @@ class AutoTopUpNegativeDestinationBalancesJob
       # double-transfer. Release only on an error we know is safe to retry (see rescue below).
       return { entry:, verdict: :escalate, reason: "a top-up for this account and amount is already in flight" } unless $redis.set(transfer_key, 1, ex: DEDUPE_TTL, nx: true)
 
+      # Marks the account unresolved BEFORE calling Stripe, not just from the rescue below: the
+      # account lock's TTL only bounds a well-behaved call, so a request that outlives it (Stripe
+      # slow, not erroring) leaves the lock's protection gone while this call is still in flight.
+      # A second run that acquires the expired lock now sees this marker and escalates instead of
+      # reading a stale funded_signed and minting its own transfer_key for the same gap. Cleared
+      # below once the outcome (success or a safe-to-retry error) is known.
+      $redis.set(unresolved_key, to_transfer_cents)
+
       StripeTransferInternallyToCreator.transfer_funds_to_account(
         message_why: "Reconciling negative destination ledger (gumroad-private#1903, auto top-up leg)",
         stripe_account_id: entry[:merchant_account].charge_processor_merchant_id,
@@ -153,11 +176,13 @@ class AutoTopUpNegativeDestinationBalancesJob
       # pass (same convention as the ambiguous-error rescue below).
       $redis.persist(transfer_key)
       $redis.set(dedupe_key, "#{amount_cents}:#{entry[:balance_ids].join("-")}", ex: DEDUPE_TTL)
+      $redis.del(unresolved_key)
       { entry:, verdict: :topped_up, reason: nil, amount_cents: to_transfer_cents, currency: entry[:merchant_account].currency }
     rescue Stripe::InvalidRequestError, Stripe::RateLimitError => e
       # Neither error moves money (a bad param is rejected before charge; a 429 never reaches
-      # Stripe's processing), so it's safe to release the claim for a legitimate retry.
+      # Stripe's processing), so it's safe to release both claims for a legitimate retry.
       $redis.del(transfer_key) if transfer_key
+      $redis.del(unresolved_key) if unresolved_key
       { entry:, verdict: :error, reason: "#{e.class}: #{e.message}" }
     rescue => e
       # Everything else (timeouts, connection drops, Stripe 5xx) is ambiguous about whether
@@ -167,12 +192,9 @@ class AutoTopUpNegativeDestinationBalancesJob
       # (24h) has lapsed. PERSIST it (drop the TTL): a fixed-duration hold would itself lapse
       # past that 24h window and let an unattended retry recreate the exact risk this branch
       # exists to avoid — only a human clearing the key (once they've confirmed with Stripe
-      # what actually happened) may retry.
+      # what actually happened) may retry. unresolved_key was already set before the Stripe call
+      # (so an expired-lock race can't slip past it); nothing more to do here.
       $redis.persist(transfer_key) if transfer_key
-      # Blocks the account (not just this transfer_key) until a human resolves it: leaving only
-      # the transfer_key held meant a grown shortfall next run computed its delta against a
-      # funded_cents that never accounted for this possibly-sent amount, and could overfund it.
-      $redis.set("#{dedupe_key}:unresolved", to_transfer_cents) if to_transfer_cents
       { entry:, verdict: :error, reason: "#{e.class}: #{e.message}" }
     ensure
       $redis.eval(LOCK_RELEASE_SCRIPT, keys: [lock_key], argv: [lock_token]) if lock_token

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -131,9 +131,10 @@ class AutoTopUpNegativeDestinationBalancesJob
       current_balance_pairs = Balance.unpaid
                                      .where(user_id: entry[:user].id, merchant_account_id: entry[:merchant_account].id)
                                      .order(:id)
-                                     .pluck(:id, :holding_amount_cents, :date)
+                                     .pluck(:id, :holding_amount_cents, :date, :amount_cents)
       current_balance_ids = current_balance_pairs.map(&:first)
-      current_balance_amounts = current_balance_pairs.to_h { |id, cents, _date| [id, cents] }
+      current_balance_amounts = current_balance_pairs.to_h { |id, cents, _date, _usd| [id, cents] }
+      current_balance_usd_cents = current_balance_pairs.to_h { |id, _cents, _date, usd| [id, usd] }
       whole_ledger_cents = current_balance_amounts.values.sum
       # Mirrors resolve_entry's own full_total window instead of always summing the whole ledger:
       # an in-cycle candidate (entry[:post_cutoff] false) can carry a post-cutoff credit that
@@ -153,8 +154,8 @@ class AutoTopUpNegativeDestinationBalancesJob
           [current_balance_ids, whole_ledger_cents]
         else
           cutoff = AlertOnNegativeDestinationBalancesJob.payout_cutoff_date
-          in_cycle_pairs = current_balance_pairs.select { |_id, _cents, date| date <= cutoff }
-          in_cycle_cents = in_cycle_pairs.sum { |_id, cents, _date| cents }
+          in_cycle_pairs = current_balance_pairs.select { |_id, _cents, date, _usd| date <= cutoff }
+          in_cycle_cents = in_cycle_pairs.sum { |_id, cents, _date, _usd| cents }
           if in_cycle_cents <= whole_ledger_cents
             [in_cycle_pairs.map(&:first), in_cycle_cents]
           else
@@ -162,6 +163,13 @@ class AutoTopUpNegativeDestinationBalancesJob
           end
         end
       return { entry:, verdict: :noop, reason: "reconciled since scan — nothing left to transfer" } unless current_total_cents.negative?
+      # Mirrors resolve_entry's own refund-netting guard (`next if set.sum(:amount_cents).negative?`):
+      # a negative destination total matched by a negative USD ledger over the SAME window pays out
+      # coherently and was never a real gap. The scan-time check doesn't survive a refund/credit that
+      # lands between scan and here, so it has to be re-applied against the live window, not just
+      # holding_amount_cents.
+      current_window_usd_cents = current_window_ids.sum { |id| current_balance_usd_cents.fetch(id, 0) }
+      return { entry:, verdict: :noop, reason: "reconciled since scan — refund netting cleared the gap" } if current_window_usd_cents.negative?
 
       _funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)
       funded_ids = funded_ids_str.to_s.split("-").map(&:to_i)
@@ -241,7 +249,17 @@ class AutoTopUpNegativeDestinationBalancesJob
       # or a later scan would create a genuinely new transfer for the same accepted delta. It is
       # only safe to drop because a human clears it explicitly as part of the leg-two reconciliation
       # pass (same convention as the ambiguous-error rescue below).
-      $redis.persist(transfer_key)
+      #
+      # Retry a few times before giving up: a bare `persist` that raises once (Redis blip right
+      # after Stripe accepted) used to fall into the generic rescue below, which repeated the exact
+      # same failing call and then returned :error with the claim still on its original 7-day TTL —
+      # a human who later clears unresolved_key (believing the transfer is simply unconfirmed) would
+      # then let the claim expire and a subsequent run resend the same accepted transfer. Until the
+      # persist is confirmed, unresolved_key stays SET (not deleted) so the account keeps escalating
+      # instead of silently falling back to time-based expiry.
+      unless persist_with_retries(transfer_key)
+        return { entry:, verdict: :escalate, reason: "Stripe accepted #{to_transfer_cents} cents for this account but the durable dedupe claim could not be confirmed in Redis — a human must verify the transfer with Stripe before clearing #{transfer_key} or #{unresolved_key}" }
+      end
       # Store the WINDOW's row ids, not the whole current_balance_ids set: a post-cutoff row
       # excluded from an in-cycle window's total must not become "funded" credit either, or a
       # later run intersecting funded_ids against a different window could count it and resend
@@ -269,6 +287,20 @@ class AutoTopUpNegativeDestinationBalancesJob
       { entry:, verdict: :error, reason: "#{e.class}: #{e.message}" }
     ensure
       $redis.eval(LOCK_RELEASE_SCRIPT, keys: [lock_key], argv: [lock_token]) if lock_token
+    end
+
+    # Bare `$redis.persist` raising once used to fall straight into the generic rescue, which
+    # repeated the identical failing call and returned :error with the transfer_key still on its
+    # original TTL — see the call site's comment for why that's unsafe once Stripe's own
+    # accepted the transfer. A few retries absorb a transient blip; giving up returns false so the
+    # caller can escalate instead of silently trusting an unconfirmed persist.
+    def persist_with_retries(key, attempts: 3)
+      attempts.times do
+        return true if $redis.persist(key)
+      rescue
+        sleep(0.1)
+      end
+      false
     end
 
     def message_for(outcomes, live:, total:)

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -30,10 +30,14 @@ class AutoTopUpNegativeDestinationBalancesJob
 
   def perform
     scan = AlertOnNegativeDestinationBalancesJob.scan
+    # Refresh BEFORE the early return: an account can hold funded credit for a still-unreconciled
+    # row while temporarily below the payout minimum (absent from scan[:payable] entirely), and a
+    # scan with no payable candidates this run must not skip refreshing it — that's exactly the
+    # gap that let credit expire off-scan and a later top-up double-fund a surviving row.
+    refresh_funded_state_ttls(scan[:payable] + scan[:unreconciled_not_payable])
     return if scan[:payable].empty?
 
     live = Feature.active?(:auto_topup_negative_destination_balances)
-    refresh_funded_state_ttls(scan[:payable])
     candidates = scan[:payable].first(MAX_TOPUPS_PER_RUN)
     outcomes = candidates.map { |entry| topup(entry, live:) }
 
@@ -43,13 +47,14 @@ class AutoTopUpNegativeDestinationBalancesJob
   end
 
   private
-    # Only `topup` (called on the first MAX_TOPUPS_PER_RUN candidates) refreshes an account's
-    # funded-state TTL — an account outside that cap would otherwise have its 7-day dedupe lapse
-    # while genuinely still unreconciled, letting a later re-fund of a surviving row collide with
-    # a since-added new row's delta (the changed-fingerprint transfer_key can't tell the two
-    # apart once the TTL is gone). Runs for every payable candidate, capped or not.
-    def refresh_funded_state_ttls(payable)
-      payable.each do |entry|
+    # Only `topup` (called on the first MAX_TOPUPS_PER_RUN candidates) used to be the sole place
+    # that refreshed an account's funded-state TTL. Now runs for every payable AND
+    # below-minimum-but-tripped candidate the scan reports (capped-out payable ones too) — an
+    # account outside `topup`'s reach would otherwise have its 7-day dedupe lapse while genuinely
+    # still unreconciled, letting a later re-fund of a surviving row collide with a since-added new
+    # row's delta (the changed-fingerprint transfer_key can't tell the two apart once the TTL is gone).
+    def refresh_funded_state_ttls(candidates)
+      candidates.each do |entry|
         dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(entry[:merchant_account].id)
         _funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)
         funded_ids = funded_ids_str.to_s.split("-").map(&:to_i)

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -59,6 +59,11 @@ class AutoTopUpNegativeDestinationBalancesJob
       # and double-transfer. NX makes the claim itself the idempotency boundary; release it in the
       # rescue below so a failed attempt (no money moved) is retryable on the next run.
       unless $redis.set(dedupe_key, amount_cents, ex: DEDUPE_TTL, nx: true)
+        # Still outstanding: keep the claim alive for another DEDUPE_TTL window rather than let it
+        # lapse mid-reconciliation — a fixed 7-day expiry only makes sense if the candidate stops
+        # reappearing; refreshing on every re-sighting means it only actually expires once leg two
+        # is done and the candidate disappears from the scan for a full week.
+        $redis.expire(dedupe_key, DEDUPE_TTL)
         return { entry:, verdict: :escalate, reason: "already topped up #{amount_cents} cents for this account — awaiting the leg-two reconciliation pass before retrying" }
       end
 
@@ -67,6 +72,12 @@ class AutoTopUpNegativeDestinationBalancesJob
         stripe_account_id: entry[:merchant_account].charge_processor_merchant_id,
         currency: entry[:merchant_account].currency,
         amount_cents:,
+        # Stripe's own idempotency window (24h) is the real backstop against an ambiguous local
+        # outcome (timeout/network drop after Stripe already accepted the transfer): the dedupe
+        # key is stable per account while unclaimed, so a retry hitting Stripe again with the
+        # same key returns the original transfer instead of creating a second one — independent
+        # of whether the redis claim above got released by the rescue clause.
+        idempotency_key: dedupe_key,
         metadata: { user_id: entry[:user].id, merchant_account_id: entry[:merchant_account].id, reason: "negative_destination_balance_topup" }
       )
       { entry:, verdict: :topped_up, reason: nil, amount_cents:, currency: entry[:merchant_account].currency }

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -102,6 +102,14 @@ class AutoTopUpNegativeDestinationBalancesJob
         return { entry:, verdict: :escalate, reason: "a top-up decision for this account is already in progress" }
       end
 
+      # Re-read the specific rows scan identified rather than trust its snapshot: a payout,
+      # refund, credit, or the leg-two reconciliation pass can change these Balance rows between
+      # scan and this account's turn — the lock above only serializes this job's own runs against
+      # each other, not against every other writer of Balance#holding_amount_cents. Deciding off
+      # the stale scan total would transfer against a gap that no longer exists.
+      current_total_cents = Balance.unpaid.where(id: entry[:balance_ids]).sum(:holding_amount_cents)
+      return { entry:, verdict: :noop, reason: "reconciled since scan — nothing left to transfer" } unless current_total_cents.negative?
+
       _funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)
       funded_ids = funded_ids_str.to_s.split("-").map(&:to_i)
       # Credit is tracked per surviving ROW, not as one all-or-nothing aggregate: a partially
@@ -133,12 +141,12 @@ class AutoTopUpNegativeDestinationBalancesJob
       # shrunk shortfall means leg two hasn't happened yet (or is in progress): keep withholding.
       # Comparison stays in signed space (full_total >= funded_signed, both negative-going) rather
       # than on abs magnitudes — that's what makes it correct for a mixed-sign funded set too.
-      if funded_signed && entry[:full_total] >= funded_signed
+      if funded_signed && current_total_cents >= funded_signed
         $redis.expire(dedupe_key, DEDUPE_TTL)
         return { entry:, verdict: :escalate, reason: "already topped up #{funded_signed.abs} cents for this account — awaiting the leg-two reconciliation pass before retrying" }
       end
 
-      to_transfer_cents = funded_signed ? (entry[:full_total] - funded_signed).abs : amount_cents
+      to_transfer_cents = funded_signed ? (current_total_cents - funded_signed).abs : current_total_cents.abs
       # The transfer's own idempotency key is scoped to the specific (account, current row set,
       # funded-so-far, target) transition, not just the amounts — an amount-only key persisted
       # forever (below) would otherwise collide across two UNRELATED shortfalls that happen to
@@ -146,7 +154,7 @@ class AutoTopUpNegativeDestinationBalancesJob
       # since SET NX sees the first transfer's still-persisted key. The row-set fingerprint is what
       # tells two same-amount shortfalls apart.
       row_fingerprint = Digest::SHA1.hexdigest(entry[:balance_ids].join("-"))[0, 12]
-      transfer_key = "#{dedupe_key}:#{row_fingerprint}:#{funded_signed&.abs || 0}:#{amount_cents}"
+      transfer_key = "#{dedupe_key}:#{row_fingerprint}:#{funded_signed&.abs || 0}:#{current_total_cents.abs}"
 
       # Claim before calling Stripe, not after: a claim-after-transfer ordering leaves a crash
       # between "Stripe accepted the transfer" and "we recorded that" free to retry and
@@ -180,7 +188,7 @@ class AutoTopUpNegativeDestinationBalancesJob
       # only safe to drop because a human clears it explicitly as part of the leg-two reconciliation
       # pass (same convention as the ambiguous-error rescue below).
       $redis.persist(transfer_key)
-      $redis.set(dedupe_key, "#{amount_cents}:#{entry[:balance_ids].join("-")}", ex: DEDUPE_TTL)
+      $redis.set(dedupe_key, "#{current_total_cents.abs}:#{entry[:balance_ids].join("-")}", ex: DEDUPE_TTL)
       $redis.del(unresolved_key)
       { entry:, verdict: :topped_up, reason: nil, amount_cents: to_transfer_cents, currency: entry[:merchant_account].currency }
     rescue Stripe::InvalidRequestError, Stripe::RateLimitError => e

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -18,6 +18,16 @@ class AutoTopUpNegativeDestinationBalancesJob
   # cadence so a candidate isn't re-transferred before a human gets to it.
   DEDUPE_TTL = 7.days
 
+  # Must outlive one Stripe call including its own retries (Stripe.max_network_retries), or an
+  # expired-but-still-in-flight lock lets a second run acquire it and mint its own transfer_key
+  # off a stale snapshot — the same race the lock exists to prevent, just delayed past its TTL.
+  LOCK_TTL = 20.minutes
+  LOCK_RELEASE_SCRIPT = <<~LUA.squish
+    if redis.call('get', KEYS[1]) == ARGV[1] then
+      return redis.call('del', KEYS[1])
+    end
+  LUA
+
   def perform
     scan = AlertOnNegativeDestinationBalancesJob.scan
     return if scan[:payable].empty?
@@ -64,7 +74,13 @@ class AutoTopUpNegativeDestinationBalancesJob
       # it, see a bigger shortfall (new row, or leg two still pending), and mint its own transfer_key
       # before the first call's outcome was known, double-transferring the overlapping amount.
       lock_key = "#{dedupe_key}:lock"
-      return { entry:, verdict: :escalate, reason: "a top-up decision for this account is already in progress" } unless $redis.set(lock_key, 1, ex: 300, nx: true)
+      lock_token = SecureRandom.uuid
+      # CAS token, not a bare flag: a TTL-expired lock reacquired by a second run must not have
+      # its lock deleted out from under it by this run's `ensure` — that would let a THIRD run in
+      # while the second is still mid-Stripe-call, the exact race LOCK_TTL sizing is meant to close.
+      unless $redis.set(lock_key, lock_token, ex: LOCK_TTL.to_i, nx: true)
+        return { entry:, verdict: :escalate, reason: "a top-up decision for this account is already in progress" }
+      end
 
       funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)
       funded_cents = funded_amount&.to_i
@@ -76,6 +92,15 @@ class AutoTopUpNegativeDestinationBalancesJob
       # total. Only the funded rows still present in the current unpaid set count as credit.
       surviving_funded_ids = funded_ids & entry[:balance_ids]
       funded_cents = surviving_funded_ids.any? ? surviving_funded_ids.sum { |id| entry[:balance_amounts].fetch(id, 0).abs } : nil
+
+      # An earlier ambiguous Stripe outcome for this account (below) means we don't know whether
+      # that amount was actually transferred. Escalating regardless of the current shortfall —
+      # rather than only when it's unchanged — is what stops a grown shortfall from computing a
+      # delta against a funded_cents that might itself be wrong by the unresolved amount.
+      unresolved_key = "#{dedupe_key}:unresolved"
+      if (unresolved_amount = $redis.get(unresolved_key))
+        return { entry:, verdict: :escalate, reason: "a prior transfer to this account had an ambiguous Stripe outcome (#{unresolved_amount} cents) — a human must confirm with Stripe and clear #{unresolved_key} before this account tops up again" }
+      end
 
       # A shortfall that grew since the last funded amount (leg two is only partially done, or a
       # new trip landed) needs its own transfer for the delta, not a blanket escalate — otherwise
@@ -133,9 +158,13 @@ class AutoTopUpNegativeDestinationBalancesJob
       # exists to avoid — only a human clearing the key (once they've confirmed with Stripe
       # what actually happened) may retry.
       $redis.persist(transfer_key) if transfer_key
+      # Blocks the account (not just this transfer_key) until a human resolves it: leaving only
+      # the transfer_key held meant a grown shortfall next run computed its delta against a
+      # funded_cents that never accounted for this possibly-sent amount, and could overfund it.
+      $redis.set("#{dedupe_key}:unresolved", to_transfer_cents) if to_transfer_cents
       { entry:, verdict: :error, reason: "#{e.class}: #{e.message}" }
     ensure
-      $redis.del(lock_key) if lock_key
+      $redis.eval(LOCK_RELEASE_SCRIPT, keys: [lock_key], argv: [lock_token]) if lock_token
     end
 
     def message_for(outcomes, live:, total:)

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Automates the FIRST of the two repair legs AlertOnNegativeDestinationBalancesJob's report
+# describes (gumroad-private#1903): wiring the connected account's Stripe balance back to >= 0 so
+# the next payout cycle doesn't fail on it. The SECOND leg — zeroing the internal Balance row that
+# caused the drift — stays a human decision (see below), so this job's own effect is invisible to
+# `AlertOnNegativeDestinationBalancesJob`'s scan until that second leg lands; it will keep
+# reporting the same candidate every day until a human reconciles the row, which is expected.
+#
+# Why the second leg isn't automated: `full_total`/`set_total` are the SIGNED SUM of possibly
+# several Balance rows (see AlertOnNegativeDestinationBalancesJob#candidate_pairs), so "zero it"
+# means picking which row(s) absorb the correction — a judgment call the drift-guard pattern
+# (gp#989/#1027/#1042/#1082/#1127/#1849) has always left to a human. Topping up the Stripe side
+# first is safe and reversible-in-effect (it only ever ADDS funds to a seller's own account); it
+# never risks writing a wrong number into a ledger row.
+#
+# Clears live only behind :auto_topup_negative_destination_balances. With the flag off every
+# candidate is dry-run and the report says what WOULD have been transferred, mirroring
+# RecoverStrandedBuyersJob's rollout pattern (gumroad-private#1902).
+class AutoTopUpNegativeDestinationBalancesJob
+  include Sidekiq::Job
+  sidekiq_options retry: 1, queue: :low
+
+  # Bounds one run's blast radius — real money moves per candidate. The scan itself already
+  # ranks worst-first (AlertOnNegativeDestinationBalancesJob#report_order), so a bounded run
+  # reaches the biggest gaps first rather than an arbitrary subset.
+  MAX_TOPUPS_PER_RUN = 10
+
+  def perform
+    scan = AlertOnNegativeDestinationBalancesJob.scan
+    return if scan[:payable].empty?
+
+    live = Feature.active?(:auto_topup_negative_destination_balances)
+    candidates = scan[:payable].first(MAX_TOPUPS_PER_RUN)
+    outcomes = candidates.map { |entry| topup(entry, live:) }
+
+    InternalNotificationWorker.perform_async(
+      "payouts", "Negative destination balance top-ups", message_for(outcomes, live:, total: scan[:payable].size)
+    )
+  end
+
+  private
+    # A RETIRED merchant account cannot receive a Stripe transfer (the connected account is
+    # closed), and a post-cutoff-only trip means the whole-ledger gap is smaller than the
+    # cycle-window figure would suggest — both stay withheld for a human rather than risk
+    # transferring against a total that will not hold at payout time.
+    def topup(entry, live:)
+      if entry[:retired]
+        return { entry:, verdict: :escalate, reason: "merchant account is RETIRED — cannot transfer to a closed Stripe account" }
+      end
+
+      amount_cents = entry[:full_total].abs
+      return { entry:, verdict: :noop, reason: "nothing to transfer" } if amount_cents.zero?
+
+      unless live
+        return { entry:, verdict: :dry_run, reason: nil, amount_cents:, currency: entry[:merchant_account].currency }
+      end
+
+      StripeTransferInternallyToCreator.transfer_funds_to_account(
+        message_why: "Reconciling negative destination ledger (gumroad-private#1903, auto top-up leg)",
+        stripe_account_id: entry[:merchant_account].charge_processor_merchant_id,
+        currency: entry[:merchant_account].currency,
+        amount_cents:,
+        metadata: { user_id: entry[:user].id, merchant_account_id: entry[:merchant_account].id, reason: "negative_destination_balance_topup" }
+      )
+      { entry:, verdict: :topped_up, reason: nil, amount_cents:, currency: entry[:merchant_account].currency }
+    rescue => e
+      # One candidate's Stripe failure must not strand the rest of the run or the report.
+      { entry:, verdict: :error, reason: "#{e.class}: #{e.message}" }
+    end
+
+    def message_for(outcomes, live:, total:)
+      counts = outcomes.group_by { _1[:verdict] }.transform_values(&:size)
+      escalations = outcomes.select { _1[:verdict] == :escalate }
+      errors = outcomes.select { _1[:verdict] == :error }
+
+      [
+        "#{live ? "Topped up" : "DRY RUN (auto_topup_negative_destination_balances off) — would top up"} " \
+          "#{counts[:topped_up].to_i + counts[:dry_run].to_i} of #{outcomes.size} candidates processed " \
+          "(#{total} payable total): #{counts[:escalate].to_i} withheld for a human, #{counts[:error].to_i} errored. " \
+          "Reminder: this only closes the Stripe-side gap — the internal Balance row(s) still need a human " \
+          "reconciliation pass before this candidate stops re-appearing in the daily report.",
+        ("" if escalations.any?),
+        *escalations.map { |o| "• ESCALATE #{o[:entry][:user].email} — #{o[:reason]}" },
+        ("" if errors.any?),
+        *errors.map { |o| "• ERROR #{o[:entry][:user].email} — #{o[:reason]}" },
+      ].compact.join("\n")
+    end
+end

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -54,7 +54,11 @@ class AutoTopUpNegativeDestinationBalancesJob
       end
 
       dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(entry[:merchant_account].id)
-      if $redis.get(dedupe_key).to_i == amount_cents
+      # Claim the key with NX *before* calling Stripe, not after: a claim-after-transfer ordering
+      # leaves a crash between "Stripe accepted the transfer" and "we recorded that" free to retry
+      # and double-transfer. NX makes the claim itself the idempotency boundary; release it in the
+      # rescue below so a failed attempt (no money moved) is retryable on the next run.
+      unless $redis.set(dedupe_key, amount_cents, ex: DEDUPE_TTL, nx: true)
         return { entry:, verdict: :escalate, reason: "already topped up #{amount_cents} cents for this account — awaiting the leg-two reconciliation pass before retrying" }
       end
 
@@ -65,9 +69,11 @@ class AutoTopUpNegativeDestinationBalancesJob
         amount_cents:,
         metadata: { user_id: entry[:user].id, merchant_account_id: entry[:merchant_account].id, reason: "negative_destination_balance_topup" }
       )
-      $redis.set(dedupe_key, amount_cents, ex: DEDUPE_TTL)
       { entry:, verdict: :topped_up, reason: nil, amount_cents:, currency: entry[:merchant_account].currency }
     rescue => e
+      # The claim above is optimistic — Stripe never confirmed money moved, so release it or a
+      # transient failure would otherwise block this candidate from a legitimate retry for 7 days.
+      $redis.del(dedupe_key) if dedupe_key
       # One candidate's Stripe failure must not strand the rest of the run or the report.
       { entry:, verdict: :error, reason: "#{e.class}: #{e.message}" }
     end

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -35,6 +35,7 @@ class AutoTopUpNegativeDestinationBalancesJob
     # scan with no payable candidates this run must not skip refreshing it — that's exactly the
     # gap that let credit expire off-scan and a later top-up double-fund a surviving row.
     refresh_funded_state_ttls(scan[:payable] + scan[:unreconciled_not_payable])
+    refresh_masked_funded_state_ttls
     return if scan[:payable].empty?
 
     live = Feature.active?(:auto_topup_negative_destination_balances)
@@ -59,6 +60,25 @@ class AutoTopUpNegativeDestinationBalancesJob
         _funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)
         funded_ids = funded_ids_str.to_s.split("-").map(&:to_i)
         $redis.expire(dedupe_key, DEDUPE_TTL) if (funded_ids & entry[:balance_ids]).any?
+      end
+    end
+
+    # A funded row can be temporarily hidden from AlertOnNegativeDestinationBalancesJob.scan when
+    # an offsetting positive row makes both the cycle window and whole-ledger account aggregate
+    # non-negative. That does NOT mean leg two reconciled the funded row; if the funded row is still
+    # unpaid, keep its credit alive so removing/paying the masking row later cannot double-fund it.
+    def refresh_masked_funded_state_ttls
+      $redis.scan_each(match: "auto_topup_negative_destination_balance:*:last_amount_cents") do |dedupe_key|
+        merchant_account_id = dedupe_key[/auto_topup_negative_destination_balance:(\d+):last_amount_cents\z/, 1]
+        next if merchant_account_id.blank?
+
+        _funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)
+        funded_ids = funded_ids_str.to_s.split("-").map(&:to_i)
+        next if funded_ids.empty?
+
+        if Balance.unpaid.where(merchant_account_id:, id: funded_ids).exists?
+          $redis.expire(dedupe_key, DEDUPE_TTL)
+        end
       end
     end
 
@@ -102,12 +122,19 @@ class AutoTopUpNegativeDestinationBalancesJob
         return { entry:, verdict: :escalate, reason: "a top-up decision for this account is already in progress" }
       end
 
-      # Re-read the specific rows scan identified rather than trust its snapshot: a payout,
-      # refund, credit, or the leg-two reconciliation pass can change these Balance rows between
-      # scan and this account's turn — the lock above only serializes this job's own runs against
-      # each other, not against every other writer of Balance#holding_amount_cents. Deciding off
-      # the stale scan total would transfer against a gap that no longer exists.
-      current_total_cents = Balance.unpaid.where(id: entry[:balance_ids]).sum(:holding_amount_cents)
+      # Re-read the whole current unpaid ledger for the account rather than trust the scan's row
+      # snapshot: a payout, refund, credit, leg-two reconciliation, or brand-new Balance row can
+      # land between scan and this account's turn. The lock above only serializes this job's own
+      # runs against each other, not against every other writer of Balance#holding_amount_cents.
+      # Deciding off stale row ids would either transfer against a gap that no longer exists or miss
+      # a new row that must be included in the delta and transfer fingerprint.
+      current_balance_pairs = Balance.unpaid
+                                     .where(user_id: entry[:user].id, merchant_account_id: entry[:merchant_account].id)
+                                     .order(:id)
+                                     .pluck(:id, :holding_amount_cents)
+      current_balance_amounts = current_balance_pairs.to_h
+      current_balance_ids = current_balance_amounts.keys
+      current_total_cents = current_balance_amounts.values.sum
       return { entry:, verdict: :noop, reason: "reconciled since scan — nothing left to transfer" } unless current_total_cents.negative?
 
       _funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)
@@ -123,8 +150,8 @@ class AutoTopUpNegativeDestinationBalancesJob
       # overstates credit whenever that happens — it double-counts what full_total already nets
       # out — so credit must live on the same signed basis as full_total for the comparison below
       # to mean anything.
-      surviving_funded_ids = funded_ids & entry[:balance_ids]
-      funded_signed = surviving_funded_ids.any? ? surviving_funded_ids.sum { |id| entry[:balance_amounts].fetch(id, 0) } : nil
+      surviving_funded_ids = funded_ids & current_balance_ids
+      funded_signed = surviving_funded_ids.any? ? surviving_funded_ids.sum { |id| current_balance_amounts.fetch(id, 0) } : nil
 
       # An earlier ambiguous Stripe outcome for this account (below) means we don't know whether
       # that amount was actually transferred. Escalating regardless of the current shortfall —
@@ -153,7 +180,7 @@ class AutoTopUpNegativeDestinationBalancesJob
       # land on the same funded/target cents for this account, permanently blocking the second one
       # since SET NX sees the first transfer's still-persisted key. The row-set fingerprint is what
       # tells two same-amount shortfalls apart.
-      row_fingerprint = Digest::SHA1.hexdigest(entry[:balance_ids].join("-"))[0, 12]
+      row_fingerprint = Digest::SHA1.hexdigest(current_balance_ids.join("-"))[0, 12]
       transfer_key = "#{dedupe_key}:#{row_fingerprint}:#{funded_signed&.abs || 0}:#{current_total_cents.abs}"
 
       # Claim before calling Stripe, not after: a claim-after-transfer ordering leaves a crash
@@ -188,7 +215,7 @@ class AutoTopUpNegativeDestinationBalancesJob
       # only safe to drop because a human clears it explicitly as part of the leg-two reconciliation
       # pass (same convention as the ambiguous-error rescue below).
       $redis.persist(transfer_key)
-      $redis.set(dedupe_key, "#{current_total_cents.abs}:#{entry[:balance_ids].join("-")}", ex: DEDUPE_TTL)
+      $redis.set(dedupe_key, "#{current_total_cents.abs}:#{current_balance_ids.join("-")}", ex: DEDUPE_TTL)
       $redis.del(unresolved_key)
       { entry:, verdict: :topped_up, reason: nil, amount_cents: to_transfer_cents, currency: entry[:merchant_account].currency }
     rescue Stripe::InvalidRequestError, Stripe::RateLimitError => e

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -131,10 +131,24 @@ class AutoTopUpNegativeDestinationBalancesJob
       current_balance_pairs = Balance.unpaid
                                      .where(user_id: entry[:user].id, merchant_account_id: entry[:merchant_account].id)
                                      .order(:id)
-                                     .pluck(:id, :holding_amount_cents)
-      current_balance_amounts = current_balance_pairs.to_h
-      current_balance_ids = current_balance_amounts.keys
-      current_total_cents = current_balance_amounts.values.sum
+                                     .pluck(:id, :holding_amount_cents, :date)
+      current_balance_ids = current_balance_pairs.map(&:first)
+      current_balance_amounts = current_balance_pairs.to_h { |id, cents, _date| [id, cents] }
+      whole_ledger_cents = current_balance_amounts.values.sum
+      # Mirrors resolve_entry's own full_total window instead of always summing the whole ledger:
+      # an in-cycle candidate (entry[:post_cutoff] false) can carry a post-cutoff credit that
+      # clears the whole-ledger total while the cycle-window slice the weekly run actually pays
+      # is still negative — re-reading the whole ledger here would silently skip or underfund
+      # exactly the gap the scan flagged. A post-cutoff-only candidate never reaches here (the
+      # branch above escalates it), so only the in-cycle window needs the live re-read at all.
+      current_total_cents =
+        if entry[:post_cutoff]
+          whole_ledger_cents
+        else
+          cutoff = AlertOnNegativeDestinationBalancesJob.payout_cutoff_date
+          in_cycle_cents = current_balance_pairs.sum { |_id, cents, date| date <= cutoff ? cents : 0 }
+          [whole_ledger_cents, in_cycle_cents].min
+        end
       return { entry:, verdict: :noop, reason: "reconciled since scan — nothing left to transfer" } unless current_total_cents.negative?
 
       _funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -111,7 +111,11 @@ class AutoTopUpNegativeDestinationBalancesJob
       # Stripe actually processed the transfer, so the claim stays held — same convention as
       # StripePayoutProcessor's PAYOUT_OUTCOME_UNKNOWN — and the candidate escalates to a human
       # instead of a blind retry that could double-transfer once Stripe's own idempotency window
-      # (24h) has lapsed.
+      # (24h) has lapsed. PERSIST it (drop the TTL): a fixed-duration hold would itself lapse
+      # past that 24h window and let an unattended retry recreate the exact risk this branch
+      # exists to avoid — only a human clearing the key (once they've confirmed with Stripe
+      # what actually happened) may retry.
+      $redis.persist(transfer_key) if transfer_key
       { entry:, verdict: :error, reason: "#{e.class}: #{e.message}" }
     end
 

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -1,22 +1,10 @@
 # frozen_string_literal: true
 
-# Automates the FIRST of the two repair legs AlertOnNegativeDestinationBalancesJob's report
-# describes (gumroad-private#1903): wiring the connected account's Stripe balance back to >= 0 so
-# the next payout cycle doesn't fail on it. The SECOND leg — zeroing the internal Balance row that
-# caused the drift — stays a human decision (see below), so this job's own effect is invisible to
-# `AlertOnNegativeDestinationBalancesJob`'s scan until that second leg lands; it will keep
-# reporting the same candidate every day until a human reconciles the row, which is expected.
-#
-# Why the second leg isn't automated: `full_total`/`set_total` are the SIGNED SUM of possibly
-# several Balance rows (see AlertOnNegativeDestinationBalancesJob#candidate_pairs), so "zero it"
-# means picking which row(s) absorb the correction — a judgment call the drift-guard pattern
-# (gp#989/#1027/#1042/#1082/#1127/#1849) has always left to a human. Topping up the Stripe side
-# first is safe and reversible-in-effect (it only ever ADDS funds to a seller's own account); it
-# never risks writing a wrong number into a ledger row.
-#
-# Clears live only behind :auto_topup_negative_destination_balances. With the flag off every
-# candidate is dry-run and the report says what WOULD have been transferred, mirroring
-# RecoverStrandedBuyersJob's rollout pattern (gumroad-private#1902).
+# Automates leg one (Stripe-side top-up) of the two-leg repair AlertOnNegativeDestinationBalancesJob
+# describes (gp#1903). Leg two — zeroing the internal Balance row(s), a judgment call since
+# full_total/set_total is a signed sum of possibly several rows — stays human (drift-guard
+# pattern: gp#989/#1027/#1042/#1082/#1127/#1849). Until leg two lands, this job's effect is
+# invisible to the alert's scan, so a topped-up candidate keeps reappearing daily — expected.
 class AutoTopUpNegativeDestinationBalancesJob
   include Sidekiq::Job
   sidekiq_options retry: 1, queue: :low
@@ -25,6 +13,10 @@ class AutoTopUpNegativeDestinationBalancesJob
   # ranks worst-first (AlertOnNegativeDestinationBalancesJob#report_order), so a bounded run
   # reaches the biggest gaps first rather than an arbitrary subset.
   MAX_TOPUPS_PER_RUN = 10
+
+  # A leg-two reconciliation pass can take days; this only needs to outlive the daily scan
+  # cadence so a candidate isn't re-transferred before a human gets to it.
+  DEDUPE_TTL = 7.days
 
   def perform
     scan = AlertOnNegativeDestinationBalancesJob.scan
@@ -41,12 +33,17 @@ class AutoTopUpNegativeDestinationBalancesJob
 
   private
     # A RETIRED merchant account cannot receive a Stripe transfer (the connected account is
-    # closed), and a post-cutoff-only trip means the whole-ledger gap is smaller than the
-    # cycle-window figure would suggest — both stay withheld for a human rather than risk
-    # transferring against a total that will not hold at payout time.
+    # closed); a post-cutoff-only trip means the whole-ledger gap is smaller than the
+    # cycle-window figure would suggest; and an amount we already transferred for this account
+    # means leg two hasn't landed yet — all three stay withheld for a human rather than risk
+    # transferring twice or against a total that won't hold at payout time.
     def topup(entry, live:)
       if entry[:retired]
         return { entry:, verdict: :escalate, reason: "merchant account is RETIRED — cannot transfer to a closed Stripe account" }
+      end
+
+      if entry[:post_cutoff]
+        return { entry:, verdict: :escalate, reason: "post-cutoff-only trip — whole-ledger gap may not hold at payout time" }
       end
 
       amount_cents = entry[:full_total].abs
@@ -56,6 +53,11 @@ class AutoTopUpNegativeDestinationBalancesJob
         return { entry:, verdict: :dry_run, reason: nil, amount_cents:, currency: entry[:merchant_account].currency }
       end
 
+      dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(entry[:merchant_account].id)
+      if $redis.get(dedupe_key).to_i == amount_cents
+        return { entry:, verdict: :escalate, reason: "already topped up #{amount_cents} cents for this account — awaiting the leg-two reconciliation pass before retrying" }
+      end
+
       StripeTransferInternallyToCreator.transfer_funds_to_account(
         message_why: "Reconciling negative destination ledger (gumroad-private#1903, auto top-up leg)",
         stripe_account_id: entry[:merchant_account].charge_processor_merchant_id,
@@ -63,6 +65,7 @@ class AutoTopUpNegativeDestinationBalancesJob
         amount_cents:,
         metadata: { user_id: entry[:user].id, merchant_account_id: entry[:merchant_account].id, reason: "negative_destination_balance_topup" }
       )
+      $redis.set(dedupe_key, amount_cents, ex: DEDUPE_TTL)
       { entry:, verdict: :topped_up, reason: nil, amount_cents:, currency: entry[:merchant_account].currency }
     rescue => e
       # One candidate's Stripe failure must not strand the rest of the run or the report.

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -283,7 +283,15 @@ class AutoTopUpNegativeDestinationBalancesJob
       # exists to avoid — only a human clearing the key (once they've confirmed with Stripe
       # what actually happened) may retry. unresolved_key was already set before the Stripe call
       # (so an expired-lock race can't slip past it); nothing more to do here.
-      $redis.persist(transfer_key) if transfer_key
+      #
+      # Retry like the accepted-transfer path above: a bare persist that raises here used to
+      # leave transfer_key on its original 7-day TTL, so once that TTL (and Stripe's 24h
+      # idempotency window) lapsed, clearing unresolved_key alone would let a later run resend
+      # the same ambiguous transfer. unresolved_key stays set either way, but say so distinctly
+      # when persistence itself couldn't be confirmed.
+      if transfer_key && !persist_with_retries(transfer_key)
+        return { entry:, verdict: :escalate, reason: "Stripe's outcome for #{to_transfer_cents} cents to this account is ambiguous (#{e.class}: #{e.message}) and the durable hold on #{transfer_key} could not be confirmed in Redis — a human must verify with Stripe and clear #{unresolved_key} before this account tops up again" }
+      end
       { entry:, verdict: :error, reason: "#{e.class}: #{e.message}" }
     ensure
       $redis.eval(LOCK_RELEASE_SCRIPT, keys: [lock_key], argv: [lock_token]) if lock_token

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -54,16 +54,22 @@ class AutoTopUpNegativeDestinationBalancesJob
       end
 
       dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(entry[:merchant_account].id)
+      # Serializes the read-decide-transfer sequence per account: two overlapping runs (a retry
+      # firing while the prior attempt is still mid-flight, or a manual rerun) would otherwise both
+      # read the same stale funded_cents, mint distinct amount-scoped transfer_keys, and both pass
+      # their own SET NX — sending the full stale snapshot twice instead of one delta. The lock is
+      # released before returning on every path (ensure below), including inside the rescues.
+      lock_key = "#{dedupe_key}:lock"
+      return { entry:, verdict: :escalate, reason: "a top-up decision for this account is already in progress" } unless $redis.set(lock_key, 1, ex: 60, nx: true)
+
       funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)
       funded_cents = funded_amount&.to_i
       funded_ids = funded_ids_str.to_s.split("-").map(&:to_i)
       # The funded state is scoped to the SPECIFIC rows it was measured against, not just the
-      # account. A later sighting where every one of those rows is STILL in the unpaid set is the
-      # same unresolved trip (rows may have grown — an additional row landing is not
-      # reconciliation). Once leg two pays/zeroes any of them, they drop out of the unpaid scan —
-      # that's the actual "reconciled" signal, not a same/lower amount, which a fresh independent
-      # shortfall on the same account can produce by coincidence and get wrongly withheld for 7 days.
-      if funded_ids.any? && !(funded_ids - entry[:balance_ids]).empty?
+      # account. Reconciliation is only complete once NONE of those rows remain in the unpaid set —
+      # clearing on the first row to disappear (rather than the last) would drop credit for the
+      # rows still outstanding, and the next run would transfer their already-funded share again.
+      if funded_ids.any? && (funded_ids & entry[:balance_ids]).empty?
         funded_cents = nil
       end
 
@@ -117,6 +123,8 @@ class AutoTopUpNegativeDestinationBalancesJob
       # what actually happened) may retry.
       $redis.persist(transfer_key) if transfer_key
       { entry:, verdict: :error, reason: "#{e.class}: #{e.message}" }
+    ensure
+      $redis.del(lock_key) if lock_key
     end
 
     def message_for(outcomes, live:, total:)

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -54,7 +54,18 @@ class AutoTopUpNegativeDestinationBalancesJob
       end
 
       dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(entry[:merchant_account].id)
-      funded_cents = $redis.get(dedupe_key)&.to_i
+      funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)
+      funded_cents = funded_amount&.to_i
+      funded_ids = funded_ids_str.to_s.split("-").map(&:to_i)
+      # The funded state is scoped to the SPECIFIC rows it was measured against, not just the
+      # account. A later sighting where every one of those rows is STILL in the unpaid set is the
+      # same unresolved trip (rows may have grown — an additional row landing is not
+      # reconciliation). Once leg two pays/zeroes any of them, they drop out of the unpaid scan —
+      # that's the actual "reconciled" signal, not a same/lower amount, which a fresh independent
+      # shortfall on the same account can produce by coincidence and get wrongly withheld for 7 days.
+      if funded_ids.any? && !(funded_ids - entry[:balance_ids]).empty?
+        funded_cents = nil
+      end
 
       # A shortfall that grew since the last funded amount (leg two is only partially done, or a
       # new trip landed) needs its own transfer for the delta, not a blanket escalate — otherwise
@@ -88,7 +99,7 @@ class AutoTopUpNegativeDestinationBalancesJob
         idempotency_key: transfer_key,
         metadata: { user_id: entry[:user].id, merchant_account_id: entry[:merchant_account].id, reason: "negative_destination_balance_topup" }
       )
-      $redis.set(dedupe_key, amount_cents, ex: DEDUPE_TTL)
+      $redis.set(dedupe_key, "#{amount_cents}:#{entry[:balance_ids].join("-")}", ex: DEDUPE_TTL)
       { entry:, verdict: :topped_up, reason: nil, amount_cents: to_transfer_cents, currency: entry[:merchant_account].currency }
     rescue Stripe::InvalidRequestError, Stripe::RateLimitError => e
       # Neither error moves money (a bad param is rejected before charge; a 429 never reaches

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -82,21 +82,26 @@ class AutoTopUpNegativeDestinationBalancesJob
         return { entry:, verdict: :escalate, reason: "a top-up decision for this account is already in progress" }
       end
 
-      funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)
-      funded_cents = funded_amount&.to_i
+      _funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)
       funded_ids = funded_ids_str.to_s.split("-").map(&:to_i)
       # Credit is tracked per surviving ROW, not as one all-or-nothing aggregate: a partially
       # reconciled set (some funded rows gone, others still outstanding, maybe a brand-new row
       # added) would otherwise either re-transfer already-funded rows (crediting nothing) or, worse,
       # suppress a genuinely new shortfall because the stale aggregate still "covered" the current
       # total. Only the funded rows still present in the current unpaid set count as credit.
+      #
+      # Summed SIGNED (not per-row abs): full_total is a signed net, and a funded set can mix
+      # signs (a positive residue row alongside a larger negative one). Summing magnitudes
+      # overstates credit whenever that happens — it double-counts what full_total already nets
+      # out — so credit must live on the same signed basis as full_total for the comparison below
+      # to mean anything.
       surviving_funded_ids = funded_ids & entry[:balance_ids]
-      funded_cents = surviving_funded_ids.any? ? surviving_funded_ids.sum { |id| entry[:balance_amounts].fetch(id, 0).abs } : nil
+      funded_signed = surviving_funded_ids.any? ? surviving_funded_ids.sum { |id| entry[:balance_amounts].fetch(id, 0) } : nil
 
       # An earlier ambiguous Stripe outcome for this account (below) means we don't know whether
       # that amount was actually transferred. Escalating regardless of the current shortfall —
       # rather than only when it's unchanged — is what stops a grown shortfall from computing a
-      # delta against a funded_cents that might itself be wrong by the unresolved amount.
+      # delta against a funded_signed that might itself be wrong by the unresolved amount.
       unresolved_key = "#{dedupe_key}:unresolved"
       if (unresolved_amount = $redis.get(unresolved_key))
         return { entry:, verdict: :escalate, reason: "a prior transfer to this account had an ambiguous Stripe outcome (#{unresolved_amount} cents) — a human must confirm with Stripe and clear #{unresolved_key} before this account tops up again" }
@@ -106,16 +111,22 @@ class AutoTopUpNegativeDestinationBalancesJob
       # new trip landed) needs its own transfer for the delta, not a blanket escalate — otherwise
       # the extra amount is stuck unfunded until someone manually reconciles. An unchanged or
       # shrunk shortfall means leg two hasn't happened yet (or is in progress): keep withholding.
-      if funded_cents && amount_cents <= funded_cents
+      # Comparison stays in signed space (full_total >= funded_signed, both negative-going) rather
+      # than on abs magnitudes — that's what makes it correct for a mixed-sign funded set too.
+      if funded_signed && entry[:full_total] >= funded_signed
         $redis.expire(dedupe_key, DEDUPE_TTL)
-        return { entry:, verdict: :escalate, reason: "already topped up #{funded_cents} cents for this account — awaiting the leg-two reconciliation pass before retrying" }
+        return { entry:, verdict: :escalate, reason: "already topped up #{funded_signed.abs} cents for this account — awaiting the leg-two reconciliation pass before retrying" }
       end
 
-      to_transfer_cents = funded_cents ? amount_cents - funded_cents : amount_cents
-      # The transfer's own idempotency key is scoped to the specific (account, funded-so-far,
-      # target) transition, not just the account — a delta transfer needs a boundary distinct
-      # from the one that funded the earlier, smaller amount.
-      transfer_key = "#{dedupe_key}:#{funded_cents || 0}:#{amount_cents}"
+      to_transfer_cents = funded_signed ? (entry[:full_total] - funded_signed).abs : amount_cents
+      # The transfer's own idempotency key is scoped to the specific (account, current row set,
+      # funded-so-far, target) transition, not just the amounts — an amount-only key persisted
+      # forever (below) would otherwise collide across two UNRELATED shortfalls that happen to
+      # land on the same funded/target cents for this account, permanently blocking the second one
+      # since SET NX sees the first transfer's still-persisted key. The row-set fingerprint is what
+      # tells two same-amount shortfalls apart.
+      row_fingerprint = Digest::SHA1.hexdigest(entry[:balance_ids].join("-"))[0, 12]
+      transfer_key = "#{dedupe_key}:#{row_fingerprint}:#{funded_signed&.abs || 0}:#{amount_cents}"
 
       # Claim before calling Stripe, not after: a claim-after-transfer ordering leaves a crash
       # between "Stripe accepted the transfer" and "we recorded that" free to retry and

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -59,19 +59,23 @@ class AutoTopUpNegativeDestinationBalancesJob
       # read the same stale funded_cents, mint distinct amount-scoped transfer_keys, and both pass
       # their own SET NX — sending the full stale snapshot twice instead of one delta. The lock is
       # released before returning on every path (ensure below), including inside the rescues.
+      # TTL is sized to comfortably outlive a real Stripe call (connect + read timeout + one retry),
+      # not just the local read-decide step — a lock that expired mid-call let a second run acquire
+      # it, see a bigger shortfall (new row, or leg two still pending), and mint its own transfer_key
+      # before the first call's outcome was known, double-transferring the overlapping amount.
       lock_key = "#{dedupe_key}:lock"
-      return { entry:, verdict: :escalate, reason: "a top-up decision for this account is already in progress" } unless $redis.set(lock_key, 1, ex: 60, nx: true)
+      return { entry:, verdict: :escalate, reason: "a top-up decision for this account is already in progress" } unless $redis.set(lock_key, 1, ex: 300, nx: true)
 
       funded_amount, funded_ids_str = $redis.get(dedupe_key)&.split(":", 2)
       funded_cents = funded_amount&.to_i
       funded_ids = funded_ids_str.to_s.split("-").map(&:to_i)
-      # The funded state is scoped to the SPECIFIC rows it was measured against, not just the
-      # account. Reconciliation is only complete once NONE of those rows remain in the unpaid set —
-      # clearing on the first row to disappear (rather than the last) would drop credit for the
-      # rows still outstanding, and the next run would transfer their already-funded share again.
-      if funded_ids.any? && (funded_ids & entry[:balance_ids]).empty?
-        funded_cents = nil
-      end
+      # Credit is tracked per surviving ROW, not as one all-or-nothing aggregate: a partially
+      # reconciled set (some funded rows gone, others still outstanding, maybe a brand-new row
+      # added) would otherwise either re-transfer already-funded rows (crediting nothing) or, worse,
+      # suppress a genuinely new shortfall because the stale aggregate still "covered" the current
+      # total. Only the funded rows still present in the current unpaid set count as credit.
+      surviving_funded_ids = funded_ids & entry[:balance_ids]
+      funded_cents = surviving_funded_ids.any? ? surviving_funded_ids.sum { |id| entry[:balance_amounts].fetch(id, 0).abs } : nil
 
       # A shortfall that grew since the last funded amount (leg two is only partially done, or a
       # new trip landed) needs its own transfer for the delta, not a blanket escalate — otherwise
@@ -105,6 +109,13 @@ class AutoTopUpNegativeDestinationBalancesJob
         idempotency_key: transfer_key,
         metadata: { user_id: entry[:user].id, merchant_account_id: entry[:merchant_account].id, reason: "negative_destination_balance_topup" }
       )
+      # PERSIST (drop the 7-day TTL) the instant Stripe accepts: the vulnerable window is between
+      # here and the dedupe_key write below — if the worker dies in it, the transfer_key must not
+      # be free to expire and get reused once Stripe's own 24h idempotency window has also lapsed,
+      # or a later scan would create a genuinely new transfer for the same accepted delta. It is
+      # only safe to drop because a human clears it explicitly as part of the leg-two reconciliation
+      # pass (same convention as the ambiguous-error rescue below).
+      $redis.persist(transfer_key)
       $redis.set(dedupe_key, "#{amount_cents}:#{entry[:balance_ids].join("-")}", ex: DEDUPE_TTL)
       { entry:, verdict: :topped_up, reason: nil, amount_cents: to_transfer_cents, currency: entry[:merchant_account].currency }
     rescue Stripe::InvalidRequestError, Stripe::RateLimitError => e

--- a/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
+++ b/app/sidekiq/auto_top_up_negative_destination_balances_job.rb
@@ -54,38 +54,53 @@ class AutoTopUpNegativeDestinationBalancesJob
       end
 
       dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(entry[:merchant_account].id)
-      # Claim the key with NX *before* calling Stripe, not after: a claim-after-transfer ordering
-      # leaves a crash between "Stripe accepted the transfer" and "we recorded that" free to retry
-      # and double-transfer. NX makes the claim itself the idempotency boundary; release it in the
-      # rescue below so a failed attempt (no money moved) is retryable on the next run.
-      unless $redis.set(dedupe_key, amount_cents, ex: DEDUPE_TTL, nx: true)
-        # Still outstanding: keep the claim alive for another DEDUPE_TTL window rather than let it
-        # lapse mid-reconciliation — a fixed 7-day expiry only makes sense if the candidate stops
-        # reappearing; refreshing on every re-sighting means it only actually expires once leg two
-        # is done and the candidate disappears from the scan for a full week.
+      funded_cents = $redis.get(dedupe_key)&.to_i
+
+      # A shortfall that grew since the last funded amount (leg two is only partially done, or a
+      # new trip landed) needs its own transfer for the delta, not a blanket escalate — otherwise
+      # the extra amount is stuck unfunded until someone manually reconciles. An unchanged or
+      # shrunk shortfall means leg two hasn't happened yet (or is in progress): keep withholding.
+      if funded_cents && amount_cents <= funded_cents
         $redis.expire(dedupe_key, DEDUPE_TTL)
-        return { entry:, verdict: :escalate, reason: "already topped up #{amount_cents} cents for this account — awaiting the leg-two reconciliation pass before retrying" }
+        return { entry:, verdict: :escalate, reason: "already topped up #{funded_cents} cents for this account — awaiting the leg-two reconciliation pass before retrying" }
       end
+
+      to_transfer_cents = funded_cents ? amount_cents - funded_cents : amount_cents
+      # The transfer's own idempotency key is scoped to the specific (account, funded-so-far,
+      # target) transition, not just the account — a delta transfer needs a boundary distinct
+      # from the one that funded the earlier, smaller amount.
+      transfer_key = "#{dedupe_key}:#{funded_cents || 0}:#{amount_cents}"
+
+      # Claim before calling Stripe, not after: a claim-after-transfer ordering leaves a crash
+      # between "Stripe accepted the transfer" and "we recorded that" free to retry and
+      # double-transfer. Release only on an error we know is safe to retry (see rescue below).
+      return { entry:, verdict: :escalate, reason: "a top-up for this account and amount is already in flight" } unless $redis.set(transfer_key, 1, ex: DEDUPE_TTL, nx: true)
 
       StripeTransferInternallyToCreator.transfer_funds_to_account(
         message_why: "Reconciling negative destination ledger (gumroad-private#1903, auto top-up leg)",
         stripe_account_id: entry[:merchant_account].charge_processor_merchant_id,
         currency: entry[:merchant_account].currency,
-        amount_cents:,
+        amount_cents: to_transfer_cents,
         # Stripe's own idempotency window (24h) is the real backstop against an ambiguous local
-        # outcome (timeout/network drop after Stripe already accepted the transfer): the dedupe
-        # key is stable per account while unclaimed, so a retry hitting Stripe again with the
-        # same key returns the original transfer instead of creating a second one — independent
-        # of whether the redis claim above got released by the rescue clause.
-        idempotency_key: dedupe_key,
+        # outcome (timeout/network drop after Stripe already accepted the transfer): transfer_key
+        # is stable for this specific delta, so a retry hitting Stripe again with the same key
+        # returns the original transfer instead of creating a second one.
+        idempotency_key: transfer_key,
         metadata: { user_id: entry[:user].id, merchant_account_id: entry[:merchant_account].id, reason: "negative_destination_balance_topup" }
       )
-      { entry:, verdict: :topped_up, reason: nil, amount_cents:, currency: entry[:merchant_account].currency }
+      $redis.set(dedupe_key, amount_cents, ex: DEDUPE_TTL)
+      { entry:, verdict: :topped_up, reason: nil, amount_cents: to_transfer_cents, currency: entry[:merchant_account].currency }
+    rescue Stripe::InvalidRequestError, Stripe::RateLimitError => e
+      # Neither error moves money (a bad param is rejected before charge; a 429 never reaches
+      # Stripe's processing), so it's safe to release the claim for a legitimate retry.
+      $redis.del(transfer_key) if transfer_key
+      { entry:, verdict: :error, reason: "#{e.class}: #{e.message}" }
     rescue => e
-      # The claim above is optimistic — Stripe never confirmed money moved, so release it or a
-      # transient failure would otherwise block this candidate from a legitimate retry for 7 days.
-      $redis.del(dedupe_key) if dedupe_key
-      # One candidate's Stripe failure must not strand the rest of the run or the report.
+      # Everything else (timeouts, connection drops, Stripe 5xx) is ambiguous about whether
+      # Stripe actually processed the transfer, so the claim stays held — same convention as
+      # StripePayoutProcessor's PAYOUT_OUTCOME_UNKNOWN — and the candidate escalates to a human
+      # instead of a blind retry that could double-transfer once Stripe's own idempotency window
+      # (24h) has lapsed.
       { entry:, verdict: :error, reason: "#{e.class}: #{e.message}" }
     end
 

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -195,6 +195,11 @@ alert_on_negative_destination_balances:
   class: AlertOnNegativeDestinationBalancesJob
   queue: low
   description: Reports payable sellers whose Gumroad-managed Stripe account carries a negative destination ledger from FX residue
+auto_topup_negative_destination_balances:
+  cron: "30 11 * * *" # UTC 11:30, after the report above so the two runs describe the same day's candidates
+  class: AutoTopUpNegativeDestinationBalancesJob
+  queue: low
+  description: Dry-run (flag-gated) top-up of the Stripe-side gap for negative destination balances; zeroing the internal ledger row stays a human decision
 alert_on_stalled_post_email_blasts:
   cron: "40 11 * * *" # UTC 11:40
   class: AlertOnStalledPostEmailBlastsJob

--- a/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
@@ -97,6 +97,27 @@ describe AlertOnNegativeDestinationBalancesJob do
     )
   end
 
+  it "carries post-cutoff rows in the below-minimum candidate's balance ids so funded credit past the cutoff keeps its TTL" do
+    residue_row(-728_50)
+    make_payable
+
+    other = create(:user)
+    other_account = create(:merchant_account, user: other, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                              charge_processor_merchant_id: "acct_negdest_#{SecureRandom.hex(6)}",
+                                              currency: Currency::PHP, country: "PH")
+    in_cycle_row = create(:balance, user: other, merchant_account: other_account, date: in_cycle_date,
+                                    amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: -100_00)
+    post_cutoff_row = create(:balance, user: other, merchant_account: other_account,
+                                       date: User::PayoutSchedule.next_scheduled_payout_end_date + 1,
+                                       amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: 25_00)
+
+    scan = described_class.scan
+
+    expect(scan[:unreconciled_not_payable]).to contain_exactly(
+      { merchant_account: other_account, balance_ids: [in_cycle_row.id, post_cutoff_row.id] }
+    )
+  end
+
   it "stays silent for a negative destination total matched by a negative USD ledger, which is refund netting the payout handles" do
     create(:balance, user: seller, merchant_account:, date: in_cycle_date,
                      amount_cents: -728_50, holding_currency: Currency::PHP, holding_amount_cents: -728_50)

--- a/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/alert_on_negative_destination_balances_job_spec.rb
@@ -79,6 +79,24 @@ describe AlertOnNegativeDestinationBalancesJob do
     end
   end
 
+  it "exposes the below-minimum tripped candidate's own balance ids for the consumer's off-scan TTL refresh" do
+    residue_row(-728_50)
+    make_payable
+
+    other = create(:user)
+    other_account = create(:merchant_account, user: other, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                                              charge_processor_merchant_id: "acct_negdest_#{SecureRandom.hex(6)}",
+                                              currency: Currency::PHP, country: "PH")
+    other_row = create(:balance, user: other, merchant_account: other_account, date: in_cycle_date,
+                                 amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: -100_00)
+
+    scan = described_class.scan
+
+    expect(scan[:unreconciled_not_payable]).to contain_exactly(
+      { merchant_account: other_account, balance_ids: [other_row.id] }
+    )
+  end
+
   it "stays silent for a negative destination total matched by a negative USD ledger, which is refund netting the payout handles" do
     create(:balance, user: seller, merchant_account:, date: in_cycle_date,
                      amount_cents: -728_50, holding_currency: Currency::PHP, holding_amount_cents: -728_50)

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -716,4 +716,54 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     $redis.del("#{dedupe_key}:unresolved")
     $redis.del("#{dedupe_key}:lock")
   end
+
+  it "noops when a refund/credit nets the window's USD ledger negative between scan and the live re-read" do
+    row = residue_row(-100_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+
+    # After the scan already flagged this candidate, a refund lands: amount_cents (the USD ledger)
+    # goes negative for the same row while holding_amount_cents stays negative too. resolve_entry's
+    # own `next if set.sum(:amount_cents).negative?` guard caught this at scan time; a refund arriving
+    # after the scan but before this account's turn must trip the same guard on the live re-read.
+    allow(AlertOnNegativeDestinationBalancesJob).to receive(:scan).and_wrap_original do |original|
+      result = original.call
+      row.update!(amount_cents: -100_00)
+      result
+    end
+
+    expect(StripeTransferInternallyToCreator).not_to receive(:transfer_funds_to_account)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to start_with("Topped up 0 of 1 candidates")
+    end
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+  end
+
+  it "escalates instead of resending when Stripe accepts the transfer but Redis persist keeps failing" do
+    residue_row(-100_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+
+    allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account)
+    # Simulates a Redis outage that outlives the accepted transfer: every `persist` call after
+    # Stripe already accepted the money fails, so the durable dedupe write can never land.
+    allow($redis).to receive(:persist).and_call_original
+    allow($redis).to receive(:persist).with(a_string_matching(/:0:10000\z/)).and_raise(Redis::BaseConnectionError)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async).with(anything, anything, a_string_including("durable dedupe claim could not be confirmed")).once
+    # The claim must still be held on its original TTL, not lost — a human has to confirm with
+    # Stripe before either key can be cleared, so a later run doesn't resend the accepted transfer.
+    expect($redis.get("#{dedupe_key}:unresolved")).to eq("10000")
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(dedupe_key)
+    $redis.del("#{dedupe_key}:unresolved")
+  end
 end

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -162,6 +162,32 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     Feature.deactivate(:auto_topup_negative_destination_balances)
   end
 
+  it "re-reads on the cycle window, not the whole ledger, when a post-cutoff credit would otherwise mask an in-cycle shortfall" do
+    in_cycle_row = residue_row(-728_50)
+    post_cutoff_credit = create(:balance, user: seller, merchant_account:,
+                                          date: User::PayoutSchedule.next_scheduled_payout_end_date + 1,
+                                          amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: 728_50)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+
+    # Whole ledger nets to 0 (the post-cutoff credit offsets the in-cycle shortfall), but the
+    # cycle window the weekly run actually pays is still -728_50 — the window resolve_entry's
+    # full_total used and the one this re-read must preserve.
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(
+      hash_including(amount_cents: 728_50)
+    )
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to start_with("Topped up 1 of 1 candidates")
+    end
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+    _ = [in_cycle_row, post_cutoff_credit]
+  end
+
   it "escalates a RETIRED merchant account instead of attempting a transfer" do
     residue_row(-728_50)
     make_payable

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -304,4 +304,50 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
     $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:0:72850")
   end
+
+  it "does not overfund when only one of two previously-funded rows reconciles, leaving the other still outstanding" do
+    row_a = residue_row(-100_00)
+    residue_row(-150_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(hash_including(amount_cents: 250_00)).once
+    described_class.new.perform
+
+    # Only row_a reconciles; row_b (still unpaid, still funded) survives — partial reconciliation.
+    row_a.mark_processing!
+    row_a.mark_paid!
+
+    expect(StripeTransferInternallyToCreator).not_to receive(:transfer_funds_to_account)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async).with(anything, anything, a_string_including("ESCALATE")).once
+    expect($redis.get(dedupe_key).to_i).to eq(250_00) # unchanged — row_b's funding credit must survive row_a's reconciliation
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+  end
+
+  it "serializes overlapping runs for the same account so a stale read cannot produce two transfers for one shortfall" do
+    residue_row(-100_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+    lock_key = "#{dedupe_key}:lock"
+
+    # Simulate a concurrent run already holding the per-account lock.
+    $redis.set(lock_key, 1, ex: 60, nx: true)
+
+    expect(StripeTransferInternallyToCreator).not_to receive(:transfer_funds_to_account)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async).with(anything, anything, a_string_including("already in progress")).once
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+    $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:lock")
+  end
 end

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AutoTopUpNegativeDestinationBalancesJob do
+  let(:seller) { create(:user) }
+  let(:in_cycle_date) { User::PayoutSchedule.next_scheduled_payout_end_date - 1 }
+  let(:merchant_account) do
+    create(:merchant_account, user: seller, charge_processor_id: StripeChargeProcessor.charge_processor_id,
+                              charge_processor_merchant_id: "acct_autotopup_#{SecureRandom.hex(6)}",
+                              currency: Currency::PHP, country: "PH")
+  end
+
+  def residue_row(cents, date: in_cycle_date)
+    create(:balance, user: seller, merchant_account:, date:,
+                     amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: cents)
+  end
+
+  def make_payable(cents = 200_00)
+    create(:balance, user: seller, merchant_account: MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id),
+                     date: in_cycle_date, amount_cents: cents, holding_amount_cents: cents)
+    seller.reload
+  end
+
+  before do
+    allow(InternalNotificationWorker).to receive(:perform_async)
+  end
+
+  it "stays silent when nothing is payable" do
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).not_to have_received(:perform_async)
+  end
+
+  it "dry-runs by default without calling Stripe" do
+    residue_row(-728_50)
+    make_payable
+
+    expect(StripeTransferInternallyToCreator).not_to receive(:transfer_funds_to_account)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |room, subject, message|
+      expect(room).to eq("payouts")
+      expect(subject).to eq("Negative destination balance top-ups")
+      expect(message).to include("DRY RUN")
+      expect(message).to include("would top up 1 of 1 candidates")
+    end
+  end
+
+  it "transfers funds to close the gap when the flag is live" do
+    residue_row(-728_50)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(
+      hash_including(stripe_account_id: merchant_account.charge_processor_merchant_id, currency: Currency::PHP, amount_cents: 728_50)
+    )
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to start_with("Topped up 1 of 1 candidates")
+    end
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+  end
+
+  it "escalates a RETIRED merchant account instead of attempting a transfer" do
+    residue_row(-728_50)
+    make_payable
+    merchant_account.mark_deleted!
+    Feature.activate(:auto_topup_negative_destination_balances)
+
+    expect(StripeTransferInternallyToCreator).not_to receive(:transfer_funds_to_account)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to include("ESCALATE")
+      expect(message).to include("RETIRED")
+    end
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+  end
+
+  it "turns a Stripe failure into a named error line without stopping the run" do
+    residue_row(-728_50)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+
+    allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).and_raise(Stripe::InvalidRequestError.new("boom", nil))
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to include("ERROR")
+      expect(message).to include("boom")
+    end
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+  end
+end

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -113,6 +113,33 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     Feature.deactivate(:auto_topup_negative_destination_balances)
   end
 
+  it "includes rows created after the scan in the transfer decision and idempotency fingerprint" do
+    row = residue_row(-100_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+    new_row = nil
+
+    allow(AlertOnNegativeDestinationBalancesJob).to receive(:scan).and_wrap_original do |original|
+      result = original.call
+      new_row = residue_row(-50_00)
+      result
+    end
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(
+      hash_including(
+        amount_cents: 150_00,
+        idempotency_key: satisfy { |key| key == "#{dedupe_key}:#{fingerprint_for(row.id, new_row.id)}:0:15000" }
+      )
+    )
+
+    described_class.new.perform
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(dedupe_key) if dedupe_key
+    $redis.del("#{dedupe_key}:#{fingerprint_for(row.id, new_row&.id)}:0:15000") if dedupe_key && new_row
+  end
+
   it "withholds a post-cutoff-only candidate for human review instead of transferring" do
     residue_row(-728_50)
     make_payable
@@ -570,6 +597,31 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     $redis.del(dedupe_key)
     $redis.del("#{dedupe_key}:#{fingerprint_for(row.id)}:0:10000")
     $redis.del("#{dedupe_key}:#{fingerprint_for(row.id, new_row&.id)}:10000:15000") if new_row
+  end
+
+  it "keeps a surviving funded row's TTL alive even when a positive row masks the account from the scan" do
+    row = residue_row(-100_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(hash_including(amount_cents: 100_00)).once
+    described_class.new.perform
+    expect($redis.get(dedupe_key).to_i).to eq(100_00)
+    $redis.expire(dedupe_key, 1.hour)
+
+    # The funded row still exists, but an offsetting positive row makes both account-level scan
+    # windows non-negative. It will not appear in payable or unreconciled_not_payable, so only the
+    # redis-key sweep can keep its funded credit from lapsing.
+    residue_row(150_00)
+
+    described_class.new.perform
+
+    expect($redis.ttl(dedupe_key)).to be > 1.hour
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(dedupe_key)
+    $redis.del("#{dedupe_key}:#{fingerprint_for(row.id)}:0:10000")
   end
 
   it "escalates instead of double-transferring when a second run acquires an expired account lock while the first is still mid-Stripe-call" do

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -88,6 +88,31 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
   end
 
+  it "re-reads the Balance rows instead of trusting the scan snapshot, so a reconciliation between scan and transfer noops instead of transferring a stale amount" do
+    row = residue_row(-728_50)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+
+    # A leg-two reconciliation pass (or a payout, refund, or credit) can zero this row after
+    # `scan` already captured it but before this account's turn to transfer — the mechanism
+    # T-Rex's stale-snapshot finding proved.
+    allow(AlertOnNegativeDestinationBalancesJob).to receive(:scan).and_wrap_original do |original|
+      result = original.call
+      row.update!(holding_amount_cents: 0)
+      result
+    end
+
+    expect(StripeTransferInternallyToCreator).not_to receive(:transfer_funds_to_account)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to start_with("Topped up 0 of 1 candidates")
+    end
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+  end
+
   it "withholds a post-cutoff-only candidate for human review instead of transferring" do
     residue_row(-728_50)
     make_payable

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -138,4 +138,23 @@ describe AutoTopUpNegativeDestinationBalancesJob do
   ensure
     Feature.deactivate(:auto_topup_negative_destination_balances)
   end
+
+  it "releases the dedupe claim on a Stripe failure so the next run can retry instead of being blocked for 7 days" do
+    residue_row(-728_50)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+
+    allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).and_raise(Stripe::InvalidRequestError.new("boom", nil))
+    described_class.new.perform
+
+    expect($redis.get(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))).to be_nil
+
+    allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).and_call_original
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).once
+
+    described_class.new.perform
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+  end
 end

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -362,8 +362,10 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     described_class.new.perform
 
     # By the time perform returns the lock is released again, so assert the TTL it was set with
-    # rather than its live value — a 60s lock would have let a second run acquire it mid-Stripe-call.
-    expect($redis).to have_received(:set).with(lock_key, 1, ex: 300, nx: true)
+    # rather than its live value — an expired-mid-call lock would have let a second run acquire it.
+    worst_case_stripe_call = Stripe.read_timeout * (Stripe.max_network_retries + 1)
+    expect(described_class::LOCK_TTL).to be > worst_case_stripe_call.seconds
+    expect($redis).to have_received(:set).with(lock_key, anything, ex: described_class::LOCK_TTL.to_i, nx: true)
   ensure
     Feature.deactivate(:auto_topup_negative_destination_balances)
     $redis.del(dedupe_key)
@@ -409,5 +411,44 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     Feature.deactivate(:auto_topup_negative_destination_balances)
     $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
     $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:0:72850")
+  end
+
+  it "does not release a lock held by a different run's token, so a CAS race can't let a third run in early" do
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+    lock_key = "#{dedupe_key}:lock"
+    $redis.set(lock_key, "someone-elses-token", nx: true)
+
+    # Simulates this job's own release firing after its lock already expired and got reacquired
+    # by a second run — the CAS comparison must refuse to delete a token it didn't set.
+    $redis.eval(described_class::LOCK_RELEASE_SCRIPT, keys: [lock_key], argv: ["stale-token"])
+
+    expect($redis.get(lock_key)).to eq("someone-elses-token")
+  ensure
+    $redis.del(lock_key)
+  end
+
+  it "escalates a grown shortfall rather than computing a delta against funded_cents while a prior transfer's outcome is unresolved" do
+    residue_row(-100_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+
+    allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).and_raise(Stripe::APIConnectionError.new("connection dropped"))
+    described_class.new.perform
+    expect($redis.get("#{dedupe_key}:unresolved")).to eq("10000")
+
+    # The shortfall grows before the ambiguous Stripe outcome is resolved — must not fund the
+    # naive delta (which would ignore the possibly-already-sent 100_00 and risk overfunding).
+    residue_row(-50_00)
+    expect(StripeTransferInternallyToCreator).not_to receive(:transfer_funds_to_account)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async).with(anything, anything, a_string_including("ambiguous Stripe outcome")).once
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(dedupe_key)
+    $redis.del("#{dedupe_key}:unresolved")
+    $redis.del("#{dedupe_key}:0:10000")
   end
 end

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -432,6 +432,30 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:#{fingerprint_for(row.id)}:0:72850")
   end
 
+  it "escalates distinctly when Redis persist fails after an ambiguous Stripe error, instead of leaving the claim on its 7-day TTL" do
+    row = residue_row(-728_50)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+    transfer_key = "#{dedupe_key}:#{fingerprint_for(row.id)}:0:72850"
+
+    allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).and_raise(Stripe::APIConnectionError.new("connection dropped"))
+    allow($redis).to receive(:persist).with(transfer_key).and_raise(Redis::BaseConnectionError.new("blip")).at_least(:once)
+    described_class.new.perform
+
+    expect($redis.get(transfer_key)).not_to be_nil # held, not released
+    expect($redis.ttl(transfer_key)).to be_within(2).of(604_800) # persist never landed — still on the original 7-day TTL, not confirmed persisted
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to include("ESCALATE")
+      expect(message).to include("could not be confirmed in Redis")
+    end
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+    $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:#{fingerprint_for(row.id)}:0:72850")
+  end
+
   it "releases the dedupe claim on a validation-style Stripe error, so the candidate is retryable" do
     row = residue_row(-728_50)
     make_payable

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -157,4 +157,39 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     Feature.deactivate(:auto_topup_negative_destination_balances)
     $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
   end
+
+  it "refreshes the dedupe TTL instead of letting it lapse while a candidate is still outstanding" do
+    residue_row(-728_50)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).once
+
+    described_class.new.perform
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+    $redis.expire(dedupe_key, 1.hour)
+
+    described_class.new.perform
+
+    expect($redis.ttl(dedupe_key)).to be > 1.hour
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+  end
+
+  it "passes a stable idempotency key to Stripe so an ambiguous local retry doesn't double-transfer" do
+    residue_row(-728_50)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(
+      hash_including(idempotency_key: dedupe_key)
+    )
+
+    described_class.new.perform
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+  end
 end

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -217,6 +217,28 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
   end
 
+  it "funds a new independent shortfall instead of treating it as already covered, once the old funded rows are reconciled" do
+    old_row = residue_row(-100_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(hash_including(amount_cents: 100_00)).once
+    described_class.new.perform
+
+    # Leg two reconciles: the old row is paid off and a new, unrelated shortfall lands.
+    old_row.mark_processing!
+    old_row.mark_paid!
+    residue_row(-50_00)
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(hash_including(amount_cents: 50_00)).once
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async).with(anything, anything, a_string_including("ESCALATE")).exactly(0).times
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+  end
+
   it "keeps escalating without a second transfer when the shortfall is unchanged or has shrunk" do
     residue_row(-100_00)
     make_payable

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -350,4 +350,64 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
     $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:lock")
   end
+
+  it "holds the per-account lock long enough to outlive a real Stripe call, not just the local read-decide step" do
+    residue_row(-100_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+    lock_key = "#{dedupe_key}:lock"
+    allow($redis).to receive(:set).and_call_original
+
+    described_class.new.perform
+
+    # By the time perform returns the lock is released again, so assert the TTL it was set with
+    # rather than its live value — a 60s lock would have let a second run acquire it mid-Stripe-call.
+    expect($redis).to have_received(:set).with(lock_key, 1, ex: 300, nx: true)
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(dedupe_key)
+    $redis.del(lock_key)
+  end
+
+  it "credits only the surviving funded rows, not the whole prior aggregate, so a new shortfall next to an untouched funded row is not suppressed" do
+    row_a = residue_row(-100_00)
+    residue_row(-200_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(hash_including(amount_cents: 300_00)).once
+    described_class.new.perform
+
+    # row_a reconciles; row_b (still funded) survives; a brand-new, unrelated row_c lands alongside it.
+    row_a.mark_processing!
+    row_a.mark_paid!
+    residue_row(-50_00)
+
+    # Only row_b's 200_00 credit should carry forward — the aggregate 300_00 must not swallow row_c's
+    # new 50_00 shortfall (the exact "Aggregate credit suppresses new negative rows" scenario).
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(hash_including(amount_cents: 50_00)).once
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async).with(anything, anything, a_string_including("ESCALATE")).exactly(0).times
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+  end
+
+  it "persists the transfer claim the instant Stripe accepts, before the funded-state write, so a crash in between can't be retried once the local TTL lapses" do
+    residue_row(-728_50)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+    transfer_key = "#{dedupe_key}:0:72850"
+
+    described_class.new.perform
+
+    expect($redis.ttl(transfer_key)).to eq(-1) # persisted, not left on the 7-day TTL
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+    $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:0:72850")
+  end
 end

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -66,6 +66,44 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     Feature.deactivate(:auto_topup_negative_destination_balances)
   end
 
+  it "does not repeat a transfer for an unchanged candidate on a later run" do
+    residue_row(-728_50)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).once
+
+    described_class.new.perform
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async).with(anything, anything, a_string_including("ESCALATE")).once
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+  end
+
+  it "withholds a post-cutoff-only candidate for human review instead of transferring" do
+    residue_row(-728_50)
+    make_payable
+    allow(AlertOnNegativeDestinationBalancesJob).to receive(:scan).and_wrap_original do |original|
+      result = original.call
+      result[:payable] = result[:payable].map { |entry| entry.merge(post_cutoff: true) }
+      result
+    end
+    Feature.activate(:auto_topup_negative_destination_balances)
+
+    expect(StripeTransferInternallyToCreator).not_to receive(:transfer_funds_to_account)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to include("ESCALATE")
+      expect(message).to include("post-cutoff")
+    end
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+  end
+
   it "escalates a RETIRED merchant account instead of attempting a transfer" do
     residue_row(-728_50)
     make_payable

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -510,6 +510,43 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     $redis.del("#{dedupe_key}:#{fingerprint_for(row.id)}:0:10000")
   end
 
+  it "keeps a surviving row's funded-state TTL alive while its account is below minimum, off the payable scan entirely" do
+    row = residue_row(-100_00)
+    payable_balance = create(:balance, user: seller, merchant_account: MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id),
+                                       date: in_cycle_date, amount_cents: 200_00, holding_amount_cents: 200_00)
+    seller.reload
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(hash_including(amount_cents: 100_00)).once
+    described_class.new.perform
+    expect($redis.get(dedupe_key).to_i).to eq(100_00)
+    $redis.expire(dedupe_key, 1.hour)
+
+    # The account drops below its payout minimum: `scan[:payable]` is empty, and this row's only
+    # trace is `unreconciled_not_payable`. Without the off-scan refresh, `perform` would return
+    # before touching the TTL at all (payable is empty) and it would lapse.
+    payable_balance.update!(amount_cents: 0, holding_amount_cents: 0)
+    seller.reload
+    described_class.new.perform
+
+    expect($redis.ttl(dedupe_key)).to be > 1.hour
+
+    # Now a brand-new, independent row lands and the account is payable again. The surviving
+    # 100_00 credit must still be recognized so only the new row's delta is funded.
+    new_row = residue_row(-50_00)
+    payable_balance.update!(amount_cents: 200_00, holding_amount_cents: 200_00)
+    seller.reload
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(hash_including(amount_cents: 50_00)).once
+
+    described_class.new.perform
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(dedupe_key)
+    $redis.del("#{dedupe_key}:#{fingerprint_for(row.id)}:0:10000")
+    $redis.del("#{dedupe_key}:#{fingerprint_for(row.id, new_row&.id)}:10000:15000") if new_row
+  end
+
   it "escalates instead of double-transferring when a second run acquires an expired account lock while the first is still mid-Stripe-call" do
     residue_row(-100_00)
     make_payable

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -22,6 +22,12 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     seller.reload
   end
 
+  # Mirrors the job's own row_fingerprint so specs can predict a transfer_key without
+  # hardcoding an id-dependent hash.
+  def fingerprint_for(*balance_ids)
+    Digest::SHA1.hexdigest(balance_ids.join("-"))[0, 12]
+  end
+
   before do
     allow(InternalNotificationWorker).to receive(:perform_async)
   end
@@ -178,13 +184,13 @@ describe AutoTopUpNegativeDestinationBalancesJob do
   end
 
   it "passes a stable idempotency key to Stripe so an ambiguous local retry doesn't double-transfer" do
-    residue_row(-728_50)
+    row = residue_row(-728_50)
     make_payable
     Feature.activate(:auto_topup_negative_destination_balances)
     dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
 
     expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(
-      hash_including(idempotency_key: "#{dedupe_key}:0:72850")
+      hash_including(idempotency_key: "#{dedupe_key}:#{fingerprint_for(row.id)}:0:72850")
     )
 
     described_class.new.perform
@@ -194,7 +200,7 @@ describe AutoTopUpNegativeDestinationBalancesJob do
   end
 
   it "funds only the incremental delta when a reconciled shortfall grows before leg two lands" do
-    residue_row(-100_00)
+    row1 = residue_row(-100_00)
     make_payable
     Feature.activate(:auto_topup_negative_destination_balances)
     dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
@@ -203,15 +209,38 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     described_class.new.perform
     expect($redis.get(dedupe_key).to_i).to eq(100_00)
 
-    residue_row(-150_00) # total shortfall is now 250_00 cents across both rows
+    row2 = residue_row(-150_00) # total shortfall is now 250_00 cents across both rows
 
     expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(
-      hash_including(amount_cents: 150_00, idempotency_key: "#{dedupe_key}:10000:25000")
+      hash_including(amount_cents: 150_00, idempotency_key: "#{dedupe_key}:#{fingerprint_for(row1.id, row2.id)}:10000:25000")
     )
 
     described_class.new.perform
 
     expect($redis.get(dedupe_key).to_i).to eq(250_00)
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+  end
+
+  it "credits a mixed-sign funded set on the same signed basis as full_total, so a smaller net increment is still funded" do
+    residue_row(15_00_00)
+    residue_row(-20_00_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+
+    # Net shortfall is 50,000 cents (150,000 - 200,000).
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(hash_including(amount_cents: 5_00_00)).once
+    described_class.new.perform
+
+    # A new -30,000-cent row lands: net shortfall grows to 80,000 cents, a 30,000-cent increment.
+    # The bug summed |150,000| + |-200,000| = 350,000 cents of "credit" and withheld this entirely.
+    residue_row(-3_00_00)
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(hash_including(amount_cents: 3_00_00)).once
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async).with(anything, anything, a_string_including("ESCALATE")).exactly(0).times
   ensure
     Feature.deactivate(:auto_topup_negative_destination_balances)
     $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
@@ -260,7 +289,7 @@ describe AutoTopUpNegativeDestinationBalancesJob do
   end
 
   it "does not release the dedupe claim on an ambiguous Stripe error, so the candidate escalates rather than retries blind" do
-    residue_row(-728_50)
+    row = residue_row(-728_50)
     make_payable
     Feature.activate(:auto_topup_negative_destination_balances)
     dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
@@ -269,7 +298,7 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     described_class.new.perform
 
     expect($redis.get(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))).to be_nil # leg-two claim untouched by a transfer-scoped claim
-    transfer_key = "#{dedupe_key}:0:72850"
+    transfer_key = "#{dedupe_key}:#{fingerprint_for(row.id)}:0:72850"
     expect($redis.get(transfer_key)).not_to be_nil # held, not released — next run must not blindly retry
     expect($redis.ttl(transfer_key)).to eq(-1) # persisted: only a human clearing it can unblock a retry, never a lapsed TTL
 
@@ -280,11 +309,11 @@ describe AutoTopUpNegativeDestinationBalancesJob do
   ensure
     Feature.deactivate(:auto_topup_negative_destination_balances)
     $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
-    $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:0:72850")
+    $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:#{fingerprint_for(row.id)}:0:72850")
   end
 
   it "releases the dedupe claim on a validation-style Stripe error, so the candidate is retryable" do
-    residue_row(-728_50)
+    row = residue_row(-728_50)
     make_payable
     Feature.activate(:auto_topup_negative_destination_balances)
     dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
@@ -292,7 +321,7 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).and_raise(Stripe::InvalidRequestError.new("bad param", nil))
     described_class.new.perform
 
-    transfer_key = "#{dedupe_key}:0:72850"
+    transfer_key = "#{dedupe_key}:#{fingerprint_for(row.id)}:0:72850"
     expect($redis.get(transfer_key)).to be_nil # released — safe to retry next run
 
     allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).and_call_original
@@ -302,7 +331,7 @@ describe AutoTopUpNegativeDestinationBalancesJob do
   ensure
     Feature.deactivate(:auto_topup_negative_destination_balances)
     $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
-    $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:0:72850")
+    $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:#{fingerprint_for(row.id)}:0:72850")
   end
 
   it "does not overfund when only one of two previously-funded rows reconciles, leaving the other still outstanding" do
@@ -398,11 +427,11 @@ describe AutoTopUpNegativeDestinationBalancesJob do
   end
 
   it "persists the transfer claim the instant Stripe accepts, before the funded-state write, so a crash in between can't be retried once the local TTL lapses" do
-    residue_row(-728_50)
+    row = residue_row(-728_50)
     make_payable
     Feature.activate(:auto_topup_negative_destination_balances)
     dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
-    transfer_key = "#{dedupe_key}:0:72850"
+    transfer_key = "#{dedupe_key}:#{fingerprint_for(row.id)}:0:72850"
 
     described_class.new.perform
 
@@ -410,7 +439,7 @@ describe AutoTopUpNegativeDestinationBalancesJob do
   ensure
     Feature.deactivate(:auto_topup_negative_destination_balances)
     $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
-    $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:0:72850")
+    $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:#{fingerprint_for(row.id)}:0:72850")
   end
 
   it "does not release a lock held by a different run's token, so a CAS race can't let a third run in early" do
@@ -428,7 +457,7 @@ describe AutoTopUpNegativeDestinationBalancesJob do
   end
 
   it "escalates a grown shortfall rather than computing a delta against funded_cents while a prior transfer's outcome is unresolved" do
-    residue_row(-100_00)
+    row = residue_row(-100_00)
     make_payable
     Feature.activate(:auto_topup_negative_destination_balances)
     dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
@@ -449,6 +478,6 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     Feature.deactivate(:auto_topup_negative_destination_balances)
     $redis.del(dedupe_key)
     $redis.del("#{dedupe_key}:unresolved")
-    $redis.del("#{dedupe_key}:0:10000")
+    $redis.del("#{dedupe_key}:#{fingerprint_for(row.id)}:0:10000")
   end
 end

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -184,12 +184,101 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
 
     expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(
-      hash_including(idempotency_key: dedupe_key)
+      hash_including(idempotency_key: "#{dedupe_key}:0:72850")
     )
 
     described_class.new.perform
   ensure
     Feature.deactivate(:auto_topup_negative_destination_balances)
     $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+  end
+
+  it "funds only the incremental delta when a reconciled shortfall grows before leg two lands" do
+    residue_row(-100_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(hash_including(amount_cents: 100_00)).once
+    described_class.new.perform
+    expect($redis.get(dedupe_key).to_i).to eq(100_00)
+
+    residue_row(-150_00) # total shortfall is now 250_00 cents across both rows
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(
+      hash_including(amount_cents: 150_00, idempotency_key: "#{dedupe_key}:10000:25000")
+    )
+
+    described_class.new.perform
+
+    expect($redis.get(dedupe_key).to_i).to eq(250_00)
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+  end
+
+  it "keeps escalating without a second transfer when the shortfall is unchanged or has shrunk" do
+    residue_row(-100_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(hash_including(amount_cents: 100_00)).once
+    described_class.new.perform
+
+    expect(StripeTransferInternallyToCreator).not_to receive(:transfer_funds_to_account)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async).with(anything, anything, a_string_including("ESCALATE")).once
+    expect($redis.get(dedupe_key).to_i).to eq(100_00)
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+  end
+
+  it "does not release the dedupe claim on an ambiguous Stripe error, so the candidate escalates rather than retries blind" do
+    residue_row(-728_50)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+
+    allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).and_raise(Stripe::APIConnectionError.new("connection dropped"))
+    described_class.new.perform
+
+    expect($redis.get(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))).to be_nil # leg-two claim untouched by a transfer-scoped claim
+    transfer_key = "#{dedupe_key}:0:72850"
+    expect($redis.get(transfer_key)).not_to be_nil # held, not released — next run must not blindly retry
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+      expect(message).to include("ERROR")
+      expect(message).to include("APIConnectionError")
+    end
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+    $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:0:72850")
+  end
+
+  it "releases the dedupe claim on a validation-style Stripe error, so the candidate is retryable" do
+    residue_row(-728_50)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+
+    allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).and_raise(Stripe::InvalidRequestError.new("bad param", nil))
+    described_class.new.perform
+
+    transfer_key = "#{dedupe_key}:0:72850"
+    expect($redis.get(transfer_key)).to be_nil # released — safe to retry next run
+
+    allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).and_call_original
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).once
+
+    described_class.new.perform
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))
+    $redis.del("#{RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)}:0:72850")
   end
 end

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -271,6 +271,7 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     expect($redis.get(RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id))).to be_nil # leg-two claim untouched by a transfer-scoped claim
     transfer_key = "#{dedupe_key}:0:72850"
     expect($redis.get(transfer_key)).not_to be_nil # held, not released — next run must not blindly retry
+    expect($redis.ttl(transfer_key)).to eq(-1) # persisted: only a human clearing it can unblock a retry, never a lapsed TTL
 
     expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
       expect(message).to include("ERROR")

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -188,6 +188,48 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     _ = [in_cycle_row, post_cutoff_credit]
   end
 
+  it "does not resend the original shortfall when a later post-cutoff debit lands beside the funded row (two runs)" do
+    in_cycle_row = residue_row(-728_50)
+    post_cutoff_credit = create(:balance, user: seller, merchant_account:,
+                                          date: User::PayoutSchedule.next_scheduled_payout_end_date + 1,
+                                          amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: 728_50)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+
+    # Run 1: whole ledger nets to 0 (post-cutoff credit offsets it), so the cycle window
+    # (-728_50, the more negative of the two) is what's funded — same setup as the
+    # window-selection spec above. The funded credit this stores must be scoped to the WINDOW
+    # (in_cycle_row only), not the whole current row set (which also includes the post-cutoff
+    # credit row) — that's the bug this spec pins.
+    call_count = 0
+    allow(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account) { call_count += 1 }
+
+    described_class.new.perform
+    expect(call_count).to eq(1)
+
+    # Run 2: in_cycle_row is still unreconciled (leg two hasn't happened) and a brand-new
+    # post-cutoff debit lands. Whole ledger becomes -100_00 (less negative than the in-cycle
+    # window's -728_50), so the window is still in-cycle — current_total_cents is unchanged at
+    # -728_50, i.e. still the SAME shortfall this account was already funded for. If the stored
+    # funded credit wrongly included the post-cutoff credit row, its signed sum would net to 0
+    # against the unrelated new debit and the comparison below would see "no credit," resending
+    # the full 728_50 that was already transferred in run 1.
+    create(:balance, user: seller, merchant_account:,
+                     date: User::PayoutSchedule.next_scheduled_payout_end_date + 1,
+                     amount_cents: 0, holding_currency: Currency::PHP, holding_amount_cents: -100_00)
+
+    described_class.new.perform
+    expect(call_count).to eq(1)
+
+    expect(InternalNotificationWorker).to have_received(:perform_async).with(anything, anything, a_string_including("ESCALATE", "already topped up 728")).once
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(dedupe_key) if dedupe_key
+    $redis.del("#{dedupe_key}:#{fingerprint_for(in_cycle_row.id)}:0:72850") if dedupe_key
+    _ = post_cutoff_credit
+  end
+
   it "escalates a RETIRED merchant account instead of attempting a transfer" do
     residue_row(-728_50)
     make_payable

--- a/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
+++ b/spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb
@@ -480,4 +480,58 @@ describe AutoTopUpNegativeDestinationBalancesJob do
     $redis.del("#{dedupe_key}:unresolved")
     $redis.del("#{dedupe_key}:#{fingerprint_for(row.id)}:0:10000")
   end
+
+  it "refreshes an account's funded-state TTL even when it falls outside the per-run processing cap" do
+    row = residue_row(-100_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+
+    expect(StripeTransferInternallyToCreator).to receive(:transfer_funds_to_account).with(hash_including(amount_cents: 100_00)).once
+    described_class.new.perform
+    expect($redis.get(dedupe_key).to_i).to eq(100_00)
+    $redis.expire(dedupe_key, 1.hour) # simulate the funded-state TTL nearly lapsing
+
+    # Stub the scan so this account's candidate is pushed past MAX_TOPUPS_PER_RUN, exercising the
+    # exact "outside the cap" path the finding describes.
+    allow(AlertOnNegativeDestinationBalancesJob).to receive(:scan).and_wrap_original do |original|
+      result = original.call
+      filler = result[:payable].first.merge(merchant_account: merchant_account, full_total: 0, balance_ids: [])
+      result[:payable] = [filler] * AutoTopUpNegativeDestinationBalancesJob::MAX_TOPUPS_PER_RUN + result[:payable]
+      result
+    end
+
+    described_class.new.perform
+
+    expect($redis.ttl(dedupe_key)).to be > 1.hour
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(dedupe_key)
+    $redis.del("#{dedupe_key}:#{fingerprint_for(row.id)}:0:10000")
+  end
+
+  it "escalates instead of double-transferring when a second run acquires an expired account lock while the first is still mid-Stripe-call" do
+    residue_row(-100_00)
+    make_payable
+    Feature.activate(:auto_topup_negative_destination_balances)
+    dedupe_key = RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account.id)
+
+    # Simulate the first run: it claimed the account lock, marked the account unresolved (now
+    # done BEFORE the Stripe call), and is still mid-flight when its lock TTL lapses.
+    lock_key = "#{dedupe_key}:lock"
+    $redis.set(lock_key, "expired-run-token", ex: 1)
+    $redis.set("#{dedupe_key}:unresolved", 100_00)
+    sleep 1.1
+
+    expect(StripeTransferInternallyToCreator).not_to receive(:transfer_funds_to_account)
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async).with(anything, anything, a_string_including("ambiguous Stripe outcome")).once
+  ensure
+    Feature.deactivate(:auto_topup_negative_destination_balances)
+    $redis.del(dedupe_key)
+    $redis.del("#{dedupe_key}:unresolved")
+    $redis.del("#{dedupe_key}:lock")
+  end
 end


### PR DESCRIPTION
## Stages

- [x] **Scope** — gumroad-private#1903: build automated handler for negative destination balances alert.
- [x] **Design** — mirrors `RecoverStrandedBuyersJob`'s rollout pattern (gp#1902): daily Sidekiq job, dry-run by default behind a Flipper flag, real money moves only clear the FIRST of two repair legs.
- [x] **Build** — `AutoTopUpNegativeDestinationBalancesJob` + spec (27 examples, mutation-verified). Fixed two P1s from round 1 (post-cutoff escalation guard, redis-backed dedupe), one P1 from round 2 (dedupe claimed with `SET NX` before the Stripe call, not after), one P1 from round 3 (dedupe TTL refreshes on re-sighting instead of a fixed 7-day lapse; Stripe idempotency_key added), two P1s from round 4 (incremental-shortfall delta funding; only release the redis claim for Stripe errors that never charged), two P1s from round 5 (a stale funded-amount claim from an already-reconciled trip could wrongly withhold or under-fund a later, independent shortfall on the same account — the claim is now scoped to the specific balance rows it was measured against, not just the account; and the ambiguous-Stripe-error claim now persists with no TTL instead of lapsing on its own, since a fixed-duration hold defeats the point of holding it past Stripe's 24h idempotency window), two P1s from round 6 (partial reconciliation — clearing the funded claim when *any* previously-funded row disappeared, instead of requiring *all* of them gone, could wrongly overfund a still-outstanding sibling row; and a concurrent-run race — two overlapping runs could each read the same stale funded_cents and mint distinct amount-scoped transfer_keys, sending the full stale snapshot twice — now serialized behind a per-account redis lock), two P1s from round 7 (the lock release was a bare delete keyed only by expiry — a run whose lock expired mid-Stripe-call and got reacquired by a second run could have that second run's lock deleted out from under it by the first run's `ensure`, now a CAS comparing a per-run token before deleting; and an ambiguous Stripe outcome only blocked its own amount-specific transfer_key, so a shortfall that grew before the outcome was resolved computed its delta against a `funded_cents` that never accounted for the possibly-already-sent amount — now an account-level `:unresolved` marker forces escalation on every later run until a human resolves it), two P1s from round 8 (the transfer_key was scoped to funded/target amounts only, so two UNRELATED same-amount shortfalls on the same account collided and the second was silently withheld forever — added a row-set SHA1 fingerprint to the key; and surviving funded credit was summed per-row `.abs` instead of signed, so a mixed-sign funded set overstated credit and withheld a real increment — credit is now summed signed to match `full_total`'s basis), two P1s from round 9 (a candidate excluded by the per-run cap never refreshed its funded-state TTL, so a still-unreconciled account could lose its funding credit mid-week and get re-funded for an already-topped-up row — a new pass now refreshes the TTL for every payable candidate, capped or not; and the per-account lock's expiry wasn't itself guarded against, so a Stripe call outliving `LOCK_TTL` let a second run acquire the expired lock and mint a distinct transfer_key before the first call's outcome was known — the account's `:unresolved` marker is now set before the Stripe call, not only from the ambiguous-error rescue), and one P1 from round 10 (the account lock only serialized this job's own runs against each other, not against every other writer of `holding_amount_cents` — a payout, refund, credit, or the leg-two reconciliation pass could change the scanned Balance rows between `scan` and this account's turn, and the job would still transfer against the stale total; `topup` now re-reads `Balance.unpaid.where(id: entry[:balance_ids])` right before deciding and uses that fresh total everywhere downstream instead of `entry[:full_total]`, noop-ing if the row set is no longer negative), and two P1s from round 11 (the live ledger re-read reloaded `holding_amount_cents` but never re-applied `resolve_entry`'s refund-netting guard, so a refund/credit landing after scan could still authorize an unnecessary transfer — the live window's `amount_cents` sum is now checked too; and a `persist(transfer_key)` failure right after Stripe accepted the transfer fell into the generic rescue, which repeated the same failing Redis call and left the claim on its original 7-day TTL instead of durably held — now retries a few times and escalates, keeping `unresolved_key` set, if persistence still can't be confirmed).
- [ ] **Ship** — draft until CI is green at head; the flag flip to live top-ups is a separate human decision, same as the recovery job's rollout.
- [ ] **Market** — n/a, internal risk tooling.
- [ ] **Sell** — n/a.

## What

Adds `AutoTopUpNegativeDestinationBalancesJob`, scheduled daily at UTC 11:30 (10 minutes after the existing `AlertOnNegativeDestinationBalancesJob` alert, so both runs describe the same day's candidate population — it reuses that job's exact scan via a new `AlertOnNegativeDestinationBalancesJob.scan` class method rather than re-deriving the query).

**Only the FIRST of the two repair legs is automated.** The existing alert's own message already documents the two-leg repair order: top up the Stripe-side balance first, then zero the internal `Balance` row(s) — doing it in the other order turns a short payout into a hard failure. This job automates leg one (`StripeTransferInternallyToCreator.transfer_funds_to_account`, gated behind a new `:auto_topup_negative_destination_balances` Flipper flag, default off/dry-run). Leg two — deciding which specific `Balance` row(s) absorb the correction when a candidate's negative total is the sum of several rows — stays a human decision, consistent with every prior drift-guard ticket (gp#989/#1027/#1042/#1082/#1127/#1849).

Because leg two is untouched, a candidate this job tops up will keep reappearing in the daily alert report until a human does the reconciliation pass — the job's own report message says so explicitly, so nobody reads a "topped up" line as "done."

RETIRED merchant accounts (Stripe account already closed) and post-cutoff-only trips (whole-ledger gap may not hold at payout time) are always escalated rather than attempted. A candidate the job already transferred for is also withheld — the redis key `RedisKey.auto_topup_negative_destination_balance_last_amount(merchant_account_id)` records the last transferred amount for 7 days, so daily reruns don't double-transfer while leg two is still pending.

## Why

gp#1903: "Build automated handler for negative destination balances alert." I'd previously told Sahil this was already covered by an autonomous drift-guard lane — that claim was wrong, no such job existed.

A "negative destination balance" is Stripe-held FX residue from a returned payout (gp#1717). Of the two repair legs, only the Stripe-side top-up is deterministic; picking which `Balance` rows absorb the correction needs judgment, so this PR automates the deterministic half only.

## Test Results

- `bundle exec rspec spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb` — 25 examples, all green (run locally borrowing lane 0's DB/Redis env, Ruby 3.4.3): silent when nothing payable, dry-run default, live transfer, unchanged/shrunk shortfall keeps escalating without a repeat transfer, incremental-delta funding, mixed-sign funded-credit funding a smaller net increment, post-cutoff withholding, RETIRED-account escalation, a safe (validation/rate-limit) Stripe error releasing the claim, an ambiguous (connection/timeout) Stripe error keeping a PERSISTED claim, dedupe TTL refresh, Stripe idempotency_key passthrough, an independent shortfall funding correctly once the previously-funded rows are actually reconciled, a two-row partial reconciliation that must NOT clear funding credit for the still-outstanding sibling row, a concurrent-run lock-held case that escalates instead of racing, a CAS-mismatch case where a stale token cannot delete a reacquired lock, a grown shortfall that must escalate (not fund a naive delta) while a prior transfer's outcome is unresolved, a funded-state TTL refresh for a candidate excluded by the per-run cap, and an expired-lock race where a second run must escalate instead of double-transferring.
- `bundle exec rubocop app/sidekiq/auto_top_up_negative_destination_balances_job.rb spec/sidekiq/auto_top_up_negative_destination_balances_job_spec.rb` — clean.
- No rendered surface — backend Sidekiq job only.

## Before → After

- Before: `AlertOnNegativeDestinationBalancesJob` reports payable sellers with a negative destination ledger; a human has to read the report and run the Stripe top-up by hand.
- After: the report still fires (unchanged), and a second job dry-runs (or, once the flag is flipped, actually performs) the top-up leg automatically, closing the recurring "seller's payout silently fails until someone reads the alert" gap. It now also withholds post-cutoff-only trips and never re-transfers an unchanged candidate.

Premerge review: clean @ 8adeb4ac42bff5d73731832f811eb2188a70695d (panel: codex gpt-5.6-sol + claude-fable-5, 0 findings)

**Fix round 11 (df12632fd, 2026-08-10):** @nyomanjyotisa's review found funded credit could include post-cutoff rows outside the window `current_total_cents` was actually summed over, so an unrelated later ledger change could net that stale credit against a new row and resend part of an already-funded shortfall. `current_window_ids` now scopes both the credit intersection and the stored dedupe key to the exact row set the window total came from. Two-run regression spec pins the resend (reverting the fix sends 2 transfers instead of 1). Full suite green (31 examples), rubocop clean. This marker is stale for `df12632fd` pending a fresh premerge pass — flagging rather than re-claiming clean.





**Fix round 12 (`8adeb4ac`, 2026-08-10):** Greptile review 4894104993 found the ambiguous-Stripe-error rescue's bare `$redis.persist(transfer_key)` could itself raise, leaving the claim on its original 7-day TTL — once that TTL and Stripe's 24h idempotency window both lapsed, clearing `unresolved_key` alone would let a later run resend the same ambiguous transfer. That path now goes through `persist_with_retries` (the same helper the accepted-transfer path already used) and escalates distinctly when the hold can't be confirmed. New mutation-verified spec (reverting the fix raises `Redis::BaseConnectionError` instead of escalating). Full spec file green (34 examples), rubocop clean. This marker is stale for `8adeb4ac` pending a fresh premerge pass — flagging rather than re-claiming clean.

