### PR TITLE
Fix payout-setup-rejection note staleness, 25-note scan cap, and nil bank-rejection note (#6927 follow-up)

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -1260,14 +1260,17 @@ module StripeMerchantAccountManager
     ADDRESS_SUBHASH_KEYS.any? { |address_key| entity[address_key].present? }
   end
 
-  # Leaf key names actually sent to Stripe, at any nesting depth — used to tell whether a
-  # rejection note's specific field (see stripe_rejected_field) was part of THIS submission.
+  # Key names actually sent to Stripe, at every nesting depth — used to tell whether a rejection
+  # note's specific field (see stripe_rejected_field below) was part of THIS submission.
+  # stripe_rejected_field records the LAST bracket segment of Stripe's param, which for a
+  # compound field like "individual[dob]" is the parent key "dob", not one of its day/month/year
+  # leaves — so parent keys must be included here too, not just leaves (Greptile finding).
   private_class_method
   def self.submitted_field_names(sent_attributes)
     return [] unless sent_attributes.is_a?(Hash)
 
     sent_attributes.flat_map do |key, value|
-      value.is_a?(Hash) ? submitted_field_names(value) : key.to_s
+      value.is_a?(Hash) ? [key.to_s] + submitted_field_names(value) : key.to_s
     end
   end
 

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -65,6 +65,10 @@ module StripeMerchantAccountManager
   # at that specific note rather than whatever seller-visible payout note happens to be newest.
   PAYOUT_SETUP_REJECTION_NOTE_FLAG = "payout_setup_rejection"
 
+  # The Stripe field name the note's rejection named (see stripe_rejected_field below), so a later
+  # update can tell whether IT resolved this note rather than some unrelated field.
+  PAYOUT_SETUP_REJECTED_FIELD_KEY = "payout_setup_rejected_field"
+
   # Prefix for the breadcrumb left when Stripe refuses the service agreement we derived from the
   # seller's legal-entity country. See update_account_attributes below.
   SERVICE_AGREEMENT_REJECTION_NOTE_PREFIX = "Stripe rejected service agreement"
@@ -581,10 +585,11 @@ module StripeMerchantAccountManager
       clear_stale_postal_code_failure_notes(user)
     end
 
-    # Reaching here means Stripe accepted the update without raising, so any earlier rejection
-    # marker is resolved — leaving it would send a seller whose setup now works back to fix an
-    # already-fixed field, or block a since-unrelated publish attempt with stale guidance.
-    clear_stale_payout_setup_rejection_notes(user)
+    # Only the specific field a prior rejection named is what that rejection's note describes —
+    # an unrelated accepted field (e.g. only the city changed) resolves nothing about it, and
+    # clearing on any success reverts to a seller-visible note vanishing for a still-unfixed
+    # rejection (Greptile finding on this PR).
+    clear_stale_payout_setup_rejection_notes(user, resolved_fields: submitted_field_names(account_update.sent_attributes))
   rescue Stripe::InvalidRequestError => e
     record_postal_code_failure_note(user, e) if notify && postal_code_invalid_error?(e)
     raise
@@ -1255,6 +1260,17 @@ module StripeMerchantAccountManager
     ADDRESS_SUBHASH_KEYS.any? { |address_key| entity[address_key].present? }
   end
 
+  # Leaf key names actually sent to Stripe, at any nesting depth — used to tell whether a
+  # rejection note's specific field (see stripe_rejected_field) was part of THIS submission.
+  private_class_method
+  def self.submitted_field_names(sent_attributes)
+    return [] unless sent_attributes.is_a?(Hash)
+
+    sent_attributes.flat_map do |key, value|
+      value.is_a?(Hash) ? submitted_field_names(value) : key.to_s
+    end
+  end
+
   def self.get_diff_attributes(current_attributes, last_attributes)
     # Stripe will error if we send unchanged data for locked fields of a verified user.
     # To work around this, we send only attributes that are not in last_attributes or are different in current_attributes.
@@ -1728,7 +1744,10 @@ module StripeMerchantAccountManager
     user.add_payout_note(
       content: seller_message,
       seller_visible: true,
-      json_data: { PAYOUT_SETUP_REJECTION_NOTE_FLAG => true }
+      json_data: {
+        PAYOUT_SETUP_REJECTION_NOTE_FLAG => true,
+        PAYOUT_SETUP_REJECTED_FIELD_KEY => stripe_rejected_field(error),
+      }
     )
   rescue => e
     # A missing breadcrumb must never turn into a second failure on top of the original
@@ -1755,14 +1774,26 @@ module StripeMerchantAccountManager
   # finding it. json_data is a serialized text column MySQL cannot filter on directly (same
   # constraint as the LIKE prefilter above), so the flag is narrowed with a LIKE on its serialized
   # form before the in-memory check that actually reads it.
+  #
+  # `resolved_fields: :all` clears every marked note regardless of which field it named — correct
+  # only at account creation, where there is no prior submission to have been partial. Other
+  # callers pass the fields they actually sent, so a note whose rejection named a specific field
+  # stays until that field is resubmitted and accepted, rather than being wiped by an unrelated
+  # accepted field. A note with no recorded field (undiagnosed rejections with no Stripe `param`,
+  # and notes written before this field was tracked) has nothing to scope to, so any success still
+  # clears it — that was the only behavior before this fix.
   private_class_method
-  def self.clear_stale_payout_setup_rejection_notes(user)
+  def self.clear_stale_payout_setup_rejection_notes(user, resolved_fields: :all)
     user.comments
         .with_type_payout_note
         .alive
         .where(author_id: GUMROAD_ADMIN_ID)
         .where("json_data LIKE ?", "%#{PAYOUT_SETUP_REJECTION_NOTE_FLAG}%")
         .select { |note| note.json_data[PAYOUT_SETUP_REJECTION_NOTE_FLAG] == true }
+        .select do |note|
+          rejected_field = note.json_data[PAYOUT_SETUP_REJECTED_FIELD_KEY]
+          resolved_fields == :all || rejected_field.nil? || resolved_fields.include?(rejected_field)
+        end
         .each { |note| note.update!(deleted_at: Time.current) }
   rescue => e
     Rails.logger.error "Failed to clear stale payout-setup-rejection notes for user #{user&.id}: #{e.class}: #{e.message}"

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -281,6 +281,7 @@ module StripeMerchantAccountManager
 
     clear_stale_postal_code_failure_notes(user)
     clear_stale_bank_sync_failure_notes(user)
+    clear_stale_payout_setup_rejection_notes(user)
 
     merchant_account
   rescue => e
@@ -579,6 +580,11 @@ module StripeMerchantAccountManager
     if person_address_submitted || address_submitted?(account_update.sent_attributes, entity_key)
       clear_stale_postal_code_failure_notes(user)
     end
+
+    # Reaching here means Stripe accepted the update without raising, so any earlier rejection
+    # marker is resolved — leaving it would send a seller whose setup now works back to fix an
+    # already-fixed field, or block a since-unrelated publish attempt with stale guidance.
+    clear_stale_payout_setup_rejection_notes(user)
   rescue Stripe::InvalidRequestError => e
     record_postal_code_failure_note(user, e) if notify && postal_code_invalid_error?(e)
     raise
@@ -1712,8 +1718,15 @@ module StripeMerchantAccountManager
       content: "#{ACCOUNT_REJECTION_NOTE_PREFIX}: #{details.join(' ')} — #{error.message.to_s.truncate(300)}",
       seller_visible: false
     )
