### PR TITLE
Fix crash on malformed upsellCard nodes missing attrs (follow-up to #7012)

### DIFF
--- a/app/services/save_content_upsells_service.rb
+++ b/app/services/save_content_upsells_service.rb
@@ -60,7 +60,9 @@ class SaveContentUpsellsService
       Array(nodes).flat_map do |node|
         next [] unless node.is_a?(Hash) || node.is_a?(ActionController::Parameters)
         nested = collect_upsell_nodes(node["content"])
-        node["type"] == "upsellCard" ? [node, *nested] : nested
+        is_well_formed_upsell_card = node["type"] == "upsellCard" &&
+          (node["attrs"].is_a?(Hash) || node["attrs"].is_a?(ActionController::Parameters))
+        is_well_formed_upsell_card ? [node, *nested] : nested
       end
     end
 

--- a/spec/services/save_content_upsells_service_spec.rb
+++ b/spec/services/save_content_upsells_service_spec.rb
@@ -139,6 +139,24 @@ describe SaveContentUpsellsService do
       end
     end
 
+    context "when an upsellCard node is malformed (missing attrs)" do
+      let(:old_content) { [{ "type" => "paragraph", "content" => "Old content" }] }
+      let(:content) do
+        [
+          { "type" => "upsellCard" },
+          {
+            "type" => "blockquote",
+            "content" => [{ "type" => "upsellCard" }]
+          }
+        ]
+      end
+
+      it "does not crash and does not create an upsell for the malformed nodes" do
+        expect { service.from_rich_content }.not_to raise_error
+        expect { service.from_rich_content }.not_to change(Upsell, :count)
+      end
+    end
+
     context "when removing an upsell" do
       let!(:upsell) { create(:upsell, seller:, product:, is_content_upsell: true) }
       let!(:offer_code) { create(:offer_code, user: seller, product_ids: [product.id]) }


### PR DESCRIPTION
## Status

- [x] Scope — Greptile P1 on merged #7012: `collect_upsell_nodes` admits any hash with `type: "upsellCard"`, but `from_rich_content` then assumes `attrs` is a Hash and assigns `node["attrs"]["id"] = ...` unconditionally, so a malformed card (`{"type" => "upsellCard"}` with no `attrs`) raises `NoMethodError` and the whole profile save fails.
- [x] Design — filter malformed nodes out inside `collect_upsell_nodes` itself (require `attrs` to be a Hash/`ActionController::Parameters` before admitting the node as a card), so every caller of the collector gets the same safety for free.
- [x] Build — branch `fix/gp7012-malformed-upsell-card-attrs`, pushed at `a40dedf7`.
- [x] Ship — pushed; marking ready per green-CI-gates-merge convention.
- [x] QA — no rendered surface change (pure defensive fix inside a Rails service); verified via executed spec + mutation-kill proof below.
- [x] Market — n/a, internal bugfix.
- [x] Sell — n/a.

## What

Confirmed the finding by reproducing the crash against `origin/main`'s `save_content_upsells_service.rb`: passing `{"type" => "upsellCard"}` (no `attrs`) through `collect_upsell_nodes` and then into `from_rich_content`'s assignment raises `NoMethodError: undefined method '[]=' for nil`.

Fixed by tightening `collect_upsell_nodes`'s admission check: a node is only treated as an upsell card if `attrs` is present and is a Hash (or `ActionController::Parameters`, matching the existing dual-type handling in this method). Malformed cards are now silently skipped instead of crashing the save — same behavior as any other unrecognized node.

## Why

#7012 merged before Greptile's post-merge P1 on this exact line landed; shipping this as a follow-up against `main`.

## Before/After

- Before: a rich-content payload containing `{"type" => "upsellCard"}` with no `attrs` crashed `from_rich_content` with `NoMethodError`, failing the entire profile-page save.
- After: the malformed node is skipped by the collector; the rest of the content (including well-formed upsell cards, nested or not) saves normally.

## Test Results

- `bundle exec rspec spec/services/save_content_upsells_service_spec.rb` — 10 passed (added `"when an upsellCard node is malformed (missing attrs)"`), run in a lane-borrowed env at `a40dedf7`.
- Mutation check: reverted `collect_upsell_nodes` to the old unconditional admission (`node["type"] == "upsellCard" ? [node, *nested] : nested`) and reran the suite — the new malformed-card spec failed exactly as expected (`NoMethodError`); the other 9 examples stayed green. Re-applied the fix, suite green again (10/10).

## QA steps

Pure defensive-guard fix inside `SaveContentUpsellsService#collect_upsell_nodes`/`#from_rich_content` — no markup, styling, or copy changed, so there is no rendered surface to screenshot. The fix and its regression coverage are fully exercised by the executed spec + mutation-kill proof above (the malformed-card scenario isn't reachable through the current rich-text UI's own controls — it requires a hand-crafted payload, which is exactly what the new spec constructs).

## AI disclosure

Builds and code in this PR were generated by claude-sonnet-5 via Hermes Agent, reviewed and pushed by an autonomous agent under human oversight.

Autoreview: clean @ a40dedf7d7420b8ecdf21b74f8ac86f782a1e83c

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (no human review requested/received yet — still mine to hand off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->


---
_Reassigned from @slavingia to nyomanjyotisa — 8/8, ahead of Monday 4:30pm mergapalooza (Sahil clearing queues to 0)._