### PR TITLE
Duplicate a product's own profile sections when duplicating the product

### DIFF
--- a/app/services/product_duplicator_service.rb
+++ b/app/services/product_duplicator_service.rb
@@ -52,6 +52,7 @@ class ProductDuplicatorService
       duplicate_third_party_analytics
       duplicate_shipping_destinations
       duplicate_refund_policy
+      duplicate_profile_sections
     end
 
     # Post process Asset Previews if product was persisted from outside the transaction
@@ -316,6 +317,23 @@ class ProductDuplicatorService
       new_refund_policy = product.product_refund_policy.dup
       new_refund_policy.product = duplicated_product
       new_refund_policy.save!
+    end
+
+    # `duplicated_product.dup` copies the `sections` json array verbatim, but the ids in it
+    # point at the source product's own SellerProfileSection rows (scoped via product_id), so
+    # they never match anything scoped to the duplicate and the section silently renders empty.
+    def duplicate_profile_sections
+      return if product.sections.blank?
+
+      section_id_mapping = product.seller_profile_sections.each_with_object({}) do |section, mapping|
+        new_section = section.dup
+        new_section.product = duplicated_product
+        new_section.save!
+        mapping[section.id] = new_section.id
+      end
+
+      duplicated_product.sections = product.sections.filter_map { |id| section_id_mapping[id] }
+      duplicated_product.save!(validate: false)
     end
 
     def duplicate_rich_content(original_entity:, duplicate_entity:)

--- a/spec/services/product_duplicator_service_spec.rb
+++ b/spec/services/product_duplicator_service_spec.rb
@@ -142,6 +142,38 @@ describe ProductDuplicatorService do
     expect(duplicate_product.product_refund_policy.fine_print).to eq(product.product_refund_policy.fine_print)
   end
 
+  describe "profile sections" do
+    it "duplicates the product's own profile sections and repoints `sections` at the new rows" do
+      other_product = create(:product, user: seller)
+      products_section = create(:seller_profile_products_section, seller:, product:, header: "Related", shown_products: [other_product.id], add_new_products: false)
+      featured_section = create(:seller_profile_featured_product_section, seller:, product:, header: "Featured", featured_product_id: other_product.id)
+      product.update!(sections: [products_section.id, featured_section.id], main_section_index: 1)
+
+      duplicate_product = ProductDuplicatorService.new(product.id).duplicate
+
+      expect(duplicate_product.seller_profile_sections.count).to eq(2)
+      expect(duplicate_product.sections).to match_array(duplicate_product.seller_profile_sections.pluck(:id))
+      expect(duplicate_product.sections).not_to include(products_section.id, featured_section.id)
+      expect(duplicate_product.main_section_index).to eq(1)
+
+      duplicated_products_section = duplicate_product.seller_profile_sections.find_by(header: "Related")
+      expect(duplicated_products_section.shown_products).to eq([other_product.id])
+      duplicated_featured_section = duplicate_product.seller_profile_sections.find_by(header: "Featured")
+      expect(duplicated_featured_section.featured_product_id).to eq(other_product.id)
+
+      # Source product's sections and their scoping are untouched.
+      expect(product.reload.sections).to eq([products_section.id, featured_section.id])
+      expect(products_section.reload.product_id).to eq(product.id)
+    end
+
+    it "does not create profile sections when the product has none" do
+      duplicate_product = ProductDuplicatorService.new(product.id).duplicate
+
+      expect(duplicate_product.sections).to eq([])
+      expect(duplicate_product.seller_profile_sections.count).to eq(0)
+    end
+  end
+
   it "duplicates the product and marks is_duplicating as false" do
     product.update!(is_duplicating: true)
 

--- a/spec/services/product_duplicator_service_spec.rb
+++ b/spec/services/product_duplicator_service_spec.rb
@@ -152,14 +152,19 @@ describe ProductDuplicatorService do
       duplicate_product = ProductDuplicatorService.new(product.id).duplicate
 
       expect(duplicate_product.seller_profile_sections.count).to eq(2)
-      expect(duplicate_product.sections).to match_array(duplicate_product.seller_profile_sections.pluck(:id))
       expect(duplicate_product.sections).not_to include(products_section.id, featured_section.id)
-      expect(duplicate_product.main_section_index).to eq(1)
 
       duplicated_products_section = duplicate_product.seller_profile_sections.find_by(header: "Related")
       expect(duplicated_products_section.shown_products).to eq([other_product.id])
       duplicated_featured_section = duplicate_product.seller_profile_sections.find_by(header: "Featured")
       expect(duplicated_featured_section.featured_product_id).to eq(other_product.id)
