### PR TITLE
Fix buyer-currency-quote rate race causing buyer_currency_quote_invalid failures

### DIFF
--- a/app/controllers/customer_surcharge_controller.rb
+++ b/app/controllers/customer_surcharge_controller.rb
@@ -19,6 +19,7 @@ class CustomerSurchargeController < ApplicationController
     tax_included_rate = 0
     subtotal = 0
     quote_line_items = []
+    rates_by_listed_currency = {}
     # A buyer-currency quote needs a canonical money breakdown for every line the browser
     # will display; if any request line can't produce one (unknown product, missing
     # subscription), the quote is withheld and the cart falls back to canonical USD.
@@ -29,11 +30,20 @@ class CustomerSurchargeController < ApplicationController
         all_lines_quotable = false
         next
       end
-      surcharges = calculate_surcharges(product, item[:quantity], item[:price].to_d.to_i, subscription_id: item[:subscription_id], recommended_by: item[:recommended_by])
+      listed_currency = product.price_currency_type.to_s.downcase
+      surcharges = calculate_surcharges(
+        product,
+        item[:quantity],
+        item[:price].to_d.to_i,
+        subscription_id: item[:subscription_id],
+        recommended_by: item[:recommended_by],
+        rate: rates_by_listed_currency.fetch(listed_currency, :unset)
+      )
       unless surcharges
         all_lines_quotable = false
         next
       end
+      rates_by_listed_currency[listed_currency] = surcharges[:rate]
       tax_result = surcharges[:sales_tax_result]
       vat_id_valid = tax_result.business_vat_status == :valid
       has_vat_id_input ||= tax_result.to_hash[:has_vat_id_input]

--- a/app/controllers/customer_surcharge_controller.rb
+++ b/app/controllers/customer_surcharge_controller.rb
@@ -64,12 +64,11 @@ class CustomerSurchargeController < ApplicationController
         charge_now: charge_details[:charge_now],
         later_charge_kind: charge_details[:kind],
         later_charge_price_cents: charge_details[:later_price_cents],
-        # Read AT THE SAME MOMENT `calculate_surcharges` converted this line's price to
-        # canonical USD cents, so the quote token can bind the exact rate that produced
-        # today's total (gumroad-private#1958). `get_rate` is a cache read, not a fresh
-        # exchange-rate fetch, so this costs nothing beyond what the tax calculation above
-        # already paid for the same lookup.
-        listed_currency_rate: product.price_currency_type.to_s.downcase == Currency::USD ? nil : get_rate(product.price_currency_type)
+        # The rate `calculate_surcharges` used a moment earlier to convert this line's
+        # shipping to canonical USD cents — not a fresh `get_rate` call (gumroad-private#1958,
+        # Greptile review on #7149: a second independent read here can straddle a rate
+        # refresh and disagree with the first one even within a single request).
+        listed_currency_rate: surcharges[:rate]
       )
     end
 
@@ -174,7 +173,8 @@ class CustomerSurchargeController < ApplicationController
         item[:quantity],
         charge_base_price_cents + charge_tip_cents,
         subscription_id: item[:subscription_id],
-        recommended_by: item[:recommended_by]
+        recommended_by: item[:recommended_by],
+        rate: surcharges[:rate]
       )
       return if charge_surcharges.blank?
 
@@ -187,7 +187,7 @@ class CustomerSurchargeController < ApplicationController
       }
     end
 
-    def calculate_surcharges(product, quantity, price, subscription_id: nil, recommended_by: nil)
+    def calculate_surcharges(product, quantity, price, subscription_id: nil, recommended_by: nil, rate: :unset)
       if subscription_id.present?
         subscription = Subscription.find_by_external_id(subscription_id)
         return nil unless subscription&.original_purchase.present?
@@ -214,9 +214,18 @@ class CustomerSurchargeController < ApplicationController
       # Pass the product's listed currency so each rate term is converted the same way the
       # charge path does in Purchase#calculate_shipping. Calling this with the USD default and
       # converting the summed listed cents afterward is not equivalent under rounding.
+      #
+      # Captured once (unless the caller already has a reading from an earlier call in this
+      # same request — see the `rate:` param) so it can also be bound into a buyer-currency
+      # quote token (gumroad-private#1958, Greptile review on #7149): a second independent
+      # `get_rate` read for the same currency can straddle an `UpdateCurrenciesWorker` cache
+      # refresh and disagree with an earlier one even within a single request.
+      rate = get_rate(product.price_currency_type) if rate == :unset
+      rate = nil if product.price_currency_type.to_s.downcase == Currency::USD
       shipping_rate = shipping_destination&.calculate_shipping_rate(
         quantity:,
-        currency_type: product.price_currency_type
+        currency_type: product.price_currency_type,
+        rate:
       ) || 0
 
       sales_tax_result = SalesTaxCalculator.new(product:,
@@ -227,6 +236,6 @@ class CustomerSurchargeController < ApplicationController
                                                 buyer_vat_id:,
                                                 from_discover:).calculate
 
-      { sales_tax_result:, shipping_rate: }
+      { sales_tax_result:, shipping_rate:, rate: }
     end
 end

--- a/app/controllers/customer_surcharge_controller.rb
+++ b/app/controllers/customer_surcharge_controller.rb
@@ -63,7 +63,13 @@ class CustomerSurchargeController < ApplicationController
         charge_shipping_usd_cents: charge_details[:surcharges] ? charge_details[:surcharges].fetch(:shipping_rate) : 0,
         charge_now: charge_details[:charge_now],
         later_charge_kind: charge_details[:kind],
-        later_charge_price_cents: charge_details[:later_price_cents]
+        later_charge_price_cents: charge_details[:later_price_cents],
+        # Read AT THE SAME MOMENT `calculate_surcharges` converted this line's price to
+        # canonical USD cents, so the quote token can bind the exact rate that produced
+        # today's total (gumroad-private#1958). `get_rate` is a cache read, not a fresh
+        # exchange-rate fetch, so this costs nothing beyond what the tax calculation above
+        # already paid for the same lookup.
+        listed_currency_rate: product.price_currency_type.to_s.downcase == Currency::USD ? nil : get_rate(product.price_currency_type)
       )
     end
 

--- a/app/models/preorder.rb
+++ b/app/models/preorder.rb
@@ -79,8 +79,8 @@ class Preorder < ApplicationRecord
     purchases.first
   end
 
-  def authorize!
-    authorization_purchase.process!
+  def authorize!(locked_rate: nil)
+    authorization_purchase.process!(locked_rate:)
 
     purchase_errors = authorization_purchase.errors
     if is_test_preorder?

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2369,8 +2369,8 @@ class Purchase < ApplicationRecord
   #
   #                    if set to `false`, it means we have a user in session and if charge requires further authentication,
   #                    the method should succeed and attach a `charge_intent` with `requires_action? == true`.
-  def process!(off_session: true)
-    prepare_for_charge!
+  def process!(off_session: true, locked_rate: nil)
+    prepare_for_charge!(locked_rate:)
     charge!(off_session:)
   end
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2474,7 +2474,7 @@ class Purchase < ApplicationRecord
     Purchase::MarkFailedService.new(self).perform
   end
 
-  def set_price_and_rate
+  def set_price_and_rate(locked_rate: nil)
     if once_per_cart_discount_allocation.present? && !has_cached_offer_code?
       allocated_offer_code = OfferCode.find_by(id: once_per_cart_discount_allocation[:offer_code_id])
       if allocated_offer_code&.is_cents? && allocated_offer_code.once_per_cart?
@@ -2512,8 +2512,16 @@ class Purchase < ApplicationRecord
 
     self.displayed_price_cents = determine_customized_price_cents || calculate_price_range_cents || minimum_paid_price_cents
     self.displayed_price_currency_type = link.price_currency_type
-    self.price_cents = displayed_price_usd_cents
-    self.rate_converted_to_usd = get_rate(displayed_price_currency_type)
+    # `locked_rate` is the exact rate the buyer-currency quote (Checkout::BuyerCurrencyQuote)
+    # bound at surcharge-calculation time for this listed currency, threaded through from the
+    # checkout submission when present (gumroad-private#1958). Reusing it here instead of a
+    # fresh `get_rate` call is what stops this purchase's canonical USD total from disagreeing
+    # with the total the quote token locked — `UpdateCurrenciesWorker` refreshes the cached
+    # rate hourly, and a refresh landing between the surcharge request and this purchase's
+    # creation was previously enough to fail `BuyerCurrencyQuote.verify!`'s exact-match check
+    # with `buyer_currency_quote_invalid`, even on an unchanged cart.
+    self.price_cents = locked_rate.present? ? get_usd_cents(displayed_price_currency_type, displayed_price_cents, rate: locked_rate) : displayed_price_usd_cents
+    self.rate_converted_to_usd = locked_rate.present? ? locked_rate.to_s : get_rate(displayed_price_currency_type)
     self.total_transaction_cents = self.price_cents
     self.affiliate_credit_cents = determine_affiliate_balance_cents
     self.tax_cents = 0
