### PR TITLE
Validate content upsells before saving

### DIFF
--- a/app/services/save_content_upsells_service.rb
+++ b/app/services/save_content_upsells_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SaveContentUpsellsService
+  MAX_FIXED_DISCOUNT_CENTS = (2**31) - 1
+
   def initialize(seller:, content:, old_content:)
     @seller = seller
     @content = content
@@ -14,16 +16,20 @@ class SaveContentUpsellsService
     old_upsell_ids = old_doc.css("upsell-card").map { |card| card["id"] }.compact
     new_upsell_cards = new_doc.css("upsell-card")
     new_upsell_ids = new_upsell_cards.map { |card| card["id"] }.compact
+    remaining_old_upsell_ids = old_upsell_ids.tally
 
-    delete_removed_upsells!(old_upsell_ids - new_upsell_ids)
+    Upsell.transaction do
+      delete_removed_upsells!(old_upsell_ids - new_upsell_ids)
 
-    new_upsell_cards.each do |card|
-      next if card["id"].present?
+      new_upsell_cards.each do |card|
+        next if consume_old_upsell_id?(card["id"], remaining_old_upsell_ids)
 
-      product_id = ObfuscateIds.decrypt(card["productid"])
-      variant_id = ObfuscateIds.decrypt(card["variantid"]) if card["variantid"]
-      discount = JSON.parse(card["discount"]) if card["discount"]
-      card["id"] = create_upsell!(product_id, variant_id, discount).external_id
+        card.remove_attribute("id")
+        product_id = ObfuscateIds.decrypt(card["productid"])
+        variant_id = ObfuscateIds.decrypt(card["variantid"]) if card["variantid"]
+        discount = parse_discount(card["discount"]) if card["discount"]
+        card["id"] = create_upsell!(product_id, variant_id, discount).external_id
+      end
     end
 
     new_doc.to_html
@@ -33,16 +39,20 @@ class SaveContentUpsellsService
     old_upsell_ids = collect_upsell_nodes(old_content).filter_map { |node| node.dig("attrs", "id") }
     new_upsell_nodes = collect_upsell_nodes(content)
     new_upsell_ids = new_upsell_nodes.map { |node| node.dig("attrs", "id") }.compact
+    remaining_old_upsell_ids = old_upsell_ids.tally
 
-    delete_removed_upsells!(old_upsell_ids - new_upsell_ids)
+    Upsell.transaction do
+      delete_removed_upsells!(old_upsell_ids - new_upsell_ids)
 
-    new_upsell_nodes.each do |node|
-      next if node.dig("attrs", "id").present?
+      new_upsell_nodes.each do |node|
+        next if consume_old_upsell_id?(node.dig("attrs", "id"), remaining_old_upsell_ids)
 
-      product_id = ObfuscateIds.decrypt(node.dig("attrs", "productId"))
-      variant_id = ObfuscateIds.decrypt(node.dig("attrs", "variantId")) if node.dig("attrs", "variantId")
-      discount = node.dig("attrs", "discount")
-      node["attrs"]["id"] = create_upsell!(product_id, variant_id, discount).external_id
+        node["attrs"].delete("id")
+        product_id = ObfuscateIds.decrypt(node.dig("attrs", "productId"))
+        variant_id = ObfuscateIds.decrypt(node.dig("attrs", "variantId")) if node.dig("attrs", "variantId")
+        discount = node.dig("attrs", "discount")
+        node["attrs"]["id"] = create_upsell!(product_id, variant_id, discount).external_id
+      end
     end
 
     content
@@ -50,6 +60,13 @@ class SaveContentUpsellsService
 
   private
     attr_reader :seller, :content, :old_content, :error
+
+    def consume_old_upsell_id?(upsell_id, remaining_old_upsell_ids)
+      return false if remaining_old_upsell_ids.fetch(upsell_id, 0).zero?
+
+      remaining_old_upsell_ids[upsell_id] -= 1
+      true
+    end
 
     # Rich-content nodes nest arbitrarily (e.g. an upsellCard inside a blockquote), so a
     # top-level-only scan misses those cards and never mints or retires their Upsell rows.
@@ -77,10 +94,16 @@ class SaveContentUpsellsService
     end
 
     def create_upsell!(product_id, variant_id, discount)
