### PR TITLE
Guard seller profile against a stale featured-product reference (Sentry GUMROAD-4R)

### DIFF
--- a/app/presenters/profile_sections_presenter.rb
+++ b/app/presenters/profile_sections_presenter.rb
@@ -178,10 +178,8 @@ class ProfileSectionsPresenter
       when "SellerProfileFeaturedProductSection"
         unless editing
           featured_product_id = cached_props.delete(:featured_product_id)
-          # Link#delete! clears this reference going forward (gumroad#5248), but that
-          # only runs for products deleted after that fix shipped — records orphaned
-          # before then (or by any other path that hard-deletes/never calls delete!)
-          # have no backfill and would otherwise 500 the whole profile page forever.
+          # Scope to alive products: an orphaned reference (deleted/soft-deleted/banned
+          # product) is treated as "no featured product" instead of crashing on nil.
           featured_product = featured_product_id.present? ? seller.products.alive.find_by_external_id(featured_product_id) : nil
           cached_props.merge!(
             {

--- a/app/presenters/profile_sections_presenter.rb
+++ b/app/presenters/profile_sections_presenter.rb
@@ -177,10 +177,16 @@ class ProfileSectionsPresenter
         end
       when "SellerProfileFeaturedProductSection"
         unless editing
+          featured_product_id = cached_props.delete(:featured_product_id)
+          # Link#delete! clears this reference going forward (gumroad#5248), but that
+          # only runs for products deleted after that fix shipped — records orphaned
+          # before then (or by any other path that hard-deletes/never calls delete!)
+          # have no backfill and would otherwise 500 the whole profile page forever.
+          featured_product = featured_product_id.present? ? seller.products.alive.find_by_external_id(featured_product_id) : nil
           cached_props.merge!(
             {
-              props: cached_props[:featured_product_id].present? ?
-                       ProductPresenter.new(product: seller.products.find_by_external_id(cached_props.delete(:featured_product_id)), pundit_user:, request:).product_props(seller_custom_domain_url:) :
+              props: featured_product.present? ?
+                       ProductPresenter.new(product: featured_product, pundit_user:, request:).product_props(seller_custom_domain_url:) :
                        nil,
             }
           )

--- a/spec/presenters/profile_sections_presenter_spec.rb
+++ b/spec/presenters/profile_sections_presenter_spec.rb
@@ -135,6 +135,20 @@ describe ProfileSectionsPresenter do
       expect(featured_section_props[:props]).to be_nil
       expect(featured_section_props[:featured_product_id]).to be_nil
     end
+
+    it "does not raise when featured_product_id references a product that no longer exists (stale reference, e.g. predating Link#delete!'s cleanup)" do
+      featured_section = sections.find { _1.is_a?(SellerProfileFeaturedProductSection) }
+      # Simulate a stale reference left behind before gumroad#5248's cleanup existed —
+      # e.g. hard deletion, or any path other than Link#delete! removing the product.
+      featured_section.update_column(:json_data, featured_section.json_data.merge("featured_product_id" => products.first.id))
+      products.first.update_column(:deleted_at, 1.day.ago)
+
+      result = nil
+      expect { result = subject.props(request:, pundit_user:, seller_custom_domain_url: nil) }.not_to raise_error
+
+      featured_section_props = result[:sections].find { _1[:type] == "SellerProfileFeaturedProductSection" }
+      expect(featured_section_props[:props]).to be_nil
+    end
   end
 
   describe "show_ratings_filter" do


### PR DESCRIPTION
## What

Guards `ProfileSectionsPresenter#section_props` against a `SellerProfileFeaturedProductSection` whose `featured_product_id` points at a product that no longer exists (or is soft-deleted/banned/purchase-disabled). Currently that renders `ProductPresenter.new(product: nil, ...)`, which raises `NoMethodError: undefined method 'user' for nil` on every visit to the seller's public profile page.

## Why

[gumroad#5248](https://github.com/antiwork/gumroad/pull/5248) added `Link#delete!` → `clear_featured_product_sections!`, which clears `featured_product_id` from the section's JSON going forward — but it only fires on products removed via `Link#delete!` *after* that fix deployed (2026-08-05). It also **reverted** the presenter's defensive nil-guard on the assumption the reference could no longer go stale. Two populations aren't covered by the forward-fix:

1. Sections that already carried a stale `featured_product_id` before 2026-08-05 (i.e. pre-existing corrupted data).
2. Any future path that removes/soft-deletes a product without going through `Link#delete!`.

One seller (`digitalreadsco`) is currently hitting this on every profile-page request — 24 events / errors over the last 14 days (Sentry `GUMROAD-4R`, `count: 117, userCount: 35, firstSeen: 2026-03-28`), continuing well after PR #5248 deployed (confirmed via release-tag ancestry: `v2026.08.05.3`, published 2026-08-05T13:27:27Z — 22 of the last 66 sampled events postdate that release, all against the same URL `https://digitalreadsco.gumroad.com/`). Their profile page 500s until this ships.

## Before / After

- **Before:** stale/hard-deleted `featured_product_id` → `ProductPresenter.new(product: nil)` → `NoMethodError` → the whole public profile 500s.
- **After:** the lookup is scoped to `seller.products.alive`; a miss (deleted, soft-deleted, purchase-disabled, banned, or genuinely gone) is treated the same as "no featured product configured" — the section renders with `props: nil` instead of crashing.

## Test Results

Ran locally (lane-borrowed Redis/DB env, `DISABLE_SPRING=1 bundle exec rspec spec/presenters/profile_sections_presenter_spec.rb`):

- Full file: **23 examples, 0 failures** with the fix in place.
- Red→green proof on the new example (`does not raise when featured_product_id references a product that no longer exists`): reverted `app/presenters/profile_sections_presenter.rb` to `origin/main`'s pre-fix content, re-ran just that example → **1 example, 1 failure** (pre-fix code returned stale/deleted-product props instead of nil — a distinct but related defect, since pre-fix code doesn't even scope to alive products). Restored the fix → full file green again.

## QA steps

Backend-only change, no rendered UI delta to screenshot (the "after" state is a page that loads normally instead of 500ing — there's no visual delta on the happy path). Verified via the spec's assertion of the props payload shape rather than a live QA click-path, since reproducing the specific stale-JSON state on a preview app would require ad hoc console writes.

---

**AI disclosure:** Generated with claude-sonnet-5. Investigated via the Sentry daily sweep (GUMROAD-4R), root-caused against the `Link#delete!` history and PR #5248, fixed and verified via a committed red→green spec proof.

Ref antiwork/gumroad-private (Sentry GUMROAD-4R)



Premerge review: clean @ 345404071a3be5ed0c27ef009c1b9b669156f26f (autoreview --engine codex, no accepted findings)