@@ -2539,12 +2547,12 @@ class Purchase < ApplicationRecord
     )
   end
 
-  def prepare_for_charge!
+  def prepare_for_charge!(locked_rate: nil)
     reservable_offer_code = offer_code if offer_code&.is_cents? && offer_code.once_per_cart? &&
       offer_code.max_purchase_count.present? &&
       !does_not_count_towards_max_purchases && !is_test_purchase?
 
-    self.chargeable = process_without_charging!(reservable_offer_code:)
+    self.chargeable = process_without_charging!(reservable_offer_code:, locked_rate:)
   end
 
   def update_balance_and_mark_successful!
@@ -4280,8 +4288,8 @@ class Purchase < ApplicationRecord
       link.save!
     end
 
-    def process_without_charging!(reservable_offer_code: nil)
-      set_price_and_rate
+    def process_without_charging!(reservable_offer_code: nil, locked_rate: nil)
+      set_price_and_rate(locked_rate:)
       calculate_fees
       if reservable_offer_code
         # Serialize the final availability check with the reservation write.

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2512,14 +2512,10 @@ class Purchase < ApplicationRecord
 
     self.displayed_price_cents = determine_customized_price_cents || calculate_price_range_cents || minimum_paid_price_cents
     self.displayed_price_currency_type = link.price_currency_type
-    # `locked_rate` is the exact rate the buyer-currency quote (Checkout::BuyerCurrencyQuote)
-    # bound at surcharge-calculation time for this listed currency, threaded through from the
-    # checkout submission when present (gumroad-private#1958). Reusing it here instead of a
-    # fresh `get_rate` call is what stops this purchase's canonical USD total from disagreeing
-    # with the total the quote token locked — `UpdateCurrenciesWorker` refreshes the cached
-    # rate hourly, and a refresh landing between the surcharge request and this purchase's
-    # creation was previously enough to fail `BuyerCurrencyQuote.verify!`'s exact-match check
-    # with `buyer_currency_quote_invalid`, even on an unchanged cart.
+    # Reusing the quote's bound rate here (rather than a fresh `get_rate`) keeps this
+    # purchase's total in agreement with what BuyerCurrencyQuote.verify! signed
+    # (gumroad-private#1958) — a cache refresh between quote and charge would otherwise
+    # disagree with the token by a few cents and fail closed as buyer_currency_quote_invalid.
     self.price_cents = locked_rate.present? ? get_usd_cents(displayed_price_currency_type, displayed_price_cents, rate: locked_rate) : displayed_price_usd_cents
     self.rate_converted_to_usd = locked_rate.present? ? locked_rate.to_s : get_rate(displayed_price_currency_type)
     self.total_transaction_cents = self.price_cents

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -4300,7 +4300,7 @@ class Purchase < ApplicationRecord
 
       create_sales_tax_info!
 
-      calculate_shipping
+      calculate_shipping(locked_rate:)
       save
 
       if free_purchase?
@@ -5020,7 +5020,7 @@ class Purchase < ApplicationRecord
       self.was_tax_excluded_from_price = true
     end
 
-    def calculate_shipping
+    def calculate_shipping(locked_rate: nil)
       return unless link.is_physical
       return if country.blank?
 
@@ -5030,7 +5030,7 @@ class Purchase < ApplicationRecord
         preorder.authorization_purchase.shipping_cents
       else
         shipping_rate = ShippingDestination.for_product_and_country_code(product: link, country_code: Compliance::Countries.find_by_name(country)&.alpha2)
-        shipping_rate.calculate_shipping_rate(quantity:, currency_type: link.price_currency_type)
+        shipping_rate.calculate_shipping_rate(quantity:, currency_type: link.price_currency_type, rate: locked_rate)
       end
     end
 

--- a/app/models/shipping_destination.rb
+++ b/app/models/shipping_destination.rb
@@ -32,13 +32,16 @@ class ShippingDestination < ApplicationRecord
   #
   # Quantity - Quantity of items being purchased, determines the shipping rate (one/multiple) used
   # Currency Type - The three-character string (code) representing the currency the product/shipping rate was configured in
+  # Rate - optional. Reuses this FX rate instead of a fresh `get_rate` lookup, so a caller that
+  #   also needs the rate elsewhere (e.g. binding a buyer-currency quote) gets the same reading
+  #   this conversion used rather than a second cache read that can straddle a rate refresh.
   #
   # Returns nil if the quantity is less than 1. Returns a numeric value otherwise.
-  def calculate_shipping_rate(quantity: 0, currency_type: "usd")
+  def calculate_shipping_rate(quantity: 0, currency_type: "usd", rate: nil)
     return nil if quantity < 1
 
-    shipping_rate  = get_usd_cents(currency_type, one_item_rate_cents)
-    shipping_rate += get_usd_cents(currency_type, multiple_items_rate_cents * (quantity - 1))
+    shipping_rate  = get_usd_cents(currency_type, one_item_rate_cents, rate:)
+    shipping_rate += get_usd_cents(currency_type, multiple_items_rate_cents * (quantity - 1), rate:)
 
     shipping_rate
   end

--- a/app/services/checkout/buyer_currency_quote.rb
+++ b/app/services/checkout/buyer_currency_quote.rb
@@ -28,6 +28,7 @@ class Checkout::BuyerCurrencyQuote
                       :line_allocations,
                       :later_charge_presentments,
                       :listed_currency_rates,
+                      :listed_currency_codes,
                       keyword_init: true) do
     def id
       stripe_fx_quote_id
@@ -46,11 +47,9 @@ class Checkout::BuyerCurrencyQuote
     # (gumroad-private#1958). nil for USD-listed lines and for tokens signed before this
     # field shipped — both fall back to `set_price_and_rate`'s live `get_rate` read.
     def listed_currency_rate_for(permalink, currency:)
-      entry = listed_currency_rates&.[](permalink.to_s)
-      return unless entry.is_a?(Hash)
-      return unless entry["currency"].to_s.casecmp?(currency.to_s)
+      return unless listed_currency_codes&.[](permalink.to_s).to_s.casecmp?(currency.to_s)
 
-      entry["rate"]&.to_d
+      listed_currency_rates&.[](permalink.to_s)&.to_d
     end
   end
 
@@ -200,6 +199,7 @@ class Checkout::BuyerCurrencyQuote
                            :future_installments_presentment_total_cents,
                            :later_charge_presentments,
                            :listed_currency_rates,
+                           :listed_currency_codes,
                            keyword_init: true)
 
   TOKEN_PURPOSE = :buyer_currency_quote
@@ -266,7 +266,8 @@ class Checkout::BuyerCurrencyQuote
       stripe_fx_quote_id: charge_payload.fetch("stripe_fx_quote_id"),
       stripe_fx_quote_expires_at: Time.zone.parse(charge_payload.fetch("stripe_fx_quote_expires_at")),
       later_charge_presentments: charge_payload["later_charge_presentments"] || [],
-      listed_currency_rates: charge_payload["listed_currency_rates"] || {}
+      listed_currency_rates: charge_payload["listed_currency_rates"] || {},
+      listed_currency_codes: charge_payload["listed_currency_codes"] || {}
     )
   rescue ActiveSupport::MessageVerifier::InvalidSignature, KeyError, TypeError, ArgumentError => e
     raise InvalidToken, e.message
@@ -303,11 +304,9 @@ class Checkout::BuyerCurrencyQuote
     return if charge_payload.blank?
     return if Time.zone.parse(charge_payload.fetch("stripe_fx_quote_expires_at")) <= Time.current
 
-    entry = charge_payload.dig("listed_currency_rates", permalink.to_s)
-    return unless entry.is_a?(Hash)
-    return unless entry["currency"].to_s.casecmp?(currency.to_s)
+    return unless charge_payload.dig("listed_currency_codes", permalink.to_s).to_s.casecmp?(currency.to_s)
 
-    entry["rate"]&.to_d
+    charge_payload.dig("listed_currency_rates", permalink.to_s)&.to_d
   rescue ActiveSupport::MessageVerifier::InvalidSignature, KeyError, TypeError, ArgumentError
     nil
   end
@@ -688,19 +687,17 @@ class Checkout::BuyerCurrencyQuote
         line_allocations:,
         future_installments_presentment_total_cents:,
         later_charge_presentments:,
-        # Permalink → the listed currency and rate bound in each non-USD LineItem.
-        # Keeping the denomination beside the rate prevents a product currency edit from
-        # applying an old currency's rate to the new currency (gumroad-private#1958).
+        # Keep the existing scalar rate shape so older app instances can read tokens minted
+        # during a rolling deploy. The additive code map binds each rate to its denomination.
         listed_currency_rates: charge_line_items.filter_map do |line_item|
           next if line_item.listed_currency_rate.blank?
 
