### PR TITLE
Preserve exact custom-page PWYW prices

### DIFF
--- a/app/services/pages/buy_button_params.rb
+++ b/app/services/pages/buy_button_params.rb
@@ -22,6 +22,9 @@
 # recurrences) are memoized on the instance so a page with many buy buttons
 # doesn't re-query `product.options` / `product.recurrences` per button.
 class Pages::BuyButtonParams
+  PRICE_INPUT_MAX_LENGTH = 64
+  PRICE_INPUT_PATTERN = /\A[+-]?(?:\d+(?:\.\d*)?|\.\d+)\z/
+
   # One-shot helper for callers validating a single node. The interpolator
   # instantiates the validator once and reuses it across all buy buttons.
   def self.from(node, product:)
@@ -72,18 +75,16 @@ class Pages::BuyButtonParams
       raw = node["data-gumroad-price"]
       return nil if raw.blank?
 
-      val = Float(raw, exception: false)
-      return nil unless val && val.finite? && val > 0
+      raw = raw.to_s
+      return nil if raw.length > PRICE_INPUT_MAX_LENGTH || !raw.match?(PRICE_INPUT_PATTERN)
 
-      # Convert to cents the same way the checkout does — LinksController#show
-      # uses (price.to_f * 100).to_i — so this validation never admits a price the
-      # checkout would itself truncate below the minimum and refuse to honor. The
-      # float quirk (e.g. 9.99 → 998) lives on both sides; dropping such a
-      # boundary price here just falls the buy button back to the default checkout.
-      val_cents = (val * 100).to_i
+      value = BigDecimal(raw)
+      return nil unless value.positive?
+
+      val_cents = (value * (product.single_unit_currency? ? 1 : 100)).round
       return nil if val_cents < product.price_cents.to_i
 
-      val
+      raw
     end
 
     def recurrence(node)

--- a/app/services/pages/buy_button_params.rb
+++ b/app/services/pages/buy_button_params.rb
@@ -83,6 +83,7 @@ class Pages::BuyButtonParams
 
       val_cents = (value * (product.single_unit_currency? ? 1 : 100)).round
       return nil if val_cents < product.price_cents.to_i
+      return nil if val_cents > BasePrice::Shared::MAX_PRICE_CENTS
 
       raw
     end

--- a/spec/services/pages/buy_button_params_spec.rb
+++ b/spec/services/pages/buy_button_params_spec.rb
@@ -85,7 +85,21 @@ describe Pages::BuyButtonParams do
 
       it "passes through a price at or above the minimum" do
         node = node_for(%(<a data-gumroad-action="buy" data-gumroad-price="9.99">Buy</a>))
-        expect(described_class.from(node, product:)).to eq(price: 9.99)
+        expect(described_class.from(node, product:)).to eq(price: "9.99")
+      end
+
+      it "passes through an exact decimal price at the minimum" do
+        product.update!(price_cents: 1_999)
+        node = node_for(%(<a data-gumroad-action="buy" data-gumroad-price="19.99">Buy</a>))
+
+        expect(described_class.from(node, product:)).to eq(price: "19.99")
+      end
+
+      it "uses the product currency's minor-unit scale" do
+        product.update!(price_currency_type: "jpy", price_cents: 1_999)
+        node = node_for(%(<a data-gumroad-action="buy" data-gumroad-price="1999">Buy</a>))
+
+        expect(described_class.from(node, product:)).to eq(price: "1999")
       end
 
       it "drops the attribute when the product isn't pay-what-you-want" do

--- a/spec/services/pages/buy_button_params_spec.rb
+++ b/spec/services/pages/buy_button_params_spec.rb
@@ -113,6 +113,12 @@ describe Pages::BuyButtonParams do
         expect(described_class.from(node, product:)).to eq({})
       end
 
+      it "drops a price above the maximum allowed price" do
+        max_price = BasePrice::Shared::MAX_PRICE_CENTS
+        node = node_for(%(<a data-gumroad-action="buy" data-gumroad-price="#{(max_price + 100) / 100.0}">Buy</a>))
+        expect(described_class.from(node, product:)).to eq({})
+      end
+
       it "drops a non-numeric value" do
         node = node_for(%(<a data-gumroad-action="buy" data-gumroad-price="free">Buy</a>))
         expect(described_class.from(node, product:)).to eq({})

--- a/spec/services/pages/interpolator_spec.rb
+++ b/spec/services/pages/interpolator_spec.rb
@@ -236,6 +236,18 @@ describe Pages::Interpolator do
       expect(result).to include(%(data-gumroad-checkout-params='{"variant":"Pro plan","quantity":2}'))
     end
 
+    it "bakes an exact PWYW minimum into the checkout href and payload" do
+      product = create(:product, customizable_price: true, price_cents: 1_999)
+
+      result = described_class.interpolate(
+        %(<a data-gumroad-action="buy" data-gumroad-price="19.99">Buy</a>),
+        product: product
+      )
+
+      expect(result).to include(%(href="/l/#{product.unique_permalink}?wanted=true&amp;price=19.99"))
+      expect(result).to include(%(data-gumroad-checkout-params='{"price":"19.99"}'))
+    end
+
     it "silently drops selection attributes the product can't honor (lenient fallback)" do
       product = create(:product, price_cents: 100) # simple product, no variants/PWYW/quantity/recurrence
 


### PR DESCRIPTION
## What
Preserves custom-page PWYW prices as their original decimal string while validating them with exact decimal arithmetic.

## Why
Float conversion can evaluate 19.99 below 1999 cents and discard a valid minimum. The prior code also assumed every currency has two minor units. This uses BigDecimal, honors single-unit currencies, and preserves the exact checkout value.

## Validation
22 examples in the focused suite, 0 failures (`bundle exec rspec spec/services/pages/buy_button_params_spec.rb`). Mutation-verified the new max-price guard: reverting it flips the new spec red.

## Fix round 1 (Greptile P1)
Added an upper bound (`BasePrice::Shared::MAX_PRICE_CENTS`) to `Pages::BuyButtonParams#price`, mirroring the same cap `LinksController` enforces, so an oversized custom-page price falls back to the default checkout instead of being emitted into the buy-button URL and rejected only after navigation.

Based on https://github.com/adityawrk/gumroad/pull/15, contributed by Aditya Patni. Imported for internal review.

---

Premerge review: clean @ f451527e3332a38735e876163e440b8db28b5ca5

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it; no human review requested/received yet — still mine to hand off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->

## AI disclosure

Imported from an external contribution (adityawrk/gumroad), reviewed and shepherded through CI/Greptile fixes by claude-sonnet-5 via Hermes Agent under human oversight.

---
_Reassigned from @slavingia to gianfrancopiana — 8/8, ahead of Monday 4:30pm mergapalooza (Sahil clearing queues to 0)._