### PR TITLE
Guard content editor writes during the variant-switch window (gp#1943)

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+import { cleanup, render, act } from "@testing-library/react";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import * as React from "react";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { ContentTabContent } from "$app/components/ProductEdit/ContentTab";
+import { Product } from "$app/components/ProductEdit/state";
+
+// The mounted TipTap editor is provided by the mocked hook so this test can fire an
+// update/blur handler synchronously, inside the deferred page-switch window that
+// editorContentPageIdRef guards (gumroad-private#1943).
+let mountedEditor: Editor | null = null;
+
+const context = vi.hoisted(() => ({
+  id: "product-id",
+  product: {},
+  updateProduct: (_update: unknown) => {},
+  save: () => Promise.resolve(true),
+  existingFiles: [],
+  setExistingFiles: () => {},
+  uniquePermalink: "permalink",
+  filesById: new Map(),
+  richContentIdMappings: {},
+  fileIdMappings: {},
+  richContentRemovedFileEmbedIds: {},
+}));
+
+vi.mock("$app/components/ProductEdit/state", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("$app/components/ProductEdit/state")>();
+  return {
+    ...mod,
+    useProductEditContext: () => context,
+  };
+});
+
+vi.mock("$app/components/RichTextEditor", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("$app/components/RichTextEditor")>();
+  return {
+    ...mod,
+    useRichTextEditor: () => mountedEditor,
+    RichTextEditorToolbar: () => null,
+    useImageUploadSettings: () => ({ isUploading: false, onUpload: () => {}, allowedExtensions: [] }),
+  };
+});
+
+vi.mock("$app/components/ProductEdit/Layout", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("$app/components/ProductEdit/Layout")>();
+  return { ...mod, useProductUrl: () => "#" };
+});
+vi.mock("$app/components/EvaporateUploader", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("$app/components/EvaporateUploader")>();
+  return {
+    ...mod,
+    useEvaporateUploader: () => ({ scheduleUpload: () => 0, cancelUpload: () => {} }),
+  };
+});
+vi.mock("$app/components/S3UploadConfig", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("$app/components/S3UploadConfig")>();
+  return {
+    ...mod,
+    useS3UploadConfig: () => ({ generateS3KeyForUpload: () => ({ s3key: "key", fileUrl: "url" }) }),
+  };
+});
+vi.mock("$app/components/useIsAboveBreakpoint", () => ({ useIsAboveBreakpoint: () => true }));
+vi.mock("$app/components/ReviewForm", () => ({ ReviewForm: () => null }));
+vi.mock("$app/components/UpsellSelectModal", () => ({ UpsellSelectModal: () => null }));
+vi.mock("$app/components/TestimonialSelectModal", () => ({ TestimonialSelectModal: () => null }));
+vi.mock("$app/components/ProductEdit/ContentTab/EpubNudge", () => ({ EpubNudge: () => null }));
+vi.mock("react-sortablejs", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+  ReactSortable: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+afterEach(() => {
+  mountedEditor?.destroy();
+  mountedEditor = null;
+  cleanup();
+});
+
+const makePage = (id: string, text: string) => ({
+  id,
+  title: null,
+  description: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text }] }] } as const,
+  updated_at: "2026-01-01T00:00:00.000Z",
+});
+
+type VariantFixture = {
+  id: string;
+  name: string;
+  rich_content: ReturnType<typeof makePage>[];
+};
+
+const buildProduct = (variants: VariantFixture[]): Product =>
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- fixture only needs the fields ContentTabContent reads
+  ({
+    id: "product-id",
+    name: "Product",
+    native_type: "digital",
+    variants,
+    rich_content: [],
+    files: [],
+  }) as unknown as Product;
+
+it("does not write the previous variant's mounted doc into the newly selected variant during the page-switch window", async () => {
+  const paidPage = makePage("page-paid-1", "PAID PAGE");
+  const freePage = makePage("page-free-1", "FREE PAGE");
+  const paidVariant: VariantFixture = { id: "variant-paid", name: "Paid", rich_content: [paidPage] };
+  const freeVariant: VariantFixture = { id: "variant-free", name: "Free", rich_content: [freePage] };
+  const product = buildProduct([paidVariant, freeVariant]);
+
+  context.product = product;
+  context.updateProduct = (update: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the update union for the fixture
+    if (typeof update === "function") (update as (p: Product) => void)(product);
+    else Object.assign(product, update);
+  };
+
+  mountedEditor = new Editor({
+    extensions: [StarterKit],
+    content: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "PAID PAGE" }] }] },
+  });
+
+  const { rerender } = render(<ContentTabContent selectedVariantId="variant-paid" />);
+  await act(async () => {});
+
+  // Switch to the free variant; the mounted ProseMirror doc is only swapped in a
+  // deferred microtask. An update/blur firing synchronously here must not be
+  // serialized into the free variant's page.
+  rerender(<ContentTabContent selectedVariantId="variant-free" />);
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the update handler ignores its args
+  mountedEditor.emit("update", { editor: mountedEditor, transaction: null } as never);
+
+  await act(async () => {});
+  expect(freeVariant.rich_content[0]?.description).toEqual(freePage.description);
+});