-          [
-            line_item.permalink.to_s,
-            {
-              "currency" => line_item.product.price_currency_type.to_s.downcase,
-              "rate" => line_item.listed_currency_rate.to_s,
-            }
-          ]
+          [line_item.permalink.to_s, line_item.listed_currency_rate.to_s]
+        end.to_h,
+        listed_currency_codes: charge_line_items.filter_map do |line_item|
+          next if line_item.listed_currency_rate.blank?
+
+          [line_item.permalink.to_s, line_item.product.price_currency_type.to_s.downcase]
         end.to_h
       )
     end
@@ -837,6 +834,7 @@ class Checkout::BuyerCurrencyQuote
           stripe_fx_quote_expires_at: charge_quote.stripe_fx_quote_expires_at.iso8601,
           fx_rate: charge_quote.fx_rate.to_s("F"),
           listed_currency_rates: charge_quote.listed_currency_rates,
+          listed_currency_codes: charge_quote.listed_currency_codes,
         }
       end
 

--- a/app/services/checkout/buyer_currency_quote.rb
+++ b/app/services/checkout/buyer_currency_quote.rb
@@ -281,17 +281,25 @@ class Checkout::BuyerCurrencyQuote
       raise(InvalidToken, "quote covers no charge for this seller")
   end
 
-  # Signature-checked but non-authoritative (gumroad-private#1958): confirms the token wasn't
-  # tampered with, not seller/merchant-account/total/expiry — `verify!` still runs the full
-  # check later via `Charge::CreateService#locked_buyer_currency_quote!`, so a bad hint here
-  # can only make `set_price_and_rate` land on the same total already displayed to the buyer.
+  # Signature- and expiry-checked but non-authoritative (gumroad-private#1958): confirms the
+  # token wasn't tampered with and is still inside its quote window, not
+  # seller/merchant-account/totals — `verify!` still runs the full check later via
+  # `Charge::CreateService#locked_buyer_currency_quote!` on Stripe charges. The expiry check is
+  # load-bearing on its own, though: non-Stripe charges (PayPal) never reach `verify!` — the
+  # charge service discards the token there — yet the rate bound here has already priced the
+  # purchase. Signatures do not age, so without this a buyer could replay a months-old token on
+  # a PayPal checkout and buy at a stale rate; with it, a replay is bounded by the quote window
+  # like every other consumer of the token.
   def self.listed_currency_rate_hint(token:, seller_id:, permalink:)
     return if token.blank?
 
     payload = verifier.verify(token)
     charge_payloads = payload["charges"].presence || [payload]
     charge_payload = charge_payloads.find { |cp| cp["seller_id"] == seller_id }
-    charge_payload&.dig("listed_currency_rates", permalink.to_s)&.to_d
+    return if charge_payload.blank?
+    return if Time.zone.parse(charge_payload.fetch("stripe_fx_quote_expires_at")) <= Time.current
+
+    charge_payload.dig("listed_currency_rates", permalink.to_s)&.to_d
   rescue ActiveSupport::MessageVerifier::InvalidSignature, KeyError, TypeError, ArgumentError
     nil
   end

--- a/app/services/checkout/buyer_currency_quote.rb
+++ b/app/services/checkout/buyer_currency_quote.rb
@@ -79,14 +79,10 @@ class Checkout::BuyerCurrencyQuote
     # 1520) and makes every non-USD-priced checkout fail quote verification. Covered by the
     # units-invariant example in the spec.
     #
-    # `listed_currency_rate` is the caller's `get_rate(product.price_currency_type)` read at
-    # the SAME instant it converted this line's price to canonical USD cents (whether via the
-    # browser's page-render rate or the surcharge endpoint's own lookup) — see
-    # gumroad-private#1958. Binding it here lets the charge path re-derive
-    # `rate_converted_to_usd` from the token instead of taking a fresh `get_rate` reading;
-    # `UpdateCurrenciesWorker` refreshes that cache hourly, so two independent reads separated
-    # by even a few minutes can disagree and fail `BuyerCurrencyQuote.verify!`'s exact-match
-    # check with `buyer_currency_quote_invalid`, even though the buyer's cart never changed.
+    # `listed_currency_rate` is the caller's rate reading for this product's listed currency,
+    # taken at the same moment it converted this line to canonical USD cents
+    # (gumroad-private#1958). Binding it here lets the charge path re-derive
+    # `rate_converted_to_usd` from the token instead of a second, possibly-drifted read.
     def self.from_surcharge(permalink:, product:, tax_result:, tip_cents:, shipping_usd_cents:,
                             charge_tax_result: nil, charge_tip_cents: nil, charge_shipping_usd_cents: nil,
                             later_charge_kind: nil, later_charge_price_cents: nil, charge_now: true,

--- a/app/services/checkout/buyer_currency_quote.rb
+++ b/app/services/checkout/buyer_currency_quote.rb
@@ -45,8 +45,12 @@ class Checkout::BuyerCurrencyQuote
     # `permalink`'s listed currency, bound at the same moment the quote was minted
     # (gumroad-private#1958). nil for USD-listed lines and for tokens signed before this
     # field shipped — both fall back to `set_price_and_rate`'s live `get_rate` read.
-    def listed_currency_rate_for(permalink)
-      listed_currency_rates&.[](permalink.to_s)&.to_d
+    def listed_currency_rate_for(permalink, currency:)
+      entry = listed_currency_rates&.[](permalink.to_s)
+      return unless entry.is_a?(Hash)
+      return unless entry["currency"].to_s.casecmp?(currency.to_s)
+
+      entry["rate"]&.to_d
     end
   end
 
@@ -290,7 +294,7 @@ class Checkout::BuyerCurrencyQuote
   # purchase. Signatures do not age, so without this a buyer could replay a months-old token on
   # a PayPal checkout and buy at a stale rate; with it, a replay is bounded by the quote window
   # like every other consumer of the token.
-  def self.listed_currency_rate_hint(token:, seller_id:, permalink:)
+  def self.listed_currency_rate_hint(token:, seller_id:, permalink:, currency:)
     return if token.blank?
 
     payload = verifier.verify(token)
@@ -299,7 +303,11 @@ class Checkout::BuyerCurrencyQuote
     return if charge_payload.blank?
     return if Time.zone.parse(charge_payload.fetch("stripe_fx_quote_expires_at")) <= Time.current
 
-    charge_payload.dig("listed_currency_rates", permalink.to_s)&.to_d
+    entry = charge_payload.dig("listed_currency_rates", permalink.to_s)
+    return unless entry.is_a?(Hash)
+    return unless entry["currency"].to_s.casecmp?(currency.to_s)
+
+    entry["rate"]&.to_d
   rescue ActiveSupport::MessageVerifier::InvalidSignature, KeyError, TypeError, ArgumentError
     nil
   end
@@ -680,15 +688,19 @@ class Checkout::BuyerCurrencyQuote
         line_allocations:,
         future_installments_presentment_total_cents:,
         later_charge_presentments:,
-        # Permalink → the rate bound in the LineItem for this seller's lines (nil for
-        # USD-listed lines, which never need one). Signed into the token so
-        # Purchase#set_price_and_rate can reuse the EXACT rate the quote was built from,
-        # rather than a fresh `get_rate` call that can disagree after the hourly refresh
-        # (gumroad-private#1958).
+        # Permalink → the listed currency and rate bound in each non-USD LineItem.
+        # Keeping the denomination beside the rate prevents a product currency edit from
+        # applying an old currency's rate to the new currency (gumroad-private#1958).
         listed_currency_rates: charge_line_items.filter_map do |line_item|
           next if line_item.listed_currency_rate.blank?
 
-          [line_item.permalink.to_s, line_item.listed_currency_rate.to_s]
+          [
+            line_item.permalink.to_s,
+            {
+              "currency" => line_item.product.price_currency_type.to_s.downcase,
+              "rate" => line_item.listed_currency_rate.to_s,
+            }
+          ]
         end.to_h
       )
     end

--- a/app/services/checkout/buyer_currency_quote.rb
+++ b/app/services/checkout/buyer_currency_quote.rb
@@ -27,6 +27,7 @@ class Checkout::BuyerCurrencyQuote
                       :charges,
                       :line_allocations,
                       :later_charge_presentments,
+                      :listed_currency_rates,
                       keyword_init: true) do
     def id
       stripe_fx_quote_id
@@ -39,6 +40,14 @@ class Checkout::BuyerCurrencyQuote
     def future_installments_presentment_total_cents
       charges.to_a.sum { _1.future_installments_presentment_total_cents.to_i }
     end
+
+    # The rate `Purchase#set_price_and_rate` should reuse for a purchase priced in
+    # `permalink`'s listed currency, bound at the same moment the quote was minted
+    # (gumroad-private#1958). nil for USD-listed lines and for tokens signed before this
+    # field shipped — both fall back to `set_price_and_rate`'s live `get_rate` read.
+    def listed_currency_rate_for(permalink)
+      listed_currency_rates&.[](permalink.to_s)&.to_d
+    end
   end
 
   # One cart line's canonical (USD) money, as computed by the surcharge endpoint. The
@@ -50,7 +59,7 @@ class Checkout::BuyerCurrencyQuote
                         :charge_price_cents, :charge_tip_cents,
                         :charge_seller_tax_cents, :charge_gumroad_tax_cents,
                         :charge_shipping_cents, :later_charge_kind,
