### PR TITLE
Block PayPal order total reductions

### DIFF
--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -630,7 +630,15 @@ class PaypalChargeProcessor
       raise ChargeProcessorError, "PayPal order currency changed when updating order"
     end
 
-    if BigDecimal(purchase_unit_info[:total].to_s) < BigDecimal(current_total.to_s)
+    begin
+      current_total_decimal = BigDecimal(current_total.to_s)
+      requested_total_decimal = BigDecimal(purchase_unit_info[:total].to_s)
+    rescue ArgumentError, TypeError
+      ErrorNotifier.notify("PayPal order total is not numeric when updating order")
+      raise ChargeProcessorError, "PayPal order total is not numeric when updating order"
+    end
+
+    if requested_total_decimal < current_total_decimal
       ErrorNotifier.notify("PayPal order update attempted to lower order total")
       raise ChargeProcessorError, "PayPal order update cannot lower the order total"
     end

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -608,43 +608,8 @@ class PaypalChargeProcessor
                                                    total_cents_usd: get_usd_cents(currency, product_info[:total_cents].to_i),
                                                    quantity: product_info[:quantity].to_i)
 
-    ensure_order_update_does_not_lower_total!(paypal_order_id, purchase_unit_info)
-
     update_order(paypal_order_id, purchase_unit_info)
   end
-
-  def self.ensure_order_update_does_not_lower_total!(paypal_order_id, purchase_unit_info)
-    order_details = fetch_order(order_id: paypal_order_id)
-    current_amount = order_details.dig("purchase_units", 0, "amount")
-    current_total = current_amount&.fetch("value", nil)
-    current_currency = current_amount&.fetch("currency_code", nil)
-
-    if current_total.blank? || current_currency.blank?
-      ErrorNotifier.notify("PayPal order total missing when updating order")
-      raise ChargeProcessorError, "PayPal order total missing when updating order"
-    end
-
-    requested_currency = purchase_unit_info[:currency].to_s
-    unless current_currency.casecmp?(requested_currency)
-      ErrorNotifier.notify("PayPal order currency changed when updating order")
-      raise ChargeProcessorError, "PayPal order currency changed when updating order"
-    end
-
-    begin
-      current_total_decimal = BigDecimal(current_total.to_s)
-      requested_total_decimal = BigDecimal(purchase_unit_info[:total].to_s)
-    rescue ArgumentError, TypeError
-      ErrorNotifier.notify("PayPal order total is not numeric when updating order")
-      raise ChargeProcessorError, "PayPal order total is not numeric when updating order"
-    end
-
-    if requested_total_decimal < current_total_decimal
-      ErrorNotifier.notify("PayPal order update attempted to lower order total")
-      raise ChargeProcessorError, "PayPal order update cannot lower the order total"
-    end
-  end
-
-  private_class_method :ensure_order_update_does_not_lower_total!
 
   def self.create_order(purchase_unit_info)
     if purchase_unit_info.blank?
@@ -724,13 +689,15 @@ class PaypalChargeProcessor
                            Charge.find_by_external_id(reference.sub(Charge::COMBINED_CHARGE_PREFIX, "")) :
                            Purchase.find_by_external_id(reference)
 
+    expected_purchase_unit_info = charge_or_purchase.is_a?(Charge) ?
+                                    self.class.paypal_order_info_from_charge(charge_or_purchase) :
+                                    self.class.paypal_order_info(charge_or_purchase)
+
     if chargeable.instance_of?(PaypalApprovedOrderChargeable)
       update_invoice_id(order_id: charge_or_purchase.paypal_order_id, invoice_id: reference)
-      capture_order(order_id: charge_or_purchase.paypal_order_id)
+      capture_order(order_id: charge_or_purchase.paypal_order_id, expected_purchase_unit_info:)
     else
-      paypal_order_id = charge_or_purchase.is_a?(Charge) ?
-                          self.class.create_order_from_charge(charge_or_purchase) :
-                          self.class.create_order_from_purchase(charge_or_purchase)
+      paypal_order_id = self.class.create_order(expected_purchase_unit_info)
       charge_or_purchase.update!(paypal_order_id:)
       charge_or_purchase.purchases.each { |purchase| purchase.update!(paypal_order_id:) } if charge_or_purchase.is_a?(Charge)
       capture_order(order_id: paypal_order_id, billing_agreement_id: chargeable.fingerprint)
@@ -748,13 +715,14 @@ class PaypalChargeProcessor
     end
   end
 
