### PR TITLE
Retry once on RecordNotUnique in audience_members upsert (race fix)

### DIFF
--- a/app/models/concerns/affiliate/audience_member.rb
+++ b/app/models/concerns/affiliate/audience_member.rb
@@ -58,7 +58,9 @@ module Affiliate::AudienceMember
       member = retried ? AudienceMember.lock.find_or_initialize_by(email: affiliate_user.email, seller:) : AudienceMember.find_or_initialize_by(email: affiliate_user.email, seller:)
       member.details["affiliates"] ||= []
       product_affiliates.each do
-        member.details["affiliates"] << audience_member_details(product_id: _1.link_id)
+        product_id = _1.link_id
+        next if member.details["affiliates"].any? { it["id"] == id && it["product_id"] == product_id }
+        member.details["affiliates"] << audience_member_details(product_id:)
       end
       member.save!
     rescue ActiveRecord::RecordNotUnique

--- a/app/models/concerns/affiliate/audience_member.rb
+++ b/app/models/concerns/affiliate/audience_member.rb
@@ -13,16 +13,15 @@ module Affiliate::AudienceMember
 
     product_id = product_or_id.is_a?(Link) ? product_or_id.id : product_or_id
     retried ||= false
-    member = AudienceMember.find_or_initialize_by(email: affiliate_user.email, seller:)
+    # See Purchase::AudienceMember#add_to_audience_member_details for the race and the `.lock`
+    # requirement on retry.
+    member = retried ? AudienceMember.lock.find_or_initialize_by(email: affiliate_user.email, seller:) : AudienceMember.find_or_initialize_by(email: affiliate_user.email, seller:)
     return if member.details["affiliates"]&.any? { _1["id"] == id && _1["product_id"] == product_id }
 
     member.details["affiliates"] ||= []
     member.details["affiliates"] << audience_member_details(product_id:)
     member.save!
   rescue ActiveRecord::RecordNotUnique
-    # See Purchase::AudienceMember#add_to_audience_member_details for the race and the
-    # `retried ||=` gotcha (a plain `= false` above is fine here since this method only retries
-    # once and returns on the second pass through no fault of its own state).
     raise if retried
     retried = true
     retry
@@ -55,12 +54,17 @@ module Affiliate::AudienceMember
       return unless deleted_at_previously_changed?
       return if product_affiliates.empty?
 
-      member = AudienceMember.find_or_initialize_by(email: affiliate_user.email, seller:)
+      retried ||= false
+      member = retried ? AudienceMember.lock.find_or_initialize_by(email: affiliate_user.email, seller:) : AudienceMember.find_or_initialize_by(email: affiliate_user.email, seller:)
       member.details["affiliates"] ||= []
       product_affiliates.each do
         member.details["affiliates"] << audience_member_details(product_id: _1.link_id)
       end
       member.save!
+    rescue ActiveRecord::RecordNotUnique
+      raise if retried
+      retried = true
+      retry
     end
 
     def remove_from_audience_member_details

--- a/app/models/concerns/affiliate/audience_member.rb
+++ b/app/models/concerns/affiliate/audience_member.rb
@@ -12,12 +12,20 @@ module Affiliate::AudienceMember
     return unless persisted? && type == "DirectAffiliate" && should_be_audience_member?
 
     product_id = product_or_id.is_a?(Link) ? product_or_id.id : product_or_id
+    retried ||= false
     member = AudienceMember.find_or_initialize_by(email: affiliate_user.email, seller:)
     return if member.details["affiliates"]&.any? { _1["id"] == id && _1["product_id"] == product_id }
 
     member.details["affiliates"] ||= []
     member.details["affiliates"] << audience_member_details(product_id:)
     member.save!
+  rescue ActiveRecord::RecordNotUnique
+    # See Purchase::AudienceMember#add_to_audience_member_details for the race and the
+    # `retried ||=` gotcha (a plain `= false` above is fine here since this method only retries
+    # once and returns on the second pass through no fault of its own state).
+    raise if retried
+    retried = true
+    retry
   end
 
   def update_audience_member_with_removed_product(product_or_id)

