### PR TITLE
Fix seller favicon consistency across profile/subscribe/wishlist/custom-domain surfaces

### DIFF
--- a/app/controllers/concerns/page_meta/base.rb
+++ b/app/controllers/concerns/page_meta/base.rb
@@ -55,9 +55,8 @@ module PageMeta::Base
       set_meta_tag(property: "stripe:api_version", value: Stripe.api_version)
       set_meta_tag(property: "twitter:site", content: "@gumroad")
       set_meta_tag(tag_name: "link", rel: "search", href: "/opensearch.xml", type: "application/opensearchdescription+xml", title: "Gumroad")
-      # head_key is explicit (not the href-derived default) so PageMeta::Favicon's
-      # set_favicon_meta_tags overwrites this entry instead of adding a second
-      # <link rel="shortcut icon">  — both tags rendering was gp#1966.
+      # head_key is explicit (not the href-derived default) so set_favicon_meta_tags
+      # overwrites this entry instead of adding a second <link rel="shortcut icon">.
       set_meta_tag(tag_name: "link", rel: "shortcut icon", href: image_path("pink-icon.png"), head_key: "shortcut-icon")
       set_meta_tag(tag_name: "link", rel: "apple-touch-icon", href: image_path("pink-icon.png"), head_key: "apple-touch-icon")
     end

--- a/app/controllers/concerns/page_meta/base.rb
+++ b/app/controllers/concerns/page_meta/base.rb
@@ -55,7 +55,10 @@ module PageMeta::Base
       set_meta_tag(property: "stripe:api_version", value: Stripe.api_version)
       set_meta_tag(property: "twitter:site", content: "@gumroad")
       set_meta_tag(tag_name: "link", rel: "search", href: "/opensearch.xml", type: "application/opensearchdescription+xml", title: "Gumroad")
-      set_meta_tag(tag_name: "link", rel: "shortcut icon", href: image_path("pink-icon.png"))
+      # head_key is explicit (not the href-derived default) so PageMeta::Favicon's
+      # set_favicon_meta_tags overwrites this entry instead of adding a second
+      # <link rel="shortcut icon">  — both tags rendering was gp#1966.
+      set_meta_tag(tag_name: "link", rel: "shortcut icon", href: image_path("pink-icon.png"), head_key: "shortcut-icon")
       set_meta_tag(tag_name: "link", rel: "apple-touch-icon", href: image_path("pink-icon.png"), head_key: "apple-touch-icon")
     end
 

--- a/app/controllers/concerns/page_meta/favicon.rb
+++ b/app/controllers/concerns/page_meta/favicon.rb
@@ -6,10 +6,14 @@ module PageMeta::Favicon
   include PageMeta::Base
 
   private
+    # head_key matches the defaults set in set_default_meta_tags so this call
+    # replaces them instead of appending a second icon link — see that method
+    # for why the key must be explicit (gp#1966: two <link rel="shortcut icon">
+    # tags rendered when the keys didn't match).
     def set_favicon_meta_tags(user)
       return unless user.avatar_url.present?
 
-      set_meta_tag(tag_name: "link", rel: "shortcut icon", href: user.avatar_url)
-      remove_meta_tag("apple-touch-icon")
+      set_meta_tag(tag_name: "link", rel: "shortcut icon", href: user.avatar_url, head_key: "shortcut-icon")
+      set_meta_tag(tag_name: "link", rel: "apple-touch-icon", href: user.avatar_url, head_key: "apple-touch-icon")
     end
 end

--- a/app/controllers/concerns/page_meta/favicon.rb
+++ b/app/controllers/concerns/page_meta/favicon.rb
@@ -6,10 +6,8 @@ module PageMeta::Favicon
   include PageMeta::Base
 
   private
-    # head_key matches the defaults set in set_default_meta_tags so this call
-    # replaces them instead of appending a second icon link — see that method
-    # for why the key must be explicit (gp#1966: two <link rel="shortcut icon">
-    # tags rendered when the keys didn't match).
+    # head_key matches set_default_meta_tags so this replaces the defaults
+    # instead of appending a second icon link.
     def set_favicon_meta_tags(user)
       return unless user.avatar_url.present?
 

--- a/app/controllers/favicons_controller.rb
+++ b/app/controllers/favicons_controller.rb
@@ -1,19 +1,24 @@
 # frozen_string_literal: true
 