-  def capture_order(order_id:, billing_agreement_id: nil)
+  def capture_order(order_id:, billing_agreement_id: nil, expected_purchase_unit_info: nil)
     paypal_transaction = self.class.capture(order_id:, billing_agreement_id:)
     capture = paypal_transaction.purchase_units[0].payments.captures[0]
 
     if capture.status.downcase == PaypalApiPaymentStatus::COMPLETED.downcase ||
         (capture.status.downcase == PaypalApiPaymentStatus::PENDING.downcase &&
             capture.status_details.reason.upcase == "PENDING_REVIEW")
+      ensure_captured_amount_matches!(capture, expected_purchase_unit_info) if expected_purchase_unit_info.present?
       charge = PaypalCharge.new(paypal_transaction_id: capture.id,
                                 order_api_used: true,
                                 payment_details: paypal_transaction)
@@ -770,6 +738,28 @@ class PaypalChargeProcessor
       raise ChargeProcessorCardError.new("paypal_capture_failure",
                                          "PayPal transaction failed with status #{capture.status}",
                                          charge_id: capture.id)
+    end
+  end
+
+  def ensure_captured_amount_matches!(capture, expected_purchase_unit_info)
+    captured_amount = capture.amount
+    captured_currency = captured_amount&.currency_code
+    captured_value = captured_amount&.value
+    expected_currency = expected_purchase_unit_info[:currency].to_s.upcase
+
+    if captured_currency.blank? || captured_value.blank? || !captured_currency.casecmp?(expected_currency)
+      raise ChargeProcessorError, "PayPal captured amount does not match Gumroad order amount"
+    end
+
+    begin
+      captured_total = BigDecimal(captured_value.to_s)
+      expected_total = BigDecimal(expected_purchase_unit_info[:total].to_s)
+    rescue ArgumentError, TypeError
+      raise ChargeProcessorError, "PayPal captured amount does not match Gumroad order amount"
+    end
+
+    if captured_total != expected_total
+      raise ChargeProcessorError, "PayPal captured amount does not match Gumroad order amount"
     end
   end
 

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -608,8 +608,35 @@ class PaypalChargeProcessor
                                                    total_cents_usd: get_usd_cents(currency, product_info[:total_cents].to_i),
                                                    quantity: product_info[:quantity].to_i)
 
+    ensure_order_update_does_not_lower_total!(paypal_order_id, purchase_unit_info)
+
     update_order(paypal_order_id, purchase_unit_info)
   end
+
+  def self.ensure_order_update_does_not_lower_total!(paypal_order_id, purchase_unit_info)
+    order_details = fetch_order(order_id: paypal_order_id)
+    current_amount = order_details.dig("purchase_units", 0, "amount")
+    current_total = current_amount&.fetch("value", nil)
+    current_currency = current_amount&.fetch("currency_code", nil)
+
+    if current_total.blank? || current_currency.blank?
+      ErrorNotifier.notify("PayPal order total missing when updating order")
+      raise ChargeProcessorError, "PayPal order total missing when updating order"
+    end
+
+    requested_currency = purchase_unit_info[:currency].to_s
+    unless current_currency.casecmp?(requested_currency)
+      ErrorNotifier.notify("PayPal order currency changed when updating order")
+      raise ChargeProcessorError, "PayPal order currency changed when updating order"
+    end
+
+    if BigDecimal(purchase_unit_info[:total].to_s) < BigDecimal(current_total.to_s)
+      ErrorNotifier.notify("PayPal order update attempted to lower order total")
+      raise ChargeProcessorError, "PayPal order update cannot lower the order total"
+    end
+  end
+
+  private_class_method :ensure_order_update_does_not_lower_total!
 
   def self.create_order(purchase_unit_info)
     if purchase_unit_info.blank?

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -722,7 +722,14 @@ class PaypalChargeProcessor
     if capture.status.downcase == PaypalApiPaymentStatus::COMPLETED.downcase ||
         (capture.status.downcase == PaypalApiPaymentStatus::PENDING.downcase &&
             capture.status_details.reason.upcase == "PENDING_REVIEW")
-      ensure_captured_amount_matches!(capture, expected_purchase_unit_info) if expected_purchase_unit_info.present?
+      if expected_purchase_unit_info.present?
+        begin
+          ensure_captured_amount_matches!(capture, expected_purchase_unit_info)
+        rescue ChargeProcessorError => e
+          refund_mismatched_capture!(paypal_transaction, capture)
+          raise e
+        end
+      end
       charge = PaypalCharge.new(paypal_transaction_id: capture.id,
                                 order_api_used: true,
                                 payment_details: paypal_transaction)
@@ -761,6 +768,19 @@ class PaypalChargeProcessor
     if captured_total != expected_total
       raise ChargeProcessorError, "PayPal captured amount does not match Gumroad order amount"
     end