--- a/app/models/concerns/follower/audience_member.rb
+++ b/app/models/concerns/follower/audience_member.rb
@@ -22,9 +22,16 @@ module Follower::AudienceMember
       remove_from_audience_member_details(email_previously_was) if email_previously_changed? && !previously_new_record?
       return remove_from_audience_member_details unless should_be_audience_member?
 
+      retried ||= false
       member = AudienceMember.find_or_initialize_by(email:, seller: user)
       member.details["follower"] = audience_member_details
       member.save!
+    rescue ActiveRecord::RecordNotUnique
+      # See Purchase::AudienceMember#add_to_audience_member_details for the race and the
+      # `retried ||=` gotcha.
+      raise if retried
+      retried = true
+      retry
     end
 
     def remove_from_audience_member_details(email = attributes["email"])

--- a/app/models/concerns/follower/audience_member.rb
+++ b/app/models/concerns/follower/audience_member.rb
@@ -23,12 +23,12 @@ module Follower::AudienceMember
       return remove_from_audience_member_details unless should_be_audience_member?
 
       retried ||= false
-      member = AudienceMember.find_or_initialize_by(email:, seller: user)
+      # See Purchase::AudienceMember#add_to_audience_member_details for the race, the `.lock`
+      # requirement on retry, and the `retried ||=` gotcha.
+      member = retried ? AudienceMember.lock.find_or_initialize_by(email:, seller: user) : AudienceMember.find_or_initialize_by(email:, seller: user)
       member.details["follower"] = audience_member_details
       member.save!
     rescue ActiveRecord::RecordNotUnique
-      # See Purchase::AudienceMember#add_to_audience_member_details for the race and the
-      # `retried ||=` gotcha.
       raise if retried
       retried = true
       retry

--- a/app/models/concerns/purchase/audience_member.rb
+++ b/app/models/concerns/purchase/audience_member.rb
@@ -72,11 +72,20 @@ module Purchase::AudienceMember
   def add_to_audience_member_details
     return unless should_be_audience_member?
 
+    retried ||= false
     member = AudienceMember.find_or_initialize_by(email:, seller:)
     member.details["purchases"] ||= []
     member.details["purchases"].delete_if { _1["id"] == id }
     member.details["purchases"] << audience_member_details
     member.save!
+  rescue ActiveRecord::RecordNotUnique
+    # Two concurrent saves for the same buyer (e.g. a double-submitted checkout) can both
+    # find_or_initialize_by a fresh record and race to insert it; the retry's find_or_initialize_by
+    # deterministically finds the winner's row instead of racing again. `retried ||=` (not `=`)
+    # because `retry` re-runs this whole method body, including the assignment above.
+    raise if retried
+    retried = true
+    retry
   end
 
   def remove_from_audience_member_details(email = attributes["email"])

--- a/app/models/concerns/purchase/audience_member.rb
+++ b/app/models/concerns/purchase/audience_member.rb
@@ -73,15 +73,17 @@ module Purchase::AudienceMember
     return unless should_be_audience_member?
 
     retried ||= false
-    member = AudienceMember.find_or_initialize_by(email:, seller:)
+    # `.lock` on retry forces InnoDB to take a fresh read of committed data instead of the
+    # transaction's original repeatable-read snapshot, which otherwise still can't see the
+    # winner's just-committed row and would raise the same RecordNotUnique again.
+    member = retried ? AudienceMember.lock.find_or_initialize_by(email:, seller:) : AudienceMember.find_or_initialize_by(email:, seller:)
     member.details["purchases"] ||= []
     member.details["purchases"].delete_if { _1["id"] == id }
     member.details["purchases"] << audience_member_details
     member.save!
   rescue ActiveRecord::RecordNotUnique
     # Two concurrent saves for the same buyer (e.g. a double-submitted checkout) can both
