### PR TITLE
Recommend products to guest buyers in receipt emails

### DIFF
--- a/app/presenters/receipt_presenter/recommended_products_info.rb
+++ b/app/presenters/receipt_presenter/recommended_products_info.rb
@@ -15,8 +15,6 @@ class ReceiptPresenter::RecommendedProductsInfo
 
   def products
     @_products ||= begin
-      return [] if purchaser.blank?
-
       recommended_product_infos.map do |product_info|
         ProductPresenter.card_for_web(
           product: product_info.product,
@@ -34,7 +32,7 @@ class ReceiptPresenter::RecommendedProductsInfo
   end
 
   private
-    RECOMMENDED_PRODUCTS_LIMIT = 2
+    RECOMMENDED_PRODUCTS_LIMIT = 4
 
     attr_reader :chargeable, :purchaser
 

--- a/spec/presenters/receipt_presenter/recommended_products_info_spec.rb
+++ b/spec/presenters/receipt_presenter/recommended_products_info_spec.rb
@@ -23,16 +23,41 @@ describe ReceiptPresenter::RecommendedProductsInfo do
     end
 
     describe "#products" do
-      RSpec.shared_examples "doesn't return products" do
-        it "doesn't return products" do
-          expect(RecommendedProductsService).not_to receive(:for_checkout)
-          expect(recommended_products_info.products).to eq([])
-          expect(recommended_products_info.present?).to eq(false)
+      context "when the purchase doesn't have a purchaser (guest checkout)" do
+        let(:recommendable_product) { create(:product, :recommendable, name: "Recommended product") }
+        let!(:affiliate) do
+          create(
+            :direct_affiliate,
+            seller: recommendable_product.user,
+            products: [recommendable_product], affiliate_user: create(:user)
+          )
         end
-      end
 
-      context "when the purchase doesn't have a purchaser" do
-        it_behaves_like "doesn't return products"
+        before do
+          seller.update!(recommendation_type: User::RecommendationType::GUMROAD_AFFILIATES_PRODUCTS)
+        end
+
+        it "still recommends products, keyed off the receipt's own items" do
+          expect(RecommendedProducts::CheckoutService).to receive(:fetch_for_receipt).with(
+            purchaser: nil,
+            receipt_product_ids: [purchase.link.id],
+            recommender_model_name: "sales",
+            limit: ReceiptPresenter::RecommendedProductsInfo::RECOMMENDED_PRODUCTS_LIMIT,
+          ).and_call_original
+          expect(RecommendedProductsService).to receive(:fetch).with(
+            {
+              model: "sales",
+              ids: [purchase.link.id],
+              exclude_ids: [purchase.link.id],
+              number_of_results: RecommendedProducts::BaseService::NUMBER_OF_RESULTS,
+              user_ids: nil,
+            }
+          ).and_return(Link.where(id: [recommendable_product.id]))
+
+          expect(recommended_products_info.products.size).to eq(1)
+          expect(recommended_products_info.present?).to eq(true)
+          expect(recommended_products_info.products.first[:name]).to eq(recommendable_product.name)
+        end
       end
 
       context "when the purchase has a purchaser" do


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

## What

Removes the guest guard in `ReceiptPresenter::RecommendedProductsInfo#products` so receipt emails recommend products to every buyer, including the 56% who check out as guests. Also raises `RECOMMENDED_PRODUCTS_LIMIT` from 2 to 4.

Implements the first two checkboxes of gp#1925 (approved by Sahil 8/8). The third, optional checkbox (click tracking on receipt emails via `HandleEmailEventInfo::ForReceiptEmail`) is not included here — it's diagnostics-only and not needed to measure the primary change, which is already measurable via the existing `recommended_by=receipt` attribution on `purchases.recommended_by`.

## Why

`RecommendedProducts::CheckoutService` already reads the purchaser with safe navigation and falls back to the receipt's own products, so removing the guard is enough — for a guest it recommends based on what they just bought, matching the existing heading "Customers who bought this item also bought". See gp#1925 for the full rationale and data (1.95M guest receipts/month currently shown zero recommendations).

## Before/After

- Before: `products` returns `[]` immediately when `purchaser.blank?` (all guest checkouts).
- After: guest and registered buyers both get recommendations; guests are recommended based on the products in their current receipt, up to 4 (was 2 for everyone).

## Test Results

`bundle exec rspec spec/presenters/receipt_presenter/recommended_products_info_spec.rb` — 9 examples, 1 failure.

The failure (`for Charge ... returns correct title`, a `merchant_account` factory uniqueness collision) reproduces identically against unmodified `origin/main`. Pre-existing/environmental, not caused by this PR.

All new/changed examples pass:

- `for Purchase`/`for Charge` — guest checkout (no purchaser) still recommends products, keyed off the receipt's own items — **new, was previously an early-return "doesn't return products" case**
- `for Purchase`/`for Charge` — registered purchaser, regular purchase, bundle purchase — unchanged, still pass
- `for Charge` — multiple purchases — unchanged, still passes

## QA steps

No rendered surface changes beyond the existing receipt email template (no new UI). The spec above verifies that (1) a guest purchase (`purchaser: nil`) populates `products` from `RecommendedProducts::CheckoutService.fetch_for_receipt` instead of short-circuiting to `[]`, and (2) the query passes `limit: 4`.

---

AI disclosure: this PR's code and description were written by claude-sonnet-5 (Hermes Agent) on behalf of gumclaw, per gp#1925.
