### PR TITLE
Cap the "payout in processing" safeguard age (gp#1918)

### DIFF
--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -31,11 +31,8 @@ class StripePayoutProcessor
   def self.is_user_payable(user, amount_payable_usd_cents, add_comment: false, from_admin: false, payout_type: Payouts::PAYOUT_TYPE_STANDARD)
     payout_date = Time.current.to_fs(:formatted_date_full_month)
 
-    # If a user's previous payment is still processing, don't allow for new payments.
-    # gp#1918: only a payment still within the settlement-lag margin blocks the next
-    # cycle — see Payment::STUCK_PROCESSING_AGE. A payment older than that has almost
-    # certainly settled but missed our completion webhook, not one genuinely in flight,
-    # so it should stop suppressing this seller's schedule.
+    # If a user's previous payment is still processing (and not stuck, see
+    # Payment::STUCK_PROCESSING_AGE), don't allow for new payments.
     processing_payment_ids = user.payments.blocking_next_payout.ids
     if processing_payment_ids.any?
       user.add_payout_note(content: "Payout on #{payout_date} was skipped because there was already a payout in processing.") if add_comment

--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -32,7 +32,11 @@ class StripePayoutProcessor
     payout_date = Time.current.to_fs(:formatted_date_full_month)
 
     # If a user's previous payment is still processing, don't allow for new payments.
-    processing_payment_ids = user.payments.processing.ids
+    # gp#1918: only a payment still within the settlement-lag margin blocks the next
+    # cycle — see Payment::STUCK_PROCESSING_AGE. A payment older than that has almost
+    # certainly settled but missed our completion webhook, not one genuinely in flight,
+    # so it should stop suppressing this seller's schedule.
+    processing_payment_ids = user.payments.blocking_next_payout.ids
     if processing_payment_ids.any?
       user.add_payout_note(content: "Payout on #{payout_date} was skipped because there was already a payout in processing.") if add_comment
       return false

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -129,8 +129,20 @@ class Payment < ApplicationRecord
 
   validate :split_payment_validation
 
+  # gp#1918: the completion webhook (`payout.paid`) for some cross-border corridors
+  # (observed: MDL/Moldova) doesn't fire for 8-9 days even though the seller's bank
+  # shows funds landed in ~2. On a 7-day payout schedule the prior payment is still
+  # `processing` by our records at the next run, so the "block if processing"
+  # safeguard trips every cycle and the seller is de facto paid biweekly instead of
+  # weekly. 5 days covers observed real settlement (~2d) plus a safety margin for
+  # slower corridors while still being short enough that it clears before the next
+  # weekly cycle — a payment older than that has very likely already settled and is
+  # just waiting on a slow/missed webhook, not something a second transfer could race.
+  STUCK_PROCESSING_AGE = 5.days
+
   scope :processed_by,            ->(processor) { where(processor:) }
   scope :processing,              -> { where(state: "processing") }
+  scope :blocking_next_payout,    -> { where(state: "processing").where("created_at > ?", STUCK_PROCESSING_AGE.ago) }
   scope :completed,               -> { where(state: "completed") }
   scope :completed_or_processing, -> { where("state = 'completed' or state = 'processing'") }
   scope :failed,                  -> { where(state: "failed").order(id: :desc) }

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -129,15 +129,9 @@ class Payment < ApplicationRecord
 
   validate :split_payment_validation
 
-  # gp#1918: the completion webhook (`payout.paid`) for some cross-border corridors
-  # (observed: MDL/Moldova) doesn't fire for 8-9 days even though the seller's bank
-  # shows funds landed in ~2. On a 7-day payout schedule the prior payment is still
-  # `processing` by our records at the next run, so the "block if processing"
-  # safeguard trips every cycle and the seller is de facto paid biweekly instead of
-  # weekly. 5 days covers observed real settlement (~2d) plus a safety margin for
-  # slower corridors while still being short enough that it clears before the next
-  # weekly cycle — a payment older than that has very likely already settled and is
-  # just waiting on a slow/missed webhook, not something a second transfer could race.
+  # A payment stuck in `processing` past this age is treated as settled-but-unconfirmed
+  # rather than still in flight, so it stops blocking the next payout run. See gp#1918
+  # for the corridor whose completion webhook lags this long.
   STUCK_PROCESSING_AGE = 5.days
 
   scope :processed_by,            ->(processor) { where(processor:) }

--- a/test/business/payments/payouts/processor/stripe/stripe_payout_processor_test.rb
+++ b/test/business/payments/payouts/processor/stripe/stripe_payout_processor_test.rb
@@ -150,6 +150,16 @@ class StripePayoutProcessorTest < ActiveSupport::TestCase
     end
   end
 
+  test "is_user_payable when the user's previous processing payout is older than STUCK_PROCESSING_AGE returns true (gp#1918)" do
+    with_cassette("is_user_payable/when_the_user_has_a_previous_payout_in_processing_state/returns_false") do
+      setup_is_user_payable
+      payment = create_payment(user: @u1, processor: "STRIPE", processor_fee_cents: 10, stripe_transfer_id: "tr_1234", stripe_connect_account_id: "acct_1234")
+      payment.update_column(:created_at, (Payment::STUCK_PROCESSING_AGE + 1.day).ago)
+
+      assert_equal true, StripePayoutProcessor.is_user_payable(@u1, 10_01)
+    end
+  end
+
   test "is_user_payable when the user has a previous payout in processing state adds a payout skipped note if the flag is set" do
     with_cassette("is_user_payable/when_the_user_has_a_previous_payout_in_processing_state/adds_a_payout_skipped_note_if_the_flag_is_set") do
       setup_is_user_payable


### PR DESCRIPTION
## Stages
- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market — n/a, internal backend correctness fix
- [ ] Sell — n/a, internal backend correctness fix

## What
Adds `Payment::STUCK_PROCESSING_AGE` (5 days) and a `Payment.blocking_next_payout` scope. `StripePayoutProcessor.is_user_payable` now only treats a payment as blocking the next payout run if it's still `processing` AND younger than 5 days, instead of any `processing` payment regardless of age.

## Why
gp#1918: seller `programare` (MDL/Moldova) is on a weekly payout schedule but has been effectively paid biweekly since May. Root cause confirmed in payment history: this corridor's `payout.paid` completion webhook fires 8-9 days after the transfer starts, even though the seller's bank shows funds landing in ~2 days. The weekly schedule re-checks after only 7 days, so the prior payment is still `processing` by our records every single cycle, tripping the "don't payout if a prior payout is still processing" safeguard (`StripePayoutProcessor#is_user_payable`) every time.

5 days covers observed real settlement (~2d) with margin for slower corridors, while remaining short enough to clear before the next weekly cycle. A payment that's still `processing` past 5 days is very likely already settled at the bank and just waiting on a slow/missed webhook — not a payment that a second transfer could actually race with.

**Scope note:** this PR only changes the Stripe path (`StripePayoutProcessor`), which is what gp#1918 reports. `PayPalPayoutProcessor` still uses the unbounded `user.payments.processing` check (`app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb:89`) — left unchanged since there's no reported PayPal-corridor lag issue, but worth a follow-up if PayPal ever exhibits the same symptom.

## Test Results
New test in `stripe_payout_processor_test.rb`: `is_user_payable when the user's previous processing payout is older than STUCK_PROCESSING_AGE returns true (gp#1918)` — creates a processing payment, backdates its `created_at` past `STUCK_PROCESSING_AGE`, asserts `is_user_payable` now returns true (previously would've returned false indefinitely).

Full file run: `bundle exec rails test test/business/payments/payouts/processor/stripe/stripe_payout_processor_test.rb -n "/is_user_payable/"` → **15 runs, 32 assertions, 0 failures, 0 errors**.

## QA steps
Backend-only safeguard-threshold fix, no UI surface — diff + test suite is the reviewable artifact. The only observable effect is a seller's payout cadence returning to the schedule they opted into.

Closes gumroad-private#1918.

Update (a1d0e6b9): condensed the two rationale comments on `STUCK_PROCESSING_AGE` per Greptile P2 — the incident narrative now lives only on gp#1918, not duplicated across `payment.rb` and `stripe_payout_processor.rb`. Comment-only change, no logic touched.

Premerge review: clean @ a1d0e6b974b00c14995c4e1fa2268d68e959fe64 (re-pinned after this comment-only push: `git diff fed8a19d..a1d0e6b9` touches only comment text in payment.rb/stripe_payout_processor.rb, no logic changed, so the fed8a19d panel review below still holds — panel: gpt-5.5/codex adversarial money-path review — traced `is_user_payable`, every `Payment.processing` caller, and the payout-creation lock path in `payouts.rb`; confirmed real payout creation locks/claims `unpaid` balances independently of this eligibility check, so no double-transfer path opens up. Verified locally: 2 targeted runs green.)

---
**AI disclosure:** Generated with claude-sonnet-5 (Anthropic) via Hermes Agent's pr-and-issue-advancer sweep, following the root-cause investigation already logged on gp#1918. Fix, test, and verification run authored and executed by the agent; adversarial pre-merge review run by a separate codex/gpt-5.5 dispatch on a fresh clone.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: assigning **@slavingia** as the human owner of this (PR) — he pilots new work for its first 24 hours; other humans get added later, at the QA-merge stage. Labelled `awaiting-human`: it's with you now.

Automated ownership fix — while an item is being worked, assignee=gumclaw; at hand-off, assignee swaps to a human. If more visibility is needed, add another human assignee rather than replacing.
<!-- gumclaw-ownership-sweep -->


---
_Reassigned from @slavingia to ershad — 8/8, ahead of Monday 4:30pm mergapalooza (Sahil clearing queues to 0)._