+  end
+
+  # Reverses a capture that already settled with the wrong amount so the underpayment
+  # doesn't sit unreconciled — a mismatch here means real money moved before the check
+  # in ensure_captured_amount_matches! ran. Swallows refund failures so the original
+  # amount-mismatch error still surfaces to the caller; Sentry has the refund failure for follow-up.
+  def refund_mismatched_capture!(paypal_transaction, capture)
+    merchant_id = paypal_transaction.purchase_units[0].payee.merchant_id
+    refund!(capture.id,
+            merchant_account: MerchantAccount.find_by(charge_processor_merchant_id: merchant_id),
+            paypal_order_purchase_unit_refund: true)
+  rescue StandardError => e
+    ErrorNotifier.notify(e, capture_id: capture.id, reason: "mismatched_capture_refund_failed")
   end
 
   def refund!(charge_id, amount_cents: nil, merchant_account: nil, paypal_order_purchase_unit_refund: nil, purchase: nil, **_args)

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -1264,14 +1264,16 @@ describe PaypalChargeProcessor, :vcr do
 
     context "when paypal order id is present in chargeable" do
       it "charges already approved order without creating a new order and returns PaypalCharge" do
-        purchase = create(:purchase, paypal_order_id: "5AF67588T4374172W")
+        purchase = create(:purchase, paypal_order_id: "5AF67588T4374172W", price_cents: 10_00)
         chargeable = PaypalApprovedOrderChargeable.new(purchase.paypal_order_id, "paypal-gr-integspecs@gumroad.com",
                                                        "US")
 
         expect_any_instance_of(PaypalChargeProcessor).not_to receive(:create_order)
         expect_any_instance_of(PaypalChargeProcessor).to receive(:update_invoice_id).and_call_original
         expect_any_instance_of(PaypalChargeProcessor).to receive(:capture_order)
-                                                           .with(order_id: purchase.paypal_order_id).and_call_original
+                                                           .with(order_id: purchase.paypal_order_id,
+                                                                 expected_purchase_unit_info: hash_including(currency: "usd"))
+                                                           .and_call_original
 
         charge = subject.create_payment_intent_or_charge!(create(:merchant_account_paypal, user: purchase.seller),
                                                           chargeable, 0, 0, purchase.external_id, "")
@@ -1311,7 +1313,7 @@ describe PaypalChargeProcessor, :vcr do
 
         it "creates new paypal order and charges it and returns PaypalChargeIntent" do
           expect(PaypalChargeProcessor).to receive(:paypal_order_info_from_charge).and_call_original
-          expect(PaypalChargeProcessor).to receive(:create_order_from_charge).and_call_original
+          expect(PaypalChargeProcessor).to receive(:create_order).and_call_original
           expect_any_instance_of(PaypalChargeProcessor).to receive(:capture_order)
                                                              .with(order_id: an_instance_of(String),
                                                                    billing_agreement_id: "B-38D505255T217912K")
@@ -1336,6 +1338,42 @@ describe PaypalChargeProcessor, :vcr do
           end.to raise_error(ChargeProcessorInvalidRequestError)
         end
       end
+    end
+  end
+
+  describe "#capture_order" do
+    def paypal_capture_response(total: "13.50", currency: "USD", status: PaypalApiPaymentStatus::COMPLETED)
+      capture = OpenStruct.new(
+        id: "79740133TG6557546",
+        status:,
+        amount: OpenStruct.new(currency_code: currency, value: total),
+        status_details: OpenStruct.new(reason: nil)
+      )
+      OpenStruct.new(
+        purchase_units: [OpenStruct.new(
+          payments: OpenStruct.new(captures: [capture])
+        )]
+      )
+    end
+
+    let(:expected_purchase_unit_info) { { currency: "usd", total: BigDecimal("13.50") } }
+
+    it "returns a charge intent when the captured amount matches Gumroad's expected order total" do
+      allow(PaypalChargeProcessor).to receive(:capture).and_return(paypal_capture_response(total: "13.50"))
+      allow(PaypalCharge).to receive(:new).and_return(OpenStruct.new(processor_transaction_id: "79740133TG6557546"))
+
+      charge_intent = subject.capture_order(order_id: "80T882348N361143U", expected_purchase_unit_info:)
+
+      expect(charge_intent).to be_a(PaypalChargeIntent)
+      expect(charge_intent.charge.processor_transaction_id).to eq("79740133TG6557546")
+    end
+
+    it "rejects a completed PayPal capture below Gumroad's expected order total" do
+      allow(PaypalChargeProcessor).to receive(:capture).and_return(paypal_capture_response(total: "6.75"))
+
+      expect do
+        subject.capture_order(order_id: "80T882348N361143U", expected_purchase_unit_info:)
+      end.to raise_error(ChargeProcessorError, /captured amount does not match/)
     end
   end
 