-# /favicon.ico previously always served the generic Gumroad icon from
-# /public/favicon.ico, because browsers request it unconditionally and no
-# per-seller route existed to intercept that on a subdomain or custom domain
-# (gp#1966). Only seller hosts get redirected to the seller's own avatar —
-# gumroad.com itself (and any host we don't resolve a seller for) keeps
-# serving the real static icon, so this must not become the ONLY route for
+# Only seller/product hosts get redirected to the owner's avatar — gumroad.com
+# itself (and any host we don't resolve an owner for) keeps serving the real
+# static /public/favicon.ico, so this must not become the ONLY route for
 # /favicon.ico on the canonical domain.
 class FaviconsController < ApplicationController
   include CustomDomainConfig
 
   def show
-    user = GumroadDomainConstraint.matches?(request) ? nil : user_by_domain(request.host)
+    user = GumroadDomainConstraint.matches?(request) ? nil : owner_by_domain(request.host)
     return send_file Rails.root.join("public", "favicon.ico"), type: "image/x-icon", disposition: "inline" unless user&.account_active?
 
     redirect_to user.avatar_url, allow_other_host: true, status: :found
   end
+
+  private
+    # user_by_domain (CustomDomainConfig) only resolves domains that carry a
+    # :user — a product-owned custom domain has no :user, so this falls back
+    # to the product's seller (gp#1966 review).
+    def owner_by_domain(host)
+      user_by_domain(host) || CustomDomain.find_by_host(host)&.product&.user
+    end
 end

--- a/app/controllers/favicons_controller.rb
+++ b/app/controllers/favicons_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# /favicon.ico previously always served the generic Gumroad icon from
+# /public/favicon.ico, because browsers request it unconditionally and no
+# per-seller route existed to intercept that on a subdomain or custom domain
+# (gp#1966). Only seller hosts get redirected to the seller's own avatar —
+# gumroad.com itself (and any host we don't resolve a seller for) keeps
+# serving the real static icon, so this must not become the ONLY route for
+# /favicon.ico on the canonical domain.
+class FaviconsController < ApplicationController
+  include CustomDomainConfig
+
+  def show
+    user = GumroadDomainConstraint.matches?(request) ? nil : user_by_domain(request.host)
+    return send_file Rails.root.join("public", "favicon.ico"), type: "image/x-icon", disposition: "inline" unless user&.account_active?
+
+    redirect_to user.avatar_url, allow_other_host: true, status: :found
+  end
+end

--- a/app/controllers/user_pages_controller.rb
+++ b/app/controllers/user_pages_controller.rb
@@ -83,8 +83,11 @@ class UserPagesController < ApplicationController
     def page_meta_head
       title = ERB::Util.h(@page.title.to_s)
       canonical = ERB::Util.h(page_url)
+      favicon_url = ERB::Util.h(@user.avatar_url)
       <<~HTML
         <link rel="canonical" href="#{canonical}">
+        <link rel="shortcut icon" href="#{favicon_url}">
+        <link rel="apple-touch-icon" href="#{favicon_url}">
         <meta property="og:title" content="#{title}">
         <meta property="og:type" content="website">
         <meta property="og:url" content="#{canonical}">

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -298,10 +298,9 @@ class UsersController < ApplicationController
       avatar_url = user.avatar_url if user.avatar.attached?
       share_image = preview_url || avatar_url || ActionController::Base.helpers.image_url("opengraph_image.png")
       escaped_share_image = ERB::Util.h(share_image)
-      # This <head> is hand-built (bypasses PageMeta::Favicon), which meant custom-domain
-      # and custom-HTML profiles served the generic pink icon instead of the seller's own
-      # image (gp#1966). user.avatar_url always resolves — to the default avatar when none
-      # is uploaded — so this always emits a seller-scoped icon.
+      # This <head> is hand-built (bypasses PageMeta::Favicon). user.avatar_url
+      # always resolves — to the default avatar when none is uploaded — so
+      # this always emits a seller-scoped icon.
       favicon_url = ERB::Util.h(user.avatar_url)
       favicon_tags = <<~HTML.strip
         <link rel="shortcut icon" href="#{favicon_url}">

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -117,6 +117,7 @@ class UsersController < ApplicationController
 
   def subscribe
     set_user_page_meta(@user)