+
+    # payout_setup_rejection_seller_message returns nil for bank-account rejections, which have
+    # their own dedicated seller messaging elsewhere — writing a note with nil content would fail
+    # Comment's presence validation and reach ErrorNotifier on every one of them.
+    seller_message = payout_setup_rejection_seller_message(error, user)
+    return if seller_message.blank?
+
     user.add_payout_note(
-      content: payout_setup_rejection_seller_message(error, user),
+      content: seller_message,
       seller_visible: true,
       json_data: { PAYOUT_SETUP_REJECTION_NOTE_FLAG => true }
     )
@@ -1734,6 +1747,25 @@ module StripeMerchantAccountManager
         .update_all(deleted_at: Time.current)
   rescue => e
     Rails.logger.error "Failed to clear stale postal-code failure notes for user #{user&.id}: #{e.class}: #{e.message}"
+    ErrorNotifier.notify(e)
+  end
+
+  # Deletes the marked seller-visible rejection note once the payout setup it describes has gone
+  # through, so `Link#publish_blocked_message` and `User#latest_payout_setup_rejection_note` stop
+  # finding it. json_data is a serialized text column MySQL cannot filter on directly (same
+  # constraint as the LIKE prefilter above), so the flag is narrowed with a LIKE on its serialized
+  # form before the in-memory check that actually reads it.
+  private_class_method
+  def self.clear_stale_payout_setup_rejection_notes(user)
+    user.comments
+        .with_type_payout_note
+        .alive
+        .where(author_id: GUMROAD_ADMIN_ID)
+        .where("json_data LIKE ?", "%#{PAYOUT_SETUP_REJECTION_NOTE_FLAG}%")
+        .select { |note| note.json_data[PAYOUT_SETUP_REJECTION_NOTE_FLAG] == true }
+        .each { |note| note.update!(deleted_at: Time.current) }
+  rescue => e
+    Rails.logger.error "Failed to clear stale payout-setup-rejection notes for user #{user&.id}: #{e.class}: #{e.message}"
     ErrorNotifier.notify(e)
   end
 

--- a/app/models/concerns/user/comments.rb
+++ b/app/models/concerns/user/comments.rb
@@ -33,14 +33,9 @@ module User::Comments
     recent_payout_notes.find { |note| PayoutNoteVisibility.seller_visible?(note) }
   end
 
-  # The newest payout note recorded because Stripe rejected the seller's payout setup, or nil.
-  # Marked with StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG when written, so a
-  # reader that needs this specific note is not left guessing from the newest visible one.
-  #
-  # Queried independently of recent_payout_notes' MAX_NOTES_SCANNED cap: that cap exists for the
-  # Payouts banner, which only ever wants the newest note regardless of which one it is. This
-  # reader wants one SPECIFIC note, which weekly-retry breadcrumbs and other payout notes can push
-  # past row 25 while it is still the live rejection blocking the seller.
+  # The marked Stripe payout-setup-rejection note, or nil. Queried independently of
+  # recent_payout_notes' MAX_NOTES_SCANNED cap because this wants one specific note, which other
+  # payout notes can push past row 25 while it is still the live rejection blocking the seller.
   def latest_payout_setup_rejection_note
     comments.with_type_payout_note
             .alive

--- a/app/models/concerns/user/comments.rb
+++ b/app/models/concerns/user/comments.rb
@@ -36,8 +36,18 @@ module User::Comments
   # The newest payout note recorded because Stripe rejected the seller's payout setup, or nil.
   # Marked with StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG when written, so a
   # reader that needs this specific note is not left guessing from the newest visible one.
+  #
+  # Queried independently of recent_payout_notes' MAX_NOTES_SCANNED cap: that cap exists for the
+  # Payouts banner, which only ever wants the newest note regardless of which one it is. This
+  # reader wants one SPECIFIC note, which weekly-retry breadcrumbs and other payout notes can push
+  # past row 25 while it is still the live rejection blocking the seller.
   def latest_payout_setup_rejection_note
-    recent_payout_notes.find { |note| note.json_data[StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG] == true }
+    comments.with_type_payout_note
+            .alive
+            .where(author_id: GUMROAD_ADMIN_ID)
+            .where("json_data LIKE ?", "%#{StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG}%")
+            .order(created_at: :desc, id: :desc)
+            .find { |note| note.json_data[StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG] == true }
   end
 
   # The newest payout note on the account, seller-facing or internal.

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_rejection_note_lifecycle_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_rejection_note_lifecycle_spec.rb
@@ -105,6 +105,24 @@ describe StripeMerchantAccountManager, ".clear_stale_payout_setup_rejection_note
 
     expect(unrelated.reload.deleted_at).to be_nil
   end
+
+  it "clears a note rejected on a compound field like dob when only its leaf keys were resubmitted (Greptile finding on round 2)" do
+    user.add_payout_note(
+      content: "Our payment partner couldn't accept the date of birth you entered.",
+      seller_visible: true,
+      json_data: {
+        StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG => true,
+        StripeMerchantAccountManager::PAYOUT_SETUP_REJECTED_FIELD_KEY => "dob",
+      }
+    )
+    submitted_fields = described_class.send(
+      :submitted_field_names, individual: { dob: { day: 2, month: 3, year: 1990 } }
+    )
+
+    described_class.send(:clear_stale_payout_setup_rejection_notes, user, resolved_fields: submitted_fields)
+
+    expect(user.latest_payout_setup_rejection_note).to be_nil
+  end
 end
 
 # update_account is the code path that resolves a prior rejection: a successful call to Stripe

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_rejection_note_lifecycle_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_rejection_note_lifecycle_spec.rb
@@ -56,14 +56,44 @@ end
 describe StripeMerchantAccountManager, ".clear_stale_payout_setup_rejection_notes" do
   let(:user) { create(:user) }
 
-  it "deletes the marked note once payout setup succeeds, so a later stale-payout-account lookup does not find it" do
+  it "deletes the marked note once the rejected field is resubmitted and accepted" do
     user.add_payout_note(
       content: "Our payment partner couldn't accept the Tax ID you entered.",
+      seller_visible: true,
+      json_data: {
+        StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG => true,
+        StripeMerchantAccountManager::PAYOUT_SETUP_REJECTED_FIELD_KEY => "id_number",
+      }
+    )
+
+    described_class.send(:clear_stale_payout_setup_rejection_notes, user, resolved_fields: ["id_number"])
+
+    expect(user.latest_payout_setup_rejection_note).to be_nil
+  end
+
+  it "leaves the note in place when an unrelated field was the one resubmitted" do
+    user.add_payout_note(
+      content: "Our payment partner couldn't accept the Tax ID you entered.",
+      seller_visible: true,
+      json_data: {
+        StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG => true,
+        StripeMerchantAccountManager::PAYOUT_SETUP_REJECTED_FIELD_KEY => "id_number",
+      }
+    )
+
+    described_class.send(:clear_stale_payout_setup_rejection_notes, user, resolved_fields: ["address"])
+
+    expect(user.latest_payout_setup_rejection_note).to be_present
+  end
+
+  it "clears a note with no recorded field on any success, same as before this fix" do
+    user.add_payout_note(
+      content: "Our payment partner couldn't accept the details you entered.",
       seller_visible: true,
       json_data: { StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG => true }
     )
 