@@ -2413,12 +2451,12 @@ describe PaypalChargeProcessor, :vcr do
   end
 
   describe ".update_order_from_product_info" do
-    it "updates the paypal order when the requested total is not lower than the current total" do
+    it "updates the paypal order with the given product info and returns true" do
       creator = create(:user)
       product = create(:product, user: creator)
       paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
                                                                  user: creator, country: "US", currency: "usd")
-      paypal_order_id = "27B71908FM8616631"
+
       purchase_unit_info = {
         external_id: product.external_id,
         currency_code: paypal_merchant_account.currency,
@@ -2430,26 +2468,22 @@ describe PaypalChargeProcessor, :vcr do
         quantity: 2,
       }
 
-      allow(PaypalChargeProcessor).to receive(:fetch_order).with(order_id: paypal_order_id).and_return(
-        "purchase_units" => [{ "amount" => { "value" => "13.50", "currency_code" => "USD" } }]
-      )
+      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(purchase_unit_info)
+      expect(paypal_order_id).to be_present
 
-      expect(PaypalChargeProcessor).to receive(:update_order).with(
-        paypal_order_id,
-        hash_including(currency: "usd", total: BigDecimal("13.50"))
-      ).and_return(true)
+      order_details = PaypalChargeProcessor.fetch_order(order_id: paypal_order_id)
+      purchase_unit = order_details["purchase_units"][0]
+      expect(purchase_unit["amount"]["value"]).to eq("13.50")
+      expect(purchase_unit["amount"]["breakdown"]["item_total"]["value"]).to eq("10.00")
+      expect(purchase_unit["amount"]["breakdown"]["shipping"]["value"]).to eq("1.50")
+      expect(purchase_unit["amount"]["breakdown"]["tax_total"]["value"]).to eq("2.00")
+      expect(purchase_unit["payee"]["merchant_id"]).to eq("MN7CSWD6RCNJ8")
+      expect(purchase_unit["items"][0]["quantity"]).to eq("2")
+      expect(purchase_unit["items"][0]["unit_amount"]["value"]).to eq("5.00")
+      expect(purchase_unit["payment_instruction"]["platform_fees"].size).to eq(1)
+      expect(purchase_unit["payment_instruction"]["platform_fees"][0]["amount"]["value"]).to eq("0.70")
 
-      success = PaypalChargeProcessor.update_order_from_product_info(paypal_order_id, purchase_unit_info)
-      expect(success).to be(true)
-    end
-
-    it "rejects updates that would lower the PayPal order total" do
-      creator = create(:user)
-      product = create(:product, user: creator)
-      paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
-                                                                 user: creator, country: "US", currency: "usd")
-      original_order_id = "27B71908FM8616631"
-      lowered_purchase_unit_info = {
+      updated_purchase_unit_info = {
         external_id: product.external_id,
         currency_code: paypal_merchant_account.currency,
         price_cents: 5_00,
@@ -2460,41 +2494,21 @@ describe PaypalChargeProcessor, :vcr do
         quantity: 2,
       }
 
-      allow(PaypalChargeProcessor).to receive(:fetch_order).with(order_id: original_order_id).and_return(
-        "purchase_units" => [{ "amount" => { "value" => "13.50", "currency_code" => "USD" } }]
-      )
+      expect(PaypalChargeProcessor).to receive(:update_order).and_call_original
+      success = PaypalChargeProcessor.update_order_from_product_info(paypal_order_id, updated_purchase_unit_info)
+      expect(success).to be (true)
 
-      expect(PaypalChargeProcessor).not_to receive(:update_order)
-      expect do
-        PaypalChargeProcessor.update_order_from_product_info(original_order_id, lowered_purchase_unit_info)
-      end.to raise_error(ChargeProcessorError, /cannot lower/)
-    end
-
-    it "rejects updates when PayPal's current order total is not numeric" do
-      creator = create(:user)
-      product = create(:product, user: creator)
-      paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
-                                                                 user: creator, country: "US", currency: "usd")
-      order_id = "27B71908FM8616631"
-      purchase_unit_info = {
-        external_id: product.external_id,
-        currency_code: paypal_merchant_account.currency,
-        price_cents: 10_00,
-        shipping_cents: 1_50,
-        tax_cents: 2_00,
-        exclusive_tax_cents: 2_00,
-        total_cents: 13_50,
-        quantity: 2,
-      }
-
-      allow(PaypalChargeProcessor).to receive(:fetch_order).with(order_id: order_id).and_return(
-        "purchase_units" => [{ "amount" => { "value" => "not-a-number", "currency_code" => "USD" } }]
-      )
-
-      expect(PaypalChargeProcessor).not_to receive(:update_order)
-      expect do
-        PaypalChargeProcessor.update_order_from_product_info(order_id, purchase_unit_info)
-      end.to raise_error(ChargeProcessorError, /not numeric/)
+      order_details = PaypalChargeProcessor.fetch_order(order_id: paypal_order_id)
+      purchase_unit = order_details["purchase_units"][0]
+      expect(purchase_unit["amount"]["value"]).to eq("6.75")
+      expect(purchase_unit["amount"]["breakdown"]["item_total"]["value"]).to eq("5.00")
+      expect(purchase_unit["amount"]["breakdown"]["shipping"]["value"]).to eq("0.75")
+      expect(purchase_unit["amount"]["breakdown"]["tax_total"]["value"]).to eq("1.00")
+      expect(purchase_unit["payee"]["email_address"]).to eq("sb-c7jpx2385730@business.example.com")
+      expect(purchase_unit["items"][0]["quantity"]).to eq("2")
+      expect(purchase_unit["items"][0]["unit_amount"]["value"]).to eq("2.50")
+      expect(purchase_unit["payment_instruction"]["platform_fees"].size).to eq(1)
+      expect(purchase_unit["payment_instruction"]["platform_fees"][0]["amount"]["value"]).to eq("0.35")
     end
 
     it "raises error if paypal order id is not present" do

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -2470,6 +2470,33 @@ describe PaypalChargeProcessor, :vcr do
       end.to raise_error(ChargeProcessorError, /cannot lower/)
     end
 
