### PR TITLE
Trim comment bloat in StripeMerchantAccountManager

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -26,14 +26,11 @@ module StripeMerchantAccountManager
   BANK_DETAILS_FORMAT_REJECTION_MESSAGE = /Invalid (routing|account) number/i
   BANK_DETAILS_DIRECTORY_MISS_MESSAGE = /couldn't find (the bank|that)/i
 
-  # Stripe refuses a specific external account outright when it is on the connected account's
-  # block list: "You cannot use this external account because it is on your block list."
-  # This is neither a format problem nor a directory miss. The details the seller typed are
-  # perfectly valid and re-entering them changes nothing — Stripe will refuse the same account
-  # every time, forever. Sellers have re-saved a correct account monthly for months against
-  # this refusal because we swallowed it and then told them to wait for a weekly re-check
-  # (gumroad-private#1476). The only fix is a DIFFERENT bank account, so it needs its own
-  # classification: no automated retries, and an email that says so.
+  # Stripe refuses a specific external account outright when it's on the connected account's
+  # block list ("...because it is on your block list"). Unlike a format or directory-miss
+  # rejection, re-entering the same details never helps — only a DIFFERENT bank account will
+  # (gumroad-private#1476), so this gets its own classification: no automated retries, and an
+  # email that says so.
   BANK_ACCOUNT_BLOCKED_MESSAGE = /because it is on your block list/i
 
   # Terminal rejections are the ones where the account itself is refused rather than the way it
@@ -107,25 +104,18 @@ module StripeMerchantAccountManager
   end
   private_class_method :stripe_payouts_pause_email_type
 
-  # Claims (at most one of each) pause email per Stripe-disabled episode,
-  # surviving admin/payout-method resumes. The marker is cleared when Stripe
-  # re-enables payouts, and also by StripePayoutsPausedEmailJob when it declines
-  # to send (see its nothing_at_stake?) so a later webhook can re-claim — an
-  # episode can therefore claim more than once. Action-required is claimed on first notice or on
-  # escalation from under-review; under-review is claimed as the first notice or
-  # on de-escalation from action-required (the seller satisfied the outstanding
-  # requirements but payouts stay paused pending Stripe's review). Updates the
-  # marker (called inside the user lock) and returns the email type to schedule
-  # after the lock commits, or nil.
+  # Claims at most one pause email per Stripe-disabled episode, surviving admin/payout-method
+  # resumes. Marker clears when Stripe re-enables payouts, or when StripePayoutsPausedEmailJob
+  # declines to send (see nothing_at_stake?) — so an episode can re-claim after that. Claims
+  # action_required on first notice or on escalation from under_review; claims under_review on
+  # first notice or de-escalation from action_required (requirements met, payouts still paused
+  # pending Stripe's review). Called inside the user lock; returns the email type to schedule
+  # after commit, or nil.
   #
-  # Each successful claim also rotates stripe_payouts_pause_email_claim_token,
-  # and a transition to a state that must never email (rejected.*,
-  # platform_paused) drops the claim entirely. The scheduled
-  # StripePayoutsPausedEmailJob carries the token it was created with and only
-  # sends if it still matches, so the token changes whenever the desired
-  # notification changes — a job left over from an earlier pause, or from a
-  # notice whose type has since escalated, de-escalated, or become
-  # a never-email state, can never send a stale or contradictory email.
+  # Each claim rotates stripe_payouts_pause_email_claim_token, and a transition to a never-email
+  # state (rejected.*, platform_paused) drops the claim entirely. The scheduled job carries the
+  # token it was created with and only sends if it still matches — so a job left over from an
+  # earlier or since-changed notice can never send a stale email.
   def self.claim_stripe_payouts_pause_email(merchant_account, pause_email_type)
     already_claimed = merchant_account.stripe_payouts_pause_email_sent
     case pause_email_type
