### PR TITLE
Remove misleading Bolivia bank-code placeholder

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.test.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.test.tsx
@@ -211,6 +211,23 @@ describe("BankAccountSection account-number hints", () => {
   );
 });
 
+describe("BankAccountSection Bolivia bank code", () => {
+  // gp#1967: the placeholder used to read as a real value ("060"), and 0/128 submissions
+  // ever linked a live Stripe account because sellers copied that literal placeholder
+  // instead of their bank's actual ASFI code. The placeholder must not look like a value.
+  it("advertises a real ASFI code is required without a copyable-looking placeholder", () => {
+    renderForCountry("BO");
+
+    const field = screen.getByLabelText<HTMLInputElement>("Bank code");
+    expect(field.maxLength).toBe(3);
+    // The old placeholder was a specific-looking value sellers copied literally.
+    expect(/\d{3}/.test(field.placeholder)).toBe(false);
+    expect(field.placeholder.toLowerCase()).toContain("asfi");
+
+    expect(screen.getByText(/3-digit ASFI code/)).toBeTruthy();
+  });
+});
+
 describe("BankAccountSection Indonesian bank code", () => {
   // Stripe resolves the ID bank from its 3-digit Sandi Bank directory. The old field advertised
   // maxLength 4 and no shape at all, so `BBSB` and `0140` typed cleanly and were only refused once

--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.test.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.test.tsx
@@ -221,10 +221,10 @@ describe("BankAccountSection Bolivia bank code", () => {
     const field = screen.getByLabelText<HTMLInputElement>("Bank code");
     expect(field.maxLength).toBe(3);
     // The old placeholder was a specific-looking value sellers copied literally.
-    expect(/\d{3}/.test(field.placeholder)).toBe(false);
+    expect(/\d{3}/u.test(field.placeholder)).toBe(false);
     expect(field.placeholder.toLowerCase()).toContain("asfi");
 
-    expect(screen.getByText(/3-digit ASFI code/)).toBeTruthy();
+    expect(screen.getByText(/3-digit ASFI code/u)).toBeTruthy();
   });
 });
 

--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -1839,13 +1839,16 @@ const BankAccountSection = ({
                   <Input
                     type="text"
                     id={`${uid}-bank-code`}
-                    placeholder="060"
+                    placeholder="Enter your bank's 3-digit ASFI code"
                     maxLength={3}
                     required
                     disabled={isFormDisabled}
                     aria-invalid={errorFieldNames.has("bank_code")}
                     onChange={(evt) => updateBankAccount({ bank_code: evt.target.value })}
                   />
+                  <FieldsetDescription>
+                    Your bank's 3-digit ASFI code. Find it on your bank's statement or ask your bank.
+                  </FieldsetDescription>
                 </Fieldset>
               ) : user.country_code === "NG" ? (
                 <Fieldset state={errorFieldNames.has("bank_code") ? "danger" : undefined}>


### PR DESCRIPTION
Closes antiwork/gumroad-private#1967.

## What
The Bolivia `Bank code` field in Settings → Payments showed a placeholder of `060`.
Because it read like a real value, sellers typed it literally as their bank code when
setting up Bolivia (Banco Mercantil Santa Cruz etc.) payouts.

## Why
Prod-console link-rate probe (2026-08-09): `bank_number = "060"` (the placeholder value)
has **128 total submissions and 0 ever linked a live Stripe bank account** — all-time, with
31 more in the last 90 days. Working codes for comparison: `022` → 44/74 linked, `001` →
28/28, `002` → 18/18. `060` was our form's placeholder text, not a real ASFI code; no
Bolivia bank maps to it, so Stripe rejected every submission.

## Before-After
**Before** — Bolivia bank-code field:
```
Bank code
[ 060 ]        <- placeholder reads as a pre-filled value; sellers copy it
```
**After** — placeholders + description no longer look like a value to copy:
```
Bank code
[ Enter your bank's 3-digit ASFI code ]
Your bank's 3-digit ASFI code. Find it on your bank's statement or ask your bank.
```

## Test Results
- `vitest run app/javascript/components/Settings/PaymentsPage/BankAccountSection.test.tsx` — **108 passed**.
- New regression test `BankAccountSection Bolivia bank code` asserts the placeholder no
  longer matches a 3-digit string and names ASFI.
- **Mutation proof**: reverting the component to `placeholder="060"` makes the new test RED
  (`AssertionError: expected true to be false`); with the fix it is GREEN.
- `prettier --write` applied; diff after formatting contains only the intended hunks.

## QA steps
1. Settings → Payments → add a Bolivia (BO) bank account.
2. Confirm the Bank code field shows "Enter your bank's 3-digit ASFI code" (not `060`) and
   the field-description line renders underneath.
3. There is no preview app for this Settings page change; the headless-component test above
   is the rendered-surface evidence (no user-facing pixel diff beyond the copy).

---
Autonomous fix. No human direction was needed — the data (`060` = 0% link rate) confirms the
placeholder is a copy trap, so this ships the safe, forward-looking correction while the
support-side question (the seller's specific bank's ASFI code) stays parked on the issue.
Model: `deepseek/deepseek-v4-flash-0731`.


Premerge review: clean @ a8000959

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it; CI failing: Lint JS/TS), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->