+    it "rejects updates when PayPal's current order total is not numeric" do
+      creator = create(:user)
+      product = create(:product, user: creator)
+      paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                                                 user: creator, country: "US", currency: "usd")
+      order_id = "27B71908FM8616631"
+      purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: paypal_merchant_account.currency,
+        price_cents: 10_00,
+        shipping_cents: 1_50,
+        tax_cents: 2_00,
+        exclusive_tax_cents: 2_00,
+        total_cents: 13_50,
+        quantity: 2,
+      }
+
+      allow(PaypalChargeProcessor).to receive(:fetch_order).with(order_id: order_id).and_return(
+        "purchase_units" => [{ "amount" => { "value" => "not-a-number", "currency_code" => "USD" } }]
+      )
+
+      expect(PaypalChargeProcessor).not_to receive(:update_order)
+      expect do
+        PaypalChargeProcessor.update_order_from_product_info(order_id, purchase_unit_info)
+      end.to raise_error(ChargeProcessorError, /not numeric/)
+    end
+
     it "raises error if paypal order id is not present" do
       updated_purchase_unit_info = {
         external_id: "JrkmJ574Xk5Nqz1Bv9cLOA==",

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -1342,7 +1342,7 @@ describe PaypalChargeProcessor, :vcr do
   end
 
   describe "#capture_order" do
-    def paypal_capture_response(total: "13.50", currency: "USD", status: PaypalApiPaymentStatus::COMPLETED)
+    def paypal_capture_response(total: "13.50", currency: "USD", status: PaypalApiPaymentStatus::COMPLETED, merchant_id: "MN7CSWD6RCNJ8")
       capture = OpenStruct.new(
         id: "79740133TG6557546",
         status:,
@@ -1351,7 +1351,8 @@ describe PaypalChargeProcessor, :vcr do
       )
       OpenStruct.new(
         purchase_units: [OpenStruct.new(
-          payments: OpenStruct.new(captures: [capture])
+          payments: OpenStruct.new(captures: [capture]),
+          payee: OpenStruct.new(merchant_id:)
         )]
       )
     end
@@ -1370,6 +1371,31 @@ describe PaypalChargeProcessor, :vcr do
 
     it "rejects a completed PayPal capture below Gumroad's expected order total" do
       allow(PaypalChargeProcessor).to receive(:capture).and_return(paypal_capture_response(total: "6.75"))
+
+      expect do
+        subject.capture_order(order_id: "80T882348N361143U", expected_purchase_unit_info:)
+      end.to raise_error(ChargeProcessorError, /captured amount does not match/)
+    end
+
+    it "refunds a mismatched capture instead of leaving the underpayment settled" do
+      merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8")
+      allow(PaypalChargeProcessor).to receive(:capture).and_return(paypal_capture_response(total: "6.75"))
+      expect(subject).to receive(:refund!).with(
+        "79740133TG6557546",
+        merchant_account:,
+        paypal_order_purchase_unit_refund: true
+      )
+
+      expect do
+        subject.capture_order(order_id: "80T882348N361143U", expected_purchase_unit_info:)
+      end.to raise_error(ChargeProcessorError, /captured amount does not match/)
+    end
+
+    it "still raises the amount-mismatch error even if reversing the capture fails" do
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8")
+      allow(PaypalChargeProcessor).to receive(:capture).and_return(paypal_capture_response(total: "6.75"))
+      allow(subject).to receive(:refund!).and_raise(ChargeProcessorInvalidRequestError, "boom")
+      expect(ErrorNotifier).to receive(:notify).with(instance_of(ChargeProcessorInvalidRequestError), hash_including(reason: "mismatched_capture_refund_failed"))
 
       expect do
         subject.capture_order(order_id: "80T882348N361143U", expected_purchase_unit_info:)

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -2413,12 +2413,12 @@ describe PaypalChargeProcessor, :vcr do
   end
 
   describe ".update_order_from_product_info" do
-    it "updates the paypal order with the given product info and returns true" do
+    it "updates the paypal order when the requested total is not lower than the current total" do
       creator = create(:user)
       product = create(:product, user: creator)
       paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
                                                                  user: creator, country: "US", currency: "usd")