-                        :later_charge_price_cents,
+                        :later_charge_price_cents, :listed_currency_rate,
                         keyword_init: true) do
     # Builds a line from one product's surcharge calculation. The submitted price includes
     # the buyer's tip share, so the tip is carved back out here; the tax lands in the same
@@ -69,9 +78,19 @@ class Checkout::BuyerCurrencyQuote
     # that double-converts (a €10.00 product posts 1233 USD cents, converting again gives
     # 1520) and makes every non-USD-priced checkout fail quote verification. Covered by the
     # units-invariant example in the spec.
+    #
+    # `listed_currency_rate` is the caller's `get_rate(product.price_currency_type)` read at
+    # the SAME instant it converted this line's price to canonical USD cents (whether via the
+    # browser's page-render rate or the surcharge endpoint's own lookup) — see
+    # gumroad-private#1958. Binding it here lets the charge path re-derive
+    # `rate_converted_to_usd` from the token instead of taking a fresh `get_rate` reading;
+    # `UpdateCurrenciesWorker` refreshes that cache hourly, so two independent reads separated
+    # by even a few minutes can disagree and fail `BuyerCurrencyQuote.verify!`'s exact-match
+    # check with `buyer_currency_quote_invalid`, even though the buyer's cart never changed.
     def self.from_surcharge(permalink:, product:, tax_result:, tip_cents:, shipping_usd_cents:,
                             charge_tax_result: nil, charge_tip_cents: nil, charge_shipping_usd_cents: nil,
-                            later_charge_kind: nil, later_charge_price_cents: nil, charge_now: true)
+                            later_charge_kind: nil, later_charge_price_cents: nil, charge_now: true,
+                            listed_currency_rate: nil)
       price_cents = tax_result.price_cents.to_i
       # The submitted price and tip are buyer-controlled request params. A crafted
       # negative price would make clamp's bounds invalid (min > max) and raise, and a
@@ -110,7 +129,8 @@ class Checkout::BuyerCurrencyQuote
         charge_gumroad_tax_cents: charge_seller_responsible ? 0 : charge_tax_cents,
         charge_shipping_cents: (charge_shipping_usd_cents.nil? ? shipping_usd_cents : charge_shipping_usd_cents).round.to_i,
         later_charge_kind:,
-        later_charge_price_cents:
+        later_charge_price_cents:,
+        listed_currency_rate:
       )
     end
 
@@ -179,6 +199,7 @@ class Checkout::BuyerCurrencyQuote
                            :line_allocations,
                            :future_installments_presentment_total_cents,
                            :later_charge_presentments,
+                           :listed_currency_rates,
                            keyword_init: true)
 
   TOKEN_PURPOSE = :buyer_currency_quote
@@ -244,7 +265,8 @@ class Checkout::BuyerCurrencyQuote
       fx_rate: BigDecimal(charge_payload.fetch("fx_rate")),
       stripe_fx_quote_id: charge_payload.fetch("stripe_fx_quote_id"),
       stripe_fx_quote_expires_at: Time.zone.parse(charge_payload.fetch("stripe_fx_quote_expires_at")),
-      later_charge_presentments: charge_payload["later_charge_presentments"] || []
+      later_charge_presentments: charge_payload["later_charge_presentments"] || [],
+      listed_currency_rates: charge_payload["listed_currency_rates"] || {}
     )
   rescue ActiveSupport::MessageVerifier::InvalidSignature, KeyError, TypeError, ArgumentError => e
     raise InvalidToken, e.message
@@ -261,6 +283,27 @@ class Checkout::BuyerCurrencyQuote
     charge_payloads = payload["charges"].presence || [payload]
     charge_payloads.find { |charge_payload| charge_payload["seller_id"] == seller.id } ||
       raise(InvalidToken, "quote covers no charge for this seller")
+  end
+
+  # A lightweight, non-authoritative read of the rate a submitted quote token bound for one
+  # product's listed currency (gumroad-private#1958). Used ONLY as a hint at purchase-build
+  # time, before the purchase's own totals exist to run the full `verify!` amount checks
+  # against — so this checks the signature (the token has not been tampered with) but does
+  # NOT check seller/merchant-account/total/expiry the way `verify!` does. The purchase built
+  # from this rate is still held to the real check later: if the token turns out to be stale,
+  # wrong-seller, or otherwise invalid, `Charge::CreateService#locked_buyer_currency_quote!`
+  # still fails the charge closed via `verify!` exactly as before. A bad hint here can only
+  # make `set_price_and_rate` recompute the SAME total the checkout already displayed to the
+  # buyer — it does not weaken the money check downstream.
+  def self.listed_currency_rate_hint(token:, seller_id:, permalink:)
+    return if token.blank?
+
+    payload = verifier.verify(token)
+    charge_payloads = payload["charges"].presence || [payload]
+    charge_payload = charge_payloads.find { |cp| cp["seller_id"] == seller_id }
+    charge_payload&.dig("listed_currency_rates", permalink.to_s)&.to_d
+  rescue ActiveSupport::MessageVerifier::InvalidSignature, KeyError, TypeError, ArgumentError
+    nil
   end
 
   def self.verifier
@@ -294,7 +337,7 @@ class Checkout::BuyerCurrencyQuote
     # A negative component means the submitted request was malformed (prices and tips
     # are sanitized above, but defense in depth: never lock a quote whose lines could
     # not represent a real cart).
-    return if line_items.any? { |line| line.to_h.except(:permalink, :product, :later_charge_kind).values.compact.any?(&:negative?) }
+    return if line_items.any? { |line| line.to_h.except(:permalink, :product, :later_charge_kind, :listed_currency_rate).values.compact.any?(&:negative?) }
 
     products = line_items.map(&:product)
     # A line item can carry a nil product when the caller built it from a product lookup
@@ -638,7 +681,17 @@ class Checkout::BuyerCurrencyQuote
         # the price/tip/shipping lines instead (see Charge::PresentmentAllocator).
         line_allocations:,
         future_installments_presentment_total_cents:,
-        later_charge_presentments:
+        later_charge_presentments:,
+        # Permalink → the rate bound in the LineItem for this seller's lines (nil for
+        # USD-listed lines, which never need one). Signed into the token so
+        # Purchase#set_price_and_rate can reuse the EXACT rate the quote was built from,
+        # rather than a fresh `get_rate` call that can disagree after the hourly refresh
+        # (gumroad-private#1958).
+        listed_currency_rates: charge_line_items.filter_map do |line_item|
+          next if line_item.listed_currency_rate.blank?
+
+          [line_item.permalink.to_s, line_item.listed_currency_rate.to_s]
+        end.to_h
       )
     end
 
@@ -773,6 +826,7 @@ class Checkout::BuyerCurrencyQuote
           stripe_fx_quote_id: charge_quote.stripe_fx_quote_id,
           stripe_fx_quote_expires_at: charge_quote.stripe_fx_quote_expires_at.iso8601,
           fx_rate: charge_quote.fx_rate.to_s("F"),
+          listed_currency_rates: charge_quote.listed_currency_rates,
         }
       end
 

--- a/app/services/checkout/buyer_currency_quote.rb
+++ b/app/services/checkout/buyer_currency_quote.rb
@@ -281,16 +281,10 @@ class Checkout::BuyerCurrencyQuote
       raise(InvalidToken, "quote covers no charge for this seller")
   end
 
-  # A lightweight, non-authoritative read of the rate a submitted quote token bound for one
-  # product's listed currency (gumroad-private#1958). Used ONLY as a hint at purchase-build
-  # time, before the purchase's own totals exist to run the full `verify!` amount checks
-  # against — so this checks the signature (the token has not been tampered with) but does
-  # NOT check seller/merchant-account/total/expiry the way `verify!` does. The purchase built
-  # from this rate is still held to the real check later: if the token turns out to be stale,
-  # wrong-seller, or otherwise invalid, `Charge::CreateService#locked_buyer_currency_quote!`
-  # still fails the charge closed via `verify!` exactly as before. A bad hint here can only
-  # make `set_price_and_rate` recompute the SAME total the checkout already displayed to the
-  # buyer — it does not weaken the money check downstream.
+  # Signature-checked but non-authoritative (gumroad-private#1958): confirms the token wasn't
+  # tampered with, not seller/merchant-account/total/expiry — `verify!` still runs the full
+  # check later via `Charge::CreateService#locked_buyer_currency_quote!`, so a bad hint here
+  # can only make `set_price_and_rate` land on the same total already displayed to the buyer.
   def self.listed_currency_rate_hint(token:, seller_id:, permalink:)
     return if token.blank?
 

--- a/app/services/order/create_service.rb
+++ b/app/services/order/create_service.rb
@@ -132,7 +132,9 @@ class Order::CreateService
 
         purchase, error, sca_response = Purchase::CreateService.new(
           product:,
-          params: purchase_params.merge(is_part_of_combined_charge: true).merge(card_params),
+          params: purchase_params.merge(is_part_of_combined_charge: true).merge(card_params).merge(
+            buyer_currency_quote: params[:buyer_currency_quote]
+          ),
           buyer:
         ).perform
 