@@ -243,14 +233,13 @@ module StripeMerchantAccountManager
       Stripe::Account.create_person(stripe_account.id, force_utf8_encoding(person_params))
     end
 
-    # An under-18 seller cannot be verified alone, so the guardian goes on the account as a second
-    # Person. Failing to sync them must not fail account creation: the account and the merchant
-    # record above are already live, and the guardian is re-synced by every later update_account.
-    # Without a guardian the account simply sits on Stripe's legal-guardian requirement, which is
-    # the same place it would be if we had never tried.
-    # StandardError, not Stripe::StripeError: the sync also writes locally, and a deadlock or
-    # lock-wait timeout there would escape a Stripe-only rescue and abort creation before the
-    # merchant account is marked alive — wedging it. A missed sync self-heals on the next update.
+    # An under-18 seller can't be verified alone, so the guardian goes on as a second Person.
+    # Sync failure must not fail account creation — the merchant account is already live and the
+    # guardian is re-synced on every later update_account, so a miss just leaves Stripe's
+    # legal-guardian requirement unmet, same as if we'd never tried.
+    # Rescue StandardError, not Stripe::StripeError: the sync also writes locally, and a deadlock
+    # or lock-wait timeout there must not escape and abort creation before the account is marked
+    # alive.
     begin
       StripeGuardianManager.sync(user, stripe_account, passphrase:)
     rescue => e
@@ -291,17 +280,11 @@ module StripeMerchantAccountManager
   rescue => e
     if merchant_account.present? && merchant_account.charge_processor_alive_at.nil?
       cleanup_failed_merchant_account(merchant_account)
-      # Bank-account rejections (unknown bank/routing code, invalid account number,
-      # "Stripe is unable to support this bank"), tax-ID rejections (placeholder values
-      # like 123456789 that Stripe disallows), phone-number rejections, Japanese
-      # address/kanji rejections (validated against Stripe's JP postal directory), and
-      # postal-code rejections are expected seller-input errors: the seller sees Stripe's
-      # message inline on the payments settings page and can correct the input themselves
-      # (a payout note breadcrumb is also recorded below for bank and postal-code
-      # rejections, and rejected postal codes are auto-retried weekly by
-      # RetryStripeRejectedPayoutSetupsJob), and the sync path (update_bank_account)
-      # already treats bank rejections as expected without alerting. Don't page Sentry
-      # for them — only unexpected failures should alert.
+      # Bank-account, tax-ID, phone-number, JP address/kanji, and postal-code rejections are
+      # expected seller-input errors — Stripe's message shows inline on the settings page and the
+      # seller can just fix it (bank/postal-code rejections also get a payout-note breadcrumb
+      # below, and postal codes are auto-retried weekly by RetryStripeRejectedPayoutSetupsJob).
+      # Don't page Sentry for them; only unexpected failures should alert.
       ErrorNotifier.notify(e) unless bank_account_invalid_error?(e) || tax_id_invalid_error?(e) || phone_number_invalid_error?(e) || jp_address_invalid_error?(e) || postal_code_invalid_error?(e)
     end
     record_postal_code_failure_note(user, e) if notify && postal_code_invalid_error?(e)
@@ -316,17 +299,13 @@ module StripeMerchantAccountManager
   end
 
   # True for Stripe rejections that would otherwise leave no trace. Postal-code and bank-account
-  # rejections are excluded because they each already record a more specific note (and the
-  # postal-code one drives the weekly automatic retry), so adding a second note for them would
-  # only duplicate what support already sees.
+  # rejections are excluded — each already records its own more specific note.
   #