-    described_class.send(:clear_stale_payout_setup_rejection_notes, user)
+    described_class.send(:clear_stale_payout_setup_rejection_notes, user, resolved_fields: ["address"])
 
     expect(user.latest_payout_setup_rejection_note).to be_nil
   end
@@ -71,15 +101,16 @@ describe StripeMerchantAccountManager, ".clear_stale_payout_setup_rejection_note
   it "leaves other payout notes alone" do
     unrelated = user.add_payout_note(content: "Your payout was skipped because your balance was below the minimum.")
 
-    described_class.send(:clear_stale_payout_setup_rejection_notes, user)
+    described_class.send(:clear_stale_payout_setup_rejection_notes, user, resolved_fields: :all)
 
     expect(unrelated.reload.deleted_at).to be_nil
   end
 end
 
 # update_account is the code path that resolves a prior rejection: a successful call to Stripe
-# means the field it once refused now goes through. Guards against the mutant that deletes the
-# clear_stale_payout_setup_rejection_notes call from that method's success path.
+# means the field it once refused now goes through — but only if THAT field was on the payload.
+# Guards against the mutant that deletes the clear_stale_payout_setup_rejection_notes call from
+# that method's success path, and against widening it back to an unscoped clear.
 describe StripeMerchantAccountManager, "#update_account clearing a resolved rejection note", :vcr do
   let(:user) { create(:user) }
   let!(:user_compliance_info) { create(:user_compliance_info, user:) }
@@ -93,19 +124,37 @@ describe StripeMerchantAccountManager, "#update_account clearing a resolved reje
       stripe_account["metadata"]["user_compliance_info_id"] = user_compliance_info.external_id
       stripe_account
     end
+  end
 
+  it "clears the marked rejection note when the field it named is resubmitted and accepted" do
     user.add_payout_note(
       content: "Our payment partner couldn't accept the Tax ID you entered.",
       seller_visible: true,
-      json_data: { StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG => true }
+      json_data: {
+        StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG => true,
+        StripeMerchantAccountManager::PAYOUT_SETUP_REJECTED_FIELD_KEY => "id_number",
+      }
     )
-  end
-
-  it "clears the marked rejection note when the update succeeds" do
-    create(:user_compliance_info, user:, city: "Palo Alto")
+    create(:user_compliance_info, user:, individual_tax_id: "111223333")
 
     described_class.update_account(user, passphrase: "1234")
 
     expect(user.latest_payout_setup_rejection_note).to be_nil
+  end
+
+  it "leaves the marked rejection note when an unrelated field was the only one accepted", :vcr do
+    user.add_payout_note(
+      content: "Our payment partner couldn't accept the Tax ID you entered.",
+      seller_visible: true,
+      json_data: {
+        StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG => true,
+        StripeMerchantAccountManager::PAYOUT_SETUP_REJECTED_FIELD_KEY => "id_number",
+      }
+    )
+    create(:user_compliance_info, user:, city: "Palo Alto")
+
+    described_class.update_account(user, passphrase: "1234")
+
+    expect(user.latest_payout_setup_rejection_note).to be_present
   end
 end

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_rejection_note_lifecycle_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_rejection_note_lifecycle_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Follow-up to gumroad#6927 (gumroad-private#1777): three gaps Greptile found once the marked
+# rejection note was live in production.
+describe StripeMerchantAccountManager, ".record_account_rejection_note" do
+  let(:user) { create(:user) }
+
+  def rejection(message, param, code: nil)
+    Stripe::InvalidRequestError.new(message, param, code:)
+  end
+
+  it "records only the support-only breadcrumb for a bank-account rejection, which has its own seller messaging" do
+    expect(ErrorNotifier).not_to receive(:notify)
+
+    described_class.record_account_rejection_note(
+      user, rejection("We couldn't find the bank for that BIC", "bank_account[routing_number]")
+    )
+
+    notes = user.comments.with_type_payout_note.alive
+    expect(notes.count).to eq(1)
+    expect(notes.first.json_data[PayoutNoteVisibility::SELLER_VISIBLE_FLAG]).to eq(false)
+  end
+
+  it "records both notes for a rejection payout_setup_rejection_seller_message handles" do
+    create(:user_compliance_info, user:, country: "Colombia")
+
+    described_class.record_account_rejection_note(
+      user, rejection("Invalid value for individual[id_number]", "individual[id_number]")
+    )
+
+    seller_note = user.latest_payout_setup_rejection_note
+    expect(seller_note).to be_present
+    expect(seller_note.content).to include("Tax ID")
+  end
+end
+
+describe "User::Comments#latest_payout_setup_rejection_note" do
+  let(:user) { create(:user) }
+
+  it "finds the marked note even when 25 newer payout notes exist" do
+    user.add_payout_note(
+      content: "Our payment partner couldn't accept the Tax ID you entered.",
+      seller_visible: true,
+      json_data: { StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG => true }
+    )
+    PayoutNoteVisibility::MAX_NOTES_SCANNED.times do
+      user.add_payout_note(content: "Your payout was skipped because your balance was below the minimum.")
+    end
+
+    expect(user.latest_payout_setup_rejection_note).to be_present
+  end
+end
+
+describe StripeMerchantAccountManager, ".clear_stale_payout_setup_rejection_notes" do
+  let(:user) { create(:user) }
+
+  it "deletes the marked note once payout setup succeeds, so a later stale-payout-account lookup does not find it" do
+    user.add_payout_note(
+      content: "Our payment partner couldn't accept the Tax ID you entered.",
+      seller_visible: true,
+      json_data: { StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG => true }
+    )
+
+    described_class.send(:clear_stale_payout_setup_rejection_notes, user)
+
+    expect(user.latest_payout_setup_rejection_note).to be_nil
+  end
+
+  it "leaves other payout notes alone" do
+    unrelated = user.add_payout_note(content: "Your payout was skipped because your balance was below the minimum.")
+
+    described_class.send(:clear_stale_payout_setup_rejection_notes, user)
+
+    expect(unrelated.reload.deleted_at).to be_nil
+  end
+end

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_rejection_note_lifecycle_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_rejection_note_lifecycle_spec.rb
@@ -76,3 +76,36 @@ describe StripeMerchantAccountManager, ".clear_stale_payout_setup_rejection_note
     expect(unrelated.reload.deleted_at).to be_nil
   end
 end
