### PR TITLE
Fix broken-image icon on wishlist cards with no thumbnails

### DIFF
--- a/app/javascript/components/Wishlist/Card.test.tsx
+++ b/app/javascript/components/Wishlist/Card.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DomainSettingsProvider } from "$app/components/DomainSettings";
+import { LoggedInUserProvider } from "$app/components/LoggedInUser";
+import { Card, CardWishlist } from "$app/components/Wishlist/Card";
+
+afterEach(cleanup);
+
+const wishlist = (overrides: Partial<CardWishlist> = {}): CardWishlist => ({
+  id: "wishlist-1",
+  url: "https://seller.gumroad.com/wishlists/example",
+  name: "Example wishlist",
+  description: null,
+  seller: { id: "seller-1", name: "Seller", profile_url: "https://seller.gumroad.com", avatar_url: "" },
+  thumbnails: [],
+  product_count: 1,
+  follower_count: 0,
+  following: false,
+  can_follow: true,
+  ...overrides,
+});
+
+const renderCard = (props: React.ComponentProps<typeof Card>) =>
+  render(
+    <DomainSettingsProvider
+      value={{
+        scheme: "https",
+        appDomain: "gumroad.com",
+        rootDomain: "gumroad.com",
+        shortDomain: "gum.co",
+        discoverDomain: "discover.gumroad.com",
+        thirdPartyAnalyticsDomain: "analytics.gumroad.com",
+        apiDomain: "api.gumroad.com",
+      }}
+    >
+      <LoggedInUserProvider value={null}>
+        <Card {...props} />
+      </LoggedInUserProvider>
+    </DomainSettingsProvider>,
+  );
+
+describe("Wishlist Card", () => {
+  // A wishlist with no thumbnails (e.g. its only product has none) used to render a bare
+  // <img> with no src, which shows the browser's broken-image icon on production
+  // (https://gumroad.com/software-development, reported by @GergelyOrosz). The figure's
+  // own placeholder background covers the empty case, so no <img> at all should render.
+  it("renders no <img> when the wishlist has no thumbnails", () => {
+    const { container } = renderCard({ wishlist: wishlist({ thumbnails: [] }) });
+
+    expect(container.querySelectorAll("figure img")).toHaveLength(0);
+  });
+
+  it("still renders an <img> per thumbnail when thumbnails exist", () => {
+    const { container } = renderCard({
+      wishlist: wishlist({
+        thumbnails: [
+          { url: "https://example.com/one.png", native_type: "digital" },
+          { url: "https://example.com/two.png", native_type: "digital" },
+        ],
+      }),
+    });
+
+    expect(container.querySelectorAll("figure img")).toHaveLength(2);
+  });
+});

--- a/app/javascript/components/Wishlist/Card.tsx
+++ b/app/javascript/components/Wishlist/Card.tsx
@@ -100,7 +100,10 @@ export const Card = ({ wishlist, hideSeller, eager }: CardProps) => {
             {...lazyLoadingProps}
           />
         ))}
-        {wishlist.thumbnails.length === 0 ? <img role="presentation" /> : null}
+        {/* A src-less <img> here rendered the browser's broken-image icon for every
+            wishlist with no thumbnails (https://gumroad.com/software-development, reported
+            by @GergelyOrosz). The figure's own bg-(image:--product-cover-placeholder)
+            background already covers this case, so render nothing. */}
       </ProductCardFigure>
       <section className="flex flex-1 flex-col lg:flex-2 lg:gap-8 lg:px-6 lg:py-4">
         <ProductCardHeader className="lg:border-b-0 lg:p-0">


### PR DESCRIPTION
## Bug

Reported by @GergelyOrosz on X, visible on production right now at https://gumroad.com/software-development — the "mac utilities" wishlist card (and any wishlist whose thumbnails are empty) renders the browser's broken-image icon instead of a normal placeholder.

## Root cause

`Wishlist::Card` (`app/javascript/components/Wishlist/Card.tsx`) had:

```tsx
{wishlist.thumbnails.length === 0 ? <img role="presentation" /> : null}
```

A bare `<img>` with **no `src` at all** — guaranteed broken-image icon in every browser whenever a wishlist has no thumbnails.

## Fix

Removed the src-less `<img>`. The figure element already carries a `bg-(image:--product-cover-placeholder)` CSS background for exactly this empty case (same pattern used by `ProductCardFigure` elsewhere), so rendering nothing is correct — the existing placeholder shows through as intended.

## QA steps

1. Visit any wishlist-discover surface with a wishlist that has zero thumbnails (e.g. https://gumroad.com/software-development, "mac utilities" wishlist card — reproduced live before this fix).
2. Before: browser's native broken-image icon in the card figure.
3. After: the card's own placeholder background (transparent/pink gradient depending on state) with no broken-image glyph.

## Test plan / evidence

- Added `Card.test.tsx`: asserts zero `<img>` elements render when `thumbnails` is empty, and that per-thumbnail `<img>` rendering is unaffected when thumbnails exist.
- Verified the new test **fails** on the pre-fix code (confirms it actually catches the regression) and **passes** after the fix.
- `tsc --noEmit`: clean.
- `eslint`: clean.

---
AI disclosure: this PR was authored autonomously by gumclaw (Hermes agent) at Sahil's direction to investigate and fix the reported bug. Model: claude-sonnet-5.

Premerge review: clean @ 703d9621aa (codex/gpt-5.6-sol, confidence 0.99, no findings)