--- a/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
@@ -1,17 +1,18 @@
 // @vitest-environment happy-dom
 import { cleanup, render, act } from "@testing-library/react";
-import { Editor } from "@tiptap/core";
-import StarterKit from "@tiptap/starter-kit";
+import type { Editor } from "@tiptap/core";
 import * as React from "react";
 import { afterEach, expect, it, vi } from "vitest";
 
 import { ContentTabContent } from "$app/components/ProductEdit/ContentTab";
 import { Product } from "$app/components/ProductEdit/state";
 
-// The mounted TipTap editor is provided by the mocked hook so this test can fire an
-// update/blur handler synchronously, inside the deferred page-switch window that
-// editorContentPageIdRef guards (gumroad-private#1943).
+// Capture the real mounted TipTap editor so the test can fire an update inside
+// the deferred page-switch window that editorContentPageIdRef guards (gp#1943).
 let mountedEditor: Editor | null = null;
+
+// vite.config.ts replaces the bare `SSR` identifier at build time.
+Object.assign(globalThis, { SSR: false });
 
 const context = vi.hoisted(() => ({
   id: "product-id",
@@ -39,7 +40,11 @@ vi.mock("$app/components/RichTextEditor", async (importOriginal) => {
   const mod = await importOriginal<typeof import("$app/components/RichTextEditor")>();
   return {
     ...mod,
-    useRichTextEditor: () => mountedEditor,
+    useRichTextEditor: (options: Parameters<typeof mod.useRichTextEditor>[0]) => {
+      const editor = mod.useRichTextEditor(options);
+      mountedEditor = editor;
+      return editor;
+    },
     RichTextEditorToolbar: () => null,
     useImageUploadSettings: () => ({ isUploading: false, onUpload: () => {}, allowedExtensions: [] }),
   };
@@ -74,10 +79,14 @@ vi.mock("react-sortablejs", () => ({
 }));
 
 afterEach(() => {
-  mountedEditor?.destroy();
-  mountedEditor = null;
   cleanup();
+  mountedEditor = null;
 });
+
+const getMountedEditor = () => {
+  if (!mountedEditor) throw new Error("Editor did not mount");
+  return mountedEditor;
+};
 
 const makePage = (id: string, text: string) => ({
   id,
@@ -103,7 +112,7 @@ const buildProduct = (variants: VariantFixture[]): Product =>
     files: [],
   }) as unknown as Product;
 
-it("does not write the previous variant's mounted doc into the newly selected variant during the page-switch window", async () => {
+it("rejects a stale variant write, resets the real editor, and persists the next edit", async () => {
   const paidPage = makePage("page-paid-1", "PAID PAGE");
   const freePage = makePage("page-free-1", "FREE PAGE");
   const paidVariant: VariantFixture = { id: "variant-paid", name: "Paid", rich_content: [paidPage] };
@@ -117,21 +126,24 @@ it("does not write the previous variant's mounted doc into the newly selected va
     else Object.assign(product, update);
   };
 
-  mountedEditor = new Editor({
-    extensions: [StarterKit],
-    content: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "PAID PAGE" }] }] },
-  });
-
   const { rerender } = render(<ContentTabContent selectedVariantId="variant-paid" />);
   await act(async () => {});
+  expect(getMountedEditor().getText()).toBe("PAID PAGE");
 
-  // Switch to the free variant; the mounted ProseMirror doc is only swapped in a
-  // deferred microtask. An update/blur firing synchronously here must not be
-  // serialized into the free variant's page.
+  // The real hook still holds the paid doc until its reset microtask runs.
   rerender(<ContentTabContent selectedVariantId="variant-free" />);
+  expect(getMountedEditor().getText()).toBe("PAID PAGE");
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the update handler ignores its args
-  mountedEditor.emit("update", { editor: mountedEditor, transaction: null } as never);
+  getMountedEditor().emit("update", { editor: getMountedEditor(), transaction: null } as never);
+  expect(freeVariant.rich_content[0]?.description).toEqual(freePage.description);
 
   await act(async () => {});
-  expect(freeVariant.rich_content[0]?.description).toEqual(freePage.description);
+  expect(getMountedEditor().getText()).toBe("FREE PAGE");
+
+  act(() => {
+    getMountedEditor().chain().focus("end").insertContent(" EDITED").run();
+  });
+  expect(getMountedEditor().getText()).toBe("FREE PAGE EDITED");
+  expect(freeVariant.rich_content[0]?.description).toEqual(getMountedEditor().getJSON());
+  expect(paidVariant.rich_content[0]?.description).toEqual(paidPage.description);
 });

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -354,6 +354,20 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
     onInputNonImageFiles: (files) => uploadFilesRef.current(files),
   });
   const removedFileEmbedIds = removedFileEmbedIdsForPage(selectedPage, richContentRemovedFileEmbedIds);