-
+      paypal_order_id = "27B71908FM8616631"
       purchase_unit_info = {
         external_id: product.external_id,
         currency_code: paypal_merchant_account.currency,
@@ -2430,22 +2430,26 @@ describe PaypalChargeProcessor, :vcr do
         quantity: 2,
       }
 
-      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(purchase_unit_info)
-      expect(paypal_order_id).to be_present
+      allow(PaypalChargeProcessor).to receive(:fetch_order).with(order_id: paypal_order_id).and_return(
+        "purchase_units" => [{ "amount" => { "value" => "13.50", "currency_code" => "USD" } }]
+      )
 
-      order_details = PaypalChargeProcessor.fetch_order(order_id: paypal_order_id)
-      purchase_unit = order_details["purchase_units"][0]
-      expect(purchase_unit["amount"]["value"]).to eq("13.50")
-      expect(purchase_unit["amount"]["breakdown"]["item_total"]["value"]).to eq("10.00")
-      expect(purchase_unit["amount"]["breakdown"]["shipping"]["value"]).to eq("1.50")
-      expect(purchase_unit["amount"]["breakdown"]["tax_total"]["value"]).to eq("2.00")
-      expect(purchase_unit["payee"]["merchant_id"]).to eq("MN7CSWD6RCNJ8")
-      expect(purchase_unit["items"][0]["quantity"]).to eq("2")
-      expect(purchase_unit["items"][0]["unit_amount"]["value"]).to eq("5.00")
-      expect(purchase_unit["payment_instruction"]["platform_fees"].size).to eq(1)
-      expect(purchase_unit["payment_instruction"]["platform_fees"][0]["amount"]["value"]).to eq("0.70")
+      expect(PaypalChargeProcessor).to receive(:update_order).with(
+        paypal_order_id,
+        hash_including(currency: "usd", total: BigDecimal("13.50"))
+      ).and_return(true)
 
-      updated_purchase_unit_info = {
+      success = PaypalChargeProcessor.update_order_from_product_info(paypal_order_id, purchase_unit_info)
+      expect(success).to be(true)
+    end
+
+    it "rejects updates that would lower the PayPal order total" do
+      creator = create(:user)
+      product = create(:product, user: creator)
+      paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                                                 user: creator, country: "US", currency: "usd")
+      original_order_id = "27B71908FM8616631"
+      lowered_purchase_unit_info = {
         external_id: product.external_id,
         currency_code: paypal_merchant_account.currency,
         price_cents: 5_00,
@@ -2456,21 +2460,14 @@ describe PaypalChargeProcessor, :vcr do
         quantity: 2,
       }
 
-      expect(PaypalChargeProcessor).to receive(:update_order).and_call_original
-      success = PaypalChargeProcessor.update_order_from_product_info(paypal_order_id, updated_purchase_unit_info)
-      expect(success).to be (true)
+      allow(PaypalChargeProcessor).to receive(:fetch_order).with(order_id: original_order_id).and_return(
+        "purchase_units" => [{ "amount" => { "value" => "13.50", "currency_code" => "USD" } }]
+      )
 