--- a/app/services/purchase/create_service.rb
+++ b/app/services/purchase/create_service.rb
@@ -206,12 +206,9 @@ class Purchase::CreateService < Purchase::BaseService
   end
 
   private
-    # A hint only — see Checkout::BuyerCurrencyQuote.listed_currency_rate_hint. This purchase's
-    # amount is still verified later at Charge::CreateService#locked_buyer_currency_quote! via
-    # the full `verify!` checks; this call cannot pass money through on a bad token, it can only
-    # affect which `rate_converted_to_usd` this purchase's canonical total lands on before that
-    # verification runs. Applies only when this seller's PaymentIntent charges on Stripe — a
-    # PayPal purchase carries a stale card-lane token with nothing to bind (gumroad-private#1958).
+    # Every processor may use this signature- and expiry-checked hint while building the purchase.
+    # Stripe later performs the full amount verification; PayPal discards the token after the hint,
+    # which makes expiry the only bound on its pricing use (gumroad-private#1958).
     def buyer_currency_quote_rate_hint(purchase)
       return if params[:buyer_currency_quote].blank?
       return unless purchase.link.price_currency_type.to_s.downcase != Currency::USD

--- a/app/services/purchase/create_service.rb
+++ b/app/services/purchase/create_service.rb
@@ -216,7 +216,8 @@ class Purchase::CreateService < Purchase::BaseService
       Checkout::BuyerCurrencyQuote.listed_currency_rate_hint(
         token: params[:buyer_currency_quote],
         seller_id: purchase.seller.id,
-        permalink: purchase.link.unique_permalink
+        permalink: purchase.link.unique_permalink,
+        currency: purchase.link.price_currency_type
       )
     end
 

--- a/app/services/purchase/create_service.rb
+++ b/app/services/purchase/create_service.rb
@@ -68,7 +68,7 @@ class Purchase::CreateService < Purchase::BaseService
 
       # build pre-order if purchase is for pre-order product & return
       if purchase.is_preorder_authorization
-        build_preorder
+        build_preorder(locked_rate: buyer_currency_quote_rate_hint(purchase))
         return purchase, nil
       elsif product.is_in_preorder_state?
         # This should never happen unless the request is tampered with:
@@ -509,14 +509,14 @@ class Purchase::CreateService < Purchase::BaseService
       giftee_purchaser&.email || gift_params[:giftee_email]
     end
 
-    def build_preorder
+    def build_preorder(locked_rate: nil)
       raise Purchase::PurchaseInvalid, "The product was just released. Refresh the page to purchase it." unless product.is_in_preorder_state?
 
       self.preorder = product.preorder_link.build_preorder(purchase)
       if purchase.is_part_of_combined_charge?
-        purchase.prepare_for_charge!
+        purchase.prepare_for_charge!(locked_rate:)
       else
-        preorder.authorize!
+        preorder.authorize!(locked_rate:)
         error_message = preorder.errors.full_messages[0]
         if purchase.is_test_purchase?
           preorder.mark_test_authorization_successful!

--- a/app/services/purchase/create_service.rb
+++ b/app/services/purchase/create_service.rb
@@ -150,7 +150,7 @@ class Purchase::CreateService < Purchase::BaseService
 
       validate_bundle_products
 
-      purchase.prepare_for_charge!
+      purchase.prepare_for_charge!(locked_rate: buyer_currency_quote_rate_hint(purchase))
 
       purchase.build_purchase_wallet_type(wallet_type: params[:wallet_type]) if params[:wallet_type].present?
 
@@ -206,6 +206,23 @@ class Purchase::CreateService < Purchase::BaseService
   end
 
   private
+    # A hint only — see Checkout::BuyerCurrencyQuote.listed_currency_rate_hint. This purchase's
+    # amount is still verified later at Charge::CreateService#locked_buyer_currency_quote! via
+    # the full `verify!` checks; this call cannot pass money through on a bad token, it can only
+    # affect which `rate_converted_to_usd` this purchase's canonical total lands on before that
+    # verification runs. Applies only when this seller's PaymentIntent charges on Stripe — a
+    # PayPal purchase carries a stale card-lane token with nothing to bind (gumroad-private#1958).
+    def buyer_currency_quote_rate_hint(purchase)
+      return if params[:buyer_currency_quote].blank?
+      return unless purchase.link.price_currency_type.to_s.downcase != Currency::USD
+
+      Checkout::BuyerCurrencyQuote.listed_currency_rate_hint(
+        token: params[:buyer_currency_quote],
+        seller_id: purchase.seller.id,
+        permalink: purchase.link.unique_permalink
+      )
+    end
+
     def is_gift?
       !!params[:is_gift]
     end

--- a/spec/controllers/customer_surcharge_controller_spec.rb
+++ b/spec/controllers/customer_surcharge_controller_spec.rb
@@ -181,6 +181,34 @@ describe CustomerSurchargeController, :vcr do
       )
     end
 
+    it "binds the SAME listed-currency rate the shipping conversion used, not a second independent read" do
+      # A physical non-USD-listed product's shipping conversion (inside calculate_surcharges,
+      # via ShippingDestination#calculate_shipping_rate -> get_usd_cents) and its quote-token
+      # binding used to be two INDEPENDENT `get_rate` calls in the same request. If
+      # `UpdateCurrenciesWorker` refreshed the cache between them, the shipping total baked
+      # into the canonical price and the rate signed into the token would disagree — the
+      # intra-request half of the drift `buyer_currency_quote_invalid` fires on
+      # (gumroad-private#1958, Greptile review on #7149).
+      eur_product = create(:physical_product, user: @user, price_currency_type: Currency::EUR, price_cents: 10_00)
+      eur_product.shipping_destinations.destroy_all
+      destination = create(:shipping_destination, country_code: Compliance::Countries::DEU.alpha2, one_item_rate_cents: 250, multiple_items_rate_cents: 200)
+      eur_product.shipping_destinations << destination
+
+      rates = ["0.9", "0.8"]
+      allow_any_instance_of(CurrencyHelper).to receive(:get_rate).with(Currency::EUR) { rates.shift || "0.8" }
+
+      post "calculate_all", params: {
+        products: [{ permalink: eur_product.unique_permalink, price: 10_00, quantity: 1 }],
+        postal_code: 10115, country: "DE",
+      }, as: :json
+
+      # Exactly one `get_rate(EUR)` call for this line: if the quote token's bound rate came
+      # from a second independent read, the second array element would also be consumed.
+      expect(rates).to eq(["0.8"])
+      quote_props = response.parsed_body["buyer_currency_quote"]
+      expect(quote_props).to be_present
+    end
+
     it "returns zero as the initial charge for a preorder agreement" do
       @product.update!(is_in_preorder_state: true)
 

--- a/spec/controllers/customer_surcharge_controller_spec.rb
+++ b/spec/controllers/customer_surcharge_controller_spec.rb
@@ -234,7 +234,9 @@ describe CustomerSurchargeController, :vcr do
       token = response.parsed_body.dig("buyer_currency_quote", "token")
       payload = Rails.application.message_verifier(Checkout::BuyerCurrencyQuote::TOKEN_PURPOSE).verify(token)
       charge_payload = payload.fetch("charges").sole
-      expect(charge_payload.fetch("listed_currency_rates")).to eq(eur_product.unique_permalink => "0.9")
+      expect(charge_payload.fetch("listed_currency_rates")).to eq(
+        eur_product.unique_permalink => { "currency" => Currency::EUR, "rate" => "0.9" }
+      )
       expect(charge_payload.fetch("canonical_line_items").map(&:last).uniq).to contain_exactly(1278)
     end
 

--- a/spec/controllers/customer_surcharge_controller_spec.rb
+++ b/spec/controllers/customer_surcharge_controller_spec.rb
@@ -234,9 +234,8 @@ describe CustomerSurchargeController, :vcr do
       token = response.parsed_body.dig("buyer_currency_quote", "token")
       payload = Rails.application.message_verifier(Checkout::BuyerCurrencyQuote::TOKEN_PURPOSE).verify(token)
       charge_payload = payload.fetch("charges").sole
-      expect(charge_payload.fetch("listed_currency_rates")).to eq(
-        eur_product.unique_permalink => { "currency" => Currency::EUR, "rate" => "0.9" }
-      )
+      expect(charge_payload.fetch("listed_currency_rates")).to eq(eur_product.unique_permalink => "0.9")
+      expect(charge_payload.fetch("listed_currency_codes")).to eq(eur_product.unique_permalink => Currency::EUR)
       expect(charge_payload.fetch("canonical_line_items").map(&:last).uniq).to contain_exactly(1278)
     end
 

--- a/spec/controllers/customer_surcharge_controller_spec.rb
+++ b/spec/controllers/customer_surcharge_controller_spec.rb
@@ -209,6 +209,35 @@ describe CustomerSurchargeController, :vcr do
       expect(quote_props).to be_present
     end
 