+    set_favicon_meta_tags(@user)
     set_meta_tag(title: "Subscribe to #{@user.name.presence || @user.username}")
     render inertia: "Users/Subscribe", props: {
       creator_profile: ProfilePresenter.new(pundit_user:, seller: @user).creator_profile
@@ -297,6 +298,15 @@ class UsersController < ApplicationController
       avatar_url = user.avatar_url if user.avatar.attached?
       share_image = preview_url || avatar_url || ActionController::Base.helpers.image_url("opengraph_image.png")
       escaped_share_image = ERB::Util.h(share_image)
+      # This <head> is hand-built (bypasses PageMeta::Favicon), which meant custom-domain
+      # and custom-HTML profiles served the generic pink icon instead of the seller's own
+      # image (gp#1966). user.avatar_url always resolves — to the default avatar when none
+      # is uploaded — so this always emits a seller-scoped icon.
+      favicon_url = ERB::Util.h(user.avatar_url)
+      favicon_tags = <<~HTML.strip
+        <link rel="shortcut icon" href="#{favicon_url}">
+        <link rel="apple-touch-icon" href="#{favicon_url}">
+      HTML
       alt = if preview_url
         title
       elsif avatar_url
@@ -337,6 +347,7 @@ class UsersController < ApplicationController
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <title>#{title}</title>
             <link rel="canonical" href="#{canonical}">
+            #{favicon_tags}
             <meta property="og:title" content="#{title}">
             <meta property="og:type" content="profile">
             <meta property="og:url" content="#{canonical}">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,13 @@ Rails.application.routes.draw do
   # not just hex — so a differently-formatted configured key still routes.
   get "/:key.txt" => "indexnow_keys#show", constraints: { key: /[a-zA-Z0-9-]{8,128}/ }, as: :indexnow_key
 
+  # Unconstrained by host so every seller subdomain/custom domain resolves its
+  # OWN favicon (gp#1966) instead of nginx's static /public/favicon.ico, which
+  # has no concept of which seller is being requested. The nginx location for
+  # /favicon.ico (docker/nginx/nginx.conf) forwards here instead of serving
+  # the static file directly.
+  get "/favicon.ico" => "favicons#show", as: :favicon
+
   use_doorkeeper do
     controllers applications: "oauth/applications"
     controllers authorized_applications: "oauth/authorized_applications"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,10 +33,8 @@ Rails.application.routes.draw do
   get "/:key.txt" => "indexnow_keys#show", constraints: { key: /[a-zA-Z0-9-]{8,128}/ }, as: :indexnow_key
 
   # Unconstrained by host so every seller subdomain/custom domain resolves its
-  # OWN favicon (gp#1966) instead of nginx's static /public/favicon.ico, which
-  # has no concept of which seller is being requested. The nginx location for
-  # /favicon.ico (docker/nginx/nginx.conf) forwards here instead of serving
-  # the static file directly.
+  # own favicon. The nginx location for /favicon.ico (docker/nginx/nginx.conf)
+  # forwards here instead of serving the static file directly.
   get "/favicon.ico" => "favicons#show", as: :favicon
 
   use_doorkeeper do

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -37,11 +37,9 @@ server {
         return 200 'ok';
     }
 
-    # /favicon.ico must resolve per-seller on subdomains/custom domains
-    # (gp#1966), so it always goes to the app rather than the static default
-    # in /public that try_files would otherwise serve for every host. The
-    # nonexistent first candidate forces the fallback to @app instead of the
-    # real /public/favicon.ico that $uri would resolve to.
+    # Nonexistent first candidate forces the fallback to @app instead of the
+    # real /public/favicon.ico that $uri would otherwise resolve to, so the
+    # app can serve a per-seller icon on subdomains/custom domains.
     location = /favicon.ico {
         try_files /nonexistent @app;
     }

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -37,6 +37,15 @@ server {
         return 200 'ok';
     }
 
+    # /favicon.ico must resolve per-seller on subdomains/custom domains
+    # (gp#1966), so it always goes to the app rather than the static default
+    # in /public that try_files would otherwise serve for every host. The
+    # nonexistent first candidate forces the fallback to @app instead of the
+    # real /public/favicon.ico that $uri would resolve to.
+    location = /favicon.ico {
+        try_files /nonexistent @app;
+    }
+
     # production static-2 URLs
     location ~ ^/res/(?<bucket>gumroad)/(assets|files|profiles)/ {
         resolver         10.1.0.2 valid=300s;

--- a/spec/controllers/favicons_controller_spec.rb
+++ b/spec/controllers/favicons_controller_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe FaviconsController do
+  render_views false
+
+  describe "GET show" do
+    context "on a seller's subdomain" do
+      it "redirects to the seller's own avatar" do
+        user = create(:named_user)
+        get :show, params: {}, env: { "HTTP_HOST" => "#{user.username}.gumroad.com" }
+        expect(response).to redirect_to(user.avatar_url)
+      end
+    end
+
+    context "on a seller's custom domain" do
+      it "redirects to the seller's own avatar" do
+        user = create(:named_user)
+        create(:custom_domain, user:, domain: "www.example-seller.com")
+        get :show, params: {}, env: { "HTTP_HOST" => "www.example-seller.com" }
+        expect(response).to redirect_to(user.avatar_url)
+      end
+    end
+
+    context "on the canonical gumroad.com host" do
+      it "serves the generic static icon rather than redirecting" do
+        get :show, params: {}, env: { "HTTP_HOST" => "gumroad.com" }
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to eq("image/x-icon")
+      end
+    end
+
+    context "when no seller resolves for the host" do
+      it "falls back to the generic static icon" do
+        get :show, params: {}, env: { "HTTP_HOST" => "no-such-seller.gumroad.com" }
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to eq("image/x-icon")
+      end
+    end
+  end
+end

--- a/spec/controllers/favicons_controller_spec.rb
+++ b/spec/controllers/favicons_controller_spec.rb
@@ -23,6 +23,17 @@ describe FaviconsController do
       end
     end
 
+    context "on a product-owned custom domain" do
+      it "redirects to the product seller's avatar" do
+        user = create(:named_user)
+        product = create(:product, user:)
+        create(:custom_domain, :with_product, product:, domain: "www.example-product.com")
+        @request.host = "www.example-product.com"
+        get :show
+        expect(response).to redirect_to(user.avatar_url)
+      end
+    end
+
     context "on the canonical gumroad host" do
       it "serves the generic static icon rather than redirecting" do
         @request.host = URI("#{PROTOCOL}://#{DOMAIN}").host

--- a/spec/controllers/favicons_controller_spec.rb
+++ b/spec/controllers/favicons_controller_spec.rb
@@ -3,13 +3,12 @@
 require "spec_helper"
 
 describe FaviconsController do
-  render_views false
-
   describe "GET show" do
     context "on a seller's subdomain" do
       it "redirects to the seller's own avatar" do
         user = create(:named_user)
-        get :show, params: {}, env: { "HTTP_HOST" => "#{user.username}.gumroad.com" }
+        @request.host = Subdomain.from_username(user.username)
+        get :show
         expect(response).to redirect_to(user.avatar_url)
       end
     end
@@ -18,14 +17,16 @@ describe FaviconsController do
       it "redirects to the seller's own avatar" do
         user = create(:named_user)
         create(:custom_domain, user:, domain: "www.example-seller.com")
-        get :show, params: {}, env: { "HTTP_HOST" => "www.example-seller.com" }
+        @request.host = "www.example-seller.com"
+        get :show
         expect(response).to redirect_to(user.avatar_url)
       end
     end
 
-    context "on the canonical gumroad.com host" do
+    context "on the canonical gumroad host" do
       it "serves the generic static icon rather than redirecting" do
-        get :show, params: {}, env: { "HTTP_HOST" => "gumroad.com" }
+        @request.host = URI("#{PROTOCOL}://#{DOMAIN}").host
+        get :show
         expect(response).to have_http_status(:ok)
         expect(response.content_type).to eq("image/x-icon")
       end
@@ -33,7 +34,8 @@ describe FaviconsController do
 
     context "when no seller resolves for the host" do
       it "falls back to the generic static icon" do
-        get :show, params: {}, env: { "HTTP_HOST" => "no-such-seller.gumroad.com" }
+        @request.host = Subdomain.from_username("no-such-seller")
+        get :show
         expect(response).to have_http_status(:ok)
         expect(response.content_type).to eq("image/x-icon")
       end

--- a/spec/controllers/wishlists_controller_spec.rb
+++ b/spec/controllers/wishlists_controller_spec.rb
@@ -97,7 +97,9 @@ describe WishlistsController, type: :controller, inertia: true do
 
       html = Nokogiri::HTML.parse(response.body)
       expect(html.xpath("//link[@rel='shortcut icon']/@href").text).to include(user.avatar_url)
-      expect(html.xpath("//link[@rel='apple-touch-icon']/@href").text).to be_blank
+      # apple-touch-icon now mirrors the shortcut icon (gp#1966: it previously stayed blank
+      # here while the seller's own product/subscribe pages already set it consistently).
+      expect(html.xpath("//link[@rel='apple-touch-icon']/@href").text).to include(user.avatar_url)
     end
 
     context "when layout is profile" do

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -122,7 +122,10 @@ describe "Profile custom HTML rendering", type: :request do
       get "http://seller.example.com/"
 
       expect(response.body).to include(%(<meta property="og:image" content="#{ERB::Util.h(seller.subscribe_preview_url)}">))
-      expect(response.body).not_to include(ERB::Util.h(seller.avatar_url))
+      # avatar_url legitimately appears elsewhere in <head> now (favicon links,
+      # gp#1966) — scope the "avatar lost the og:image race" assertion to the
+      # og:image tag itself instead of the whole document.
+      expect(response.body).not_to include(%(<meta property="og:image" content="#{ERB::Util.h(seller.avatar_url)}">))
       expect(response.body).to include(%(<meta property="og:image:alt" content="Jane Doe">))
     end
 
@@ -134,7 +137,9 @@ describe "Profile custom HTML rendering", type: :request do
 
       expect(response.body).to include(%(<meta property="og:image" content="#{ERB::Util.h(ActionController::Base.helpers.image_url("opengraph_image.png"))}">))
       expect(response.body).to include(%(<meta property="og:image:alt" content="Gumroad">))
-      expect(response.body).not_to include("gumroad-default-avatar")
+      # The favicon links (gp#1966) legitimately point at the default avatar
+      # asset when none is uploaded — only the og:image tag itself must avoid it.
+      expect(response.body).not_to include(%(<meta property="og:image" content="#{ERB::Util.h(ActionController::Base.helpers.image_url("gumroad-default-avatar-5.png"))}">))
       expect(response.body).not_to include(%(property="twitter:image"))
     end
   end

--- a/spec/requests/user/favicon_spec.rb
+++ b/spec/requests/user/favicon_spec.rb
@@ -34,7 +34,7 @@ describe "User favicons", type: :system, js: true do
     end
 
     it "does display on the subscribe page (gp#1966)" do
-      visit custom_domain_subscribe_path(host: URI.parse(@user.subdomain_with_protocol).host)
+      visit custom_domain_subscribe_url(host: @user.subdomain_with_protocol)
       expect(page).to have_xpath("/html/head/link[@href='#{@user.avatar_url}']", visible: false)
     end
   end

--- a/spec/requests/user/favicon_spec.rb
+++ b/spec/requests/user/favicon_spec.rb
@@ -18,6 +18,11 @@ describe "User favicons", type: :system, js: true do
       expect(page).to have_xpath("/html/head/link[@href='#{@user.avatar_url}']", visible: false)
     end
 
+    it "does not duplicate the shortcut icon link (gp#1966)" do
+      visit("/#{@user.username}")
+      expect(page).to have_xpath("/html/head/link[@rel='shortcut icon']", count: 1, visible: false)
+    end
+
     it "does display on a post's page" do
       visit(view_post_path(username: @user.username, slug: @post.slug, purchase_id: @purchase.external_id))
       expect(page).to have_xpath("/html/head/link[@href='#{@user.avatar_url}']", visible: false)
@@ -25,6 +30,11 @@ describe "User favicons", type: :system, js: true do
 
     it "does display on a product page" do
       visit short_link_path(@product)
+      expect(page).to have_xpath("/html/head/link[@href='#{@user.avatar_url}']", visible: false)
+    end
+
+    it "does display on the subscribe page (gp#1966)" do
+      visit custom_domain_subscribe_path(host: URI.parse(@user.subdomain_with_protocol).host)
       expect(page).to have_xpath("/html/head/link[@href='#{@user.avatar_url}']", visible: false)
     end
   end


### PR DESCRIPTION
Closes antiwork/gumroad-private#1966.

## Bug
The seller's uploaded favicon rendered inconsistently across surfaces — some pages showed the generic pink Gumroad icon, some showed both the seller's icon AND the generic one, and `/favicon.ico` on any seller subdomain/custom domain always served the static generic file.

## Root causes (per surface)
- **Duplicate icon on product/profile pages**: `PageMeta::Base`'s default `<link rel="shortcut icon">` and `PageMeta::Favicon`'s override used the *implicit*, href-derived `head_key` — different hrefs meant different keys, so both tags rendered instead of the seller's replacing the default.
- **Missing apple-touch-icon**: `PageMeta::Favicon` called `remove_meta_tag("apple-touch-icon")` instead of pointing it at the seller's avatar.
- **Subscribe page**: `UsersController#subscribe` never called `set_favicon_meta_tags` at all — plain omission.
- **Custom-domain / custom-HTML wrapper**: this document is hand-built HTML (bypasses `PageMeta` entirely) and had no icon tags.
- **Standalone Pages** (`UserPagesController`): same — hand-built head, no icon tags.
- **`/favicon.ico`**: no per-seller route existed; nginx served `public/favicon.ico` unconditionally for every host.

## Fix
- Shared an explicit `head_key` between the default and seller-override favicon tags.
- `PageMeta::Favicon` now sets both shortcut-icon and apple-touch-icon to the seller's avatar.
- Added the missing call in `subscribe`.
- Added icon tags to both hand-built `<head>` documents.
- Added `FaviconsController` + a host-unconstrained `/favicon.ico` route; nginx now forwards to the app for that path instead of serving the static file directly, so subdomains/custom domains resolve their own seller's icon (canonical gumroad.com hosts and unresolved hosts still get the generic static icon).

## Testing
- `spec/requests/user/favicon_spec.rb`: added a duplicate-tag regression check + subscribe-page coverage. All 5 pass.
- `spec/controllers/favicons_controller_spec.rb`: subdomain, custom domain, product-owned custom domain, canonical host, unresolved host. All 5 pass.
- `spec/controllers/wishlists_controller_spec.rb`: updated a stale assertion that apple-touch-icon stays blank on the wishlist page — that assertion was encoding the bug, not intended behavior. Passes with the corrected expectation.
- `ruby -c` clean on all touched files (rubocop not re-run this round).

## Review round 2 (Greptile)
- P1: `favicons#show` now falls back to the product's seller (`CustomDomain#product&.user`) when a custom domain carries no direct `:user` — product-owned custom domains resolve the seller's avatar instead of the static fallback. Mutation-checked (reverting the fallback fails the new spec).
- P2: trimmed repeated gp#1966 history narration from comments in `page_meta/base.rb`, `page_meta/favicon.rb`, `routes.rb`, `nginx.conf`, `users_controller.rb` down to the non-obvious constraint only.

Premerge review: clean @ 6970928bf18a0bfc41d779ed9aa0eda30fa3e990

QA steps: `curl -I http://<seller>.gumroad.com/favicon.ico` on a seller subdomain redirects to that seller's avatar_url; `curl -I http://gumroad.com/favicon.ico` still returns the static generic icon. On a product/profile page, inspect `<head>` and confirm exactly one `<link rel="shortcut icon">` (previously two). Automated coverage: spec/requests/user/favicon_spec.rb, spec/controllers/favicons_controller_spec.rb, spec/controllers/wishlists_controller_spec.rb — all passing locally (see below).

No visual/UI surface changed (this is `<head>` link tags + a redirect route), so no before/after screenshot — the rendered page looks identical; only its favicon resolution changed, which a screenshot can't distinguish from the bug it fixes.

---
AI disclosure: this PR was written autonomously by gumclaw (Hermes agent) at Sahil's direction, using Claude Sonnet 5. No human wrote code in this diff; a pre-merge review (codex/gpt-5.6-sol via the autoreview harness) ran clean before marking ready.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (CI failing: Compute relevant specs; no human review requested/received yet — still mine to hand off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->

