### PR TITLE
Preserve description paragraph structure on custom landing pages

### DIFF
--- a/app/services/pages/interpolator.rb
+++ b/app/services/pages/interpolator.rb
@@ -9,10 +9,22 @@ class Pages::Interpolator
   # allowlisted tags would render as literal text instead of markup.
   RAW_HTML_FIELDS = %w[description].freeze
 
+  # HTML5 forbids block content (p/h1-h3/ul) inside these phrasing-content elements — a browser
+  # auto-closes the marker on the first nested block tag, so a seller's <p data-gumroad-field=
+  # "description"> would silently lose its own wrapper (and any CSS scoped to it) the moment the
+  # description has more than one paragraph. Unwrap the marker instead of nesting into it when
+  # both conditions hold; see the block-tag check below.
+  PHRASING_ONLY_MARKER_TAGS = %w[p span a em strong b i small label].freeze
+
   # Kept narrow: enough to preserve a description's paragraph/heading/list structure and
   # inline emphasis without turning this marker into a second copy of Ai::PageSanitizer's
   # much larger custom-HTML allowlist.
   DESCRIPTION_SANITIZE_OPTIONS = { tags: %w[p br h1 h2 h3 strong em ul li a], attributes: %w[href] }.freeze
+
+  # The block-level subset of DESCRIPTION_SANITIZE_OPTIONS' tags — what triggers the
+  # PHRASING_ONLY_MARKER_TAGS unwrap above. br/strong/em/li/a are inline or only ever nested,
+  # so they can't invalidate a phrasing-only marker on their own.
+  DESCRIPTION_BLOCK_TAGS = /<(?:p|h1|h2|h3|ul)[\s>]/
 
   FIELDS = {
     "name" => ->(product) { product.name.to_s },
@@ -125,7 +137,15 @@ class Pages::Interpolator
       # their tags into literal text.
       next if value.nil?
 
-      node.inner_html = RAW_HTML_FIELDS.include?(field) ? value : ERB::Util.h(value)
+      if RAW_HTML_FIELDS.include?(field) && PHRASING_ONLY_MARKER_TAGS.include?(node.name) && value.match?(DESCRIPTION_BLOCK_TAGS)
+        # Replacing the marker node itself, rather than writing into it, means the seller's own
+        # id/class/data attributes on the marker are lost for this element — acceptable here since
+        # nothing in the allowlisted output is meant to inherit marker-specific styling, and the
+        # alternative (nesting block content into a phrasing element) is the bug being fixed.
+        node.replace(Loofah.fragment(value).children)
+      else
+        node.inner_html = RAW_HTML_FIELDS.include?(field) ? value : ERB::Util.h(value)
+      end
     end
 
     # The selection params (variant/quantity/PWYW price/recurrence) are

--- a/app/services/pages/interpolator.rb
+++ b/app/services/pages/interpolator.rb
@@ -4,6 +4,16 @@
 # product values, not placeholders. Unknown markers pass through unchanged
 # so the agent's fallback text renders instead of breaking the page.
 class Pages::Interpolator
+  # Values under these keys are already-sanitized HTML fragments, not plain text — the
+  # interpolate loop below must write them raw instead of through ERB::Util.h, or the
+  # allowlisted tags would render as literal text instead of markup.
+  RAW_HTML_FIELDS = %w[description].freeze
+
+  # Kept narrow: enough to preserve a description's paragraph/heading/list structure and
+  # inline emphasis without turning this marker into a second copy of Ai::PageSanitizer's
+  # much larger custom-HTML allowlist.
+  DESCRIPTION_SANITIZE_OPTIONS = { tags: %w[p br h1 h2 h3 strong em ul li a], attributes: %w[href] }.freeze
+
   FIELDS = {
     "name" => ->(product) { product.name.to_s },
     # The price a first-time buyer is charged: default offer code applied and, for memberships,
@@ -11,7 +21,10 @@ class Pages::Interpolator
     # (BestOfferCodeService, ProductPresenter::Card), so the plain set price here would disagree
     # with the page this markup replaces.
     "price" => ->(product) { product.price_formatted_verbose(for_default_duration: true, discounted: true).to_s },
-    "description" => ->(product) { ActionView::Base.full_sanitizer.sanitize(product.description.to_s) },
+    # full_sanitizer strips every tag with no inserted breaks, collapsing a multi-paragraph
+    # description into one run-on sentence — sanitize with an allowlist instead so paragraph/
+    # heading/list structure survives.
+    "description" => ->(product) { ActionController::Base.helpers.sanitize(product.description.to_s, **DESCRIPTION_SANITIZE_OPTIONS) },
   }.freeze
 
   # Both fields read the summary that interpolate computes at most once per render.
@@ -107,8 +120,12 @@ class Pages::Interpolator
 
       # nil means "leave the author's own copy in place" (reviews hidden, or none yet), matching
       # interpolate_profile. An empty STRING still writes, so a blank description keeps clearing
-      # its placeholder as before.
-      node.inner_html = ERB::Util.h(value) unless value.nil?
+      # its placeholder as before. RAW_HTML_FIELDS values are pre-sanitized fragments (see
+      # DESCRIPTION_SANITIZE_OPTIONS) and must not go through ERB::Util.h, which would escape
+      # their tags into literal text.
+      next if value.nil?
+
+      node.inner_html = RAW_HTML_FIELDS.include?(field) ? value : ERB::Util.h(value)
     end
 
     # The selection params (variant/quantity/PWYW price/recurrence) are

--- a/spec/services/pages/interpolator_spec.rb
+++ b/spec/services/pages/interpolator_spec.rb
@@ -142,13 +142,28 @@ describe Pages::Interpolator do
       expect(result).to include(">$5 once<")
     end
 
-    it "replaces data-gumroad-field='description' with plain-text description" do
-      html = %(<p data-gumroad-field="description">placeholder</p>)
+    it "preserves the description's paragraph/heading structure instead of collapsing it to plain text" do
+      product.update!(description: "<h1>Title</h1><p>First paragraph.</p><p>Second <strong>paragraph</strong>.</p>")
+      html = %(<div data-gumroad-field="description">placeholder</div>)
 
       result = described_class.interpolate(html, product: product)
 
-      expect(result).to include("Real description")
-      expect(result).not_to include("<strong>")
+      expect(result).to include("<h1>Title</h1>")
+      expect(result).to include("<p>First paragraph.</p>")
+      expect(result).to include("<p>Second <strong>paragraph</strong>.</p>")
+      expect(result).not_to include("placeholder")
+    end
+
+    it "strips tags outside the description allowlist but keeps their text" do
+      product.update!(description: %(<p>Safe</p><script>alert("xss")</script><table><tr><td>cell</td></tr></table>))
+      html = %(<div data-gumroad-field="description"></div>)
+
+      result = described_class.interpolate(html, product: product)
+
+      expect(result).to include("<p>Safe</p>")
+      expect(result).not_to include("<script>")
+      expect(result).not_to include("<table>")
+      expect(result).to include("cell")
     end
 
     it "prepares <a data-gumroad-action='buy'> for the delegated checkout bridge" do

--- a/spec/services/pages/interpolator_spec.rb
+++ b/spec/services/pages/interpolator_spec.rb
@@ -166,6 +166,27 @@ describe Pages::Interpolator do
       expect(result).to include("cell")
     end
 
+    it "unwraps a multi-paragraph description out of a phrasing-only marker (e.g. <p>) instead of nesting invalid HTML" do
+      product.update!(description: "<p>First paragraph.</p><p>Second paragraph.</p>")
+      html = %(<p data-gumroad-field="description">placeholder</p>)
+
+      result = described_class.interpolate(html, product: product)
+
+      expect(result).to include("<p>First paragraph.</p><p>Second paragraph.</p>")
+      # The marker itself must not survive wrapping the block content — a browser would have
+      # auto-closed it on the first nested <p> anyway, which is the bug this guards against.
+      expect(result).not_to match(%r{<p data-gumroad-field="description">})
+    end
+
+    it "leaves a single-line description nested inside its own <p> marker (no block tags, no unwrap needed)" do
+      product.update!(description: "Just one line, no breaks.")
+      html = %(<p data-gumroad-field="description">placeholder</p>)
+
+      result = described_class.interpolate(html, product: product)
+
+      expect(result).to include(%(<p data-gumroad-field="description">Just one line, no breaks.</p>))
+    end
+
     it "prepares <a data-gumroad-action='buy'> for the delegated checkout bridge" do
       html = %(<a data-gumroad-action="buy" href="#">Buy</a>)
 


### PR DESCRIPTION
## Status

- [x] Scope — sanitize `description` with an HTML allowlist instead of stripping all tags
- [x] Design — narrow allowlist (`p br h1 h2 h3 strong em ul li a`), write raw (not escaped); unwrap block content out of a phrasing-only marker instead of nesting it
- [x] Build — `app/services/pages/interpolator.rb`
- [x] QA — spec suite green, new specs mutation-verified against pre-fix code
- [ ] Ship — awaiting CI + review
- [ ] Market / Sell — n/a, internal bug fix

## What

`Pages::Interpolator`'s `description` field used `ActionView::Base.full_sanitizer`, which strips every HTML tag with no inserted line breaks — collapsing a seller's multi-paragraph description into one run-on sentence on any custom landing page using a `data-gumroad-field="description"` element. Sanitize with a narrow allowlist (`p br h1 h2 h3 strong em ul li a`) instead, and write the result as raw HTML rather than through `ERB::Util.h` (which would otherwise escape the allowed tags back into literal text).

A follow-up round addresses a Greptile finding: when the seller marks the field with a phrasing-only element (`<p data-gumroad-field="description">`, `<span>`, `<a>`, etc.) and the description has block content (`<p>`/`<h1>`-`<h3>`/`<ul>`), nesting that content inside the marker produces invalid HTML5 — a browser auto-closes the marker on the first nested block tag, silently dropping the marker element itself. The interpolator now detects that case and unwraps: it replaces the marker node with the sanitized fragment directly instead of writing into it. Single-line descriptions (no block tags) still nest normally, so existing pages using inline markers are unaffected.

## Why

Confirmed live on a seller's custom landing page product: a 9-paragraph description rendered as a single block. Reported via Helper ticket `e110b02c95a1952f2ec14a4ac0ca806f`. See linked issue for full repro details.

## Before/After

- Before (original bug): `<h1>Title</h1><p>A</p><p>B</p>` → `TitleAB` (all tags stripped, no breaks)
- After: `<h1>Title</h1><p>A</p><p>B</p>` → same structure preserved, `<script>`/`<table>`/other tags still stripped
- Marker-nesting case: `<p data-gumroad-field="description">` + a 2-paragraph description → unwrapped to `<p>First paragraph.</p><p>Second paragraph.</p>` instead of `<p data-gumroad-field="description"><p>...</p><p>...</p></p>` (invalid nested markup a browser would have mangled anyway)

## Test Results

`bundle exec rspec spec/services/pages/interpolator_spec.rb` — 41 examples, 0 failures (captured output, ran locally at head `fdc02a15`). Four new examples total across both rounds; the two newest (phrasing-only-marker unwrap, and the negative case confirming single-line descriptions still nest normally) were mutation-verified by reverting the unwrap branch and re-running just those two — the unwrap example failed red against the pre-fix code, and both pass with the fix restored. `rubocop` clean on both changed files.

## QA steps

Ran the spec suite directly rather than a browser click-path — this is a backend template-rendering change with no new UI surface; the existing/updated specs exercise the exact `data-gumroad-field="description"` marker sellers use on custom pages, including the phrasing-only-marker case Greptile flagged.

Fixes antiwork/gumroad-private#1913

---

## AI disclosure

Built with AI assistance — model: Claude Sonnet 5.


Premerge review: clean @ fdc02a155c18a

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->


---
_Reassigned from @slavingia to gianfrancopiana — 8/8, ahead of Monday 4:30pm mergapalooza (Sahil clearing queues to 0)._