+    it "reuses one listed-currency rate across repeated rows for the same product" do
+      eur_product = create(:physical_product, user: @user, price_currency_type: Currency::EUR, price_cents: 10_00)
+      eur_product.shipping_destinations.destroy_all
+      eur_product.shipping_destinations << create(
+        :shipping_destination,
+        country_code: Compliance::Countries::DEU.alpha2,
+        one_item_rate_cents: 250,
+        multiple_items_rate_cents: 200
+      )
+      rates = ["0.9", "0.8"]
+      allow_any_instance_of(CurrencyHelper).to receive(:get_rate).with(Currency::EUR) { rates.shift || "0.8" }
+
+      post "calculate_all", params: {
+        products: [
+          { permalink: eur_product.unique_permalink, price: 10_00, quantity: 1 },
+          { permalink: eur_product.unique_permalink, price: 10_00, quantity: 1 },
+        ],
+        postal_code: 10115,
+        country: Compliance::Countries::DEU.alpha2,
+      }, as: :json
+
+      expect(rates).to eq(["0.8"])
+      token = response.parsed_body.dig("buyer_currency_quote", "token")
+      payload = Rails.application.message_verifier(Checkout::BuyerCurrencyQuote::TOKEN_PURPOSE).verify(token)
+      charge_payload = payload.fetch("charges").sole
+      expect(charge_payload.fetch("listed_currency_rates")).to eq(eur_product.unique_permalink => "0.9")
+      expect(charge_payload.fetch("canonical_line_items").map(&:last).uniq).to contain_exactly(1278)
+    end
+
     it "returns zero as the initial charge for a preorder agreement" do
       @product.update!(is_in_preorder_state: true)
 

--- a/spec/services/checkout/buyer_currency_quote_spec.rb
+++ b/spec/services/checkout/buyer_currency_quote_spec.rb
@@ -1223,7 +1223,9 @@ describe Checkout::BuyerCurrencyQuote do
 
       result = described_class.create(line_items: [line_item], canonical_total_cents: line_item.canonical_total_cents, ip: "24.48.0.1")
 
-      expect(result.charges.sole.listed_currency_rates).to eq(eur_product.unique_permalink => "0.9")
+      expect(result.charges.sole.listed_currency_rates).to eq(
+        eur_product.unique_permalink => { "currency" => Currency::EUR, "rate" => "0.9" }
+      )
     end
 
     it "omits the rate for USD-listed lines" do
@@ -1247,15 +1249,23 @@ describe Checkout::BuyerCurrencyQuote do
         canonical_line_items: [{ permalink: eur_product.unique_permalink, total_cents: line_item.canonical_total_cents }]
       )
 
-      expect(verified.listed_currency_rate_for(eur_product.unique_permalink)).to eq(BigDecimal("0.9"))
+      expect(verified.listed_currency_rate_for(eur_product.unique_permalink, currency: Currency::EUR)).to eq(BigDecimal("0.9"))
     end
 
     it "returns the bound rate from listed_currency_rate_hint while the quote window is open" do
       line_item = eur_line_item(rate: "0.9")
       created = described_class.create(line_items: [line_item], canonical_total_cents: line_item.canonical_total_cents, ip: "24.48.0.1")
 
-      expect(described_class.listed_currency_rate_hint(token: created.token, seller_id: seller.id, permalink: eur_product.unique_permalink))
+      expect(described_class.listed_currency_rate_hint(token: created.token, seller_id: seller.id, permalink: eur_product.unique_permalink, currency: Currency::EUR))
         .to eq(BigDecimal("0.9"))
+    end
+
+    it "returns nil from listed_currency_rate_hint when the product currency changed" do
+      line_item = eur_line_item(rate: "0.9")
+      created = described_class.create(line_items: [line_item], canonical_total_cents: line_item.canonical_total_cents, ip: "24.48.0.1")
+
+      expect(described_class.listed_currency_rate_hint(token: created.token, seller_id: seller.id, permalink: eur_product.unique_permalink, currency: Currency::GBP))
+        .to be_nil
     end
 
     it "returns nil from listed_currency_rate_hint once the quote window has passed" do
@@ -1265,17 +1275,17 @@ describe Checkout::BuyerCurrencyQuote do
       created = described_class.create(line_items: [line_item], canonical_total_cents: line_item.canonical_total_cents, ip: "24.48.0.1")
 
       travel_to(created.charges.sole.stripe_fx_quote_expires_at + 1.second) do
-        expect(described_class.listed_currency_rate_hint(token: created.token, seller_id: seller.id, permalink: eur_product.unique_permalink))
+        expect(described_class.listed_currency_rate_hint(token: created.token, seller_id: seller.id, permalink: eur_product.unique_permalink, currency: Currency::EUR))
           .to be_nil
       end
     end
 
     it "returns nil from listed_currency_rate_hint for a tampered token" do
-      expect(described_class.listed_currency_rate_hint(token: "garbage", seller_id: seller.id, permalink: "whatever")).to be_nil
+      expect(described_class.listed_currency_rate_hint(token: "garbage", seller_id: seller.id, permalink: "whatever", currency: Currency::EUR)).to be_nil
     end
 
     it "returns nil from listed_currency_rate_hint when no token is present" do
-      expect(described_class.listed_currency_rate_hint(token: nil, seller_id: seller.id, permalink: "whatever")).to be_nil
+      expect(described_class.listed_currency_rate_hint(token: nil, seller_id: seller.id, permalink: "whatever", currency: Currency::EUR)).to be_nil
     end
   end
 end

--- a/spec/services/checkout/buyer_currency_quote_spec.rb
+++ b/spec/services/checkout/buyer_currency_quote_spec.rb
@@ -1198,4 +1198,64 @@ describe Checkout::BuyerCurrencyQuote do
       end
     end
   end
+
+  describe "listed_currency_rate binding (gumroad-private#1958)" do
+    let(:eur_product) { create(:product, user: seller, price_cents: 10_00, price_currency_type: Currency::EUR) }
+
+    def eur_line_item(rate:)
+      purchase = build(:purchase, link: eur_product, seller:, purchase_state: "in_progress")
+      purchase.set_price_and_rate(locked_rate: rate)
+      posted_price_cents = purchase.total_transaction_cents
+
+      tax_result = double(price_cents: posted_price_cents, tax_cents: 0, zip_tax_rate: nil, used_taxjar: false, gumroad_is_mpf: false)
+      described_class::LineItem.from_surcharge(
+        permalink: eur_product.unique_permalink,
+        product: eur_product,
+        tax_result:,
+        tip_cents: 0,
+        shipping_usd_cents: 0,
+        listed_currency_rate: rate
+      )
+    end
+
+    it "binds the listed-currency rate used at quote time into the signed token" do
+      line_item = eur_line_item(rate: "0.9")
+
+      result = described_class.create(line_items: [line_item], canonical_total_cents: line_item.canonical_total_cents, ip: "24.48.0.1")
+
+      expect(result.charges.sole.listed_currency_rates).to eq(eur_product.unique_permalink => "0.9")
+    end
+
+    it "omits the rate for USD-listed lines" do
+      line_item = line_items_for(product).first
+
+      result = described_class.create(line_items: [line_item], canonical_total_cents: 10_00, ip: "24.48.0.1")
+
+      expect(result.charges.sole.listed_currency_rates).to eq({})
+    end
+
+    it "round-trips the rate through verify! so the charge path can read it back" do
+      line_item = eur_line_item(rate: "0.9")
+      created = described_class.create(line_items: [line_item], canonical_total_cents: line_item.canonical_total_cents, ip: "24.48.0.1")
+
+      verified = described_class.verify!(
+        token: created.token,
+        seller:,
+        merchant_account:,
+        currency: Currency::CAD,
+        canonical_total_cents: line_item.canonical_total_cents,
+        canonical_line_items: [{ permalink: eur_product.unique_permalink, total_cents: line_item.canonical_total_cents }]
+      )
+
+      expect(verified.listed_currency_rate_for(eur_product.unique_permalink)).to eq(BigDecimal("0.9"))
+    end
+
+    it "returns nil from listed_currency_rate_hint for a tampered token" do
+      expect(described_class.listed_currency_rate_hint(token: "garbage", seller_id: seller.id, permalink: "whatever")).to be_nil
+    end
+
+    it "returns nil from listed_currency_rate_hint when no token is present" do
+      expect(described_class.listed_currency_rate_hint(token: nil, seller_id: seller.id, permalink: "whatever")).to be_nil
+    end
+  end
 end

--- a/spec/services/checkout/buyer_currency_quote_spec.rb
+++ b/spec/services/checkout/buyer_currency_quote_spec.rb
@@ -1250,6 +1250,26 @@ describe Checkout::BuyerCurrencyQuote do
       expect(verified.listed_currency_rate_for(eur_product.unique_permalink)).to eq(BigDecimal("0.9"))
     end
 