+  // The mounted TipTap doc is only swapped to the new page's content in a
+  // deferred microtask (useRichTextEditor's reset), so between a page/variant
+  // switch and that reset the editor still holds the PREVIOUS page's doc. An
+  // "update"/"blur" fired in that window (nodeview transactions do this) would
+  // serialize the old doc into the newly selected page — cross-variant content
+  // corruption (gumroad-private#1943). Track which page the mounted doc belongs
+  // to; the microtask here is queued after the reset's (hook order), so the flag
+  // only flips once the editor really holds the new page's doc.
+  const editorContentPageIdRef = React.useRef<string | undefined>(selectedPageId);
+  React.useEffect(() => {
+    queueMicrotask(() => {
+      editorContentPageIdRef.current = selectedPageId;
+    });
+  }, [selectedPageId]);
   React.useEffect(() => {
     if (editor) reconcileMountedEditorFileEmbedIds(editor, fileIdMappings);
   }, [editor, fileIdMappings]);
@@ -368,6 +382,11 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
   }, [editor, removedFileEmbedIds]);
   const updateContentRef = useRefToLatest(() => {
     if (!editor) return;
+    // The editor still holds a previous page's doc until the deferred content
+    // reset runs; writing it into the currently selected page would cross
+    // page/variant content (gumroad-private#1943). Skip — the stale doc's
+    // content is already stored under its own page.
+    if (editorContentPageIdRef.current !== selectedPageId) return;
 
     // Correctly set the IDs of the file embeds copied from another product
     const fragment = DOMSerializer.fromSchema(editor.schema).serializeFragment(editor.state.doc.content);

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -175,7 +175,7 @@ const FileUploadMenu = ({
   </Menu>
 );
 
-const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | null }) => {
+export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | null }) => {
   const {
     id,
     product,

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -354,14 +354,9 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
     onInputNonImageFiles: (files) => uploadFilesRef.current(files),
   });
   const removedFileEmbedIds = removedFileEmbedIdsForPage(selectedPage, richContentRemovedFileEmbedIds);
