### PR TITLE
Preserve exact PayPal processor fees

### DIFF
--- a/app/business/payments/charging/implementations/paypal/paypal_charge.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge.rb
@@ -59,7 +59,10 @@ class PaypalCharge < BaseProcessorCharge
     end
 
     def fee_cents(fee_amount, currency)
-      fee_amount.to_f * unit_scaling_factor(currency)
+      scaled_fee = BigDecimal(fee_amount) * unit_scaling_factor(currency)
+      scaled_fee.to_i if scaled_fee.finite? && scaled_fee == scaled_fee.to_i
+    rescue ArgumentError, TypeError, FloatDomainError
+      nil
     end
 
     def fetch_capture_details(capture_id, order_details)

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -136,14 +136,34 @@ class PaypalChargeProcessor
     paypal_fee = event_info.dig("resource", "seller_receivable_breakdown", "paypal_fee")
     return if paypal_fee.blank?
 
+    fee_cents = paypal_fee_cents(paypal_fee["value"], paypal_fee["currency_code"])
+    unless fee_cents
+      ErrorNotifier.notify(
+        "PayPal capture completed webhook: fee has unsupported precision; skipping fee update",
+        capture_id: event_info.dig("resource", "id"),
+        fee_currency: paypal_fee["currency_code"],
+        fee_value: paypal_fee["value"],
+        webhook_event_id: event_info["id"]
+      )
+      return
+    end
+
     purchase = Purchase.successful.find_by(stripe_transaction_id: event_info["resource"]["id"])
     return unless purchase
 
     purchase.processor_fee_cents_currency = paypal_fee["currency_code"]
-    purchase.processor_fee_cents = paypal_fee["value"].to_f * unit_scaling_factor(purchase.processor_fee_cents_currency)
+    purchase.processor_fee_cents = fee_cents
     purchase.save!
   end
   private_class_method :handle_payment_capture_completed_event
+
+  def self.paypal_fee_cents(value, currency)
+    scaled_fee = BigDecimal(value) * unit_scaling_factor(currency)
+    scaled_fee.to_i if scaled_fee.finite? && scaled_fee == scaled_fee.to_i
+  rescue ArgumentError, TypeError, FloatDomainError
+    nil
+  end
+  private_class_method :paypal_fee_cents
 
   def self.handle_payment_capture_denied_event(event_info)
     refund_purchase(capture_id: event_info["resource"]["id"])

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -136,6 +136,9 @@ class PaypalChargeProcessor
     paypal_fee = event_info.dig("resource", "seller_receivable_breakdown", "paypal_fee")
     return if paypal_fee.blank?
 
+    purchase = Purchase.successful.find_by(stripe_transaction_id: event_info["resource"]["id"])
+    return unless purchase
+
     fee_cents = paypal_fee_cents(paypal_fee["value"], paypal_fee["currency_code"])
     unless fee_cents
       ErrorNotifier.notify(
@@ -147,9 +150,6 @@ class PaypalChargeProcessor
       )
       return
     end
-
-    purchase = Purchase.successful.find_by(stripe_transaction_id: event_info["resource"]["id"])
-    return unless purchase
 
     purchase.processor_fee_cents_currency = paypal_fee["currency_code"]
     purchase.processor_fee_cents = fee_cents

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -512,6 +512,7 @@ describe PaypalChargeProcessor, :vcr do
       end
 
       it "skips and reports a PayPal fee with unsupported precision" do
+        create(:purchase, stripe_transaction_id: "capture-id", processor_fee_cents: nil, processor_fee_cents_currency: nil)
         allow(ErrorNotifier).to receive(:notify)
 
         described_class.handle_order_events(
@@ -530,6 +531,38 @@ describe PaypalChargeProcessor, :vcr do
           fee_value: "1.151",
           webhook_event_id: "event-id"
         )