+
+# update_account is the code path that resolves a prior rejection: a successful call to Stripe
+# means the field it once refused now goes through. Guards against the mutant that deletes the
+# clear_stale_payout_setup_rejection_notes call from that method's success path.
+describe StripeMerchantAccountManager, "#update_account clearing a resolved rejection note", :vcr do
+  let(:user) { create(:user) }
+  let!(:user_compliance_info) { create(:user_compliance_info, user:) }
+  let!(:tos_agreement) { create(:tos_agreement, user:) }
+  let!(:merchant_account) { described_class.create_account(user, passphrase: "1234") }
+
+  before do
+    original_stripe_account_retrieve = Stripe::Account.method(:retrieve)
+    allow(Stripe::Account).to receive(:retrieve).with(merchant_account.charge_processor_merchant_id) do |*args|
+      stripe_account = original_stripe_account_retrieve.call(*args)
+      stripe_account["metadata"]["user_compliance_info_id"] = user_compliance_info.external_id
+      stripe_account
+    end
+
+    user.add_payout_note(
+      content: "Our payment partner couldn't accept the Tax ID you entered.",
+      seller_visible: true,
+      json_data: { StripeMerchantAccountManager::PAYOUT_SETUP_REJECTION_NOTE_FLAG => true }
+    )
+  end
+
+  it "clears the marked rejection note when the update succeeds" do
+    create(:user_compliance_info, user:, city: "Palo Alto")
+
+    described_class.update_account(user, passphrase: "1234")
+
+    expect(user.latest_payout_setup_rejection_note).to be_nil
+  end
+end