-  # Only InvalidRequestError counts, matching the update path in UpdateUserComplianceInfo. That is
-  # the class Stripe uses when it actually objected to something the seller submitted, which is the
-  # only case where "Stripe rejected your payout setup" is a true statement. The other StripeError
-  # subclasses are our problem, not the seller's: APIConnectionError, RateLimitError and
-  # AuthenticationError mean the request never got a verdict, so recording a rejection note for
-  # them would tell support a transient outage was the seller's data being refused and send them
-  # looking for a bad field that does not exist.
+  # Only InvalidRequestError counts (matching UpdateUserComplianceInfo's update path): that's the
+  # class Stripe uses when it actually objected to something the seller submitted. Other
+  # StripeError subclasses (APIConnectionError, RateLimitError, AuthenticationError) mean the
+  # request never got a verdict — recording a rejection note for those would blame the seller's
+  # data for what was really a transient outage.
   private_class_method
   def self.undiagnosed_stripe_rejection?(error)
     return false unless error.is_a?(Stripe::InvalidRequestError)
@@ -481,19 +460,17 @@ module StripeMerchantAccountManager
     entity_key = user_compliance_info.is_business? ? :company : :individual
     switching_to_business = user_compliance_info.is_business? && last_user_compliance_info&.is_individual?
 
-    # A switch that failed partway leaves the account as a company that Stripe still holds on
-    # company.owners_provided. The metadata marker read above has already moved forward by then, so
-    # switching_to_business is false on every later attempt and nothing repairs the account again.
-    # Detect the shape from Stripe's live state instead, so the seller's next payout-settings save
-    # heals it.
+    # A switch that failed partway leaves the account a company still blocked on
+    # company.owners_provided, but the metadata marker has already moved forward, so
+    # switching_to_business is false on later attempts and nothing repairs it again. Detect the
+    # shape from Stripe's live state instead, so the next payout-settings save heals it.
     #
-    # An empty owner list on its own is a legitimate resting state for an account created as a
-    # business — the seller never filled the beneficial-owners form, or no individual holds a
-    # reportable share — and seeding a 100% owner there would invent an ownership claim the seller
-    # never made. Requiring the record IMMEDIATELY BEFORE the live one to be an individual is what
-    # separates an interrupted migration from an ordinary business account. A seller who switched
-    # years ago and has since saved payout settings again has a business record in that slot, so a
-    # legitimate company that later cleared its ownership is not mistaken for a stuck switch.
+    # An empty owner list alone is a legitimate resting state for an ordinary business account
+    # (nobody filled the beneficial-owners form, or no one holds a reportable share) — seeding a
+    # 100% owner there would invent a claim the seller never made. Requiring the record
+    # IMMEDIATELY BEFORE the live one to be an individual is what distinguishes an interrupted
+    # migration from that: a seller who switched years ago and saved again has a business record
+    # in that slot, so a legitimate company isn't mistaken for a stuck switch.
     owners_provided_blocking = user_compliance_info.is_business? && !switching_to_business &&
                                owners_provided_blocking_payouts?(stripe_account) &&
                                switched_from_individual_immediately_before?(user, user_compliance_info)
@@ -511,14 +488,13 @@ module StripeMerchantAccountManager
     seed_representative_ownership = switching_to_business || stuck_mid_migration
 
     # The other half of the stuck population: a representative who already holds a share, on an
-    # account still blocked because nothing ever attested the list. Seeding would be wrong there and
-    # the attestation is the whole fix, so the two conditions cannot share one flag.
+    # account still blocked only because nothing ever attested the list. Seeding would be wrong
+    # here — attestation is the whole fix — so the two conditions can't share one flag.
     #
-    # A positive share is not the same as a COMPLETE list: a company whose representative holds 25%
-    # still has 75% sitting with beneficial owners nobody has entered, and attesting there tells
-    # Stripe a list is finished when three quarters of the company is missing from it. Only a list
-    # that accounts for the whole company can be called complete, and no UI asks the seller to
-    # affirm completeness, so the accounting is the only evidence available.
+    # A positive share isn't a COMPLETE list: a rep holding 25% still leaves 75% with owners
+    # nobody entered, and attesting there would falsely tell Stripe the list is finished. Only the
+    # ownership total says a list accounts for the whole company — no UI asks the seller to
+    # affirm completeness directly.
     owner_list_complete = seed_representative_ownership || fully_accounted_ownership?(recorded_ownership_percent)
 
     # Read the ownership Stripe already has on file BEFORE the account update below, because that