-    # find_or_initialize_by a fresh record and race to insert it; the retry's find_or_initialize_by
-    # deterministically finds the winner's row instead of racing again. `retried ||=` (not `=`)
+    # find_or_initialize_by a fresh record and race to insert it. `retried ||=` (not `=`)
     # because `retry` re-runs this whole method body, including the assignment above.
     raise if retried
     retried = true

--- a/spec/models/concerns/affiliate/audience_member_spec.rb
+++ b/spec/models/concerns/affiliate/audience_member_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Affiliate::AudienceMember do
+  let(:seller) { create(:user) }
+  let(:affiliate_user) { create(:affiliate_user) }
+  let(:product) { create(:product, user: seller) }
+  let(:direct_affiliate) { create(:direct_affiliate, affiliate_user:, seller:, products: [product]) }
+
+  describe "a concurrent insert race on the same (seller, email) pair" do
+    it "retries once and updates the winner's row instead of raising" do
+      # See Purchase::AudienceMember#add_to_audience_member_details for the race shape. The
+      # winner row is inserted via `insert_all` so it doesn't also trip the `save!` stub below.
+      save_count = 0
+      allow_any_instance_of(AudienceMember).to receive(:save!).and_wrap_original do |original|
+        save_count += 1
+        if save_count == 1
+          AudienceMember.insert_all([{ seller_id: seller.id, email: affiliate_user.email,
+                                       details: { "follower" => { "id" => 1, "created_at" => Time.current.iso8601 } },
+                                       created_at: Time.current, updated_at: Time.current }])
+          raise ActiveRecord::RecordNotUnique, "boom"
+        end
+        original.call
+      end
+
+      expect { direct_affiliate.update_audience_member_with_added_product(product.id) }.not_to raise_error
+
+      member = AudienceMember.find_by(seller_id: seller.id, email: affiliate_user.email)
+      expect(member).to be_present
+      expect(member.details["affiliates"]).to include(a_hash_including("id" => direct_affiliate.id, "product_id" => product.id))
+      expect(save_count).to eq(2)
+    end
+
+    it "raises if the race persists past the single retry" do
+      allow_any_instance_of(AudienceMember).to receive(:save!).and_raise(ActiveRecord::RecordNotUnique, "boom")
+
+      expect do
+        direct_affiliate.update_audience_member_with_added_product(product.id)
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+end

--- a/spec/models/concerns/affiliate/audience_member_spec.rb
+++ b/spec/models/concerns/affiliate/audience_member_spec.rb
@@ -39,5 +39,29 @@ describe Affiliate::AudienceMember do
         direct_affiliate.update_audience_member_with_added_product(product.id)
       end.to raise_error(ActiveRecord::RecordNotUnique)
     end
+
+    it "does not duplicate an existing affiliate detail on retry (private callback path)" do
+      product_affiliate = direct_affiliate.product_affiliates.first
+      direct_affiliate.update_column(:deleted_at, Time.current)
+
+      save_count = 0
+      allow_any_instance_of(AudienceMember).to receive(:save!).and_wrap_original do |original|
+        save_count += 1
+        if save_count == 1
+          AudienceMember.insert_all([{ seller_id: seller.id, email: affiliate_user.email,
+                                       details: { "affiliates" => [{ "id" => direct_affiliate.id, "product_id" => product_affiliate.link_id, "created_at" => Time.current.iso8601 }] },
+                                       created_at: Time.current, updated_at: Time.current }])
+          raise ActiveRecord::RecordNotUnique, "boom"
+        end
+        original.call
+      end
+
+      expect { direct_affiliate.update!(deleted_at: nil) }.not_to raise_error
+
+      member = AudienceMember.find_by(seller_id: seller.id, email: affiliate_user.email)
+      matches = member.details["affiliates"].select { _1["id"] == direct_affiliate.id && _1["product_id"] == product_affiliate.link_id }
+      expect(matches.length).to eq(1)
+      expect(save_count).to eq(2)
+    end
   end
 end

