### PR TITLE
Persist completion tip USD cents on commission purchases

### DIFF
--- a/app/models/commission.rb
+++ b/app/models/commission.rb
@@ -53,7 +53,11 @@ class Commission < ApplicationRecord
     completion_purchase.inherit_offer_code_from(deposit_purchase)
 
     if completion_tip_value_cents.positive?
-      completion_purchase.build_tip(value_cents: completion_tip_value_cents)
+      # Presentment accounting reads value_usd_cents; schema default is 0 if omitted.
+      completion_purchase.build_tip(
+        value_cents: completion_tip_value_cents,
+        value_usd_cents: completion_tip_value_usd_cents
+      )
     end
 
     if deposit_purchase.is_purchasing_power_parity_discounted &&

--- a/spec/models/commission_spec.rb
+++ b/spec/models/commission_spec.rb
@@ -109,6 +109,44 @@ describe Commission, :vcr do
       expect { commission.create_completion_purchase! }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
+    # Tip USD must be set on the completion tip: LaterChargePresentment.canonical_price_cents_for
+    # subtracts tip.value_usd_cents, and a 0 default would make a principal-only fixing look stale.
+    it "persists completion tip USD so a buyer-presentment fixing still matches when tipped" do
+      product = create(:commission_product)
+      merchant_account = create(:merchant_account, user: product.user, charge_processor_merchant_id: "commission-tip-usd-presentment")
+      deposit_purchase = create(
+        :purchase,
+        link: product,
+        merchant_account:,
+        is_commission_deposit_purchase: true,
+        price_cents: 1_100,
+        total_transaction_cents: 1_100
+      )
+      # Distinct presentment vs USD proves we do not copy value_cents into value_usd_cents.
+      deposit_purchase.create_tip!(value_cents: 80, value_usd_cents: 100)
+      commission = create(:commission, status: Commission::STATUS_IN_PROGRESS, deposit_purchase:)
+      attach_commission_file(commission)
+      fixing = create(
+        :later_charge_presentment,
+        owner: commission,
+        presentment_currency: "eur",
+        presentment_price_cents: 899,
+        canonical_price_cents: 1_000
+      )
+
+      expect_any_instance_of(Purchase).to receive(:process!) do |completion_purchase|
+        expect(completion_purchase.tip.value_cents).to eq(80)
+        expect(completion_purchase.tip.value_usd_cents).to eq(100)
+        completion_purchase.price_cents = 1_000
+        completion_purchase.total_transaction_cents = 1_100
+        expect(LaterChargePresentment.canonical_price_cents_for(completion_purchase))
+          .to eq(fixing.canonical_price_cents)
+        completion_purchase.errors.add(:base, "Stop before charging")
+      end
+
+      expect { commission.create_completion_purchase! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
     context "when the deposit is no longer chargeable" do
       let(:commission) { create(:commission, status: Commission::STATUS_IN_PROGRESS) }
       let(:deposit_purchase) { commission.deposit_purchase }
@@ -197,7 +235,8 @@ describe Commission, :vcr do
         attach_commission_file(commission)
         deposit_purchase.update!(zip_code: "10001")
         deposit_purchase.update!(displayed_price_cents: 100)
-        deposit_purchase.create_tip!(value_cents: 20)
+        # Distinct presentment vs USD proves we do not copy value_cents into value_usd_cents.
+        deposit_purchase.create_tip!(value_cents: 20, value_usd_cents: 25)
         deposit_purchase.variant_attributes << create(:variant, name: "Deluxe")
       end
 
@@ -228,6 +267,7 @@ describe Commission, :vcr do
         expect(completion_purchase.offer_code).to eq(deposit_purchase.offer_code)
         expect(completion_purchase.is_commission_completion_purchase).to be true
         expect(completion_purchase.tip.value_cents).to eq(20)
+        expect(completion_purchase.tip.value_usd_cents).to eq(25)
         expect(completion_purchase.variant_attributes).to eq(deposit_purchase.variant_attributes)
         expect(completion_purchase).to be_successful
 


### PR DESCRIPTION
## What
Set both `value_cents` and `value_usd_cents` when `Commission#create_completion_purchase!` builds the completion tip, using the existing `completion_tip_value_usd_cents` helper.

## Why
The completion tip was built with only `value_cents`, so `value_usd_cents` kept its schema default of 0. `LaterChargePresentment.canonical_price_cents_for` subtracts `tip.value_usd_cents`, so a tipped completion purchase computed a canonical price inflated by the tip amount, and a buyer-presentment fixing could read as stale — falling back to unlocked USD instead of the locked presentment price.

## Before / After
- **Before:** completion tip `value_usd_cents = 0` despite a positive tip; `canonical_price_cents_for(completion_purchase)` ≠ the fixing's `canonical_price_cents` for any tipped commission.
- **After:** completion tip carries `completion_tip_value_usd_cents`; the presentment fixing match holds (asserted directly in the new spec with distinct presentment vs USD tip values, proving no `value_cents` copy).

Backend-only, no rendered surface. Contributor's walkthrough video + test-run capture live on the source PR: https://github.com/adityawrk/gumroad/pull/21 (binary `qa-media/` deliberately not imported).

## Test Results
- `bundle exec rspec spec/models/commission_spec.rb` at this head: **40 examples, 0 failures**.
- Failing-first proof (`app/models/commission.rb` reverted to `origin/main`, specs kept): the new example fails with `Expected 0 to eq 100` on `completion_purchase.tip.value_usd_cents` — red on exactly the persisted-USD assertion; green with the fix restored (**1 example, 0 failures**).

## QA steps
Reviewer path: read the 4-line `build_tip` diff; run the spec file above; optionally in console build a tipped commission deposit and confirm `commission.create_completion_purchase!`'s tip carries a nonzero `value_usd_cents`.

---
Based on https://github.com/adityawrk/gumroad/pull/21 by @adityawrk (submitted via Helper; tracker: antiwork/gumroad-private#1912).

AI disclosure: Claude Sonnet 5 was used to review the original PR, verify the fix failing-first, and import the changes. Contributor's disclosure: Cursor Grok 4.5 implemented; Cursor agents validated.


Premerge review: clean @ cdfc41bc6cdaa151bb191b2ad960271ec000bb65
(autoreview panel — codex/gpt-5.6-sol + claude-fable-5, 0 findings, "patch is correct (0.99)")

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (no human review requested/received yet — still mine to hand off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
