### PR TITLE
Trim historical narration from wishlist card comment

### DIFF
--- a/app/javascript/components/Wishlist/Card.test.tsx
+++ b/app/javascript/components/Wishlist/Card.test.tsx
@@ -43,10 +43,8 @@ const renderCard = (props: React.ComponentProps<typeof Card>) =>
   );
 
 describe("Wishlist Card", () => {
-  // A wishlist with no thumbnails (e.g. its only product has none) used to render a bare
-  // <img> with no src, which shows the browser's broken-image icon on production
-  // (https://gumroad.com/software-development, reported by @GergelyOrosz). The figure's
-  // own placeholder background covers the empty case, so no <img> at all should render.
+  // No <img> should render when there are no thumbnails — the figure's own
+  // placeholder background covers the empty case.
   it("renders no <img> when the wishlist has no thumbnails", () => {
     const { container } = renderCard({ wishlist: wishlist({ thumbnails: [] }) });
 

--- a/app/javascript/components/Wishlist/Card.tsx
+++ b/app/javascript/components/Wishlist/Card.tsx
@@ -100,10 +100,8 @@ export const Card = ({ wishlist, hideSeller, eager }: CardProps) => {
             {...lazyLoadingProps}
           />
         ))}
-        {/* A src-less <img> here rendered the browser's broken-image icon for every
-            wishlist with no thumbnails (https://gumroad.com/software-development, reported
-            by @GergelyOrosz). The figure's own bg-(image:--product-cover-placeholder)
-            background already covers this case, so render nothing. */}
+        {/* No <img> when there are no thumbnails — the figure's own
+            bg-(image:--product-cover-placeholder) background covers the empty case. */}
       </ProductCardFigure>
       <section className="flex flex-1 flex-col lg:flex-2 lg:gap-8 lg:px-6 lg:py-4">
         <ProductCardHeader className="lg:border-b-0 lg:p-0">


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

## What

Trims the historical narration (production URL, reporter handle, bug-discovery story) out of the comment `#7116` added, keeping only the implementation invariant — per Greptile's P2 finding on that PR and `AGENTS.md`'s comment-style rule.

## Why

Follow-up to #7116 (merged). Greptile flagged the comment as citing incident history a maintainer who already knows this codebase doesn't need: [P2 finding](https://github.com/antiwork/gumroad/pull/7116#discussion_r3732140378).

## Before/After

Before: `// A src-less <img> here rendered the browser's broken-image icon for every wishlist with no thumbnails (https://gumroad.com/software-development, reported by @GergelyOrosz). The figure's own bg-(image:--product-cover-placeholder) background already covers this case, so render nothing.`

After: `// No <img> when there are no thumbnails — the figure's own bg-(image:--product-cover-placeholder) background covers the empty case.`

Same trim applied to the mirrored comment in `Card.test.tsx`.

## Test Results

Comment-only diff (no behavior change) — no new specs needed. eslint not run in this environment (no node_modules installed); diff is a pure comment edit with no code touched, so no functional risk.

## QA steps

Read-diff review: confirmed only comment text changed, JSX/logic untouched.

---
AI disclosure: this PR was authored autonomously by gumclaw (Hermes agent) as a follow-up to a Greptile review finding on #7116. Model: claude-sonnet-5.

Premerge review: clean @ c1609c5a89 (comment-only diff; no behavior, logic, or JSX changed — verified by diff inspection)
