### PR TITLE
Preserve subscription magic links on invalid requests

### DIFF
--- a/app/controllers/subscriptions/magic_links_controller.rb
+++ b/app/controllers/subscriptions/magic_links_controller.rb
@@ -13,13 +13,12 @@ class Subscriptions::MagicLinksController < ApplicationController
   end
 
   def create
-    @subscription.refresh_token
-
     emails = @subscription.emails
-    email_source = params[:email_source].to_sym
+    email_source = params[:email_source].to_sym if params[:email_source].is_a?(String)
     email = emails[email_source]
     e404 if email.nil?
 
+    @subscription.refresh_token
     CustomerMailer.subscription_magic_link(@subscription.id, email).deliver_later(queue: "critical")
 
     redirect_to new_subscription_magic_link_path(@subscription.external_id, email_sent: email_source),

--- a/spec/controllers/subscriptions/magic_links_controller_spec.rb
+++ b/spec/controllers/subscriptions/magic_links_controller_spec.rb
@@ -58,6 +58,15 @@ describe Subscriptions::MagicLinksController, inertia: true do
       expect(@subscription.reload.token).to_not be_nil
     end
 
+    it "replaces an existing token after validating the email source" do
+      @subscription.refresh_token
+      original_token = @subscription.token
+
+      post :create, params: { subscription_id: @subscription.external_id, email_source: "user" }
+
+      expect(@subscription.reload.token).to_not eq(original_token)
+    end
+
     it "sets the token to expire in 24 hours" do
       expect(@subscription.token_expires_at).to be_nil
       post :create, params: { subscription_id: @subscription.external_id, email_source: "user" }
@@ -66,7 +75,7 @@ describe Subscriptions::MagicLinksController, inertia: true do
 
     it "sends the magic link email and redirects with flash" do
       mail_double = double
-      allow(mail_double).to receive(:deliver_later)
+      expect(mail_double).to receive(:deliver_later).with(queue: "critical")
       expect(CustomerMailer).to receive(:subscription_magic_link).and_return(mail_double)
       post :create, params: { subscription_id: @subscription.external_id, email_source: "user" }
 
@@ -118,6 +127,38 @@ describe Subscriptions::MagicLinksController, inertia: true do
         it "raises a 404 error" do
           expect do
             post :create, params: { subscription_id: @subscription.external_id, email_source: "invalid source" }
+          end.to raise_error(ActionController::RoutingError, "Not Found")
+        end
+
+        it "does not replace an existing magic-link token" do
+          @subscription.refresh_token
+          original_token = @subscription.token
+
+          expect do
+            post :create, params: { subscription_id: @subscription.external_id, email_source: "invalid source" }
+          end.to raise_error(ActionController::RoutingError, "Not Found")
+
+          expect(@subscription.reload.token).to eq(original_token)
+        end
+      end
+
+      context "when the email source is missing" do
+        it "raises a 404 error without replacing an existing magic-link token" do
+          @subscription.refresh_token
+          original_token = @subscription.token
+
+          expect do
+            post :create, params: { subscription_id: @subscription.external_id }
+          end.to raise_error(ActionController::RoutingError, "Not Found")
+
+          expect(@subscription.reload.token).to eq(original_token)
+        end
+      end
+
+      context "when the email source is not a string" do
+        it "raises a 404 error" do
+          expect do
+            post :create, params: { subscription_id: @subscription.external_id, email_source: ["user"] }
           end.to raise_error(ActionController::RoutingError, "Not Found")
         end
       end


### PR DESCRIPTION
## What

Validates `email_source` before refreshing a subscription magic-link token.

Malformed, missing, array-shaped, or unknown sources now follow the controller's existing 404 path without replacing a previously issued valid token. Valid sources continue to rotate the token, enqueue the email on the critical queue, and redirect normally.

## Why

The controller refreshed the token before validating `email_source`. An invalid request therefore invalidated an existing usable magic link even though no replacement email was sent. A missing or non-string source could also raise `NoMethodError` instead of following the normal not-found response.

Validation is kept in the controller and moved before the state change, which fixes the ordering bug without changing the normal UI or mail delivery flow.

## Test results

Verified locally in a clean worktree off `origin/main`:

- Failing-first check: reverting only the controller change (keeping the new spec) reproduces exactly the 3 new regression examples as RED; restoring the fix returns all 15 examples GREEN.
- `bundle exec rspec spec/controllers/subscriptions/magic_links_controller_spec.rb` — 15 examples, 0 failures (also reran under seeds 7, 999, 4242, 12345 — all green, no order dependency).
- `bundle exec rubocop app/controllers/subscriptions/magic_links_controller.rb spec/controllers/subscriptions/magic_links_controller_spec.rb` — no offenses.

Premerge review: clean @ 18c1ba5d409c3f6d509b178a319b735a83283c7c

---

Based on https://github.com/RealBhupesh/gumroad/pull/7 by @RealBhupesh.

AI Disclosure: Claude Sonnet 4.5 was used to review the original PR, verify the fix failing-first, and import the changes.


## QA steps

No new before/after media captured for this import: the original contributor's QA walkthrough video covers the manual click-path (unknown/missing/array-shaped email_source now 404s without rotating the token; valid source still rotates + redirects) and is linked in the source PR: https://github.com/RealBhupesh/gumroad/pull/7. This import is backend-only (no visual/design changes), and the reviewable evidence here is the failing-first test verification described above.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (CI failing: Lint JS/TS), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->