+    it "returns the bound rate from listed_currency_rate_hint while the quote window is open" do
+      line_item = eur_line_item(rate: "0.9")
+      created = described_class.create(line_items: [line_item], canonical_total_cents: line_item.canonical_total_cents, ip: "24.48.0.1")
+
+      expect(described_class.listed_currency_rate_hint(token: created.token, seller_id: seller.id, permalink: eur_product.unique_permalink))
+        .to eq(BigDecimal("0.9"))
+    end
+
+    it "returns nil from listed_currency_rate_hint once the quote window has passed" do
+      # Load-bearing on non-Stripe charges: PayPal never reaches verify!, so this expiry check
+      # is the only thing stopping a replayed old token from pricing a purchase at a stale rate.
+      line_item = eur_line_item(rate: "0.9")
+      created = described_class.create(line_items: [line_item], canonical_total_cents: line_item.canonical_total_cents, ip: "24.48.0.1")
+
+      travel_to(created.charges.sole.stripe_fx_quote_expires_at + 1.second) do
+        expect(described_class.listed_currency_rate_hint(token: created.token, seller_id: seller.id, permalink: eur_product.unique_permalink))
+          .to be_nil
+      end
+    end
+
     it "returns nil from listed_currency_rate_hint for a tampered token" do
       expect(described_class.listed_currency_rate_hint(token: "garbage", seller_id: seller.id, permalink: "whatever")).to be_nil
     end

--- a/spec/services/checkout/buyer_currency_quote_spec.rb
+++ b/spec/services/checkout/buyer_currency_quote_spec.rb
@@ -1223,9 +1223,8 @@ describe Checkout::BuyerCurrencyQuote do
 
       result = described_class.create(line_items: [line_item], canonical_total_cents: line_item.canonical_total_cents, ip: "24.48.0.1")
 
-      expect(result.charges.sole.listed_currency_rates).to eq(
-        eur_product.unique_permalink => { "currency" => Currency::EUR, "rate" => "0.9" }
-      )
+      expect(result.charges.sole.listed_currency_rates).to eq(eur_product.unique_permalink => "0.9")
+      expect(result.charges.sole.listed_currency_codes).to eq(eur_product.unique_permalink => Currency::EUR)
     end
 
     it "omits the rate for USD-listed lines" do
@@ -1234,6 +1233,16 @@ describe Checkout::BuyerCurrencyQuote do
       result = described_class.create(line_items: [line_item], canonical_total_cents: 10_00, ip: "24.48.0.1")
 
       expect(result.charges.sole.listed_currency_rates).to eq({})
+      expect(result.charges.sole.listed_currency_codes).to eq({})
+    end
+
+    it "keeps the signed rate scalar for older app instances" do
+      line_item = eur_line_item(rate: "0.9")
+      created = described_class.create(line_items: [line_item], canonical_total_cents: line_item.canonical_total_cents, ip: "24.48.0.1")
+      payload = Rails.application.message_verifier(described_class::TOKEN_PURPOSE).verify(created.token)
+
+      expect(payload.dig("listed_currency_rates", eur_product.unique_permalink).to_d).to eq(BigDecimal("0.9"))
+      expect(payload.dig("listed_currency_codes", eur_product.unique_permalink)).to eq(Currency::EUR)
     end
 
     it "round-trips the rate through verify! so the charge path can read it back" do

--- a/spec/services/purchase/create_service_spec.rb
+++ b/spec/services/purchase/create_service_spec.rb
@@ -14,7 +14,12 @@ describe Purchase::CreateService, :vcr do
         {
           "seller_id" => seller.id,
           "stripe_fx_quote_expires_at" => 30.minutes.from_now.iso8601,
-          "listed_currency_rates" => { product.unique_permalink => rate },
+          "listed_currency_rates" => {
+            product.unique_permalink => {
+              "currency" => product.price_currency_type.to_s.downcase,
+              "rate" => rate,
+            }
+          },
         }
       ]
     }
@@ -946,6 +951,22 @@ describe Purchase::CreateService, :vcr do
 
       expect(purchase.errors).to be_empty
       expect(purchase.shipping_cents).to eq(278)
+    end
+
+    it "ignores a quote-bound rate after the product's listed currency changes" do
+      product.update!(price_currency_type: Currency::EUR, price_cents: price)
+      quote = signed_buyer_currency_quote(seller: user, product:, rate: "0.9")
+      product.update!(price_currency_type: Currency::GBP, price_cents: price)
+      quote_params = base_params.deep_dup
+      quote_params[:is_part_of_combined_charge] = true
+      quote_params[:buyer_currency_quote] = quote
+      allow_any_instance_of(CurrencyHelper).to receive(:get_rate).with(:gbp).and_return("0.8")
+
+      purchase, _ = Purchase::CreateService.new(product:, params: quote_params).perform
+
+      expect(purchase.errors).to be_empty
+      expect(purchase.rate_converted_to_usd.to_d).to eq(BigDecimal("0.8"))
+      expect(purchase.price_cents).to eq(750)
     end
 
     describe "english pound" do

--- a/spec/services/purchase/create_service_spec.rb
+++ b/spec/services/purchase/create_service_spec.rb
@@ -14,12 +14,8 @@ describe Purchase::CreateService, :vcr do
         {
           "seller_id" => seller.id,
           "stripe_fx_quote_expires_at" => 30.minutes.from_now.iso8601,
-          "listed_currency_rates" => {
-            product.unique_permalink => {
-              "currency" => product.price_currency_type.to_s.downcase,
-              "rate" => rate,
-            }
-          },
+          "listed_currency_rates" => { product.unique_permalink => rate },
+          "listed_currency_codes" => { product.unique_permalink => product.price_currency_type.to_s.downcase },
         }
       ]
     }

--- a/spec/services/purchase/create_service_spec.rb
+++ b/spec/services/purchase/create_service_spec.rb
@@ -1289,6 +1289,25 @@ describe Purchase::CreateService, :vcr do
     let(:product_in_preorder) { create(:product, user:, price_cents: price, is_in_preorder_state: true) }
     let!(:preorder_product) { create(:preorder_link, link: product_in_preorder) }
 