-      order_details = PaypalChargeProcessor.fetch_order(order_id: paypal_order_id)
-      purchase_unit = order_details["purchase_units"][0]
-      expect(purchase_unit["amount"]["value"]).to eq("6.75")
-      expect(purchase_unit["amount"]["breakdown"]["item_total"]["value"]).to eq("5.00")
-      expect(purchase_unit["amount"]["breakdown"]["shipping"]["value"]).to eq("0.75")
-      expect(purchase_unit["amount"]["breakdown"]["tax_total"]["value"]).to eq("1.00")
-      expect(purchase_unit["payee"]["email_address"]).to eq("sb-c7jpx2385730@business.example.com")
-      expect(purchase_unit["items"][0]["quantity"]).to eq("2")
-      expect(purchase_unit["items"][0]["unit_amount"]["value"]).to eq("2.50")
-      expect(purchase_unit["payment_instruction"]["platform_fees"].size).to eq(1)
-      expect(purchase_unit["payment_instruction"]["platform_fees"][0]["amount"]["value"]).to eq("0.35")
+      expect(PaypalChargeProcessor).not_to receive(:update_order)
+      expect do
+        PaypalChargeProcessor.update_order_from_product_info(original_order_id, lowered_purchase_unit_info)
+      end.to raise_error(ChargeProcessorError, /cannot lower/)
     end
 
     it "raises error if paypal order id is not present" do

--- a/spec/controllers/paypal_controller_spec.rb
+++ b/spec/controllers/paypal_controller_spec.rb
@@ -348,19 +348,23 @@ describe PaypalController, :vcr do
     let!(:merchant_account) { create(:merchant_account_paypal, user: product.user, charge_processor_merchant_id: "CJS32DZ7NDN5L") }
 
     before do
-      allow(PaypalChargeProcessor).to receive(:update_order_from_product_info).and_return(true)
+      expect(PaypalChargeProcessor).to receive(:update_order_from_product_info).and_call_original
     end
 
     it "updates the paypal order with the given info and returns true" do
-      post :update_order, params: { order_id: "27B71908FM8616631", product: updated_product_info }
+      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(product_info)
+
+      post :update_order, params: { order_id: paypal_order_id, product: updated_product_info }
 
       expect(response.parsed_body["success"]).to be(true)
     end
 
     it "returns false if updating the paypal order with the given info fails" do
-      expect(PaypalChargeProcessor).to receive(:update_order_from_product_info).and_raise(ChargeProcessorError)
+      expect(PaypalChargeProcessor).to receive(:update_order).and_raise(ChargeProcessorError)
 
-      post :update_order, params: { order_id: "27B71908FM8616631", product: updated_product_info }
+      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(product_info)
+
+      post :update_order, params: { order_id: paypal_order_id, product: updated_product_info }
 
       expect(response.parsed_body["success"]).to be(false)
     end

--- a/spec/controllers/paypal_controller_spec.rb
+++ b/spec/controllers/paypal_controller_spec.rb
@@ -348,23 +348,19 @@ describe PaypalController, :vcr do
     let!(:merchant_account) { create(:merchant_account_paypal, user: product.user, charge_processor_merchant_id: "CJS32DZ7NDN5L") }
 
     before do
-      expect(PaypalChargeProcessor).to receive(:update_order_from_product_info).and_call_original
+      allow(PaypalChargeProcessor).to receive(:update_order_from_product_info).and_return(true)
     end
 
     it "updates the paypal order with the given info and returns true" do
-      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(product_info)
-
-      post :update_order, params: { order_id: paypal_order_id, product: updated_product_info }
+      post :update_order, params: { order_id: "27B71908FM8616631", product: updated_product_info }
 
       expect(response.parsed_body["success"]).to be(true)
     end
 
     it "returns false if updating the paypal order with the given info fails" do
-      expect(PaypalChargeProcessor).to receive(:update_order).and_raise(ChargeProcessorError)
+      expect(PaypalChargeProcessor).to receive(:update_order_from_product_info).and_raise(ChargeProcessorError)
 
-      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(product_info)
-
-      post :update_order, params: { order_id: paypal_order_id, product: updated_product_info }
+      post :update_order, params: { order_id: "27B71908FM8616631", product: updated_product_info }
 
       expect(response.parsed_body["success"]).to be(false)
     end


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship — draft; full CI with `run-all-specs` still pending
- [ ] Market — n/a, backend payment-integrity guard with no user-facing surface
- [ ] Sell — n/a

## What

- Blocks `/paypal/update_order` from replacing a PayPal order with a lower total than PayPal already has on the order.
- Fails closed when the current PayPal order total or currency cannot be read, when the current total is not a valid number, or when the requested update changes the order currency.
- Validates the captured PayPal amount against Gumroad's authoritative order total (currency + value) before marking the charge successful, closing the create/capture-side gap noted below.
- Reverses (refunds) a capture whose settled amount doesn't match Gumroad's expected total, instead of leaving the underpayment settled with no local charge record.
- Keeps the controller behavior unchanged: successful updates return `success: true`; processor errors return `success: false`.

## Why

antiwork/gumroad-private#1916 reports that an anonymous buyer can call `POST /paypal/update_order` with lower `product[price_cents]`, shipping, or tax values before capture, and that the capture path trusts a completed PayPal capture without checking the amount actually settled against Gumroad's local price.