@@ -540,14 +516,13 @@ module StripeMerchantAccountManager
     # and on that save the identifier must go back on the payload for the note to ever be retired.
     force_identity_into_diff!(diff_attributes, current_attributes, user)
 
-    # update_person is the only path that retires a representative-scoped note, and it is skipped
-    # once the seller is no longer a business — so a rejection recorded while they were a company
-    # would outlive the entity it describes. Scoped to the transition itself rather than to every
-    # individual save, because the two scopes are deliberately independent namespaces: an ordinary
-    # individual save must not delete a representative note (see the isolation spec).
-    # Snapshot the ids BEFORE the update for the same reason clear_identity_rejection_notes takes
-    # ids rather than re-querying — a note written by an overlapping resync is a diagnostic this
-    # save has no result for.
+    # update_person is the only path that retires a representative-scoped note, and it's skipped
+    # once the seller isn't a business — so a note from when they were a company would outlive it.
+    # Scoped to the transition itself, not every individual save: the two note scopes are
+    # deliberately independent (an ordinary individual save must not delete a representative
+    # note — see the isolation spec). Ids are snapshotted BEFORE the update for the same reason
+    # clear_identity_rejection_notes takes ids rather than re-querying: a note from an overlapping
+    # resync is a diagnostic this save has no result for.
     switching_to_individual = !user_compliance_info.is_business? && last_user_compliance_info&.is_business?
     obsolete_representative_note_ids = switching_to_individual ? identity_rejection_note_ids(user, scope: :representative) : []
 


### PR DESCRIPTION
## What
Compresses 8 long comment blocks in `StripeMerchantAccountManager` — no code touched, no behaviour change.

## Why
These comments narrated history, restated the code below them, or repeated the same point three times across paragraph breaks. Cut them down to the one thing a maintainer who already knows this file needs: the non-obvious *why*, ordering constraint, or trap.

## Before/after
57 insertions(+), 82 deletions(-) — net **-25 lines**, one file.

## Test Results
- `ruby -c` — syntax OK
- `bundle exec rubocop app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb` — no offenses
- `bundle exec rspec` on the four spec files covering this class (stripe_merchant_account_manager_spec.rb, ..._rejection_note_lifecycle_spec.rb, ..._rejection_message_spec.rb, ..._guardian_wiring_spec.rb) — **442 examples, 0 failures**

Comments only, no behaviour change.

Premerge review: clean @ 7eb059bb3b67e2f0467c594bb1814039b4638e84

## What I deliberately KEPT (and why)
- The bank-rejection classification comment block near the top (FORMAT vs TERMINAL vs DIRECTORY_MISS) — real Stripe-domain rule about which of three rejection shapes needs which seller advice, kept as-is.
- The under-18 guardian handling comment (trimmed, not cut) — the rescue-class choice (StandardError, not Stripe::StripeError) and the "don't wedge account creation" reasoning is genuine non-obvious behavior a future editor needs.
- The stuck-mid-migration ownership-seeding logic (trimmed) — real domain knowledge about a Stripe edge case (interrupted individual-to-business switch) that's hard to re-derive; compressed three overlapping explanations into one each, kept the invariant.
- Left spec/business/payments/payouts/payouts_spec.rb, payouts.rb, renders_custom_html_pages.rb, user/comments.rb, and CustomHtmlPreview.tsx untouched — reviewed each flagged block there and found genuine, hard-to-re-derive domain/security reasoning (PayPal terminal-block suppression logic, CSP/sandbox security-boundary invariants, production measurements backing a design decision) that would lose real information if cut. A second PR for those was out of scope for "one PR per run."

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (CI failing: Lint JS/TS), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->