-  // The mounted TipTap doc is only swapped to the new page's content in a
-  // deferred microtask (useRichTextEditor's reset), so between a page/variant
-  // switch and that reset the editor still holds the PREVIOUS page's doc. An
-  // "update"/"blur" fired in that window (nodeview transactions do this) would
-  // serialize the old doc into the newly selected page — cross-variant content
-  // corruption (gumroad-private#1943). Track which page the mounted doc belongs
-  // to; the microtask here is queued after the reset's (hook order), so the flag
-  // only flips once the editor really holds the new page's doc.
+  // Tracks which page the mounted doc actually belongs to. Queued after
+  // useRichTextEditor's own reset microtask (hook order), so it only flips
+  // once the editor really holds the new page's doc — see updateContentRef.
   const editorContentPageIdRef = React.useRef<string | undefined>(selectedPageId);
   React.useEffect(() => {
     queueMicrotask(() => {
@@ -382,10 +377,8 @@ const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: string | 
   }, [editor, removedFileEmbedIds]);
   const updateContentRef = useRefToLatest(() => {
     if (!editor) return;
-    // The editor still holds a previous page's doc until the deferred content
-    // reset runs; writing it into the currently selected page would cross
-    // page/variant content (gumroad-private#1943). Skip — the stale doc's
-    // content is already stored under its own page.
+    // Mounted doc still belongs to the previous page during the switch window
+    // (gp#1943); skip rather than misfile it under the newly selected page.
     if (editorContentPageIdRef.current !== selectedPageId) return;
 
     // Correctly set the IDs of the file embeds copied from another product

--- a/app/javascript/components/RichTextEditor.test.ts
+++ b/app/javascript/components/RichTextEditor.test.ts
@@ -180,4 +180,36 @@ describe("useRichTextEditor", () => {
 
     expect(getEditor().getText()).toBe("before\n\nafter");
   });
+
+  // The window ContentTab's editorContentPageIdRef guard exists for (gumroad-private#1943):
+  // after initialValue changes, the mounted doc is only swapped in a queueMicrotask, so an
+  // update/blur handler firing synchronously in that window still reads the PREVIOUS page's
+  // doc. Serializing it into the newly selected page crosses page/variant content.
+  it("still holds the previous doc between an initialValue change and the deferred reset", async () => {
+    let editor: Editor | null = null;
+    const Harness = ({ initialValue }: { initialValue: object }) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- exercising the hook's public Content type
+      editor = useRichTextEditor({ initialValue: initialValue as never });
+      return null;
+    };
+    const getEditor = (): Editor => {
+      if (!editor) throw new Error("editor did not mount");
+      return editor;
+    };
+
+    const pageA = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "PAGE A" }] }] };
+    const pageB = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "PAGE B" }] }] };
+    const { rerender } = render(React.createElement(Harness, { initialValue: pageA }));
+    expect(getEditor().getText()).toBe("PAGE A");
+
+    // Synchronously after the switch — before microtasks flush — the editor still serializes
+    // page A. Anything persisting editor state here must not attribute it to page B.
+    rerender(React.createElement(Harness, { initialValue: pageB }));
+    expect(getEditor().getText()).toBe("PAGE A");
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getEditor().getText()).toBe("PAGE B");
+  });
 });


### PR DESCRIPTION
## What

Guards the product content editor against writing one page/variant's content into another during the variant-switch window. Fixes antiwork/gumroad-private#1943.