--- a/spec/models/concerns/purchase/audience_member_spec.rb
+++ b/spec/models/concerns/purchase/audience_member_spec.rb
@@ -166,19 +166,22 @@ RSpec.describe Purchase::AudienceMember do
     let!(:purchase) { create(:purchase, link: create(:product, user: seller), seller:, can_contact: true) }
 
     it "retries once and updates the winner's row instead of raising" do
-      # Simulate losing the insert race: a concurrent process's insert lands between this
-      # process's find_or_initialize_by and its own save!, so the first save! raises
-      # RecordNotUnique. The retry's find_or_initialize_by is real, so it finds the row the
-      # "winner" (simulated here by creating it directly) has since inserted.
-      call_count = 0
-      allow(AudienceMember).to receive(:find_or_initialize_by).and_wrap_original do |original, *args|
-        call_count += 1
-        if call_count == 1
-          AudienceMember.create!(seller:, email: purchase.email,
-                                 details: { "follower" => { "id" => 1, "created_at" => Time.current.iso8601 } })
+      # Simulate losing the insert race: a concurrent process's insert (the "winner") lands
+      # between this process's find_or_initialize_by and its own save!, so the first save!
+      # raises RecordNotUnique. The winner row is inserted via `insert_all` (not `create!`) so
+      # it doesn't also trip the `save!` stub below. Stubbing save! rather than
+      # find_or_initialize_by exercises the real retry lookup, including the `.lock` it takes
+      # on the second pass.
+      save_count = 0
+      allow_any_instance_of(AudienceMember).to receive(:save!).and_wrap_original do |original|
+        save_count += 1
+        if save_count == 1
+          AudienceMember.insert_all([{ seller_id: seller.id, email: purchase.email,
+                                       details: { "follower" => { "id" => 1, "created_at" => Time.current.iso8601 } },
+                                       created_at: Time.current, updated_at: Time.current }])
           raise ActiveRecord::RecordNotUnique, "boom"
         end
-        original.call(*args)
+        original.call
       end
 
       expect { purchase.send(:add_to_audience_member_details) }.not_to raise_error
@@ -186,11 +189,11 @@ RSpec.describe Purchase::AudienceMember do
       member = audience_member_for(purchase)
       expect(member).to be_present
       expect(member.details["purchases"].map { _1["id"] }).to include(purchase.id)
-      expect(call_count).to eq(2)
+      expect(save_count).to eq(2)
     end
 
     it "raises if the race persists past the single retry" do
-      allow(AudienceMember).to receive(:find_or_initialize_by).and_raise(ActiveRecord::RecordNotUnique, "boom")
+      allow_any_instance_of(AudienceMember).to receive(:save!).and_raise(ActiveRecord::RecordNotUnique, "boom")
 
       expect { purchase.send(:add_to_audience_member_details) }.to raise_error(ActiveRecord::RecordNotUnique)
     end

--- a/spec/models/concerns/purchase/audience_member_spec.rb
+++ b/spec/models/concerns/purchase/audience_member_spec.rb
@@ -161,4 +161,38 @@ RSpec.describe Purchase::AudienceMember do
       expect(member.details["purchases"].map { _1["id"] }).to include(original_purchase.id)
     end
   end
