### PR TITLE
Add DeepSeek V4 Flash as a third store-agent model option

### DIFF
--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -4,7 +4,8 @@
 # assistant that can answer questions about their store and *propose* changes to it.
 #
 # The agent runs on Grok 4.5 via OpenRouter's Anthropic-compatible endpoint (see MODEL below), with
-# Claude Opus 5 as the request-level fallback when Grok errors.
+# Claude Opus 5 as the request-level fallback when Grok errors. DeepSeek V4 Flash is ramped
+# independently as a third option (see DEEPSEEK_MODEL below), also falling back to Opus.
 #
 # Safety model:
 #   - READ tools (api_read) run automatically and only ever query data the seller already owns. They
@@ -23,14 +24,24 @@ class Ai::StoreAgentService
   class Error < StandardError; end
 
   MODEL = Ai::AnthropicClient::DEFAULT_MODEL
-  # Grok is only reachable through OpenRouter, so the cutover keys off routing: a direct-Anthropic
-  # config keeps serving Opus unchanged.
+  # Grok and DeepSeek are only reachable through OpenRouter, so the cutover keys off routing: a
+  # direct-Anthropic config keeps serving Opus unchanged.
   OPENROUTER_MODEL = "x-ai/grok-4.5"
   # When Grok errors (provider down, rate limited), OpenRouter retries the turn on this model
   # rather than the client's default GPT fallback.
   OPENROUTER_FALLBACK_MODEL = "anthropic/claude-opus-5"
   # Below 100%, gates Grok vs Opus per seller in addition to OPENROUTER_API_KEY being configured.
   GROK_RAMP_FEATURE = :store_agent_grok
+  # DeepSeek V4 Flash: cheap, fast MoE model worth ramping as a third option alongside Claude and
+  # Grok — same OpenRouter routing and Anthropic-compatible endpoint, so no client changes needed
+  # beyond the model id. Falls back to Opus rather than Grok so a DeepSeek outage doesn't cascade
+  # into a second experimental model.
+  DEEPSEEK_MODEL = "deepseek/deepseek-v4-flash-0731"
+  DEEPSEEK_FALLBACK_MODEL = "anthropic/claude-opus-5"
+  # Below 100%, gates DeepSeek vs Opus per seller in addition to OPENROUTER_API_KEY being
+  # configured. Independent of GROK_RAMP_FEATURE — see #client for precedence when both are active
+  # for the same seller (DeepSeek is checked first; a seller in both ramps gets DeepSeek).
+  DEEPSEEK_RAMP_FEATURE = :store_agent_deepseek
   # Passed to Ai::AnthropicClient as its READ timeout. For the streamed reply this bounds silence
   # between chunks (not the total generation time — a long healthy stream is fine); for the buffered
   # calls it bounds the wait for the full response. Production showed a steady stream of 60-second
@@ -1544,7 +1555,10 @@ class Ai::StoreAgentService
     end
 
     def client
-      @_client ||= if Ai::AnthropicClient.openrouter_configured? && Feature.active?(GROK_RAMP_FEATURE, seller)
+      @_client ||= if Ai::AnthropicClient.openrouter_configured? && Feature.active?(DEEPSEEK_RAMP_FEATURE, seller)
+        @_client_model = DEEPSEEK_MODEL
+        Ai::AnthropicClient.new(timeout: REQUEST_TIMEOUT_IN_SECONDS, model: DEEPSEEK_MODEL, fallback_model: DEEPSEEK_FALLBACK_MODEL)
+      elsif Ai::AnthropicClient.openrouter_configured? && Feature.active?(GROK_RAMP_FEATURE, seller)
         @_client_model = OPENROUTER_MODEL
         Ai::AnthropicClient.new(timeout: REQUEST_TIMEOUT_IN_SECONDS, model: OPENROUTER_MODEL, fallback_model: OPENROUTER_FALLBACK_MODEL)
       else

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -2213,16 +2213,6 @@ describe Ai::StoreAgentService do
       expect(captured[:fallback_model]).to eq("anthropic/claude-opus-5")
     end
 
-    it "keeps requesting Opus when OpenRouter is configured but the seller is not in the ramp" do
-      allow(Ai::AnthropicClient).to receive(:openrouter_configured?).and_return(true)
-      allow(client).to receive(:messages).and_return(text_result("hi"))
-
-      service.respond(messages: [{ role: "user", content: "hello" }])
-
-      expect(captured[:model]).to eq(Ai::AnthropicClient::DEFAULT_MODEL)
-      expect(captured[:fallback_model]).to be_nil
-    end
-
     it "keeps requesting Opus directly from Anthropic when OpenRouter is not configured" do
       allow(Ai::AnthropicClient).to receive(:openrouter_configured?).and_return(false)
       Feature.activate_user(described_class::GROK_RAMP_FEATURE, seller)
