### PR TITLE
Trim AI-slop comments in PayPal charge processor and Stripe payout processor

### DIFF
--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -367,15 +367,6 @@ class PaypalChargeProcessor
     ChargeProcessor.handle_event(event)
   end
 
-  # Dispute Outcome Types
-  # RESOLVED_BUYER_FAVOUR - The dispute was resolved in the customer's favor.
-  # RESOLVED_SELLER_FAVOUR - The dispute was resolved in the merchant's favor.
-  # RESOLVED_WITH_PAYOUT - PayPal provided the merchant or customer with protection and the case is resolved.
-  # CANCELED_BY_BUYER - The customer canceled the dispute.
-  # ACCEPTED - The dispute was accepted.
-  # DENIED - The dispute was denied.
-  # NONE - The dispute was closed without a decision.
-  # Empty - The dispute was not resolved.
   def self.determine_resolved_dispute_event_type(dispute_outcome)
     if DISPUTE_OUTCOME_SELLER_FAVOUR.include? dispute_outcome.upcase
       ChargeEvent::TYPE_DISPUTE_WON
@@ -892,29 +883,6 @@ class PaypalChargeProcessor
                        payment_details: order_details)
     end
 
-    # Types of error which could be raised while refunding using the Orders API:
-    #
-    # INTERNAL_ERROR (An internal service error occurred)
-    #
-    # MISSING_ARGS (Missing Required Arguments)
-    #
-    # INVALID_RESOURCE_ID (Requested resource ID was not found)
-    #
-    # PERMISSION_DENIED (Permission denied)
-    #
-    # TRANSACTION_REFUSED (Request was refused)
-    #
-    # INVALID_PAYER_ID (Payer ID is invalid)
-    #
-    # INSTRUMENT_DECLINED (Processor or bank declined funding instrument or it cannot be used for this payment)
-    #
-    # RISK_CONTROL_MAX_AMOUNT (Request was refused)
-    #
-    # REFUND_ALREADY_INITIATED (Refund refused. Refund was already issued for transaction)
-    #
-    # REFUND_FAILED_INSUFFICIENT_FUNDS (Refund failed due to insufficient funds in your PayPal account)
-    #
-    # EXTDISPUTE_REFUND_FAILED_INSUFFICIENT_FUNDS (Refund failed due to insufficient funds in seller's PayPal account)
     def refund_order_purchase_unit!(capture_id, merchant_account, amount_cents, purchase: nil)
       paypal_rest_api = PaypalRestApi.new
       refund_amount_cents = refund_amount_in_merchant_currency_cents(paypal_rest_api, capture_id, amount_cents, merchant_account, purchase)

--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -22,12 +22,6 @@ class StripePayoutProcessor
   # immediately.
   CROSS_BORDER_PAYOUT_DELAY = 25.hours
 
-  # Public: Determines if it's possible for this processor to payout
-  # the user by checking that the user has provided us with the
-  # information we need to be able to payout with this processor.
-  #
-  # This payout processor can payout any user who has a Stripe managed account
-  # and has a bank account setup.
   def self.is_user_payable(user, amount_payable_usd_cents, add_comment: false, from_admin: false, payout_type: Payouts::PAYOUT_TYPE_STANDARD)
     payout_date = Time.current.to_fs(:formatted_date_full_month)
 


### PR DESCRIPTION
## What
Comment-only cleanup in two files flagged by the AI-slop scanner:

- `app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb`
  - Removed a 9-line "Dispute Outcome Types" comment that just re-lists PayPal's
    outcome-code constant names with a one-line paraphrase of each — the names
    (`RESOLVED_BUYER_FAVOUR`, `CANCELED_BY_BUYER`, etc.) are already self-explanatory
    and visible right there in `DISPUTE_OUTCOME_SELLER_FAVOUR`/`DISPUTE_OUTCOME_BUYER_FAVOUR`.
  - Removed a 23-line "Types of error which could be raised…" comment that lists
    PayPal Orders API error codes with their doc description in parentheses —
    only `INTERNAL_ERROR`, `TRANSACTION_REFUSED`, and `REFUND_FAILED_INSUFFICIENT_FUNDS`
    are actually referenced in this file, and those are self-evident at their call
    sites lower down.
- `app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb`
  - Removed a 6-line rdoc-style comment on `is_user_payable` that restates the
    method name and its already-obvious behavior ("Determines if it's possible
    for this processor to payout the user...").

## Why
Per the codebase's comment standard (`AGENTS.md` → Code comments): write for a
colleague who already knows this file, cut anything that just restates the
code below it. These three blocks add no information a maintainer reading the
constant names or the method body doesn't already have.

## What I deliberately KEPT (not slop)
- The ASCII state-machine diagram in `payment.rb` (`Payment` state transitions)
  — genuinely hard to re-derive from the `state_machine` DSL alone.
- Every "why" comment explaining PayPal capture-sharing/refund-attribution
  edge cases, the `pause_payouts_after_repeated_failures` interaction with the
  terminal-PayPal-failure path, and the NULL-handling gotchas in SQL `NOT IN`
  clauses — all cite real incidents or non-obvious invariants that would bite
  the next editor.
- The `pays_user_via_stripe_connect?` comment explaining its coupling to
  `PaypalPayoutProcessor.terminal_failure_blocking_payouts?` — a cross-file
  invariant that isn't visible from either method alone.
- Comments in `payment.rb`, `link.rb`, `store_agent_service.rb`, and
  `payment.ts` flagged by the scanner but containing real domain knowledge
  (tax/refund rules, currency rounding, checkout invariants) — left untouched
  in this PR to keep the diff small and reviewable.

## Before / after line counts
- `paypal_charge_processor.rb`: 1100 -> 1068 lines (-32)
- `stripe_payout_processor.rb`: 878 -> 872 lines (-6)
- Total: -38 lines, 0 added, comments only.

## Test Results
- `ruby -c` on both changed files: syntax OK.
- `bundle exec rubocop` on both changed files: no offenses.
- Local `bundle exec rspec` for `paypal_charge_processor_spec.rb` currently
  fails identically on a clean `origin/main` checkout in this environment
  (dirty shared test DB - `ActiveRecord::RecordInvalid` on merchant account
  factory, unrelated to this diff). Confirmed the same 39/249 failures occur
  on unmodified main, so this is a pre-existing local environment issue, not
  something this PR introduces. Relying on branch CI for the authoritative
  spec run.

Comments only, no behaviour change.

Premerge review: exempt (comment-only diff, no logic/behaviour change — verified via ruby -c, rubocop, and diff-vs-baseline spec comparison above)

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (CI still running (5 checks) — settle before handing off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
