### PR TITLE
Skip non-unpaid balances when marking payout balances processing

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -581,10 +581,19 @@ class Payouts
       payable_balances = payout_processor.filter_aggregate_payable_balances(user, payable_balances)
     end
 
-    payable_balances.each do |balance|
-      balance.with_lock { balance.mark_processing! }
+    # Select unpaid under the same lock that transitions: two overlapping create_payment
+    # calls (instant + scheduled, duplicate jobs) can both load the same unpaid rows, and
+    # an unconditional mark_processing! then raises InvalidTransition for the loser. Skip
+    # balances that left unpaid while we waited, and only return those we actually marked
+    # so a concurrent winner's balances are not attached to a second Payment.
+    payable_balances.filter_map do |balance|
+      balance.with_lock do
+        next unless balance.unpaid?
+
+        balance.mark_processing!
+        balance
+      end
     end
-    payable_balances
   end
   private_class_method :mark_balances_processing
 end

--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -581,11 +581,8 @@ class Payouts
       payable_balances = payout_processor.filter_aggregate_payable_balances(user, payable_balances)
     end
 
-    # Select unpaid under the same lock that transitions: two overlapping create_payment
-    # calls (instant + scheduled, duplicate jobs) can both load the same unpaid rows, and
-    # an unconditional mark_processing! then raises InvalidTransition for the loser. Skip
-    # balances that left unpaid while we waited, and only return those we actually marked
-    # so a concurrent winner's balances are not attached to a second Payment.
+    # Eligibility check and transition happen under the same lock, so only balances we
+    # actually claim are returned.
     payable_balances.filter_map do |balance|
       balance.with_lock do
         next unless balance.unpaid?

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -716,10 +716,11 @@ describe Payouts do
   describe ".create_payment" do
     let(:payout_date) { Date.today - 1 }
     let(:user) { create(:user) }
+    let!(:merchant_account) { create(:merchant_account, user:) }
 
     before do
       create(:ach_account, user:)
-      create(:balance, user:, date: payout_date - 1, amount_cents: 10_00)
+      create(:balance, user:, merchant_account:, date: payout_date - 1, amount_cents: 10_00)
     end
 
     it "marks the payment as processing when preparation succeeds" do
@@ -756,6 +757,50 @@ describe Payouts do
         expect(payment.state).to eq("failed")
         expect(payment_errors).to eq([error_message])
       end.not_to raise_error
+    end
+
+    it "skips a balance that left unpaid between selection and lock instead of raising" do
+      allow(StripePayoutProcessor).to receive(:is_balance_payable).and_return(true)
+      balance = user.balances.sole
+      expect(balance).to be_unpaid
+
+      # Simulate the concurrent loser: it selected this row while unpaid, then the winner
+      # marked it processing before the loser's with_lock ran. unpaid_balances_up_to_date
+      # would normally omit processing rows, so stub the stale selection the loser still holds.
+      balance.mark_processing!
+      allow(user).to receive(:unpaid_balances_up_to_date).with(payout_date).and_return(Balance.where(id: balance.id))
+
+      # Without the unpaid? guard, mark_processing! raises StateMachines::InvalidTransition.
+      marked = nil
+      expect do
+        marked = described_class.send(:mark_balances_processing, payout_date, PayoutProcessorType::STRIPE, user)
+      end.not_to raise_error
+
+      expect(marked).to eq([])
+      expect(balance.reload).to be_processing
+    end
+
+    it "marks only still-unpaid balances when a concurrent winner took part of the selection" do
+      allow(StripePayoutProcessor).to receive(:is_balance_payable).and_return(true)
+      first = user.balances.sole
+      second = create(:balance, user:, merchant_account:, date: payout_date - 2, amount_cents: 5_00)
+      expect(first).to be_unpaid
+      expect(second).to be_unpaid
+
+      # Stale selection holds both ids as unpaid in memory; the winner already claimed `first`.
+      first.mark_processing!
+      allow(user).to receive(:unpaid_balances_up_to_date).with(payout_date).and_return(
+        Balance.where(id: [first.id, second.id]).order(:id)
+      )
+
+      marked = nil
+      expect do
+        marked = described_class.send(:mark_balances_processing, payout_date, PayoutProcessorType::STRIPE, user)
+      end.not_to raise_error
+
+      expect(marked.map(&:id)).to eq([second.id])
+      expect(first.reload).to be_processing
+      expect(second.reload).to be_processing
     end
   end
 


### PR DESCRIPTION
## What
`Payouts.mark_balances_processing` now selects unpaid balances under the same lock that transitions them, and only returns the balances it actually marked.

## Why
Two overlapping `create_payment` calls (instant + scheduled payout, or a duplicate job) can both load the same unpaid balances before either transitions them. The old code called `balance.mark_processing!` unconditionally, so whichever call lost the race raised `StateMachines::InvalidTransition (failed -> processing)`. The fix checks `balance.unpaid?` inside the lock and skips balances that left `unpaid` while waiting, then returns only the marked subset so a concurrent winner's balances never get attached to a second `Payment`.

## Test Results
Verified in a clean worktree off `origin/main`:
- `spec/business/payments/payouts/payouts_spec.rb`: **103 examples, 0 failures**
- `rubocop` on all changed files: no offenses

Premerge review: clean @ 5ce7e91f6841b8539bba22fa725207fddc3bf1a8

---

Based on https://github.com/adityawrk/gumroad/pull/19 by @adityawrk.

AI Disclosure: Claude Opus 4.6 (1M context) was used to review the original PR and import the changes.