--- a/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager_update_account_clearing_a_resolved_rejection_note/clears_the_marked_rejection_note_when_the_field_it_named_is_resubmitted_and_accepted.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager_update_account_clearing_a_resolved_rejection_note/clears_the_marked_rejection_note_when_the_field_it_named_is_resubmitted_and_accepted.yml
@@ -1,0 +1,1006 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=9302619774006&metadata[tos_agreement_id]=InbaGIxUjQVUPUtZesP6AQ%3D%3D&metadata[user_compliance_info_id]=1eGkXMXNQhgNnEEE60IOuA%3D%3D&tos_acceptance[date]=1786044161&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgar63b0e5b7_15%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 53233645-aced-481e-b8fb-99ce39bd65b9
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 06 Aug 2026 19:22:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5942'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=POc9qWM_9oBeswXAAo_k5JE7X7Qe3rJIpgT3wJLtwHrgmuHheK9BEaxGBrhWLy9OHy4oMBw7qR3xnoWl;
+        report-to csp
+      Idempotency-Key:
+      - 53233645-aced-481e-b8fb-99ce39bd65b9
+      Original-Request:
+      - req_yy6RKeFN4hoqQe
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=POc9qWM_9oBeswXAAo_k5JE7X7Qe3rJIpgT3wJLtwHrgmuHheK9BEaxGBrhWLy9OHy4oMBw7qR3xnoWl&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=POc9qWM_9oBeswXAAo_k5JE7X7Qe3rJIpgT3wJLtwHrgmuHheK9BEaxGBrhWLy9OHy4oMBw7qR3xnoWl&t=1"
+      Request-Id:
+      - req_yy6RKeFN4hoqQe
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1U1WsHIV0Q1fQ95A",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1786044163,
+          "default_currency": "usd",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1U1WsHIV0Q1fQ95A/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1U1WsHIV0Q1fQ95A1dO5fUKR",
+            "object": "person",
+            "account": "acct_1U1WsHIV0Q1fQ95A",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1786044162,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar63b0e5b7_15@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "tos_agreement_id": "InbaGIxUjQVUPUtZesP6AQ==",
+            "user_compliance_info_id": "1eGkXMXNQhgNnEEE60IOuA==",
+            "user_id": "9302619774006"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "past_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": false,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1786044161,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Thu, 06 Aug 2026 19:22:44 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/accounts/acct_1U1WsHIV0Q1fQ95A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_yy6RKeFN4hoqQe","request_duration_ms":3183}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 06 Aug 2026 19:22:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5942'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe&t=1"
+      Request-Id:
+      - req_wM5AChewMdtGDu
+      Stripe-Account:
+      - acct_1U1WsHIV0Q1fQ95A
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1U1WsHIV0Q1fQ95A",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1786044163,
+          "default_currency": "usd",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1U1WsHIV0Q1fQ95A/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1U1WsHIV0Q1fQ95A1dO5fUKR",
+            "object": "person",
+            "account": "acct_1U1WsHIV0Q1fQ95A",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1786044162,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar63b0e5b7_15@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "tos_agreement_id": "InbaGIxUjQVUPUtZesP6AQ==",
+            "user_compliance_info_id": "1eGkXMXNQhgNnEEE60IOuA==",
+            "user_id": "9302619774006"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "past_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": false,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1786044161,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Thu, 06 Aug 2026 19:22:46 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts/acct_1U1WsHIV0Q1fQ95A
+    body:
+      encoding: UTF-8
+      string: metadata[user_id]=9302619774006&metadata[tos_agreement_id]=InbaGIxUjQVUPUtZesP6AQ%3D%3D&metadata[user_compliance_info_id]=RM1zd5egDceNZ14g2unAWw%3D%3D&tos_acceptance[date]=1786044161&tos_acceptance[ip]=54.234.242.13&business_profile[name]=Updated+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Updated+Bartowski&individual[first_name]=Updated&individual[email]=edgar63b0e5b7_15%40gumroad.com&individual[phone]=0000000000&capabilities[card_payments][requested]=true&capabilities[transfers][requested]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_wM5AChewMdtGDu","request_duration_ms":621}}'
+      Idempotency-Key:
+      - ebb495cf-66e7-448f-a3ad-8910e690cea8
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 06 Aug 2026 19:22:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5960'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe;
+        report-to csp
+      Idempotency-Key:
+      - ebb495cf-66e7-448f-a3ad-8910e690cea8
+      Original-Request:
+      - req_Pm0mt4fpayKb1c
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe&t=1"
+      Request-Id:
+      - req_Pm0mt4fpayKb1c
+      Stripe-Account:
+      - acct_1U1WsHIV0Q1fQ95A
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1U1WsHIV0Q1fQ95A",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Updated Bartowski",
+            "product_description": "Updated Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1786044163,
+          "default_currency": "usd",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1U1WsHIV0Q1fQ95A/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1U1WsHIV0Q1fQ95A1dO5fUKR",
+            "object": "person",
+            "account": "acct_1U1WsHIV0Q1fQ95A",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1786044162,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar63b0e5b7_15@gumroad.com",
+            "first_name": "Updated",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "tos_agreement_id": "InbaGIxUjQVUPUtZesP6AQ==",
+            "user_compliance_info_id": "RM1zd5egDceNZ14g2unAWw==",
+            "user_id": "9302619774006"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "past_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": "Stripe",
+              "service_user_number": "449900"
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "UPDATED BA",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Updated Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "UPDATED BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": false,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1786044161,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Thu, 06 Aug 2026 19:22:49 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager_update_account_clearing_a_resolved_rejection_note/clears_the_marked_rejection_note_when_the_update_succeeds.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager_update_account_clearing_a_resolved_rejection_note/clears_the_marked_rejection_note_when_the_update_succeeds.yml
@@ -1,0 +1,1006 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=248901874756&metadata[tos_agreement_id]=yz-bMbYw-mOLkYUZ-F7zkg%3D%3D&metadata[user_compliance_info_id]=5T-zi6t1ksIVSH_9UK5yIQ%3D%3D&tos_acceptance[date]=1786042563&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgar326114bf_11%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - c18eee84-6f63-4fb2-b68a-373357552771
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 06 Aug 2026 18:56:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5941'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=w3xnsA1i9BNcwQJ3YEhhmUzO-ZEun9VuV8rEXB6w-bRExfYDKCm-gvoVufcJRzwTC83N5EEjeDSFK963;
+        report-to csp
+      Idempotency-Key:
+      - c18eee84-6f63-4fb2-b68a-373357552771
+      Original-Request:
+      - req_7qhsHg1KdED7tJ
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=w3xnsA1i9BNcwQJ3YEhhmUzO-ZEun9VuV8rEXB6w-bRExfYDKCm-gvoVufcJRzwTC83N5EEjeDSFK963&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=w3xnsA1i9BNcwQJ3YEhhmUzO-ZEun9VuV8rEXB6w-bRExfYDKCm-gvoVufcJRzwTC83N5EEjeDSFK963&t=1"
+      Request-Id:
+      - req_7qhsHg1KdED7tJ
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1U1WSVEcPZvVRRbP",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1786042565,
+          "default_currency": "usd",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1U1WSVEcPZvVRRbP/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1U1WSVEcPZvVRRbPrnfn1gsS",
+            "object": "person",
+            "account": "acct_1U1WSVEcPZvVRRbP",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1786042564,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar326114bf_11@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "tos_agreement_id": "yz-bMbYw-mOLkYUZ-F7zkg==",
+            "user_compliance_info_id": "5T-zi6t1ksIVSH_9UK5yIQ==",
+            "user_id": "248901874756"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "past_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": false,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1786042563,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Thu, 06 Aug 2026 18:56:07 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/accounts/acct_1U1WSVEcPZvVRRbP
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_7qhsHg1KdED7tJ","request_duration_ms":4178}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 06 Aug 2026 18:56:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5941'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=eqzUFPaiNOhea33DImzKkYzsD4ZWOnNyXfOQSisL_vOufsA_zILjm12P3zuoDVIgTVViTjjFRHcJbHFR;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=eqzUFPaiNOhea33DImzKkYzsD4ZWOnNyXfOQSisL_vOufsA_zILjm12P3zuoDVIgTVViTjjFRHcJbHFR&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=eqzUFPaiNOhea33DImzKkYzsD4ZWOnNyXfOQSisL_vOufsA_zILjm12P3zuoDVIgTVViTjjFRHcJbHFR&t=1"
+      Request-Id:
+      - req_qdRooVUbdNZqiZ
+      Stripe-Account:
+      - acct_1U1WSVEcPZvVRRbP
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1U1WSVEcPZvVRRbP",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1786042565,
+          "default_currency": "usd",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1U1WSVEcPZvVRRbP/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1U1WSVEcPZvVRRbPrnfn1gsS",
+            "object": "person",
+            "account": "acct_1U1WSVEcPZvVRRbP",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1786042564,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar326114bf_11@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "tos_agreement_id": "yz-bMbYw-mOLkYUZ-F7zkg==",
+            "user_compliance_info_id": "5T-zi6t1ksIVSH_9UK5yIQ==",
+            "user_id": "248901874756"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "past_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": false,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1786042563,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Thu, 06 Aug 2026 18:56:08 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts/acct_1U1WSVEcPZvVRRbP
+    body:
+      encoding: UTF-8
+      string: metadata[user_id]=248901874756&metadata[tos_agreement_id]=yz-bMbYw-mOLkYUZ-F7zkg%3D%3D&metadata[user_compliance_info_id]=0CJSXTRcNwLc47k_MuXKZg%3D%3D&tos_acceptance[date]=1786042563&tos_acceptance[ip]=54.234.242.13&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[email]=edgar326114bf_11%40gumroad.com&individual[phone]=0000000000&individual[address][city]=Palo+Alto&capabilities[card_payments][requested]=true&capabilities[transfers][requested]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_qdRooVUbdNZqiZ","request_duration_ms":680}}'
+      Idempotency-Key:
+      - 68e9f54a-3a2c-43fd-ab13-5af07390e70c
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 06 Aug 2026 18:56:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5941'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=eqzUFPaiNOhea33DImzKkYzsD4ZWOnNyXfOQSisL_vOufsA_zILjm12P3zuoDVIgTVViTjjFRHcJbHFR;
+        report-to csp
+      Idempotency-Key:
+      - 68e9f54a-3a2c-43fd-ab13-5af07390e70c
+      Original-Request:
+      - req_UJSWCnH1JUkHd4
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=eqzUFPaiNOhea33DImzKkYzsD4ZWOnNyXfOQSisL_vOufsA_zILjm12P3zuoDVIgTVViTjjFRHcJbHFR&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=eqzUFPaiNOhea33DImzKkYzsD4ZWOnNyXfOQSisL_vOufsA_zILjm12P3zuoDVIgTVViTjjFRHcJbHFR&t=1"
+      Request-Id:
+      - req_UJSWCnH1JUkHd4
+      Stripe-Account:
+      - acct_1U1WSVEcPZvVRRbP
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1U1WSVEcPZvVRRbP",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "Palo Alto",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1786042565,
+          "default_currency": "usd",
+          "details_submitted": false,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1U1WSVEcPZvVRRbP/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1U1WSVEcPZvVRRbPrnfn1gsS",
+            "object": "person",
+            "account": "acct_1U1WSVEcPZvVRRbP",
+            "address": {
+              "city": "Palo Alto",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1786042564,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgar326114bf_11@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "tos_agreement_id": "yz-bMbYw-mOLkYUZ-F7zkg==",
+            "user_compliance_info_id": "0CJSXTRcNwLc47k_MuXKZg==",
+            "user_id": "248901874756"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "past_due": [
+              "business_profile.mcc",
+              "external_account"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": "Stripe",
+              "service_user_number": "449900"
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": false,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "daily"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1786042563,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Thu, 06 Aug 2026 18:56:10 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager_update_account_clearing_a_resolved_rejection_note/leaves_the_marked_rejection_note_when_an_unrelated_field_was_the_only_one_accepted.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager_update_account_clearing_a_resolved_rejection_note/leaves_the_marked_rejection_note_when_an_unrelated_field_was_the_only_one_accepted.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.stripe.com/v1/accounts
     body:
       encoding: UTF-8
-      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=248901874756&metadata[tos_agreement_id]=yz-bMbYw-mOLkYUZ-F7zkg%3D%3D&metadata[user_compliance_info_id]=5T-zi6t1ksIVSH_9UK5yIQ%3D%3D&tos_acceptance[date]=1786042563&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgar326114bf_11%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=6587105348950&metadata[tos_agreement_id]=hdpKl5ZZ4XTQ1_y-Zx58rw%3D%3D&metadata[user_compliance_info_id]=p7EwhWgpM-ZLUnaVPkiN0g%3D%3D&tos_acceptance[date]=1786044170&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgarc02bcfe9_17%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/12.5.0
@@ -13,8 +13,10 @@ http_interactions:
       - Bearer <STRIPE_API_KEY>
       Content-Type:
       - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Pm0mt4fpayKb1c","request_duration_ms":3452}}'
       Idempotency-Key:
-      - c18eee84-6f63-4fb2-b68a-373357552771
+      - 395c5e88-362b-4041-ad9e-4ec4b957b84f
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -31,11 +33,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 06 Aug 2026 18:56:07 GMT
+      - Thu, 06 Aug 2026 19:22:53 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '5941'
+      - '5942'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -54,18 +56,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=w3xnsA1i9BNcwQJ3YEhhmUzO-ZEun9VuV8rEXB6w-bRExfYDKCm-gvoVufcJRzwTC83N5EEjeDSFK963;
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe;
         report-to csp
       Idempotency-Key:
-      - c18eee84-6f63-4fb2-b68a-373357552771
+      - 395c5e88-362b-4041-ad9e-4ec4b957b84f
       Original-Request:
-      - req_7qhsHg1KdED7tJ
+      - req_rAPJUHwpoPixdT
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=w3xnsA1i9BNcwQJ3YEhhmUzO-ZEun9VuV8rEXB6w-bRExfYDKCm-gvoVufcJRzwTC83N5EEjeDSFK963&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=w3xnsA1i9BNcwQJ3YEhhmUzO-ZEun9VuV8rEXB6w-bRExfYDKCm-gvoVufcJRzwTC83N5EEjeDSFK963&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe&t=1"
       Request-Id:
-      - req_7qhsHg1KdED7tJ
+      - req_rAPJUHwpoPixdT
       Stripe-Notice:
       - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
         We recommend upgrading to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
@@ -88,7 +90,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1U1WSVEcPZvVRRbP",
+          "id": "acct_1U1WsQEpLOIk0orZ",
           "object": "account",
           "business_profile": {
             "annual_revenue": null,
@@ -149,7 +151,7 @@ http_interactions:
             "type": "application"
           },
           "country": "US",
-          "created": 1786042565,
+          "created": 1786044172,
           "default_currency": "usd",
           "details_submitted": false,
           "email": null,
@@ -158,7 +160,7 @@ http_interactions:
             "data": [],
             "has_more": false,
             "total_count": 0,
-            "url": "/v1/accounts/acct_1U1WSVEcPZvVRRbP/external_accounts"
+            "url": "/v1/accounts/acct_1U1WsQEpLOIk0orZ/external_accounts"
           },
           "future_requirements": {
             "alternatives": [],
@@ -171,9 +173,9 @@ http_interactions:
             "pending_verification": []
           },
           "individual": {
-            "id": "person_1U1WSVEcPZvVRRbPrnfn1gsS",
+            "id": "person_1U1WsQEpLOIk0orZxGsogrlz",
             "object": "person",
-            "account": "acct_1U1WSVEcPZvVRRbP",
+            "account": "acct_1U1WsQEpLOIk0orZ",
             "address": {
               "city": "San Francisco",
               "country": "US",
@@ -182,13 +184,13 @@ http_interactions:
               "postal_code": "94107",
               "state": "California"
             },
-            "created": 1786042564,
+            "created": 1786044171,
             "dob": {
               "day": 1,
               "month": 1,
               "year": 1901
             },
-            "email": "edgar326114bf_11@gumroad.com",
+            "email": "edgarc02bcfe9_17@gumroad.com",
             "first_name": "Chuck",
             "future_requirements": {
               "alternatives": [],
@@ -247,9 +249,9 @@ http_interactions:
             }
           },
           "metadata": {
-            "tos_agreement_id": "yz-bMbYw-mOLkYUZ-F7zkg==",
-            "user_compliance_info_id": "5T-zi6t1ksIVSH_9UK5yIQ==",
-            "user_id": "248901874756"
+            "tos_agreement_id": "hdpKl5ZZ4XTQ1_y-Zx58rw==",
+            "user_compliance_info_id": "p7EwhWgpM-ZLUnaVPkiN0g==",
+            "user_id": "6587105348950"
           },
           "payouts_enabled": false,
           "requirements": {
@@ -328,16 +330,16 @@ http_interactions:
             "sepa_debit_payments": {}
           },
           "tos_acceptance": {
-            "date": 1786042563,
+            "date": 1786044170,
             "ip": "54.234.242.13",
             "user_agent": null
           },
           "type": "custom"
         }
