### PR TITLE
Preserve exact audience price filters

### DIFF
--- a/app/models/concerns/with_filtering.rb
+++ b/app/models/concerns/with_filtering.rb
@@ -113,9 +113,13 @@ module WithFiltering
     true
   end
 
+  # Bounds the parsed value so a compact exponent-form price (e.g. "1e100000") can't force
+  # BigDecimal#to_i to allocate a many-thousand-digit Integer.
+  MAX_PRICE_FILTER_MAGNITUDE = BigDecimal("1e15")
+
   def price_filter_cents(value, currency)
     amount = BigDecimal(value.to_s)
-    return nil unless amount.finite?
+    return nil unless amount.finite? && amount.abs <= MAX_PRICE_FILTER_MAGNITUDE
 
     currency_cents = (amount * unit_scaling_factor(currency)).to_i
     get_usd_cents(currency, currency_cents)

--- a/app/models/concerns/with_filtering.rb
+++ b/app/models/concerns/with_filtering.rb
@@ -62,14 +62,14 @@ module WithFiltering
       if params[:paid_more_than_cents].present?
         params[:paid_more_than_cents]
       elsif params[:paid_more_than].present?
-        get_usd_cents(currency, (params[:paid_more_than].to_f * unit_scaling_factor(currency)).to_i)
+        price_filter_cents(params[:paid_more_than], currency)
       end
     end
     self.paid_less_than_cents = if seller_or_product_or_variant_type?
       if params[:paid_less_than_cents].present?
         params[:paid_less_than_cents]
       elsif params[:paid_less_than].present?
-        get_usd_cents(currency, (params[:paid_less_than].to_f * unit_scaling_factor(currency)).to_i)
+        price_filter_cents(params[:paid_less_than], currency)
       end
     end
     self.bought_products = (!audience_type? && params[:bought_products].present?) ? Array.wrap(params[:bought_products]) : []
@@ -111,6 +111,16 @@ module WithFiltering
     return false if created_before.present? && affiliate.created_at > created_before
     return false if affiliate_products.present? && (affiliate_products & affiliate.products.pluck(:unique_permalink)).empty?
     true
+  end
+
+  def price_filter_cents(value, currency)
+    amount = BigDecimal(value.to_s)
+    return nil unless amount.finite?
+
+    currency_cents = (amount * unit_scaling_factor(currency)).to_i
+    get_usd_cents(currency, currency_cents)
+  rescue ArgumentError, FloatDomainError
+    nil
   end
 
   def follower_passes_filters(follower)

--- a/spec/shared_examples/with_filtering_support.rb
+++ b/spec/shared_examples/with_filtering_support.rb
@@ -72,6 +72,13 @@ shared_examples_for "common customer recipient filter validation behavior" do |a
         expect(filterable_object.paid_more_than_cents).to be_nil
       end
 
+      it "drops a finite but oversized exponent-form price filter" do
+        params[:paid_more_than] = "1e100000"
+
+        expect { add_and_validate_filters }.not_to raise_error
+        expect(filterable_object.paid_more_than_cents).to be_nil
+      end
+
       context "when paid_more_than_cents and paid_less_than_cents are given" do
         let(:params) do
           {

--- a/spec/shared_examples/with_filtering_support.rb
+++ b/spec/shared_examples/with_filtering_support.rb
@@ -55,6 +55,23 @@ shared_examples_for "common customer recipient filter validation behavior" do |a
         expect(filterable_object.bought_from).to eq("United States")
       end
 
+      it "keeps decimal price filters in exact minor units" do
+        params[:paid_more_than] = "1.15"
+        params[:paid_less_than] = "2.15"
+
+        add_and_validate_filters
+
+        expect(filterable_object.paid_more_than_cents).to eq(115)
+        expect(filterable_object.paid_less_than_cents).to eq(215)
+      end
+
+      it "drops a non-finite decimal price filter" do
+        params[:paid_more_than] = "NaN"
+
+        expect { add_and_validate_filters }.not_to raise_error
+        expect(filterable_object.paid_more_than_cents).to be_nil
+      end
+
       context "when paid_more_than_cents and paid_less_than_cents are given" do
         let(:params) do
           {


### PR DESCRIPTION
## What
Parses decimal audience price filters with BigDecimal so valid values retain their exact minor-unit amount.

## Why
The previous float conversion could turn a submitted USD value of 1.15 into 114 cents, selecting the wrong purchases. Non-finite values are now ignored instead of raising.

## Validation
40 examples in the focused suite, 0 failures.

Based on https://github.com/adityawrk/gumroad/pull/16, contributed by Aditya Patni. Imported for internal review.

Premerge review: clean @ ed78f639bd7ddf9632403a9cd6c1fa854061e78a

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ CORRECTED THIS SWEEP — the branch previously pushed here (`7b007920d`) contained the wrong diff: an earlier import step accidentally applied the PayPal-processor-fee change (from `fix/paypal-capture-fee-exact-price`, now antiwork/gumroad#7131) onto this branch instead of the actual audience-filter fix from `adityawrk/gumroad#16` (`bbd30a6a5`, `Preserve exact audience price filters`, touching `app/models/concerns/with_filtering.rb` + its shared spec). Force-pushed the correct diff at `034121a0d`, rubocop clean. CI now running fresh against the real content.
<!-- gumclaw-ownership-sweep -->

## AI disclosure

Imported from an external contribution (adityawrk/gumroad), reviewed and shepherded through CI/Greptile fixes by claude-sonnet-5 via Hermes Agent under human oversight.

---
_Reassigned from @slavingia to nyomanjyotisa — 8/8, ahead of Monday 4:30pm mergapalooza (Sahil clearing queues to 0)._