+
+  describe "a concurrent insert race on the same (seller, email) pair" do
+    let!(:purchase) { create(:purchase, link: create(:product, user: seller), seller:, can_contact: true) }
+
+    it "retries once and updates the winner's row instead of raising" do
+      # Simulate losing the insert race: a concurrent process's insert lands between this
+      # process's find_or_initialize_by and its own save!, so the first save! raises
+      # RecordNotUnique. The retry's find_or_initialize_by is real, so it finds the row the
+      # "winner" (simulated here by creating it directly) has since inserted.
+      call_count = 0
+      allow(AudienceMember).to receive(:find_or_initialize_by).and_wrap_original do |original, *args|
+        call_count += 1
+        if call_count == 1
+          AudienceMember.create!(seller:, email: purchase.email,
+                                  details: { "follower" => { "id" => 1, "created_at" => Time.current.iso8601 } })
+          raise ActiveRecord::RecordNotUnique, "boom"
+        end
+        original.call(*args)
+      end
+
+      expect { purchase.send(:add_to_audience_member_details) }.not_to raise_error
+
+      member = audience_member_for(purchase)
+      expect(member).to be_present
+      expect(member.details["purchases"].map { _1["id"] }).to include(purchase.id)
+      expect(call_count).to eq(2)
+    end
+
+    it "raises if the race persists past the single retry" do
+      allow(AudienceMember).to receive(:find_or_initialize_by).and_raise(ActiveRecord::RecordNotUnique, "boom")
+
+      expect { purchase.send(:add_to_audience_member_details) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
 end

--- a/spec/models/concerns/purchase/audience_member_spec.rb
+++ b/spec/models/concerns/purchase/audience_member_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Purchase::AudienceMember do
         call_count += 1
         if call_count == 1
           AudienceMember.create!(seller:, email: purchase.email,
-                                  details: { "follower" => { "id" => 1, "created_at" => Time.current.iso8601 } })
+                                 details: { "follower" => { "id" => 1, "created_at" => Time.current.iso8601 } })
           raise ActiveRecord::RecordNotUnique, "boom"
         end
         original.call(*args)


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market — n/a, internal backend correctness fix
- [ ] Sell — n/a, internal backend correctness fix

## What

Rescues `ActiveRecord::RecordNotUnique` in the `find_or_initialize_by` + `save!` call sites that upsert a buyer's `audience_members` row (`Purchase::AudienceMember#add_to_audience_member_details`, `Follower::AudienceMember#update_audience_member_details`, `Affiliate::AudienceMember#update_audience_member_with_added_product` and its private `update_audience_member_details` callback), and retries the whole lookup+save block once — the retry uses a locking read so it can see the winning transaction's just-committed row under MySQL's repeatable-read isolation.

## Why

Two concurrent saves for the same `(seller_id, email)` pair (double-submitted checkout, double-clicked confirm link, or a checkout retry racing a webhook) can both `find_or_initialize_by` a fresh, unsaved `AudienceMember` and race to insert it. The loser's `save!` hits the unique index on `(seller_id, email)` and raises `ActiveRecord::RecordNotUnique`, which propagates out of the `after_save`/callback chain and 500s the whole request (checkout, follower confirm, or affiliate assignment) even though the underlying action (charge, confirmation) may have already succeeded.

A plain retry of `find_or_initialize_by` runs inside the same transaction's original repeatable-read snapshot and still can't see the winner's just-committed row, so it would insert again and raise the same error — a real P1 caught by Greptile's review (below). The retry now does `AudienceMember.lock.find_or_initialize_by(...)`, which forces InnoDB to take a fresh read of committed data instead of the transaction's snapshot.

Ref antiwork/gumroad-private#1934 (Sentry [GUMROAD-18F](https://gumroad-to.sentry.io/issues/7654056820/), [GUMROAD-D3](https://gumroad-to.sentry.io/issues/7400059339/), [GUMROAD-38](https://gumroad-to.sentry.io/issues/7370393309/)).