@@ -2232,6 +2222,39 @@ describe Ai::StoreAgentService do
 
       expect(captured[:model]).to eq(Ai::AnthropicClient::DEFAULT_MODEL)
       expect(captured[:fallback_model]).to be_nil
+    end
+
+    it "requests DeepSeek with an Opus fallback once OpenRouter and the DeepSeek ramp flag are both on" do
+      allow(Ai::AnthropicClient).to receive(:openrouter_configured?).and_return(true)
+      Feature.activate_user(described_class::DEEPSEEK_RAMP_FEATURE, seller)
+      allow(client).to receive(:messages).and_return(text_result("hi"))
+
+      service.respond(messages: [{ role: "user", content: "hello" }])
+
+      expect(captured[:model]).to eq("deepseek/deepseek-v4-flash-0731")
+      expect(captured[:fallback_model]).to eq("anthropic/claude-opus-5")
+    end
+
+    it "keeps requesting Opus when OpenRouter is configured but the seller is in neither ramp" do
+      allow(Ai::AnthropicClient).to receive(:openrouter_configured?).and_return(true)
+      allow(client).to receive(:messages).and_return(text_result("hi"))
+
+      service.respond(messages: [{ role: "user", content: "hello" }])
+
+      expect(captured[:model]).to eq(Ai::AnthropicClient::DEFAULT_MODEL)
+      expect(captured[:fallback_model]).to be_nil
+    end
+
+    it "prefers DeepSeek over Grok when a seller is in both ramps" do
+      allow(Ai::AnthropicClient).to receive(:openrouter_configured?).and_return(true)
+      Feature.activate_user(described_class::GROK_RAMP_FEATURE, seller)
+      Feature.activate_user(described_class::DEEPSEEK_RAMP_FEATURE, seller)
+      allow(client).to receive(:messages).and_return(text_result("hi"))
+
+      service.respond(messages: [{ role: "user", content: "hello" }])
+
+      expect(captured[:model]).to eq("deepseek/deepseek-v4-flash-0731")
+      expect(captured[:fallback_model]).to eq("anthropic/claude-opus-5")
     end
   end
 end


### PR DESCRIPTION
## What

The store agent (`Ai::StoreAgentService`) currently ramps between Claude Opus 5 (default, direct Anthropic) and Grok 4.5 (via OpenRouter, gated by the `store_agent_grok` Flipper flag). This adds **DeepSeek V4 Flash** (`deepseek/deepseek-v4-flash-0731`, OpenRouter) as a third option, gated by its own `store_agent_deepseek` flag.

- Same OpenRouter routing / Anthropic-compatible-endpoint mechanism already used for Grok — no client changes needed beyond the model id.
- Falls back to **Opus**, not Grok, on error — a DeepSeek outage shouldn't cascade into a second experimental model.
- Independent ramp flag from Grok's, so the two can be rolled out on separate schedules/percentages.
- If a seller is enrolled in both ramps, DeepSeek wins (checked first) — documented in the `#client` comment.

## Why

Sahil asked for DeepSeek V4 Flash (0731) added as another model option alongside Claude and Grok for the store agent, presumably for cost/latency experimentation — it's a cheap, fast MoE model (13B active / 284B total params) well suited to the read/propose tool-use loop this service runs.

## Rollout

Ships at 0% (flag exists, not enabled for anyone). Ramp is a Flipper percentage/actor toggle exactly like `store_agent_grok` — no code change needed to turn it on for a cohort once someone wants to start testing.

## Test plan

- `spec/services/ai/store_agent_service_spec.rb` — extended the existing "model selection" describe block with 3 new cases: DeepSeek ramp routes to DeepSeek+Opus-fallback, neither ramp routes to Opus directly, and DeepSeek takes precedence when a seller is in both ramps.
- Full spec file: 105/105 passing.
- `rubocop`: clean on both changed files.

Premerge review: clean @ f911d7eb85e6f8df61930e8544f4eab04644cae5 (panel: codex gpt-5.6-sol + claude-fable-5, per gp#1804 money/risk ruling — this touches the store agent's write-capable tool loop)


## QA

No rendered surface — this is a backend model-selection flag (which upstream API a request routes to), invisible in the UI regardless of which model answers. Ships at 0% so there's no behavior change to screenshot yet; verification is the model-selection spec (5 cases covering all ramp combinations) plus the panel review.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: assigning **@slavingia** as the human owner of this (PR) — he pilots new work for its first 24 hours; other humans get added later, at the QA-merge stage. Labelled `awaiting-human`: it's with you now.

Automated ownership fix — while an item is being worked, assignee=gumclaw; at hand-off, assignee swaps to a human. If more visibility is needed, add another human assignee rather than replacing.
<!-- gumclaw-ownership-sweep -->