-  recorded_at: Thu, 06 Aug 2026 18:56:07 GMT
+  recorded_at: Thu, 06 Aug 2026 19:22:53 GMT
 - request:
     method: get
-    uri: https://api.stripe.com/v1/accounts/acct_1U1WSVEcPZvVRRbP
+    uri: https://api.stripe.com/v1/accounts/acct_1U1WsQEpLOIk0orZ
     body:
       encoding: US-ASCII
       string: ''
@@ -349,7 +351,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_7qhsHg1KdED7tJ","request_duration_ms":4178}}'
+      - '{"last_request_metrics":{"request_id":"req_rAPJUHwpoPixdT","request_duration_ms":3281}}'
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -366,11 +368,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 06 Aug 2026 18:56:08 GMT
+      - Thu, 06 Aug 2026 19:22:55 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '5941'
+      - '5942'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -389,16 +391,16 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=eqzUFPaiNOhea33DImzKkYzsD4ZWOnNyXfOQSisL_vOufsA_zILjm12P3zuoDVIgTVViTjjFRHcJbHFR;
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe;
         report-to csp
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=eqzUFPaiNOhea33DImzKkYzsD4ZWOnNyXfOQSisL_vOufsA_zILjm12P3zuoDVIgTVViTjjFRHcJbHFR&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=eqzUFPaiNOhea33DImzKkYzsD4ZWOnNyXfOQSisL_vOufsA_zILjm12P3zuoDVIgTVViTjjFRHcJbHFR&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe&t=1"
       Request-Id:
-      - req_qdRooVUbdNZqiZ
+      - req_8WlaKhDI83JZzH
       Stripe-Account:
-      - acct_1U1WSVEcPZvVRRbP
+      - acct_1U1WsQEpLOIk0orZ
       Stripe-Notice:
       - You are using an outdated API version (2023-10-16). We recommend upgrading
         to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
@@ -418,7 +420,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1U1WSVEcPZvVRRbP",
+          "id": "acct_1U1WsQEpLOIk0orZ",
           "object": "account",
           "business_profile": {
             "annual_revenue": null,
@@ -479,7 +481,7 @@ http_interactions:
             "type": "application"
           },
           "country": "US",