## Before/After

No rendered surface changes. This is a backend payment-integrity guard on the PayPal order-update and capture paths.

| Case | Before | After |
| --- | --- | --- |
| Existing PayPal order total `$13.50`, update payload total `$6.75` | Calls PayPal `update_order` and can lower the capture total | Raises `ChargeProcessorError` before `update_order`; controller returns `success: false` |
| Existing PayPal order total `$13.50`, update payload total `$13.50` | Calls PayPal `update_order` | Calls PayPal `update_order` |
| Missing current PayPal amount/currency | Could continue without comparing to PayPal's current order | Raises `ChargeProcessorError` before mutation |
| Currency changes on update | Could patch PayPal with a different currency payload | Raises `ChargeProcessorError` before mutation |
| PayPal returns a non-numeric current total | Unhandled `ArgumentError` from `BigDecimal` | Raises `ChargeProcessorError` before mutation; controller returns `success: false` |
| PayPal capture amount lower than Gumroad's expected order total | Marked successful based on capture status alone; underpayment settled with no local charge and no reversal | `ensure_captured_amount_matches!` raises `ChargeProcessorError` before the charge is recorded successful, and the mismatched capture is refunded |

## Test Results

- RED: `DISABLE_SPRING=1 OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bundle exec rspec spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb:2476` failed because `update_order` was still called for the lower-total payload.
- GREEN: `DISABLE_SPRING=1 OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bundle exec rspec spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb -e '.update_order_from_product_info'` — 5 examples, 0 failures (includes a non-numeric PayPal `current_total` spec, per Greptile's first P1).
- GREEN: `DISABLE_SPRING=1 OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bundle exec rspec spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb -e '#capture_order'` — 4 examples, 0 failures. Added two specs for Greptile's second P1 (captured underpayment not reversed): one asserts `refund!` is called with the capture id + merchant account on a mismatch, one asserts the amount-mismatch error still raises (and the failure is reported via `ErrorNotifier`) if the reversal itself fails.
- `DISABLE_SPRING=1 OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bundle exec rspec spec/controllers/paypal_controller_spec.rb -e 'update_order'` — 2 examples, 0 failures.
- Confirmed 9 pre-existing failures in the same spec file (PayPal dispute-event handling, unrelated to capture/update) reproduce identically on the pre-fix commit — environmental, not caused by this diff.
- `ruby -c` on both changed files — Syntax OK.
- `run-all-specs` label added for the payment-path change; full CI (Test Fast/Slow) is still running.

## QA steps

1. Read `PaypalChargeProcessor.update_order_from_product_info` and confirm it raises before `update_order` when the requested total is lower or PayPal's reported total is not numeric.
2. Read `PaypalChargeProcessor#capture_order` / `#ensure_captured_amount_matches!` and confirm a captured-amount mismatch raises before the charge/purchase is marked successful, and that the mismatched capture is now refunded via `refund!` before the error propagates.
3. Run the specs above.
4. Confirm there is no preview-app surface to click; the changed behavior is the JSON result of the backend PayPal endpoints.

### Live truth table on the deployed preview (backend-only, no rendered surface)

No screenshots — per standing QA guidance for no-pixel-surface PRs, called `#ensure_captured_amount_matches!` directly on the live `fix-gp1916-paypal-price-integrit.apps.staging.gumroad.org` deploy at this exact head (`c58d37c332bd30b2a44512bbf4a6e2021c067acb`) via `rails runner`, varying only the discriminating input:

| Leg | Expected total | Captured amount | Result |
| --- | --- | --- | --- |
| Matching amount (control) | `13.50 USD` | `13.50 USD` | no error — capture proceeds (correct) |
| Lower captured amount | `13.50 USD` | `6.75 USD` | raised `ChargeProcessorError: PayPal captured amount does not match Gumroad order amount` (correct — this is the underpayment path from gumroad-private#1916) |
| Currency mismatch | `13.50 USD` | `13.50 EUR` | raised `ChargeProcessorError` (correct) |
| Non-numeric captured value | `13.50 USD` | `not-a-number USD` | raised `ChargeProcessorError` (correct — no unhandled `ArgumentError`) |

The control leg (matching amount, no error) rules out a check that always rejects; the three failing legs confirm the guard is load-bearing across amount, currency, and malformed-input mismatches.

Premerge review: clean @ c58d37c332bd30b2a44512bbf4a6e2021c067acb

---

## AI disclosure

AI disclosure: Implemented by Hermes Agent using `claude-sonnet-5`. Prompt: autonomously dispatch antiwork/gumroad-private#1916, verify the reported PayPal update-order underpayment path, build the smallest server-side fix with tests, and open a draft PR following the Gumroad PR process.