+      end
+
+      it "does not report an unsupported precision fee when no successful purchase matches the capture" do
+        allow(ErrorNotifier).to receive(:notify)
+
+        described_class.handle_order_events(
+          "id" => "event-id",
+          "event_type" => PaypalEventType::PAYMENT_CAPTURE_COMPLETED,
+          "resource" => {
+            "id" => "unmatched-capture-id",
+            "seller_receivable_breakdown" => { "paypal_fee" => { "value" => "1.151", "currency_code" => "TND" } }
+          }
+        )
+
+        expect(ErrorNotifier).not_to have_received(:notify)
+      end
+
+      it "does not report an unsupported precision fee when the matching purchase is not successful" do
+        create(:purchase, purchase_state: "failed", stripe_transaction_id: "capture-id",
+                           processor_fee_cents: nil, processor_fee_cents_currency: nil)
+        allow(ErrorNotifier).to receive(:notify)
+
+        described_class.handle_order_events(
+          "id" => "event-id",
+          "event_type" => PaypalEventType::PAYMENT_CAPTURE_COMPLETED,
+          "resource" => {
+            "id" => "capture-id",
+            "seller_receivable_breakdown" => { "paypal_fee" => { "value" => "1.151", "currency_code" => "TND" } }
+          }
+        )
+
+        expect(ErrorNotifier).not_to have_received(:notify)
       end
 
       it "does nothing if seller_receivable_breakdown is absent" do

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -473,6 +473,65 @@ describe PaypalChargeProcessor, :vcr do
         expect(purchase.processor_fee_cents_currency).to eq("GBP")
       end
 
+      it "keeps a decimal PayPal fee in exact minor units" do
+        purchase = instance_double(Purchase)
+        successful_purchases = instance_double(ActiveRecord::Relation)
+        allow(Purchase).to receive(:successful).and_return(successful_purchases)
+        allow(successful_purchases).to receive(:find_by).with(stripe_transaction_id: "capture-id").and_return(purchase)
+        expect(purchase).to receive(:processor_fee_cents_currency=).with("USD")
+        allow(purchase).to receive(:processor_fee_cents_currency).and_return("USD")
+        expect(purchase).to receive(:processor_fee_cents=).with(115)
+        expect(purchase).to receive(:save!)
+
+        described_class.handle_order_events(
+          "event_type" => PaypalEventType::PAYMENT_CAPTURE_COMPLETED,
+          "resource" => {
+            "id" => "capture-id",
+            "seller_receivable_breakdown" => { "paypal_fee" => { "value" => "1.15", "currency_code" => "USD" } }
+          }
+        )
+      end
+
+      it "persists an exact decimal PayPal fee" do
+        purchase = build(:purchase, purchase_state: "successful", stripe_transaction_id: "capture-id", processor_fee_cents: nil, processor_fee_cents_currency: nil)
+        purchase.save!(validate: false)
+        allow(purchase).to receive(:save!).and_wrap_original { |original| original.call(validate: false) }
+        successful_purchases = instance_double(ActiveRecord::Relation)
+        allow(Purchase).to receive(:successful).and_return(successful_purchases)
+        allow(successful_purchases).to receive(:find_by).with(stripe_transaction_id: "capture-id").and_return(purchase)
+
+        described_class.handle_order_events(
+          "event_type" => PaypalEventType::PAYMENT_CAPTURE_COMPLETED,
+          "resource" => {
+            "id" => "capture-id",
+            "seller_receivable_breakdown" => { "paypal_fee" => { "value" => "1.15", "currency_code" => "USD" } }
+          }
+        )
+
+        expect(purchase.reload).to have_attributes(processor_fee_cents: 115, processor_fee_cents_currency: "USD")
+      end
+
+      it "skips and reports a PayPal fee with unsupported precision" do
+        allow(ErrorNotifier).to receive(:notify)
+
+        described_class.handle_order_events(
+          "id" => "event-id",
+          "event_type" => PaypalEventType::PAYMENT_CAPTURE_COMPLETED,
+          "resource" => {
+            "id" => "capture-id",
+            "seller_receivable_breakdown" => { "paypal_fee" => { "value" => "1.151", "currency_code" => "TND" } }
+          }
+        )
+
+        expect(ErrorNotifier).to have_received(:notify).with(
+          "PayPal capture completed webhook: fee has unsupported precision; skipping fee update",
+          capture_id: "capture-id",
+          fee_currency: "TND",
+          fee_value: "1.151",
+          webhook_event_id: "event-id"
+        )
+      end
+
       it "does nothing if seller_receivable_breakdown is absent" do
         purchase = create(:purchase, stripe_transaction_id: "5B223658W54364539",
                                      processor_fee_cents: nil, processor_fee_cents_currency: nil)

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -550,7 +550,7 @@ describe PaypalChargeProcessor, :vcr do
 
       it "does not report an unsupported precision fee when the matching purchase is not successful" do
         create(:purchase, purchase_state: "failed", stripe_transaction_id: "capture-id",
-                           processor_fee_cents: nil, processor_fee_cents_currency: nil)
+                          processor_fee_cents: nil, processor_fee_cents_currency: nil)
         allow(ErrorNotifier).to receive(:notify)
 
         described_class.handle_order_events(

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_spec.rb
@@ -450,6 +450,18 @@ describe PaypalCharge do
                                        card_visual: "paypal-gr-integspecs@gumroad.com")
       end
 