-          "created": 1786042565,
+          "created": 1786044172,
           "default_currency": "usd",
           "details_submitted": false,
           "email": null,
@@ -488,7 +490,7 @@ http_interactions:
             "data": [],
             "has_more": false,
             "total_count": 0,
-            "url": "/v1/accounts/acct_1U1WSVEcPZvVRRbP/external_accounts"
+            "url": "/v1/accounts/acct_1U1WsQEpLOIk0orZ/external_accounts"
           },
           "future_requirements": {
             "alternatives": [],
@@ -501,9 +503,9 @@ http_interactions:
             "pending_verification": []
           },
           "individual": {
-            "id": "person_1U1WSVEcPZvVRRbPrnfn1gsS",
+            "id": "person_1U1WsQEpLOIk0orZxGsogrlz",
             "object": "person",
-            "account": "acct_1U1WSVEcPZvVRRbP",
+            "account": "acct_1U1WsQEpLOIk0orZ",
             "address": {
               "city": "San Francisco",
               "country": "US",
@@ -512,13 +514,13 @@ http_interactions:
               "postal_code": "94107",
               "state": "California"
             },
-            "created": 1786042564,
+            "created": 1786044171,
             "dob": {
               "day": 1,
               "month": 1,
               "year": 1901
             },
-            "email": "edgar326114bf_11@gumroad.com",
+            "email": "edgarc02bcfe9_17@gumroad.com",
             "first_name": "Chuck",
             "future_requirements": {
               "alternatives": [],
@@ -577,9 +579,9 @@ http_interactions:
             }
           },
           "metadata": {
-            "tos_agreement_id": "yz-bMbYw-mOLkYUZ-F7zkg==",
-            "user_compliance_info_id": "5T-zi6t1ksIVSH_9UK5yIQ==",
-            "user_id": "248901874756"
+            "tos_agreement_id": "hdpKl5ZZ4XTQ1_y-Zx58rw==",
+            "user_compliance_info_id": "p7EwhWgpM-ZLUnaVPkiN0g==",
+            "user_id": "6587105348950"
           },
           "payouts_enabled": false,
           "requirements": {
@@ -658,19 +660,19 @@ http_interactions:
             "sepa_debit_payments": {}
           },
           "tos_acceptance": {
-            "date": 1786042563,
+            "date": 1786044170,
             "ip": "54.234.242.13",
             "user_agent": null
           },
           "type": "custom"
         }
-  recorded_at: Thu, 06 Aug 2026 18:56:08 GMT
+  recorded_at: Thu, 06 Aug 2026 19:22:55 GMT
 - request:
     method: post
-    uri: https://api.stripe.com/v1/accounts/acct_1U1WSVEcPZvVRRbP
+    uri: https://api.stripe.com/v1/accounts/acct_1U1WsQEpLOIk0orZ
     body:
       encoding: UTF-8
-      string: metadata[user_id]=248901874756&metadata[tos_agreement_id]=yz-bMbYw-mOLkYUZ-F7zkg%3D%3D&metadata[user_compliance_info_id]=0CJSXTRcNwLc47k_MuXKZg%3D%3D&tos_acceptance[date]=1786042563&tos_acceptance[ip]=54.234.242.13&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[email]=edgar326114bf_11%40gumroad.com&individual[phone]=0000000000&individual[address][city]=Palo+Alto&capabilities[card_payments][requested]=true&capabilities[transfers][requested]=true
+      string: metadata[user_id]=6587105348950&metadata[tos_agreement_id]=hdpKl5ZZ4XTQ1_y-Zx58rw%3D%3D&metadata[user_compliance_info_id]=rfa936FHOTAFtBNIQlQvFA%3D%3D&tos_acceptance[date]=1786044170&tos_acceptance[ip]=54.234.242.13&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[email]=edgarc02bcfe9_17%40gumroad.com&individual[phone]=0000000000&individual[address][city]=Palo+Alto&capabilities[card_payments][requested]=true&capabilities[transfers][requested]=true
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/12.5.0
@@ -679,9 +681,9 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_qdRooVUbdNZqiZ","request_duration_ms":680}}'
+      - '{"last_request_metrics":{"request_id":"req_8WlaKhDI83JZzH","request_duration_ms":499}}'
       Idempotency-Key:
-      - 68e9f54a-3a2c-43fd-ab13-5af07390e70c
+      - dc311e73-6487-40a7-9466-71011a73e5d5
       Stripe-Version:
       - '2023-10-16'
       X-Stripe-Client-User-Agent:
@@ -698,11 +700,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 06 Aug 2026 18:56:10 GMT
+      - Thu, 06 Aug 2026 19:22:57 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '5941'
+      - '5942'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -721,20 +723,20 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=eqzUFPaiNOhea33DImzKkYzsD4ZWOnNyXfOQSisL_vOufsA_zILjm12P3zuoDVIgTVViTjjFRHcJbHFR;
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe;
         report-to csp
       Idempotency-Key:
-      - 68e9f54a-3a2c-43fd-ab13-5af07390e70c
+      - dc311e73-6487-40a7-9466-71011a73e5d5
       Original-Request:
-      - req_UJSWCnH1JUkHd4
+      - req_b0p8DHJQtqkEZs
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=eqzUFPaiNOhea33DImzKkYzsD4ZWOnNyXfOQSisL_vOufsA_zILjm12P3zuoDVIgTVViTjjFRHcJbHFR&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=eqzUFPaiNOhea33DImzKkYzsD4ZWOnNyXfOQSisL_vOufsA_zILjm12P3zuoDVIgTVViTjjFRHcJbHFR&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=G_IhKtmhvPTg7_w14f_UNrMWQ7hWAT3m1mTCH6DbSWS3xP5qt2bN5BqnEY9yjVOI-QQoPpWpQpYXWpOe&t=1"
       Request-Id:
-      - req_UJSWCnH1JUkHd4
+      - req_b0p8DHJQtqkEZs
       Stripe-Account:
-      - acct_1U1WSVEcPZvVRRbP
+      - acct_1U1WsQEpLOIk0orZ
       Stripe-Notice:
       - You are using an outdated API version (2023-10-16). We recommend upgrading
         to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
@@ -756,7 +758,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "acct_1U1WSVEcPZvVRRbP",
+          "id": "acct_1U1WsQEpLOIk0orZ",
           "object": "account",
           "business_profile": {
             "annual_revenue": null,
@@ -817,7 +819,7 @@ http_interactions:
             "type": "application"
           },
           "country": "US",
-          "created": 1786042565,
+          "created": 1786044172,
           "default_currency": "usd",
           "details_submitted": false,
           "email": null,
@@ -826,7 +828,7 @@ http_interactions:
             "data": [],
             "has_more": false,
             "total_count": 0,