+      product = Link.find_by(id: product_id)
+      raise_invalid_upsell!(:product) if product.nil?
+
+      variant = BaseVariant.find_by(id: variant_id) if variant_id
+      raise_invalid_upsell!(:variant) if variant_id && variant.nil?
+
       Upsell.create!(
         seller:,
-        product_id:,
-        variant_id:,
+        product:,
+        variant:,
         is_content_upsell: true,
         cross_sell: true,
         offer_code: build_offer_code(product_id, discount),
@@ -90,7 +113,7 @@ class SaveContentUpsellsService
     def build_offer_code(product_id, discount)
       return nil unless discount.present?
 
-      discount = JSON.parse(discount) if discount.is_a?(String)
+      discount = parse_discount(discount)
 
       OfferCode.build(
         user: seller,
@@ -100,5 +123,39 @@ class SaveContentUpsellsService
         universal: false,
         product_ids: [product_id]
       )
+    end
+
+    def parse_discount(discount)
+      discount = JSON.parse(discount) if discount.is_a?(String)
+      unless discount.is_a?(Hash) || discount.is_a?(ActionController::Parameters)
+        raise_invalid_upsell!(:base, "Content contains invalid upsell data.")
+      end
+
+      amount_key = discount["type"] == "fixed" ? "cents" : "percents"
+      amount = parse_integer(discount[amount_key])
+      valid = case discount["type"]
+              when "fixed" then amount.is_a?(Integer) && amount.between?(0, MAX_FIXED_DISCOUNT_CENTS)
+              when "percent" then amount.is_a?(Integer) && amount.between?(0, 100)
+              else false
+      end
+      raise_invalid_upsell!(:base, "Content contains invalid upsell data.") unless valid
+
+      discount[amount_key] = amount
+      discount
+    rescue JSON::ParserError
+      raise_invalid_upsell!(:base, "Content contains invalid upsell data.")
+    end
+
+    def parse_integer(value)
+      return value if value.is_a?(Integer)
+      return unless value.is_a?(String) && value.match?(/\A\d+\z/)
+
+      Integer(value, 10)
+    end
+
+    def raise_invalid_upsell!(attribute, message = "is invalid")
+      upsell = Upsell.new
+      upsell.errors.add(attribute, message)
+      raise ActiveRecord::RecordInvalid, upsell
     end
 end

--- a/spec/services/save_content_upsells_service_spec.rb
+++ b/spec/services/save_content_upsells_service_spec.rb
@@ -29,6 +29,39 @@ describe SaveContentUpsellsService do
         expect(result.at_css("upsell-card")["id"]).to be_present
       end
 
+      context "when the new content copies a persisted upsell id" do
+        let!(:existing_upsell) { create(:upsell, seller:, product:, is_content_upsell: true) }
+        let(:content) do
+          %(<p>Copied content</p><upsell-card id="#{existing_upsell.external_id}" productid="#{product.external_id}"></upsell-card>)
+        end
+
+        it "creates an independent upsell" do
+          result = nil
+          expect { result = service.from_html }.to change(Upsell, :count).by(1)
+
+          copied_id = Nokogiri::HTML.fragment(result).at_css("upsell-card")["id"]
+          expect(copied_id).to eq(Upsell.last.external_id)
+          expect(copied_id).not_to eq(existing_upsell.external_id)
+          expect(existing_upsell.reload).to be_alive
+        end
+      end
+
+      context "when the content duplicates its existing upsell" do
+        let!(:existing_upsell) { create(:upsell, seller:, product:, is_content_upsell: true) }
+        let(:old_content) do
+          %(<upsell-card id="#{existing_upsell.external_id}" productid="#{product.external_id}"></upsell-card>)
+        end
+        let(:content) { old_content + old_content }
+
+        it "keeps one id and creates one independent upsell" do
+          result = nil
+          expect { result = service.from_html }.to change(Upsell, :count).by(1)
+
+          ids = Nokogiri::HTML.fragment(result).css("upsell-card").map { _1["id"] }
+          expect(ids).to contain_exactly(existing_upsell.external_id, Upsell.last.external_id)
+        end
+      end
+
       context "with discount" do
         let(:content) do
           %(<p>Content with upsell</p><upsell-card productid="#{product.external_id}" discount='{"type":"fixed","cents":500}'></upsell-card>)
@@ -41,6 +74,36 @@ describe SaveContentUpsellsService do
           expect(offer_code.amount_cents).to eq(500)
           expect(offer_code.amount_percentage).to be_nil
           expect(offer_code.product_ids).to eq([product.id])
+        end
+
+        it "rejects a discount with an invalid shape" do
+          invalid_content = %(<upsell-card productid="#{product.external_id}" discount="1"></upsell-card>)
+          service = described_class.new(seller:, content: invalid_content, old_content:)
+
+          expect { service.from_html }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+
+        it "rejects a discount with an invalid value" do
+          invalid_content = %(<upsell-card productid="#{product.external_id}" discount='{"type":"percent","percents":101}'></upsell-card>)
+          service = described_class.new(seller:, content: invalid_content, old_content:)
+
+          expect { service.from_html }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Content contains invalid upsell data.")
+        end
+
+        it "rejects a fixed discount outside the database integer range" do
+          cents = SaveContentUpsellsService::MAX_FIXED_DISCOUNT_CENTS + 1
+          invalid_content = %(<upsell-card productid="#{product.external_id}" discount='{"type":"fixed","cents":#{cents}}'></upsell-card>)
+          service = described_class.new(seller:, content: invalid_content, old_content:)
+
+          expect { service.from_html }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Content contains invalid upsell data.")
+        end
+
+        it "rejects a product that does not belong to the seller" do
+          other_product = create(:product)
+          invalid_content = %(<upsell-card productid="#{other_product.external_id}"></upsell-card>)
+          service = described_class.new(seller:, content: invalid_content, old_content:)
+
+          expect { service.from_html }.to raise_error(ActiveRecord::RecordInvalid)
         end
       end
     end
@@ -60,6 +123,15 @@ describe SaveContentUpsellsService do
 
         expect(upsell.reload.deleted?).to be true
         expect(offer_code.reload.deleted?).to be true
+      end
+
+      it "keeps the old upsell when a new card is invalid" do
+        invalid_content = %(<upsell-card productid="invalid"></upsell-card>)
+        service = described_class.new(seller:, content: invalid_content, old_content:)
+
+        expect { service.from_html }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(upsell.reload).to be_alive
+        expect(offer_code.reload).to be_alive
       end
     end
   end
@@ -92,6 +164,46 @@ describe SaveContentUpsellsService do
         expect(result.last["attrs"]["id"]).to be_present
       end
 
+      context "when the new content copies a persisted upsell id" do
+        let!(:existing_upsell) { create(:upsell, seller:, product:, is_content_upsell: true) }
+        let(:content) do
+          [
+            {
+              "type" => "upsellCard",
+              "attrs" => { "id" => existing_upsell.external_id, "productId" => product.external_id }
+            }
+          ]
+        end
+
+        it "creates an independent upsell" do
+          expect { service.from_rich_content }.to change(Upsell, :count).by(1)
+
+          copied_id = content.first.dig("attrs", "id")
+          expect(copied_id).to eq(Upsell.last.external_id)
+          expect(copied_id).not_to eq(existing_upsell.external_id)
+          expect(existing_upsell.reload).to be_alive
+        end
+      end
+
+      context "when the content duplicates its existing upsell" do
+        let!(:existing_upsell) { create(:upsell, seller:, product:, is_content_upsell: true) }
+        let(:upsell_node) do
+          {
+            "type" => "upsellCard",
+            "attrs" => { "id" => existing_upsell.external_id, "productId" => product.external_id }
+          }
+        end
+        let(:old_content) { [upsell_node.deep_dup] }
+        let(:content) { [upsell_node.deep_dup, upsell_node.deep_dup] }
+
+        it "keeps one id and creates one independent upsell" do
+          expect { service.from_rich_content }.to change(Upsell, :count).by(1)
+
+          ids = content.map { _1.dig("attrs", "id") }
+          expect(ids).to contain_exactly(existing_upsell.external_id, Upsell.last.external_id)
+        end
+      end
+
       context "with discount" do
         let(:content) do
           [
@@ -113,6 +225,17 @@ describe SaveContentUpsellsService do
           expect(offer_code.amount_cents).to be_nil
           expect(offer_code.amount_percentage).to eq(20)
           expect(offer_code.product_ids).to eq([product.id])
+        end
+
+        it "accepts a form-encoded discount amount" do
+          content.last["attrs"]["discount"] = ActionController::Parameters.new(
+            "type" => "percent",
+            "percents" => "20"
+          )
+
+          service.from_rich_content
+
+          expect(OfferCode.last.amount_percentage).to eq(20)
         end
       end
     end
@@ -177,6 +300,15 @@ describe SaveContentUpsellsService do
 
         expect(upsell.reload.deleted?).to be true
         expect(offer_code.reload.deleted?).to be true
+      end
+
+      it "keeps the old upsell when a new node is invalid" do
+        invalid_content = [{ "type" => "upsellCard", "attrs" => { "productId" => "invalid" } }]
+        service = described_class.new(seller:, content: invalid_content, old_content:)
+
+        expect { service.from_rich_content }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(upsell.reload).to be_alive
+        expect(offer_code.reload).to be_alive
       end
     end
   end


### PR DESCRIPTION
## What

- Validate the product, variant, and discount before the content save completes.
- Save all upsell removals and additions in one transaction.
- Give each copied upsell card a new upsell ID.

## Why

The prior save could remove valid upsells before a later invalid card failed. A copied card could also reuse one upsell row.

This is the first PR in the split of #7123. It contains only content upsell safety changes.

## Before/after

Before, one invalid card could leave a partial save. After, the transaction restores the prior upsells when any new card fails.

## QA steps

1. Add two upsell cards to product content.
2. Copy one card and save the content.
3. Confirm that each card has an independent upsell ID.
4. Submit one invalid card with one valid card.
5. Confirm that the save fails and preserves the prior upsells.

## Test results

- `bundle exec rspec spec/services/save_content_upsells_service_spec.rb` — 21 examples passed.
- `bundle exec rubocop app/services/save_content_upsells_service.rb spec/services/save_content_upsells_service_spec.rb` — no offenses.
- `bin/test-confidence` — reached 99 percent. Redis test isolation was unavailable, so the direct focused suite supplies the test result.
- Autoreview — clean after one fix and a second full review.

---

AI disclosure: GPT-5.6 Sol implemented and reviewed this change.