+
+      # Order-sensitive: `sections` must preserve the source's order (products section first,
+      # featured section second), not just contain the same ids — `main_section_index` is a
+      # plain array position into this array.
+      expect(duplicate_product.sections).to eq([duplicated_products_section.id, duplicated_featured_section.id])
+      expect(duplicate_product.main_section_index).to eq(1)
+      expect(duplicate_product.sections[duplicate_product.main_section_index]).to eq(duplicated_featured_section.id)
 
       # Source product's sections and their scoping are untouched.
       expect(product.reload.sections).to eq([products_section.id, featured_section.id])


### PR DESCRIPTION
## What

Fixes a bug where products created via "Duplicate" never show their "related products"/profile-products section on their own page, while manually-created products do.

Fixes antiwork/gumroad-private#1931

## Why

Sellers duplicating a product to reuse most of its setup lose a section they never touched — the duplicate silently renders with one fewer section than the original, and nothing in the UI explains why.

## Root Cause

`ProductPresenter#product_page_props` resolves which sections render on a product page by intersecting the product's own `sections` json array against sections **scoped to that product** (`product.seller_profile_sections`, i.e. `SellerProfileSection.where(product_id: product.id)`).

`ProductDuplicatorService#duplicate` does `product.dup`, which copies the `json_data` blob — including the `sections` array — verbatim from the source product, but never creates new per-product `SellerProfileSection` rows for the duplicate. So the duplicate's `sections` array keeps pointing at the *source* product's own section rows, which stay scoped to the original product (`product_id`). The lookup above returns nothing for the duplicate and the section silently never renders, even though `sections` is non-empty.

Confirmed live (read-only console) against a real seller's account: two products duplicated from an older one both had `sections` pointing at `SellerProfileSection` rows belonging to a *different* product.

## Before / after

- Before: `ProductDuplicatorService.new(product.id).duplicate` → `duplicate.sections == [source_section_id]`, `duplicate.seller_profile_sections == []` → page renders zero sections.
- After: `duplicate.seller_profile_sections.count == source.seller_profile_sections.count` and `duplicate.sections` points at the new rows — confirmed in the new regression test.

## Fix

- `ProductDuplicatorService#duplicate_profile_sections`: for each of the source product's own `seller_profile_sections`, `dup` the row, point it at `duplicated_product`, and rebuild `duplicated_product.sections` from the new rows' ids — mirrors the existing `duplicate_shipping_destinations`/`duplicate_refund_policy` pattern. `main_section_index` needs no change since it's a plain array-position integer.
- No-op when the source product has no sections.

## Test Results

- `bundle exec rspec spec/services/product_duplicator_service_spec.rb -e "profile sections"` — 2 examples, 0 failures (new regression test: a products section + a featured-product section duplicate correctly with their own settings; no-op when the product has no sections).
- `bundle exec rspec spec/services/product_duplicator_service_spec.rb` — full file, 23 examples, 0 failures.
- `bundle exec rspec spec/controllers/product_duplicates_controller_spec.rb` — 13 examples, 0 failures.
- Fix round (Greptile P2, order sensitivity): the regression test now asserts `duplicate_product.sections` equals `[products_section_id, featured_section_id]` in source order, not just the same set — `main_section_index` is a plain array position, so a reorder is the actual regression risk. Mutation-verified: reversing the copied id array in `duplicate_profile_sections` fails this assertion (`Expected [8, 7] to eq [7, 8]`); reverted, full file re-run green (23 examples, 0 failures).

## QA steps

Backend-only service change with no rendered surface of its own (the render path itself is untouched — `ProductPresenter` isn't touched by this diff). Exercised via the regression test above rather than a preview-app click-path: created a product with a per-product "products" section and a "featured product" section, duplicated it, and asserted the duplicate has its own section rows (with the same `shown_products`/`featured_product_id`) and that `sections` on the duplicate resolves against them — the exact failure mode reported live. Source product's sections and their scoping are asserted untouched.

- [x] Scope
- [x] Design
- [x] Build
- [x] QA
- [ ] Shipped
- [ ] Market
- [ ] Sell

---

## AI disclosure

Generated with Hermes Agent (claude-sonnet-5). Self-filed issue with root cause confirmed against live production data; fix and regression tests written and run locally by the agent.



Premerge review: clean @ 54a7a9ee657c45476debb2276466cda7c3bf5504

<!-- gumclaw-ownership-sweep -->