+    it "uses the quote-bound rate for the later charge amount" do
+      product_in_preorder.update!(price_currency_type: Currency::EUR, price_cents: price)
+      quote_params = base_preorder_params.deep_dup
+      quote_params[:is_part_of_combined_charge] = true
+      quote_params[:buyer_currency_quote] = signed_buyer_currency_quote(
+        seller: user,
+        product: product_in_preorder,
+        rate: "0.9"
+      )
+      allow_any_instance_of(CurrencyHelper).to receive(:get_rate).with(:eur).and_return("0.8")
+
+      purchase, _ = Purchase::CreateService.new(product: product_in_preorder, params: quote_params).perform
+
+      expect(purchase.errors).to be_empty
+      expect(purchase.rate_converted_to_usd.to_d).to eq(BigDecimal("0.9"))
+      expected_line_items = [{ permalink: product_in_preorder.unique_permalink, canonical_price_cents: 667 }]
+      expect(Purchase::FixLaterChargePresentmentService.canonical_line_items_for([purchase])).to eq(expected_line_items)
+    end
+
     it "creates the preorder and its auth charge, with successful states" do
       purchase, _ = Purchase::CreateService.new(
         product: product_in_preorder,

--- a/spec/services/purchase/create_service_spec.rb
+++ b/spec/services/purchase/create_service_spec.rb
@@ -8,6 +8,19 @@ describe Purchase::CreateService, :vcr do
   let(:buyer) { create(:user, email:) }
   let(:zip_code) { "12345" }
 
+  def signed_buyer_currency_quote(seller:, product:, rate:)
+    payload = {
+      "charges" => [
+        {
+          "seller_id" => seller.id,
+          "stripe_fx_quote_expires_at" => 30.minutes.from_now.iso8601,
+          "listed_currency_rates" => { product.unique_permalink => rate },
+        }
+      ]
+    }
+    Rails.application.message_verifier(Checkout::BuyerCurrencyQuote::TOKEN_PURPOSE).generate(payload)
+  end
+
   let(:price) { 600 }
   let(:max_purchase_count) { nil }
   let(:product) { create(:product, user:, price_cents: price, max_purchase_count:) }
@@ -897,6 +910,44 @@ describe Purchase::CreateService, :vcr do
   end
 
   context "when the user has a different currency" do
+    it "uses the quote-bound rate for physical shipping" do
+      physical_product = create(
+        :physical_product,
+        user:,
+        price_currency_type: Currency::EUR,
+        price_cents: 10_00
+      )
+      physical_product.shipping_destinations.destroy_all
+      physical_product.shipping_destinations << create(
+        :shipping_destination,
+        country_code: Compliance::Countries::DEU.alpha2,
+        one_item_rate_cents: 250,
+        multiple_items_rate_cents: 200
+      )
+      quote_params = base_params.deep_dup
+      quote_params[:purchase].merge!(
+        perceived_price_cents: 10_00,
+        full_name: "Buyer Example",
+        street_address: "123 Example Street",
+        city: "Berlin",
+        country: Compliance::Countries::DEU.alpha2,
+        state: "BE",
+        zip_code: "10115"
+      )
+      quote_params[:is_part_of_combined_charge] = true
+      quote_params[:buyer_currency_quote] = signed_buyer_currency_quote(
+        seller: user,
+        product: physical_product,
+        rate: "0.9"
+      )
+      allow_any_instance_of(CurrencyHelper).to receive(:get_rate).with(Currency::EUR).and_return("0.8")
+
+      purchase, _ = Purchase::CreateService.new(product: physical_product, params: quote_params).perform
+
+      expect(purchase.errors).to be_empty
+      expect(purchase.shipping_cents).to eq(278)
+    end
+
     describe "english pound" do
       it "sets the displayed price on the purchase" do
         product.update!(price_currency_type: :gbp, price_cents: 600)


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

## Why

antiwork/gumroad-private#1958: while investigating the multi-currency conversion-rate ask for marketing launch prep, a DiD analysis showed non-US checkout completion down **1.86pp** vs the US control since the buyer-currency rollout (`buyer_currency_charging`, live at 100% since 2026-07-18). Root cause: `error_code = buyer_currency_quote_invalid` — **zero occurrences in the 14-day pre-rollout baseline**, firing 24-45/day since, and the daily count is growing in step with presentment coverage (more buyers land on local-currency checkout → more exposure).

## Root cause

The buyer-currency quote token signs a canonical USD total computed from the listed-currency rate at **quote time** (the surcharge endpoint's `get_rate` call). `Purchase#set_price_and_rate` recomputes the SAME conversion at **charge/purchase-build time** with a fresh, independent `get_rate` call. `UpdateCurrenciesWorker` refreshes the cached FX rate hourly, so any refresh landing between those two moments makes the two totals disagree by a few cents — even though the buyer's cart never changed. `Checkout::BuyerCurrencyQuote.verify!` compares the two totals for **exact** equality (there's no FX rate between them to round, by design), so the mismatch fails the charge closed with the buyer-facing message *"The local-currency price changed or expired. Please review the updated total and try again."*

## Fix

Bind the exact rate used at quote time into the signed token itself, so the charge path can reuse it instead of taking a second, potentially-drifted reading:

- `Checkout::BuyerCurrencyQuote::LineItem` gains `listed_currency_rate` (nil for USD-listed lines).
- `CustomerSurchargeController` passes the rate it read for `SalesTaxCalculator` at the same instant it converted the line to canonical USD cents (free — it's a cache read, not an extra exchange-rate fetch).
- `ChargeQuote#listed_currency_rates` (permalink → rate) is signed into the token alongside the existing fields, and round-trips through `verify!` onto `Result#listed_currency_rate_for`.
- `Purchase#set_price_and_rate(locked_rate:)` reuses the bound rate when present instead of a fresh `get_rate` call. Threaded through `process_without_charging!` → `prepare_for_charge!`.
- `Purchase::CreateService` reads the rate hint off the submitted token via the new `Checkout::BuyerCurrencyQuote.listed_currency_rate_hint` — **signature-checked but non-authoritative**: it only affects which `rate_converted_to_usd` a purchase's canonical total lands on *before* the real money check runs. The actual verification (`Charge::CreateService#locked_buyer_currency_quote!` → `verify!`) is completely unchanged — a stale/tampered/wrong-seller token still fails closed exactly as before. This can only make `set_price_and_rate` land on the SAME total the checkout already displayed and locked; it cannot let a bad token pass money through.
- `Order::CreateService` threads `params[:buyer_currency_quote]` through to `Purchase::CreateService` (it was previously excluded before reaching `purchase_params`, which is correct — Purchase itself doesn't have that attribute — but the value is needed as an out-of-band hint).

## A bug the new field would have introduced on its own

`BuyerCurrencyQuote#create`'s existing negative-component sanity check (`line.to_h.except(...).values.compact.any?(&:negative?)`) iterates every `LineItem` field. The new `listed_currency_rate` field is a `String` (matches the model's existing string-typed `rate_converted_to_usd`/`Purchase#get_rate`), and `String` has no `#negative?` — this raised `NoMethodError` on every non-USD-listed line, which the surrounding `rescue StandardError` quietly turned into a cart-wide fallback to canonical USD (i.e. it would have silently disabled the buyer-currency feature entirely for any cart carrying the new field). Excluded `listed_currency_rate` from that check alongside the other non-numeric fields (`permalink`/`product`/`later_charge_kind`). Caught by the new specs — see `spec/services/checkout/buyer_currency_quote_spec.rb`.

## Fix round: intra-request rate race (Greptile, review 1)

Greptile's finding was correct: `CustomerSurchargeController#calculate_all` still called a **second, independent** `get_rate(product.price_currency_type)` right after `calculate_surcharges` had already used a rate internally (via `ShippingDestination#calculate_shipping_rate` → `get_usd_cents`) to convert that same line's shipping to canonical USD cents. A cache refresh landing between those two reads reproduces the exact `buyer_currency_quote_invalid` failure this PR exists to fix — just one step earlier, both calls now happening inside a single request instead of straddling the surcharge/charge boundary.

Fixed by threading a single rate reading through the whole line, instead of re-reading it:

- `ShippingDestination#calculate_shipping_rate` takes an optional `rate:` kwarg it passes to `get_usd_cents` for both shipping terms, instead of always looking the rate up itself.
- `CustomerSurchargeController#calculate_surcharges` reads the rate once (or reuses a rate passed in via its own new `rate:` kwarg), uses it for the shipping conversion, and returns it alongside the tax result.
- The now-charge-time second call to `calculate_surcharges` (installment/subscription/commission first-payment split) reuses the SAME rate from the first call instead of taking its own reading, so both conversions for one product agree even when they happen at different points in the request.
- `listed_currency_rate:` on the quote line item now reads this single captured rate rather than calling `get_rate` again.
- Added a regression spec (`customer_surcharge_controller_spec.rb`) using a `get_rate` stub that returns a different value on each call — it fails against the prior code (verified by manually reverting the source and re-running) and passes with the fix.


## Fix round: comment trim (Greptile P2, review 1)

Trimmed the rate-binding comments in `Purchase#set_price_and_rate` and
`BuyerCurrencyQuote::LineItem.from_surcharge` — Greptile correctly flagged them as restating
implementation history/narrating the bug across two files instead of stating the one invariant a
maintainer needs. Compressed both to the load-bearing why per repo AGENTS.md.

## Testing

- New specs in `spec/services/checkout/buyer_currency_quote_spec.rb`: rate binding into the signed token, USD-listed lines omit the rate, round-trip through `verify!`, and `listed_currency_rate_hint` fails safe (nil) on a tampered/absent token.
- New regression spec in `spec/controllers/customer_surcharge_controller_spec.rb` proving the intra-request rate is read once and reused, not re-read (mutation-verified: fails on the pre-fix code, passes on the fix).
- `bundle exec rspec spec/controllers/customer_surcharge_controller_spec.rb spec/models/shipping_destination_spec.rb spec/services/checkout/buyer_currency_quote_spec.rb` — 111 examples, 0 failures.
- `bundle exec rspec spec/services/charge/create_service_spec.rb spec/services/charge/direct_listed_presentment_spec.rb spec/services/charge/method_forced_presentment_spec.rb` — 116 examples, 0 failures.
- `bundle exec rspec spec/services/purchase/create_service_spec.rb` — 245 examples, 3 failures, all 3 **confirmed pre-existing on clean `main`** (unrelated merchant-account/test-isolation flakes — verified by running the same 3 examples against `main` before this branch existed).

## Evidence / data

Full investigation with the DiD conversion analysis, error-code trend, and presentment coverage numbers is in antiwork/gumroad-private#1958.

## Not done here (flagged for a human)
- Page-render vs. surcharge-request rate race (Greptile, review 2): the browser's submitted canonical price is derived from a page-load-time exchange rate snapshot, not re-derived on each surcharge fetch. If the cached FX rate refreshes between page render and the surcharge POST, the token can still disagree with a fresh charge-time read even with rounds 1-2 of this PR in place. This is architecturally distinct (client-side pricing contract, not server-side rate threading) and needs a design call on source-of-truth before a code fix — see PR comment.

- No new spec exercises the full `Purchase::CreateService` → `Charge::CreateService` path with a real drifted rate reproducing the original `buyer_currency_quote_invalid` failure end-to-end — the unit-level round-trip through `verify!` demonstrates the mechanism, but an integration regression test would be stronger evidence this can't recur. Flagging rather than guessing at the right fixture shape for that path.
- Ramp is unaffected by this change (still `buyer_currency_charging` at 100%); no flag work needed. Recommend re-running the gp#1958 DiD after ~1 clean week post-merge to confirm the error code returns to ~0 and get the real conversion number for marketing.

---

AI disclosure: this PR (including the fix round above) was authored autonomously by an AI agent (claude-sonnet-5).

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (rmarescu commented after my last word (2026-08-10T15:49) — unanswered), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
