### PR TITLE
Align percentage tip line allocations with cart display tip

### DIFF
--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -2224,6 +2224,20 @@ describe("computeTipsForLines", () => {
     }
   });
 
+  // The canonical lane's callers (Show.tsx order lines) pass prices in the product's OWN minor
+  // units, while state.products holds unrounded USD — a KRW ₩5,000 product reads 500_000 in the
+  // lines and ~521 in state. Percentage tips must be derived from the lines themselves; reading
+  // the cart total from state.products misprices every non-USD tip (tipping_spec.rb "computes
+  // the correct tip", KRW).
+  it("computes canonical-lane percentage tips in the caller's line units for non-USD products", () => {
+    const s = state({
+      products: tippableProducts([521]),
+      tip: { type: "percentage", percentage: 20 },
+    });
+    const lines = [{ price: 500_000, permalink: "product-0" }];
+    expect(computeTipsForLines(s, lines)).toEqual([100_000]);
+  });
+
   it("keeps listed-basis percentage tips summing to round(pct * listedTotal)", () => {
     const s = state({
       products: tippableProducts([916, 916]),

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -2071,7 +2071,9 @@ describe("computeTipForListedLines", () => {
     const lines = [{ price: 4_990, permalink: "prod" }];
 
     expect(computeTipForListedLines(s, lines)).toBe(749);
-    expect(computeTipForListedLines(s, lines)).toBe(computeTipsForLines(s, lines).reduce(sumTips, 0));
+    expect(computeTipForListedLines(s, lines)).toBe(
+      computeTipsForLines(s, lines, { basis: "listed" }).reduce(sumTips, 0),
+    );
     // Converting the canonical figure back up instead lands two centavos low.
     expect(computeTip(s)).toBe(137);
   });
@@ -2192,9 +2194,50 @@ describe("computeTipsForLines", () => {
     expect(tips.reduce((sum: number, tip) => sum + (tip ?? 0), 0)).toBe(137);
   });
 
-  it("matches computeTipForPrice's per-line rounding for percentage tips", () => {
-    const s = state({ products: tippableProducts([999, 1_001]), tip: { type: "percentage", percentage: 10 } });
-    expect(computeTipsForLines(s, linesFor(s))).toEqual([100, 100]);
+  // Independent Math.round(pct * line) over [999, 1999, 2999] @ 20% yields 200+400+600 = 1200,
+  // while TipSelector / Subtotal / confirm show computeTip = Math.round(0.2 * 5997) = 1199.
+  // Allocation must make the charged line tips sum to that displayed cart tip.
+  it("never charges more percentage tip than computeTip shows (999/1999/2999 @ 20%)", () => {
+    const s = state({
+      products: tippableProducts([999, 1_999, 2_999]),
+      tip: { type: "percentage", percentage: 20 },
+    });
+    expect(computeTip(s)).toBe(1_199);
+    const tips = computeTipsForLines(s, linesFor(s));
+    expect(tips.reduce((sum: number, tip) => sum + (tip ?? 0), 0)).toBe(computeTip(s));
+    // Independent per-line rounding is the stale path this guards against.
+    expect([999, 1_999, 2_999].map((price) => Math.round(0.2 * price)).reduce((a, b) => a + b, 0)).toBe(1_200);
+  });
+
+  it("sums percentage line tips exactly to computeTip across uneven lines and rates", () => {
+    const cases: { prices: number[]; percentage: number }[] = [
+      { prices: [999, 1_001], percentage: 10 },
+      { prices: [1, 1, 1], percentage: 10 },
+      { prices: [199, 1_050, 333, 2_499, 61], percentage: 15 },
+      { prices: [333, 333, 334], percentage: 33 },
+      { prices: [50, 50], percentage: 1 },
+    ];
+    for (const { prices, percentage } of cases) {
+      const s = state({ products: tippableProducts(prices), tip: { type: "percentage", percentage } });
+      const tips = computeTipsForLines(s, linesFor(s));
+      expect(tips.reduce((sum: number, tip) => sum + (tip ?? 0), 0)).toBe(computeTip(s));
+    }
+  });
+
+  it("keeps listed-basis percentage tips summing to round(pct * listedTotal)", () => {
+    const s = state({
+      products: tippableProducts([916, 916]),
+      tip: { type: "percentage", percentage: 20 },
+    });
+    const lines = [
+      { price: 4_990, permalink: "product-0" },
+      { price: 4_990, permalink: "product-1" },
+    ];
+    const listedTotal = 9_980;
+    const expectedTip = Math.round(0.2 * listedTotal);
+    const tips = computeTipsForLines(s, lines, { basis: "listed" });
+    expect(tips.reduce((sum: number, tip) => sum + (tip ?? 0), 0)).toBe(expectedTip);
+    expect(computeTipForListedLines(s, lines)).toBe(expectedTip);
   });
 
   // isTippingEnabled requires a positive cart total, so a free cart yields no tips here —

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -618,15 +618,17 @@ export function computeTipForPrice(state: State, price: number, permalink: strin
 }
 
 // Computes each cart line's tip so the per-line integers sum exactly to the tip the buyer
-// selected. `computeTipForPrice` rounds each line independently, which can overshoot for a
-// fixed tip: two equal items with a 1-cent fixed tip each round to 1 cent, sending 2 cents
-// of tip in total even though `computeTip(state)` is 1 cent. Fixed tips are instead split
-// with a largest-remainder allocation (floor every line's exact proportional share, then
-// hand the leftover cents to the lines with the largest fractional parts). Every consumer
-// that builds per-line money for the server (the surcharge quote request and the order's
-// line items) must use this same function, because the buyer-currency quote token is
-// verified at charge time by comparing the quote's line totals against the purchases' —
-// two call sites rounding differently would make every affected charge fail verification.
+// selected (the same figure TipSelector / Subtotal / confirm show via `computeTip`, or its
+// listed-currency counterpart). `computeTipForPrice` rounds each line independently, which
+// overshoots for both tip types: two equal items with a 1-cent fixed tip each round to 1 cent
+// (2 charged vs 1 chosen), and prices like [999, 1999, 2999] at 20% round to 200+400+600 = 1200
+// while `computeTip` is 1199. Both tip types therefore use largest-remainder allocation (floor
+// every line's exact proportional share, then hand leftover cents to the lines with the largest
+// fractional parts). Every consumer that builds per-line money for the server (the surcharge
+// quote request and the order's line items) must use this same function, because the
+// buyer-currency quote token is verified at charge time by comparing the quote's line totals
+// against the purchases': two call sites rounding differently would make every affected charge
+// fail verification.
 export function computeTipsForLines(
   state: State,
   lines: { price: number; permalink: string | undefined }[],
@@ -647,8 +649,16 @@ export function computeTipsForLines(
     }
     return allocateFixedTipCents(listedAmount ?? state.tip.amount ?? 0, lines, totalPriceCents);
   }
-  const percentage = state.tip.percentage;
-  return lines.map((line) => Math.round((percentage / 100) * line.price));
+  // One cart tip, then the same allocator fixed tips use. On a normal cart the line
+  // tips sum to the display tip; when line bases are smaller than the cart total
+  // (commission deposit / free-trial zeroing), leftover tip stays uncollected, same
+  // as fixed tips.
+  if (basis === "listed") {
+    const totalPriceCents = lines.reduce((sum, line) => sum + line.price, 0);
+    const tipCents = Math.round((state.tip.percentage / 100) * totalPriceCents);
+    return allocateFixedTipCents(tipCents, lines, totalPriceCents);
+  }
+  return allocateFixedTipCents(computeTip(state), lines, getTotalPriceFromProducts(state));
 }
 
 // The tip to DISPLAY on the method-forced listed-currency lane, in the listed currency's minor
@@ -672,6 +682,8 @@ export function computeTipForListedLines(state: State, lines: { price: number; p
 }
 
 function allocateFixedTipCents(tipAmountCents: number, lines: { price: number }[], totalPriceCents: number): number[] {
+  // Used for both fixed tip amounts and the single cart tip derived from a percentage, so
+  // per-line integers always sum to the tip the buyer saw (or the listed-lane equivalent).
   if (tipAmountCents <= 0 || totalPriceCents <= 0) return lines.map(() => 0);
 
   const exactShares = lines.map((line) => (tipAmountCents * line.price) / totalPriceCents);

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -649,16 +649,14 @@ export function computeTipsForLines(
     }
     return allocateFixedTipCents(listedAmount ?? state.tip.amount ?? 0, lines, totalPriceCents);
   }
-  // One cart tip, then the same allocator fixed tips use. On a normal cart the line
-  // tips sum to the display tip; when line bases are smaller than the cart total
-  // (commission deposit / free-trial zeroing), leftover tip stays uncollected, same
-  // as fixed tips.
-  if (basis === "listed") {
-    const totalPriceCents = lines.reduce((sum, line) => sum + line.price, 0);
-    const tipCents = Math.round((state.tip.percentage / 100) * totalPriceCents);
-    return allocateFixedTipCents(tipCents, lines, totalPriceCents);
-  }
-  return allocateFixedTipCents(computeTip(state), lines, getTotalPriceFromProducts(state));
+  // One cart tip, then the same allocator fixed tips use. The tip must be derived from the
+  // caller's own line bases, never from `state.products`: on the canonical lane the caller's
+  // prices are the products' own minor units while `state.products` holds unrounded USD, so
+  // mixing them misprices every non-USD cart's tip. Deriving from the lines is unit-correct on
+  // both lanes, and commission-deposit lines tip on the deposit they charge today, as before.
+  const totalPriceCents = lines.reduce((sum, line) => sum + line.price, 0);
+  const tipCents = Math.round((state.tip.percentage / 100) * totalPriceCents);
+  return allocateFixedTipCents(tipCents, lines, totalPriceCents);
 }
 
 // The tip to DISPLAY on the method-forced listed-currency lane, in the listed currency's minor


### PR DESCRIPTION
## What
Make multi-item percentage tips charge the same cents TipSelector and Subtotal display. `computeTipsForLines` now takes the once-rounded cart tip from `computeTip` and allocates it with the same largest-remainder helper fixed tips already use, instead of independently rounding each line. The listed-basis (method-forced) lane allocates `round(pct * listedTotal)` the same way.

## Why
On carts like `$9.99 + $19.99 + $29.99` at 20%, display showed **1199¢** while the charge/surcharge path used **1200¢** (200+400+600 from per-line rounding). Fixed tips were already reconciled through `allocateFixedTipCents`; percentage tips were not. Per-line money sent to the server must sum to the tip the buyer saw — the buyer-currency quote token is verified at charge time against per-line totals, so the two paths rounding differently is a display/charge money mismatch.

## Before / After
- **Before:** independent per-line `Math.round` can disagree with the displayed cart-level tip by ±1¢ (999/1999/2999 @ 20%: charged 1200¢, displayed 1199¢).
- **After:** line tips sum exactly to the displayed cart tip on both the canonical and listed lanes; when line bases are smaller than the cart total (commission deposit / free-trial zeroing), leftover tip stays uncollected, same as fixed tips.

No rendered-surface pixel change: the fix moves which integer cents are charged, not what the checkout renders (the displayed tip was already correct — the charge is what moves to match it). Contributor's walkthrough video + test-run capture live on the source PR: https://github.com/adityawrk/gumroad/pull/20 (binary `qa-media/` deliberately not imported).

## Test Results
- `npx vitest run app/javascript/components/Checkout/payment.test.ts` at this head: **157 passed, 0 failed**.
- Failing-first proof (code file reverted to `origin/main`, contributed tests kept): **2 failed | 155 passed** — `never charges more percentage tip than computeTip shows (999/1999/2999 @ 20%)` and `sums percentage line tips exactly to computeTip across uneven lines and rates` both red against the pre-fix code.

## QA steps
Reviewer path: read the `computeTipsForLines` percentage branch diff; run the vitest file above; optionally reproduce with a 3-item cart (9.99/19.99/29.99) at 20% tip and compare the displayed tip against the order's per-line tip sum.

---
Based on https://github.com/adityawrk/gumroad/pull/20 by @adityawrk (submitted via Helper; tracker: antiwork/gumroad-private#1912).

AI disclosure: Claude Sonnet 5 was used to review the original PR, verify the fix failing-first, and import the changes. Contributor's disclosure: Cursor Grok 4.5 implemented; Cursor agents validated.


Premerge review: clean @ 9e4440c2dfb463462fee85f0d0a7797378dd60ca (re-verdicted after slavingia's KRW-regression fix touched only payment.ts/payment.test.ts, both reviewed above)

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it; slavingia commented after my last word (2026-08-07T14:10) — unanswered), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->