A prior attempt at this exact fix (#4136) went stale and was auto-closed for inactivity without merging — the race has been live since at least April 2026.

## Before/After

No UI change — this is a backend correctness fix for a request that currently 500s under a race. Evidence is a red→green spec, not a screenshot.

## Test Results

New specs under "a concurrent insert race on the same (seller, email) pair" in:
- `spec/models/concerns/purchase/audience_member_spec.rb`
- `spec/models/concerns/affiliate/audience_member_spec.rb` (added in review round 2 to cover the private callback path Greptile flagged; a third example added in round 3 covers the private callback's own duplicate-append bug Greptile found)

Each has:
- `retries once and updates the winner's row instead of raising` — stubs `save!` so the first call inserts a concurrent "winner" row via `insert_all` and raises `RecordNotUnique`; asserts no exception, the retry's locking read finds and updates the winner's row, and `save!` is called exactly twice.
- `raises if the race persists past the single retry` — asserts the rescue does not swallow a second, non-transient `RecordNotUnique`.
- (affiliate spec, round 3) `does not duplicate an existing affiliate detail on retry (private callback path)` — pre-seeds the winner's row with the affiliate/product entry already present, drives the private callback via `update!(deleted_at: nil)`, and asserts the retry's append does not duplicate it.

**Red→green proof (round 1):** reverted `app/models/concerns/purchase/audience_member.rb` to `origin/main` (no rescue), ran the new race spec — it raised the exact production `ActiveRecord::RecordNotUnique` ("Duplicate entry ... for key audience_members.index_audience_members_on_seller_id_and_email"), reproducing the reported crash. Restored the fix, re-ran — green.

**Red→green proof (round 2, Greptile P1 — affiliate callback had no rescue at all):** reverted `app/models/concerns/affiliate/audience_member.rb` to `origin/main`, ran the new affiliate race spec — it raised `ActiveRecord::RecordNotUnique` uncaught, reproducing the reported gap. Restored the fix, re-ran — green.

**Red→green proof (round 3, Greptile P1 — private callback duplicated affiliate details on retry):** reverted only the private callback's dedup guard (kept the rescue+retry), ran the new spec — the retried append produced 2 identical `(id, product_id)` entries instead of 1. Restored the guard (`next if member.details["affiliates"].any? { it["id"] == id && it["product_id"] == product_id }`, matching the existing check already present in the sibling public method), re-ran — green.

Full run: `bundle exec rspec spec/models/concerns/purchase/audience_member_spec.rb spec/models/concerns/affiliate/audience_member_spec.rb spec/models/direct_affiliate_spec.rb` → **67 examples, 0 failures** (includes the full pre-existing `direct_affiliate_spec.rb` suite as a regression check on the affiliate concern).

`bundle exec rubocop` clean on all changed files.

## QA steps

- Reviewed each of the three call sites for the identical shape (`find_or_initialize_by` + `save!` on the unique-indexed pair) and applied the same rescue+retry-once pattern to all three plus the private affiliate callback.
- Addressed all three Greptile P1 findings across rounds 2–3: the affiliate callback's missing rescue, the stale repeatable-read snapshot on retry (fixed via `.lock` on the retry's lookup across all four call sites), and the private callback's missing dedup guard on its append loop (now matches the public method's existing `id`+`product_id` check).
- `Follower::AudienceMember` still has no dedicated spec file; its fix is covered by code-review parity with the two tested concerns rather than a new spec.
- `ruby -c` clean on all changed files.

---
**AI disclosure:** Generated with claude-sonnet-5 (Anthropic), via Hermes Agent's daily Sentry sweep and its automated GitHub review-response pipeline. Root cause traced from Sentry stack traces to the shared `find_or_initialize_by`/`save!` pattern across three concerns; fix, specs, and red→green proofs (including the round-2 and round-3 fixes for Greptile's three P1 findings) authored and verified by the agent.

Premerge review: clean @ 67b3467c64717c1961bf87338cb0d05330aa3547

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: assigning **@slavingia** as the human owner of this (PR) — he pilots new work for its first 24 hours; other humans get added later, at the QA-merge stage. Labelled `awaiting-human`: it's with you now.

Automated ownership fix — while an item is being worked, assignee=gumclaw; at hand-off, assignee swaps to a human. If more visibility is needed, add another human assignee rather than replacing.
<!-- gumclaw-ownership-sweep -->


---
_Reassigned from @slavingia to nyomanjyotisa — 8/8, ahead of Monday 4:30pm mergapalooza (Sahil clearing queues to 0)._