+      it "keeps a decimal PayPal fee in exact minor units" do
+        order_details["purchase_units"][0]["payments"]["captures"][0]["seller_receivable_breakdown"]["paypal_fee"]["value"] = "1.15"
+
+        expect(subject.fee).to eq(115)
+      end
+
+      it "leaves an unsupported precision fee unset" do
+        order_details["purchase_units"][0]["payments"]["captures"][0]["seller_receivable_breakdown"]["paypal_fee"] = { "value" => "1.151", "currency_code" => "TND" }
+
+        expect(subject.fee).to be_nil
+      end
+
       it "does not throw error if paypal_fee value is absent" do
         payment_details = order_details.tap { |order| order["purchase_units"][0]["payments"]["captures"][0]["seller_receivable_breakdown"].delete("paypal_fee") }
 
@@ -527,6 +539,19 @@ describe PaypalCharge do
         expect(paypal_charge.card_fingerprint).to eq("paypal_sample-fingerprint-source")
         expect(paypal_charge.card_type).to eq(CardType::PAYPAL)
         expect(paypal_charge.card_country).to eq(Compliance::Countries::USA.alpha2)
+      end
+
+      it "keeps an exact decimal fee from Express Checkout" do
+        paypal_payment_info.FeeAmount.value = "1.15"
+
+        paypal_charge = PaypalCharge.new(paypal_transaction_id: "5SP884803B810025T",
+                                         order_api_used: false,
+                                         payment_details: {
+                                           paypal_payment_info:,
+                                           paypal_payer_info:
+                                         })
+
+        expect(paypal_charge.fee).to eq(115)
       end
 
       it "populates the required payment and does not set payer fields if payload is not passed in" do


### PR DESCRIPTION
## Stages
- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

## What
Uses exact decimal parsing for PayPal processor fees from capture webhooks, Order API responses, and Express Checkout responses.

## Why
PayPal returns Money values as strings. Float conversion could turn a fee of 1.15 into 114 cents instead of 115. Values that cannot be represented exactly in the existing integer fee column are left unset, and capture webhooks report that condition via ErrorNotifier only when the capture matches an existing successful purchase — an unmatched or non-successful capture is not actionable and no longer alerts.

## Validation
9 focused examples across webhook persistence, Order API, and Express Checkout paths, 0 failures. Added coverage for the two non-actionable cases Greptile flagged (no matching purchase, matching purchase not successful) — both pass at `1d0b39c5`.

Based on https://github.com/adityawrk/gumroad/pull/17, contributed by Aditya Patni. Imported for internal review.

Premerge review: clean @ c85e9b3db963fa673180a85dd39a5b577ed2538d

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it; CI failing: Lint JS/TS, Lint Ruby; no human review requested/received yet — still mine to hand off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->

## AI disclosure

Imported from an external contribution (adityawrk/gumroad), reviewed and shepherded through CI/Greptile fixes by claude-sonnet-5 via Hermes Agent under human oversight.

---
_Reassigned from @slavingia to ershad — 8/8, ahead of Monday 4:30pm mergapalooza (Sahil clearing queues to 0)._