Three changes:
- `ContentTab/index.tsx`: track which page the mounted TipTap doc actually belongs to (`editorContentPageIdRef`, flipped in a microtask queued after `useRichTextEditor`'s deferred content reset), and skip `updateContentRef` while the mounted doc and the selected page disagree.
- `RichTextEditor.test.ts`: a test pinning the race-window premise — after `initialValue` changes, the mounted doc synchronously still serializes the PREVIOUS page's content until the queued microtask reset runs. If TipTap/our hook ever makes that reset synchronous, this test fails and the guard becomes removable dead code.
- `ContentTab/index.test.tsx` (new): a ContentTab-level regression test that drives the actual race — mounts a paid variant, switches the selected variant to a free variant, then fires an editor `update` synchronously inside the deferred window. Without the guard the free variant's `rich_content[0].description` is overwritten with the paid page's doc ("PAID PAGE"); with the guard it stays "FREE PAGE". Mutation-proved RED without the guard, GREEN with it — see Test Results.

## Why

`useRichTextEditor` swaps the mounted doc to the new page's content in a `queueMicrotask` (to discard undo history). Between a variant/page switch and that reset, the editor still holds the previous page's doc. Any `update`/`blur` event fired in that window (nodeview transactions, focus loss during the switch click) ran `updateContentRef`, which serialized the OLD doc and stored it under the NEWLY selected page — cross-variant content corruption. That is exactly the reported symptom: the `Editing:` dropdown shows the new variant while the content pane (and an in-window write) carries the previous variant's page.

Production forensics on the reported product (Link 10281061, full `RichContent.unscoped` history via the audited console, logged on gp#1943):
- 2025-11-23 05:42:06: **both pages of a then-live variant were soft-deleted in a single save with no replacement rows**, leaving the variant content-less — exactly this bug class flowing into `save_rich_contents`.
- 2025-11-01 22:01–22:30: 12 create/delete churn cycles of the same page across *both* variants with second-identical timestamps — the seller fighting the editor.
- The seller's session also raised `AmbiguousRichContentIdConflict` (per the Helper report), consistent with page rows being misfiled across variants.

So the race is not just a mis-render: it reaches the save path and destroys content. The guard is cheap (one ref compare) and fails safe — a skipped write in the window loses nothing, because the stale doc's content is already stored under its own page.

Rejected alternative: remounting `ContentTabContent` via `key={selectedVariantId}` would also close the window, but it resets page selection and re-creates the editor on every variant switch and does nothing for the in-place write path; the ref guard fixes the actual write mechanism without churn.

## Before → After

- Before: switching variant in the `Editing:` dropdown while an editor `update`/`blur` lands in the microtask window silently copies the previous variant's page content into the new variant (and, on save, persists/misfiles it).
- After: writes are dropped while the mounted doc belongs to a different page; the first write after the reset lands normally.

No pixel changes — this is an event-guard fix; before/after screenshots would be byte-identical (invisible-frontend-fix class). Evidence is the two tests (one mutation-proved) plus the prod forensics.

## Test Results

Local (2026-08-08, happy-dom):
- `npx vitest run app/javascript/components/RichTextEditor.test.ts app/javascript/components/ProductEdit/ContentTab/index.test.tsx` — **15 passed** (13 pre-existing + 1 RichTextEditor race-premise + 1 new ContentTab race test).
- New ContentTab test is a genuine regression guard: temporarily removing `if (editorContentPageIdRef.current !== selectedPageId) return;` makes it fail with `- "text": "FREE PAGE"` / `+ "text": "PAID PAGE"`; restored, it passes.
- `npm run typecheck` — 0 errors.
- `eslint` on both touched test files + `ContentTab/index.tsx` — clean (no `Routes.*` environmental hits on these files).

## QA steps

1. Open a product with per-variant content, two variants with distinct page content.
2. Type in variant A's page, then immediately switch to variant B via the `Editing:` dropdown (blur fires mid-switch).
3. Verify variant B renders its own content and variant A's content is unchanged after save/reload. (Non-deterministic race — a repro system spec run 6× under load could not force it; the guard closes the window regardless, and the ContentTab test forces the window deterministically.)

---

**AI disclosure:** Authored by gumclaw (Hermes Agent, model per `~/.hermes/config.yaml`). Instructions: autonomous dev dispatcher standing order (Sahil 2026-07-19/2026-08-02) against gumroad-private#1943.

Premerge review: clean @ a4b2a33746