-            "url": "/v1/accounts/acct_1U1WSVEcPZvVRRbP/external_accounts"
+            "url": "/v1/accounts/acct_1U1WsQEpLOIk0orZ/external_accounts"
           },
           "future_requirements": {
             "alternatives": [],
@@ -839,9 +841,9 @@ http_interactions:
             "pending_verification": []
           },
           "individual": {
-            "id": "person_1U1WSVEcPZvVRRbPrnfn1gsS",
+            "id": "person_1U1WsQEpLOIk0orZxGsogrlz",
             "object": "person",
-            "account": "acct_1U1WSVEcPZvVRRbP",
+            "account": "acct_1U1WsQEpLOIk0orZ",
             "address": {
               "city": "Palo Alto",
               "country": "US",
@@ -850,13 +852,13 @@ http_interactions:
               "postal_code": "94107",
               "state": "California"
             },
-            "created": 1786042564,
+            "created": 1786044171,
             "dob": {
               "day": 1,
               "month": 1,
               "year": 1901
             },
-            "email": "edgar326114bf_11@gumroad.com",
+            "email": "edgarc02bcfe9_17@gumroad.com",
             "first_name": "Chuck",
             "future_requirements": {
               "alternatives": [],
@@ -915,9 +917,9 @@ http_interactions:
             }
           },
           "metadata": {
-            "tos_agreement_id": "yz-bMbYw-mOLkYUZ-F7zkg==",
-            "user_compliance_info_id": "0CJSXTRcNwLc47k_MuXKZg==",
-            "user_id": "248901874756"
+            "tos_agreement_id": "hdpKl5ZZ4XTQ1_y-Zx58rw==",
+            "user_compliance_info_id": "rfa936FHOTAFtBNIQlQvFA==",
+            "user_id": "6587105348950"
           },
           "payouts_enabled": false,
           "requirements": {
@@ -996,11 +998,11 @@ http_interactions:
             "sepa_debit_payments": {}
           },
           "tos_acceptance": {
-            "date": 1786042563,
+            "date": 1786044170,
             "ip": "54.234.242.13",
             "user_agent": null
           },
           "type": "custom"
         }
-  recorded_at: Thu, 06 Aug 2026 18:56:10 GMT
+  recorded_at: Thu, 06 Aug 2026 19:22:57 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Stages

- [x] **Scope** — three unresolved Greptile findings on merged #6927 (gumroad-private#1777)
- [x] **Design** — clear stale notes on payout-setup success; read the marked note independently of the banner scan cap; skip the note write when the seller message is blank
- [x] **Build** — 4 files changed, 1 new spec file
- [ ] **Ship** — pending review/merge
- [ ] **Market** — n/a (internal correctness fix)
- [ ] **Sell** — n/a

## What

Three follow-ups Greptile found on #6927 after it merged, all in the payout-setup-rejection note it introduced:

1. **`clear_stale_payout_setup_rejection_notes`** — the marked seller-visible rejection note was never cleared once payout setup succeeded. A seller who fixed the flagged field and later lost or disconnected their payout account would still see the old rejection guidance instead of the correct "connect a payment method" message. Called at the end of both `create_account` and `update_account`'s success paths.
2. **`User::Comments#latest_payout_setup_rejection_note`** — queried through `recent_payout_notes`, which caps the scan at `PayoutNoteVisibility::MAX_NOTES_SCANNED` (25) for the Payouts banner. Once 25 newer payout notes existed, the marked rejection fell off the scan and the publish block silently reverted to the generic message. Now queried independently with its own `json_data LIKE` prefilter, unbounded by that cap.
3. **`record_account_rejection_note`** — `payout_setup_rejection_seller_message` returns `nil` for bank-account rejections (which already have dedicated messaging), and the note write still passed that `nil` as required content, tripping `Comment`'s presence validation on every bank-account rejection and reaching `ErrorNotifier`. Now skips the seller-visible note write when the message is blank.

### Round 2 — Greptile P1 on round 1

Greptile ran an executable harness and reproduced (1) above deleting an *unresolved* rejection note on an unrelated, successful account update: a seller with an open Tax ID rejection who only changed their city would have that specific guidance silently replaced by the generic "connect a payment method" message.

Fixed by recording which Stripe field a rejection named (`PAYOUT_SETUP_REJECTED_FIELD_KEY`) and scoping the clear to only fire when that field was resubmitted and accepted (`submitted_field_names(account_update.sent_attributes)`). Notes with no recorded field — undiagnosed rejections with no Stripe `param`, and any note written before this field existed — still clear on any success, which is the prior (and only sane) behavior for that case. `create_account`'s clear stays unscoped (`resolved_fields: :all`) since there is no prior submission to have been partial.

### Round 3 (this push) — Greptile P1 on round 2

Greptile found that `submitted_field_names` only ever returned leaf keys (`day`, `month`, `year` for a DOB submission), while `stripe_rejected_field` records Stripe's *parent* field name (`dob`) for compound fields. A seller who corrected a rejected date of birth would have it accepted by Stripe but the field-scoped clear from round 2 would never match, leaving the stale DOB rejection note (and its payout-block guidance) in place indefinitely. Fixed by including both the parent key and its leaves in `submitted_field_names`'s output, so a compound field like `dob` now satisfies the scope check the same way a flat field does.

Also confirmed the P2 finding on round 1 — the `latest_payout_setup_rejection_note` comment was already trimmed to the concise form in round 2's push; no further change needed there.

## Why

gumroad-private#1777, review thread on #6927. None of these are hypothetical: (1) and (2) both affect the exact publish-block message the merged PR added, (3) fires on every bank-account Stripe rejection going forward, and round 3's DOB gap affects a real Stripe field shape (individual DOB is always submitted as day/month/year) that would have shipped a permanently-stale note for that rejection class.

## Test Results

Run in a dedicated worktree (`DISABLE_SPRING=1 bundle exec rspec`), head `f362f8f80`:

| Check | Result |
|---|---|
| Lifecycle spec (11 examples, incl. 1 new for the compound-field fix) | 11 examples, 0 failures |
| Together with `link_publish_payout_block_spec.rb` | **14 examples, 0 failures** in 15.5s |
| `rubocop` on both changed files | no offenses |

### Mutation proof — compound-field fix reddens when reverted

Fix committed, mutant applied in place (reverted `submitted_field_names` to leaf-only), then restored from a backup of the fixed file:

| Mutant | Effect | Result |
|---|---|---|
| `submitted_field_names` reverted to leaf-only (reproduces the exact Greptile-found bug) | DOB rejection note never clears after an accepted DOB correction | 1 failure — the new "clears a note rejected on a compound field like dob" example ✅ |
| control — restored file | | 14 examples, 0 failures ✅ |

## QA steps

- Ran the lifecycle spec plus `link_publish_payout_block_spec.rb` (see Test Results above). Exact click-path: reject a Stripe bank-account update, confirm no seller-visible note error; reject a phone/tax-id update, confirm the seller-visible note appears; save an unrelated field (e.g. city) and confirm the note is still present; resubmit and have the originally-rejected field (including compound fields like DOB) accepted and confirm the note clears.

---

AI disclosure: built autonomously (claude-sonnet-5). Round 1 in response to unresolved Greptile P1/P2 findings on the merged #6927; round 2 in response to Greptile's P1 finding on round 1 itself; round 3 in response to Greptile's P1 finding on round 2 itself.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
