### PR TITLE
Fix Prettier formatting on CustomHtmlPreview iframe (unblock red main ci/green)

### DIFF
--- a/app/javascript/components/Pages/CustomHtmlPreview.tsx
+++ b/app/javascript/components/Pages/CustomHtmlPreview.tsx
@@ -108,13 +108,5 @@ export const CustomHtmlPreview = ({
     return () => window.removeEventListener("message", onMessage);
   }, [productsSrc, productsDefaultLimit]);
 
-  return (
-    <iframe
-      ref={frameRef}
-      title={title}
-      src={src}
-      sandbox="allow-scripts"
-      className={className}
-    />
-  );
+  return <iframe ref={frameRef} title={title} src={src} sandbox="allow-scripts" className={className} />;
 };


### PR DESCRIPTION
## What
Reformats the `<iframe>` return in `CustomHtmlPreview.tsx` to satisfy Prettier. No behavior change.

## Why
`ci/green` on `main` has been failing since #7110 merged (215123a3 onward) because Prettier now flags this JSX shape. That red `ci/green` on main cascades — every subsequent PR inherits a failing `Lint JS/TS` / `ci/green` check on its own run **even when the PR's diff never touches this file**. Observed live on #7124, #7122, #7119, #7113 and others (all showing an unexplained Lint JS/TS failure despite unrelated diffs).

## Verification
- `DISABLE_TYPE_CHECKED=1 npx eslint app/javascript/components/Pages/CustomHtmlPreview.tsx` → clean (was 1 error before this fix)
- Confirmed root cause via GH API: `repos/antiwork/gumroad/commits/<sha>/status` shows `ci/green: failure` starting at 7f06d3b6 (#7110) through 215123a3 (current main tip)
- Pure formatting change, zero logic touched

Premerge review: exempt (pure Prettier reformat, zero logic/behavior change, single JSX statement)

cc @slavingia — flagging this as a found-and-fixed automation/CI issue rather than an individual PR problem: several unrelated gumclaw PRs will likely go green automatically once this merges and their checks are re-run.