### PR TITLE
Keep workflow schedules on committed state

### DIFF
--- a/app/models/installment_rule.rb
+++ b/app/models/installment_rule.rb
@@ -1,6 +1,38 @@
 # frozen_string_literal: true
 
 class InstallmentRule < ApplicationRecord
+  VERSION_CACHE_TTL = 1.day
+  PENDING_OWNER_CACHE_TTL = 5.minutes
+  PENDING_VERSION_CACHE_TTL = PENDING_OWNER_CACHE_TTL + 1.minute
+  CACHE_PENDING_VERSION_SCRIPT = <<~LUA
+    local current = redis.call("GET", KEYS[1])
+    if not current or tonumber(ARGV[1]) >= tonumber(current) then
+      redis.call("SET", KEYS[1], ARGV[1], "EX", ARGV[3])
+      redis.call("SET", KEYS[2], ARGV[2], "EX", ARGV[4])
+      return tonumber(ARGV[1])
+    end
+    return tonumber(current)
+  LUA
+  CACHE_COMMITTED_VERSION_SCRIPT = <<~LUA
+    local current = redis.call("GET", KEYS[1])
+    local owner = redis.call("GET", KEYS[2])
+    if current and tonumber(current) > tonumber(ARGV[1]) then
+      return tonumber(current)
+    end
+    if owner and (ARGV[2] == "" or owner ~= ARGV[2]) then
+      return current and tonumber(current) or false
+    end
+    redis.call("SET", KEYS[1], ARGV[1], "EX", ARGV[3])
+    redis.call("DEL", KEYS[2])
+    return tonumber(ARGV[1])
+  LUA
+  CLEAR_PENDING_VERSION_SCRIPT = <<~LUA
+    if redis.call("GET", KEYS[2]) == ARGV[1] then
+      return redis.call("DEL", KEYS[1], KEYS[2])
+    end
+    return 0
+  LUA
+
   has_paper_trail version: :paper_trail_version
 
   include Deletable
@@ -20,10 +52,68 @@ class InstallmentRule < ApplicationRecord
   validate :to_be_published_at_cannot_be_in_the_past
   validate :to_be_published_at_must_exist_for_non_workflow_posts
 
-  # We increment the version when delivery date changes so the correct job is processed, not an old one. We have the version starting
-  # at 1 even though the schema shows a default value of 0. If there is no rule to go with an installment, we pass version = 0 as a
-  # parameter so changing version to start at 0 will disrupt current installment jobs in the queue.
+  # A version change invalidates jobs that use old delivery or publication state.
+  # The version starts at 1 although the schema default is 0. Jobs use version 0 when no rule exists.
   before_save :increment_version, if: :delivery_date_changed?
+  # Publish before SQL so stale jobs cannot cross a transaction that changes delivery state.
+  before_save :cache_pending_version, if: :publish_pending_version?
+  after_commit :cache_committed_version, if: :workflow_rule?
+
+  def self.cached_version(installment_id)
+    $redis.get(RedisKey.workflow_installment_rule_version(installment_id))&.to_i
+  end
+
+  def self.cached_version_state(installment_id)
+    version, owner = $redis.mget(*cache_keys(installment_id))
+    [version&.to_i, owner.present?]
+  end
+
+  def self.cache_pending_version!(installment_id:, version:, token:)
+    $redis.eval(
+      CACHE_PENDING_VERSION_SCRIPT,
+      keys: cache_keys(installment_id),
+      argv: [version, token, PENDING_VERSION_CACHE_TTL.to_i, PENDING_OWNER_CACHE_TTL.to_i]
+    ).to_i
+  end
+
+  def self.cache_committed_version!(installment_id:, version:, expected_pending_token: nil, expires_in: VERSION_CACHE_TTL)
+    result = $redis.eval(
+      CACHE_COMMITTED_VERSION_SCRIPT,
+      keys: cache_keys(installment_id),
+      argv: [version, expected_pending_token.to_s, expires_in.to_i]
+    )
+    result&.to_i
+  end
+
+  def self.clear_pending_version!(installment_id:, token:)
+    $redis.eval(
+      CLEAR_PENDING_VERSION_SCRIPT,
+      keys: cache_keys(installment_id),
+      argv: [token]
+    )
+  end
+
+  def self.promote_pending_version(installment_id:, installment_rule_id:, version:, token:)
+    cache_committed_version!(installment_id:, version:, expected_pending_token: token)
+  rescue Redis::BaseError, RedisClient::Error => e
+    ErrorNotifier.notify(e, installment_rule_id:)
+  end
+
+  def self.clear_pending_version(installment_id:, installment_rule_id:, token:)
+    clear_pending_version!(installment_id:, token:)
+  rescue Redis::BaseError, RedisClient::Error => e
+    ErrorNotifier.notify(e, installment_rule_id:)
+  end
+
+  def cache_version!(expires_in: VERSION_CACHE_TTL)
+    return if installment_id.nil?
+
+    self.class.cache_committed_version!(installment_id:, version:, expires_in:)
+  end
+
+  def advance_version!
+    with_lock { update!(version: version + 1) }
+  end
 
   # Public: Converts the delayed_delivery_time back into the number the creator entered using the time period of the rule
   #
@@ -51,6 +141,53 @@ class InstallmentRule < ApplicationRecord
   end
 
   private
+    def cache_pending_version
+      token = SecureRandom.uuid
+      rule_class = self.class
+      pending_installment_id = installment_id
+      pending_rule_id = id
+      pending_version = version
+
+      AfterCommitEverywhere.after_commit do
+        rule_class.promote_pending_version(
+          installment_id: pending_installment_id,
+          installment_rule_id: pending_rule_id,
+          version: pending_version,
+          token:
+        )
+      end
+      AfterCommitEverywhere.after_rollback do
+        rule_class.clear_pending_version(
+          installment_id: pending_installment_id,
+          installment_rule_id: pending_rule_id,
+          token:
+        )
+      end
+      rule_class.cache_pending_version!(installment_id: pending_installment_id, version: pending_version, token:)
+    end
+
+    def publish_pending_version?
+      workflow_rule? && will_save_change_to_version? && persisted?
+    end
+
+    def workflow_rule?
+      installment&.workflow_id.present?
+    end
+
+    def cache_committed_version
+      cache_version!
+    rescue Redis::BaseError, RedisClient::Error => e
+      ErrorNotifier.notify(e, installment_rule_id: id)
+    end
+
+    def self.cache_keys(installment_id)
+      [
+        RedisKey.workflow_installment_rule_version(installment_id),
+        RedisKey.workflow_installment_rule_pending_token(installment_id),
+      ]
+    end
+    private_class_method :cache_keys
+
     # Private: Increments version of InstallmentRule. This is so PublishInstallment jobs are ignored if the version of the job does not match the
     # most recent version of the InstallmentRule. We want to update the version every time the creator changes when it is scheduled.
     def increment_version

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -51,56 +51,86 @@ class Workflow < ApplicationRecord
   end
 
   def mark_deleted!
-    self.deleted_at = Time.current
-    installments.each do |installment|
-      installment.mark_deleted!
-      installment.installment_rule.mark_deleted!
+    self.class.transaction do
+      lock!
+      self.deleted_at = Time.current
+      installments.each do |installment|
+        rule = installment.installment_rule
+        rule&.advance_version!
+        installment.mark_deleted!
+        rule&.mark_deleted!
+      end
+      save!
     end
-    save!
   end
 
   def publish!
-    return true if published_at.present?
+    with_transition_lock do
+      next true if published_at.present?
 
-    if !abandoned_cart_type? && !seller.eligible_to_send_emails?
-      errors.add(:base, "You cannot publish a workflow until you have made at least #{Money.from_cents(Installment::MINIMUM_SALES_CENTS_VALUE).format(no_cents: true)} in total earnings and received a payout")
-      raise ActiveRecord::RecordInvalid.new(self)
-    end
+      if !abandoned_cart_type? && !seller.eligible_to_send_emails?
+        errors.add(:base, "You cannot publish a workflow until you have made at least #{Money.from_cents(Installment::MINIMUM_SALES_CENTS_VALUE).format(no_cents: true)} in total earnings and received a payout")
+        raise ActiveRecord::RecordInvalid.new(self)
+      end
 
-    self.published_at = DateTime.current
-    self.first_published_at ||= published_at
-    installments.alive.find_each do |installment|
-      installment.publish!(published_at:)
-      schedule_installment(installment)
+      self.published_at = DateTime.current.change(usec: 0)
+      self.first_published_at ||= published_at
+      installments_to_schedule = []
+      installments.alive.find_each do |installment|
+        rule = installment.installment_rule
+        rule&.advance_version!
+        installment.publish!(published_at:)
+        installments_to_schedule << [installment, rule.version] if rule.present? && !installment.abandoned_cart_type?
+      end
+      save!
+      installments_to_schedule.each do |installment, rule_version|
+        WorkflowInstallmentScheduleIntent.enqueue!(
+          installment:,
+          rule_version:,
+          old_delayed_delivery_time: nil,
+          cutoff_reference_time: published_at,
+          expected_published_at: published_at
+        )
+      end
     end
-    save!
   end
 
   def unpublish!
-    return true if published_at.nil?
+    with_transition_lock do
+      next true if published_at.nil?
 
-    self.published_at = nil
-    installments.alive.find_each(&:unpublish!)
-    save!
+      self.published_at = nil
+      installments.alive.find_each do |installment|
+        installment.installment_rule&.advance_version!
+        installment.unpublish!
+      end
+      save!
+    end
   end
 
   def has_never_been_published?
     first_published_at.nil?
   end
 
-  def schedule_installment(installment, old_delayed_delivery_time: nil)
-    return if installment.abandoned_cart_type?
-    return unless alive?
-    return unless installment.published?
+  def schedule_installment(installment, old_delayed_delivery_time: nil, cutoff_reference_time: Time.current, minimum_rule_version: nil, schedule_intent_token: nil)
+    return :not_applicable if installment.abandoned_cart_type?
+    return :not_applicable unless alive?
+    return :not_applicable unless installment.published?
 
     if member_cancellation_trigger?
-      SendWorkflowEmailsToPastCanceledMembersJob.perform_async(installment.id) if send_to_past_customers?
-      return
+      if send_to_past_customers?
+        args = [installment.id]
+        args.concat([nil, nil, minimum_rule_version]) if minimum_rule_version.present? || schedule_intent_token.present?
+        args << schedule_intent_token if schedule_intent_token.present?
+        job_id = SendWorkflowEmailsToPastCanceledMembersJob.perform_async(*args)
+        return job_id.present? ? :enqueued : :not_enqueued
+      end
+      return :not_applicable
     end
 
-    return unless new_customer_trigger?
+    return :not_applicable unless new_customer_trigger?
     # don't schedule the installment if it is only for new customers/followers and it hasn't been scheduled before (old_delayed_delivery_time is nil)
-    return if old_delayed_delivery_time.nil? && installment.is_for_new_customers_of_workflow
+    return :not_applicable if old_delayed_delivery_time.nil? && installment.is_for_new_customers_of_workflow
 
     # earliest_valid_time is:
     #   `installment.published_at` if the installment is for new customers only
@@ -110,12 +140,25 @@ class Workflow < ApplicationRecord
     # installment has not been delivered to them and needs to be (re-)scheduled.
     earliest_valid_time = if old_delayed_delivery_time.nil?
       nil
-    elsif installment.is_for_new_customers_of_workflow && installment.published_at >= old_delayed_delivery_time.seconds.ago
+    elsif installment.is_for_new_customers_of_workflow && installment.published_at >= cutoff_reference_time - old_delayed_delivery_time.seconds
       installment.published_at
     else
-      old_delayed_delivery_time.seconds.ago
+      cutoff_reference_time - old_delayed_delivery_time.seconds
     end
 
-    SendWorkflowPostEmailsJob.perform_async(installment.id, earliest_valid_time&.iso8601)
+    args = [installment.id, earliest_valid_time&.iso8601]
+    args.concat([false, minimum_rule_version]) if minimum_rule_version.present? || schedule_intent_token.present?
+    args << schedule_intent_token if schedule_intent_token.present?
+    SendWorkflowPostEmailsJob.perform_async(*args).present? ? :enqueued : :not_enqueued
   end
+
+  private
+    def with_transition_lock
+      self.class.transaction do
+        # An update acquires the same row lock when a callback leaves the workflow dirty.
+        save! if has_changes_to_save?
+        lock!
+        yield
+      end
+    end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -112,7 +112,7 @@ class Workflow < ApplicationRecord
     first_published_at.nil?
   end
 
-  def schedule_installment(installment, old_delayed_delivery_time: nil, cutoff_reference_time: Time.current, minimum_rule_version: nil, schedule_intent_token: nil)
+  def schedule_installment(installment, old_delayed_delivery_time: nil, cutoff_reference_time: Time.current, minimum_rule_version: nil, schedule_intent_token: nil, schedule_intent_fanout_token: nil)
     return :not_applicable if installment.abandoned_cart_type?
     return :not_applicable unless alive?
     return :not_applicable unless installment.published?
@@ -120,8 +120,10 @@ class Workflow < ApplicationRecord
     if member_cancellation_trigger?
       if send_to_past_customers?
         args = [installment.id]
-        args.concat([nil, nil, minimum_rule_version]) if minimum_rule_version.present? || schedule_intent_token.present?
-        args << schedule_intent_token if schedule_intent_token.present?
+        with_intent = minimum_rule_version.present? || schedule_intent_token.present? || schedule_intent_fanout_token.present?
+        args.concat([nil, nil, minimum_rule_version]) if with_intent
+        args << schedule_intent_token if schedule_intent_token.present? || schedule_intent_fanout_token.present?
+        args << schedule_intent_fanout_token if schedule_intent_fanout_token.present?
         job_id = SendWorkflowEmailsToPastCanceledMembersJob.perform_async(*args)
         return job_id.present? ? :enqueued : :not_enqueued
       end
@@ -147,8 +149,10 @@ class Workflow < ApplicationRecord
     end
 
     args = [installment.id, earliest_valid_time&.iso8601]
-    args.concat([false, minimum_rule_version]) if minimum_rule_version.present? || schedule_intent_token.present?
-    args << schedule_intent_token if schedule_intent_token.present?
+    with_intent = minimum_rule_version.present? || schedule_intent_token.present? || schedule_intent_fanout_token.present?
+    args.concat([false, minimum_rule_version]) if with_intent
+    args << schedule_intent_token if schedule_intent_token.present? || schedule_intent_fanout_token.present?
+    args << schedule_intent_fanout_token if schedule_intent_fanout_token.present?
     SendWorkflowPostEmailsJob.perform_async(*args).present? ? :enqueued : :not_enqueued
   end
 

--- a/app/models/workflow_installment_schedule_intent.rb
+++ b/app/models/workflow_installment_schedule_intent.rb
@@ -5,6 +5,7 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
 
   DISPATCH_LEASE = 15.minutes
   FANOUT_LEASE = 2.hours
+  FANOUT_HEARTBEAT_INTERVAL = 5.minutes
 
   scope :pending, -> { where(processed_at: nil) }
   scope :dispatchable, ->(at = Time.current) do
@@ -106,6 +107,17 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
       intent.update!(fanout_token:, fanout_expires_at: now + FANOUT_LEASE)
       true
     end
+  end
+
+  def self.renew_fanout(intent_token:, fanout_token:)
+    return true if intent_token.blank? && fanout_token.blank?
+    return false if intent_token.blank? || fanout_token.blank?
+
+    now = Time.current
+    pending.where(token: intent_token, fanout_token:).update_all(
+      fanout_expires_at: now + FANOUT_LEASE,
+      updated_at: now
+    ).positive?
   end
 
   def self.release_dispatch(token:, dispatch_token:)

--- a/app/models/workflow_installment_schedule_intent.rb
+++ b/app/models/workflow_installment_schedule_intent.rb
@@ -4,9 +4,14 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
   class EnqueueError < StandardError; end
 
   DISPATCH_LEASE = 15.minutes
+  FANOUT_LEASE = 2.hours
 
   scope :pending, -> { where(processed_at: nil) }
-  scope :dispatchable, ->(at = Time.current) { pending.where("dispatch_expires_at IS NULL OR dispatch_expires_at <= ?", at) }
+  scope :dispatchable, ->(at = Time.current) do
+    pending
+      .where("dispatch_expires_at IS NULL OR dispatch_expires_at <= ?", at)
+      .where("fanout_expires_at IS NULL OR fanout_expires_at <= ?", at)
+  end
 
   validates :token, :installment_id, :rule_version, :cutoff_reference_time, presence: true
 
@@ -46,20 +51,61 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
     nil
   end
 
-  def self.mark_processed(token)
+  def self.mark_processed(token, fanout_token: nil)
     return if token.blank?
 
     now = Time.current
-    pending.where(token:).update_all(
+    scope = pending.where(token:)
+    scope = scope.where(fanout_token:) if fanout_token.present?
+    scope.update_all(
       processed_at: now,
       dispatch_token: nil,
       dispatch_expires_at: nil,
+      fanout_token: nil,
+      fanout_expires_at: nil,
       updated_at: now
     )
   end
 
   def mark_processed!
-    update!(processed_at: Time.current, dispatch_token: nil, dispatch_expires_at: nil)
+    update!(
+      processed_at: Time.current,
+      dispatch_token: nil,
+      dispatch_expires_at: nil,
+      fanout_token: nil,
+      fanout_expires_at: nil
+    )
+  end
+
+  def claim_fanout!
+    now = Time.current
+    return if processed_at.present? || fanout_expires_at.present? && fanout_expires_at > now
+
+    token = SecureRandom.uuid
+    update!(fanout_token: token, fanout_expires_at: now + FANOUT_LEASE)
+    token
+  end
+
+  def self.begin_fanout(intent_token:, fanout_token:)
+    return true if intent_token.blank? && fanout_token.blank?
+    return false if intent_token.blank? || fanout_token.blank?
+
+    intent = find_by(token: intent_token)
+    return false if intent.nil?
+
+    intent.with_lock do
+      next false if intent.processed_at.present?
+
+      now = Time.current
+      another_fanout_active = intent.fanout_token.present? &&
+                              intent.fanout_token != fanout_token &&
+                              intent.fanout_expires_at.present? &&
+                              intent.fanout_expires_at > now
+      next false if another_fanout_active
+
+      intent.update!(fanout_token:, fanout_expires_at: now + FANOUT_LEASE)
+      true
+    end
   end
 
   def self.release_dispatch(token:, dispatch_token:)

--- a/app/models/workflow_installment_schedule_intent.rb
+++ b/app/models/workflow_installment_schedule_intent.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class WorkflowInstallmentScheduleIntent < ApplicationRecord
+  class EnqueueError < StandardError; end
+
+  DISPATCH_LEASE = 15.minutes
+
+  scope :pending, -> { where(processed_at: nil) }
+  scope :dispatchable, ->(at = Time.current) { pending.where("dispatch_expires_at IS NULL OR dispatch_expires_at <= ?", at) }
+
+  validates :token, :installment_id, :rule_version, :cutoff_reference_time, presence: true
+
+  def self.enqueue!(installment:, rule_version:, old_delayed_delivery_time:, cutoff_reference_time:, expected_published_at: nil)
+    raise EnqueueError, "A database transaction is required" unless connection.transaction_open?
+
+    intent = create!(
+      token: SecureRandom.uuid,
+      installment_id: installment.id,
+      rule_version:,
+      old_delayed_delivery_time:,
+      cutoff_reference_time:,
+      expected_published_at:
+    )
+
+    token = intent.token
+    AfterCommitEverywhere.after_commit { enqueue(token) }
+
+    intent
+  end
+
+  def self.enqueue(token)
+    dispatch_token = SecureRandom.uuid
+    now = Time.current
+    claimed = dispatchable(now).where(token:).update_all(
+      dispatch_token:,
+      dispatch_expires_at: now + DISPATCH_LEASE,
+      updated_at: now
+    )
+    return if claimed.zero?
+
+    job_id = ScheduleWorkflowInstallmentJob.perform_async(token)
+    release_dispatch(token:, dispatch_token:) if job_id.blank?
+    job_id
+  rescue => e
+    Rails.logger.error("[#{name}] could not enqueue token=#{token}: #{e.class}: #{e.message}")
+    nil
+  end
+
+  def self.mark_processed(token)
+    return if token.blank?
+
+    now = Time.current
+    pending.where(token:).update_all(
+      processed_at: now,
+      dispatch_token: nil,
+      dispatch_expires_at: nil,
+      updated_at: now
+    )
+  end
+
+  def mark_processed!
+    update!(processed_at: Time.current, dispatch_token: nil, dispatch_expires_at: nil)
+  end
+
+  def self.release_dispatch(token:, dispatch_token:)
+    pending.where(token:, dispatch_token:).update_all(
+      dispatch_token: nil,
+      dispatch_expires_at: nil,
+      updated_at: Time.current
+    )
+  end
+  private_class_method :release_dispatch
+end

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -40,6 +40,8 @@ class RedisKey
     def blast_sent_emails(blast_id) = "blast:#{blast_id}:sent_emails"
     def blast_audience_snapshot(blast_id) = "blast:#{blast_id}:audience_snapshot"
     def blast_non_opener_emails(blast_id) = "blast:#{blast_id}:non_opener_emails"
+    def workflow_installment_rule_version(installment_id) = "workflow_installment_rule:#{installment_id}:version"
+    def workflow_installment_rule_pending_token(installment_id) = "workflow_installment_rule:#{installment_id}:pending_token"
     def audience_member_load_max_execution_time_seconds = "audience_member_load:max_execution_time_seconds"
     def impersonated_user(admin_user_id) = "impersonated_user_by_admin_#{admin_user_id}"
     def undeliverable_ping_subscription_notified(resource_subscription_id, reason) = "undeliverable_ping_subscription:#{resource_subscription_id}:#{reason}"

--- a/app/services/workflow/save_installments_service.rb
+++ b/app/services/workflow/save_installments_service.rb
@@ -21,14 +21,21 @@ class Workflow::SaveInstallmentsService
       return [false, errors]
     end
 
-    if workflow.abandoned_cart_type? && params[:installments].size != 1
-      workflow.errors.add(:base, "An abandoned cart workflow can only have one email.")
-      @errors = workflow.errors
-      return [false, errors]
-    end
-
     begin
       ActiveRecord::Base.transaction do
+        workflow.lock!
+        unless workflow.alive?
+          workflow.errors.add(:base, "The workflow was not found.")
+          @errors = workflow.errors
+          raise ActiveRecord::Rollback
+        end
+
+        if workflow.abandoned_cart_type? && params[:installments].size != 1
+          workflow.errors.add(:base, "An abandoned cart workflow can only have one email.")
+          @errors = workflow.errors
+          raise ActiveRecord::Rollback
+        end
+
         if @workflow.has_never_been_published?
           @workflow.update!(send_to_past_customers: params[:send_to_past_customers])
         end
@@ -75,6 +82,7 @@ class Workflow::SaveInstallmentsService
     def delete_removed_installments
       deleted_external_ids = workflow.installments.alive.map(&:external_id) - params[:installments].pluck(:id)
       workflow.installments.by_external_ids(deleted_external_ids).find_each do |installment|
+        installment.installment_rule&.advance_version!
         installment.mark_deleted!
         installment.installment_rule&.mark_deleted!
       end
@@ -110,7 +118,12 @@ class Workflow::SaveInstallmentsService
       rule.save!
 
       if installment.published_at.present? && params[:save_action_name] == Workflow::SAVE_ACTION
-        installment.workflow.schedule_installment(installment, old_delayed_delivery_time:)
+        WorkflowInstallmentScheduleIntent.enqueue!(
+          installment:,
+          rule_version: rule.version,
+          old_delayed_delivery_time:,
+          cutoff_reference_time: Time.current
+        )
       end
     end
 end

--- a/app/sidekiq/delete_processed_workflow_installment_schedule_intents_job.rb
+++ b/app/sidekiq/delete_processed_workflow_installment_schedule_intents_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class DeleteProcessedWorkflowInstallmentScheduleIntentsJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low
+
+  RETENTION_PERIOD = 30.days
+
+  def perform
+    WorkflowInstallmentScheduleIntent
+      .where(processed_at: ...RETENTION_PERIOD.ago)
+      .in_batches(of: 1_000)
+      .delete_all
+  end
+end

--- a/app/sidekiq/dispatch_pending_workflow_installment_schedule_intents_job.rb
+++ b/app/sidekiq/dispatch_pending_workflow_installment_schedule_intents_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class DispatchPendingWorkflowInstallmentScheduleIntentsJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low, lock: :until_executed
+
+  include RecurringLockTtl
+  recurring_lock_ttl max_attempt: 10.minutes
+
+  def perform
+    WorkflowInstallmentScheduleIntent.dispatchable.find_each do |intent|
+      WorkflowInstallmentScheduleIntent.enqueue(intent.token)
+    end
+  end
+end

--- a/app/sidekiq/schedule_workflow_installment_job.rb
+++ b/app/sidekiq/schedule_workflow_installment_job.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class ScheduleWorkflowInstallmentJob
+  class IntentNotCommittedError < StandardError; end
+  class FanoutNotEnqueuedError < StandardError; end
+
+  include Sidekiq::Job
+  sidekiq_options retry: 10, queue: :low
+
+  def perform(intent_token)
+    ActiveRecord::Base.connection.stick_to_primary!
+    intent = WorkflowInstallmentScheduleIntent.find_by(token: intent_token)
+    return if intent.nil?
+
+    intent.with_lock do
+      next if intent.processed_at.present?
+
+      installment = Installment.find_by(id: intent.installment_id)
+      if installment.nil? || installment.installment_rule.nil?
+        intent.mark_processed!
+        next
+      end
+
+      current_version = installment.installment_rule.version
+      raise IntentNotCommittedError if current_version < intent.rule_version
+
+      workflow = installment.workflow
+      if workflow.nil?
+        intent.mark_processed!
+        next
+      end
+
+      if intent.expected_published_at.present?
+        publication_matches = false
+        workflow.with_lock do
+          installment.reload
+          publication_matches = workflow.published_at&.change(usec: 0) == intent.expected_published_at &&
+                                installment.published_at&.change(usec: 0) == intent.expected_published_at
+        end
+        unless publication_matches
+          intent.mark_processed!
+          next
+        end
+      end
+      unless workflow.alive? && installment.alive? && installment.published?
+        intent.mark_processed!
+        next
+      end
+
+      result = workflow.schedule_installment(
+        installment,
+        old_delayed_delivery_time: intent.old_delayed_delivery_time,
+        cutoff_reference_time: intent.cutoff_reference_time,
+        minimum_rule_version: current_version,
+        schedule_intent_token: intent.token
+      )
+      case result
+      when :enqueued, :not_applicable
+        intent.mark_processed!
+      else
+        raise FanoutNotEnqueuedError, "Unexpected schedule result: #{result.inspect}"
+      end
+    end
+  ensure
+    Makara::Context.release_all
+  end
+end

--- a/app/sidekiq/schedule_workflow_installment_job.rb
+++ b/app/sidekiq/schedule_workflow_installment_job.rb
@@ -47,15 +47,21 @@ class ScheduleWorkflowInstallmentJob
         next
       end
 
+      fanout_token = intent.claim_fanout!
+      next if fanout_token.nil?
+
       result = workflow.schedule_installment(
         installment,
         old_delayed_delivery_time: intent.old_delayed_delivery_time,
         cutoff_reference_time: intent.cutoff_reference_time,
         minimum_rule_version: current_version,
-        schedule_intent_token: intent.token
+        schedule_intent_token: intent.token,
+        schedule_intent_fanout_token: fanout_token
       )
       case result
-      when :enqueued, :not_applicable
+      when :enqueued
+        next
+      when :not_applicable
         intent.mark_processed!
       else
         raise FanoutNotEnqueuedError, "Unexpected schedule result: #{result.inspect}"

--- a/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
+++ b/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
@@ -1,24 +1,39 @@
 # frozen_string_literal: true
 
 class SendWorkflowEmailsToPastCanceledMembersJob
+  class FanoutNotEnqueuedError < StandardError; end
   class RuleNotCommittedError < StandardError; end
 
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 
-  def perform(installment_id, _old_delayed_delivery_time = nil, _cutoff_reference_time = nil, minimum_rule_version = nil, schedule_intent_token = nil)
-    WorkflowInstallmentScheduleIntent.mark_processed(schedule_intent_token)
-    primary_pinned = minimum_rule_version.present?
+  def perform(installment_id, _old_delayed_delivery_time = nil, _cutoff_reference_time = nil, minimum_rule_version = nil, schedule_intent_token = nil, schedule_intent_fanout_token = nil)
+    primary_pinned = minimum_rule_version.present? || schedule_intent_token.present?
     ActiveRecord::Base.connection.stick_to_primary! if primary_pinned
+    return unless WorkflowInstallmentScheduleIntent.begin_fanout(
+      intent_token: schedule_intent_token,
+      fanout_token: schedule_intent_fanout_token
+    )
     installment = Installment.find(installment_id)
     workflow = installment.workflow
-    return unless workflow&.alive? && installment.alive? && installment.published?
-    return unless workflow.member_cancellation_trigger?
-    return unless workflow.send_to_past_customers?
-    return unless workflow.seller_or_product_or_variant_type?
+    unless workflow&.alive? && installment.alive? && installment.published? &&
+           workflow.member_cancellation_trigger? && workflow.send_to_past_customers? &&
+           workflow.seller_or_product_or_variant_type?
+      WorkflowInstallmentScheduleIntent.mark_processed(
+        schedule_intent_token,
+        fanout_token: schedule_intent_fanout_token
+      )
+      return
+    end
 
     rule = installment.installment_rule
-    return if rule.nil?
+    if rule.nil?
+      WorkflowInstallmentScheduleIntent.mark_processed(
+        schedule_intent_token,
+        fanout_token: schedule_intent_fanout_token
+      )
+      return
+    end
     raise RuleNotCommittedError if minimum_rule_version.present? && rule.version < minimum_rule_version
     rule.cache_version!
 
@@ -33,11 +48,18 @@ class SendWorkflowEmailsToPastCanceledMembersJob
       next if original_purchase.nil?
       next unless workflow.applies_to_purchase?(original_purchase)
 
-      SendWorkflowInstallmentWorker.perform_at(
+      job_id = SendWorkflowInstallmentWorker.perform_at(
         subscription.deactivated_at + delay,
         installment.id, rule_version, nil, nil, nil, subscription.id
       )
+      if job_id.blank?
+        raise FanoutNotEnqueuedError, "Sidekiq did not enqueue the workflow installment"
+      end
     end
+    WorkflowInstallmentScheduleIntent.mark_processed(
+      schedule_intent_token,
+      fanout_token: schedule_intent_fanout_token
+    )
   ensure
     Makara::Context.release_all if primary_pinned
   end

--- a/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
+++ b/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 class SendWorkflowEmailsToPastCanceledMembersJob
+  class RuleNotCommittedError < StandardError; end
+
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 
-  def perform(installment_id)
+  def perform(installment_id, _old_delayed_delivery_time = nil, _cutoff_reference_time = nil, minimum_rule_version = nil, schedule_intent_token = nil)
+    WorkflowInstallmentScheduleIntent.mark_processed(schedule_intent_token)
+    primary_pinned = minimum_rule_version.present?
+    ActiveRecord::Base.connection.stick_to_primary! if primary_pinned
     installment = Installment.find(installment_id)
     workflow = installment.workflow
     return unless workflow&.alive? && installment.alive? && installment.published?
@@ -14,9 +19,13 @@ class SendWorkflowEmailsToPastCanceledMembersJob
 
     rule = installment.installment_rule
     return if rule.nil?
+    raise RuleNotCommittedError if minimum_rule_version.present? && rule.version < minimum_rule_version
+    rule.cache_version!
 
     delay = rule.delayed_delivery_time
     rule_version = rule.version
+    Makara::Context.release_all
+    primary_pinned = false
 
     candidate_subscriptions(workflow).includes(:original_purchase).find_each do |subscription|
       next unless subscription.cancelled?
@@ -29,6 +38,8 @@ class SendWorkflowEmailsToPastCanceledMembersJob
         installment.id, rule_version, nil, nil, nil, subscription.id
       )
     end
+  ensure
+    Makara::Context.release_all if primary_pinned
   end
 
   private

--- a/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
+++ b/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
@@ -45,22 +45,8 @@ class SendWorkflowEmailsToPastCanceledMembersJob
     Makara::Context.release_all
     primary_pinned = false
 
-    candidate_subscriptions(workflow).includes(:original_purchase).find_each do |subscription|
-      return unless renew_fanout_lease
+    return unless enqueue_all_member_jobs(workflow:, installment:, delay:, rule_version:)
 
-      next unless subscription.cancelled?
-      original_purchase = subscription.original_purchase
-      next if original_purchase.nil?
-      next unless workflow.applies_to_purchase?(original_purchase)
-
-      job_id = SendWorkflowInstallmentWorker.perform_at(
-        subscription.deactivated_at + delay,
-        installment.id, rule_version, nil, nil, nil, subscription.id
-      )
-      if job_id.blank?
-        raise FanoutNotEnqueuedError, "Sidekiq did not enqueue the workflow installment"
-      end
-    end
     WorkflowInstallmentScheduleIntent.mark_processed(
       schedule_intent_token,
       fanout_token: schedule_intent_fanout_token
@@ -70,6 +56,26 @@ class SendWorkflowEmailsToPastCanceledMembersJob
   end
 
   private
+    def enqueue_all_member_jobs(workflow:, installment:, delay:, rule_version:)
+      candidate_subscriptions(workflow).includes(:original_purchase).find_each do |subscription|
+        return false unless renew_fanout_lease
+
+        next unless subscription.cancelled?
+        original_purchase = subscription.original_purchase
+        next if original_purchase.nil?
+        next unless workflow.applies_to_purchase?(original_purchase)
+
+        job_id = SendWorkflowInstallmentWorker.perform_at(
+          subscription.deactivated_at + delay,
+          installment.id, rule_version, nil, nil, nil, subscription.id
+        )
+        if job_id.blank?
+          raise FanoutNotEnqueuedError, "Sidekiq did not enqueue the workflow installment"
+        end
+      end
+      true
+    end
+
     def renew_fanout_lease
       return true if @schedule_intent_token.blank? && @schedule_intent_fanout_token.blank?
 

--- a/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
+++ b/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
@@ -8,12 +8,15 @@ class SendWorkflowEmailsToPastCanceledMembersJob
   sidekiq_options retry: 5, queue: :low
 
   def perform(installment_id, _old_delayed_delivery_time = nil, _cutoff_reference_time = nil, minimum_rule_version = nil, schedule_intent_token = nil, schedule_intent_fanout_token = nil)
+    @schedule_intent_token = schedule_intent_token
+    @schedule_intent_fanout_token = schedule_intent_fanout_token
     primary_pinned = minimum_rule_version.present? || schedule_intent_token.present?
     ActiveRecord::Base.connection.stick_to_primary! if primary_pinned
     return unless WorkflowInstallmentScheduleIntent.begin_fanout(
       intent_token: schedule_intent_token,
       fanout_token: schedule_intent_fanout_token
     )
+    @next_fanout_heartbeat_at = fanout_heartbeat_time + WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f
     installment = Installment.find(installment_id)
     workflow = installment.workflow
     unless workflow&.alive? && installment.alive? && installment.published? &&
@@ -43,6 +46,8 @@ class SendWorkflowEmailsToPastCanceledMembersJob
     primary_pinned = false
 
     candidate_subscriptions(workflow).includes(:original_purchase).find_each do |subscription|
+      return unless renew_fanout_lease
+
       next unless subscription.cancelled?
       original_purchase = subscription.original_purchase
       next if original_purchase.nil?
@@ -65,6 +70,24 @@ class SendWorkflowEmailsToPastCanceledMembersJob
   end
 
   private
+    def renew_fanout_lease
+      return true if @schedule_intent_token.blank? && @schedule_intent_fanout_token.blank?
+
+      now = fanout_heartbeat_time
+      return true if now < @next_fanout_heartbeat_at
+
+      renewed = WorkflowInstallmentScheduleIntent.renew_fanout(
+        intent_token: @schedule_intent_token,
+        fanout_token: @schedule_intent_fanout_token
+      )
+      @next_fanout_heartbeat_at = now + WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f if renewed
+      renewed
+    end
+
+    def fanout_heartbeat_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
     def candidate_subscriptions(workflow)
       scope = Subscription.where.not(deactivated_at: nil).where.not(cancelled_at: nil)
       if workflow.product_or_variant_type?

--- a/app/sidekiq/send_workflow_installment_worker.rb
+++ b/app/sidekiq/send_workflow_installment_worker.rb
@@ -1,20 +1,43 @@
 # frozen_string_literal: true
 
 class SendWorkflowInstallmentWorker
+  class RuleNotCommittedError < StandardError; end
+
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 
-  def perform(installment_id, version, purchase_id, follower_id, affiliate_user_id = nil, subscription_id = nil)
-    installment = Installment.find_by(id: installment_id)
+  def perform(installment_id, version, purchase_id, follower_id, affiliate_user_id = nil, subscription_id = nil, _reschedule_reference_time = nil)
+    primary_pinned = false
+    expected_rule_version = current_rule_version(installment_id)
+    return if expected_rule_version.nil?
 
-    return if installment.nil?
+    if expected_rule_version != version
+      ActiveRecord::Base.connection.stick_to_primary!
+      primary_pinned = true
+    end
+
+    installment = Installment.find_by(id: installment_id)
+    installment_rule = installment&.installment_rule
+    if installment.nil? || installment_rule.nil? || installment_rule.version != version
+      unless primary_pinned
+        ActiveRecord::Base.connection.stick_to_primary!
+        primary_pinned = true
+      end
+      installment = Installment.find_by(id: installment_id)
+      return if installment.nil?
+
+      installment_rule = installment.installment_rule
+      return if installment_rule.nil?
+    end
+    if installment_rule.version < expected_rule_version || installment_rule.version < version
+      raise RuleNotCommittedError
+    end
+
     return if installment.seller&.suspended?
     return unless installment.workflow.alive?
     return unless installment.alive?
     return unless installment.published?
 
-    installment_rule = installment.installment_rule
-    return if installment_rule.nil?
     return if installment_rule.version != version
 
     if purchase_id.present? && follower_id.nil? && affiliate_user_id.nil? && subscription_id.nil?
@@ -31,5 +54,25 @@ class SendWorkflowInstallmentWorker
       # a whole class of workflows could deliver nothing at all without anyone noticing.
       Rails.logger.error("[#{self.class.name}] installment_id=#{installment_id} got an unusable recipient combination (purchase=#{purchase_id.inspect} follower=#{follower_id.inspect} affiliate=#{affiliate_user_id.inspect} subscription=#{subscription_id.inspect}); nothing sent")
     end
+  ensure
+    Makara::Context.release_all if primary_pinned
   end
+
+  private
+    def current_rule_version(installment_id)
+      cached_version, pending = InstallmentRule.cached_version_state(installment_id)
+      return cached_version if cached_version.present? && !pending
+
+      primary_pinned = true
+      ActiveRecord::Base.connection.stick_to_primary!
+      effective_version = InstallmentRule.transaction do
+        rule = InstallmentRule.lock.find_by(installment_id:)
+        rule&.cache_version!
+      end
+      raise RuleNotCommittedError if effective_version.nil? && pending
+
+      effective_version
+    ensure
+      Makara::Context.release_all if primary_pinned
+    end
 end

--- a/app/sidekiq/send_workflow_installment_worker.rb
+++ b/app/sidekiq/send_workflow_installment_worker.rb
@@ -60,28 +60,14 @@ class SendWorkflowInstallmentWorker
 
   private
     def current_rule_version(installment_id)
-      cache_read_failed = false
-      pending = false
-      begin
-        cached_version, pending = InstallmentRule.cached_version_state(installment_id)
-        return cached_version if cached_version.present? && !pending
-      rescue Redis::BaseError, RedisClient::Error
-        cache_read_failed = true
-      end
+      cached_version, pending = InstallmentRule.cached_version_state(installment_id)
+      return cached_version if cached_version.present? && !pending
 
       primary_pinned = true
       ActiveRecord::Base.connection.stick_to_primary!
       effective_version = InstallmentRule.transaction do
         rule = InstallmentRule.lock.find_by(installment_id:)
-        if cache_read_failed
-          rule&.version
-        else
-          begin
-            rule&.cache_version!
-          rescue Redis::BaseError, RedisClient::Error
-            rule&.version
-          end
-        end
+        rule&.cache_version!
       end
       raise RuleNotCommittedError if effective_version.nil? && pending
 

--- a/app/sidekiq/send_workflow_installment_worker.rb
+++ b/app/sidekiq/send_workflow_installment_worker.rb
@@ -60,14 +60,28 @@ class SendWorkflowInstallmentWorker
 
   private
     def current_rule_version(installment_id)
-      cached_version, pending = InstallmentRule.cached_version_state(installment_id)
-      return cached_version if cached_version.present? && !pending
+      cache_read_failed = false
+      pending = false
+      begin
+        cached_version, pending = InstallmentRule.cached_version_state(installment_id)
+        return cached_version if cached_version.present? && !pending
+      rescue Redis::BaseError, RedisClient::Error
+        cache_read_failed = true
+      end
 
       primary_pinned = true
       ActiveRecord::Base.connection.stick_to_primary!
       effective_version = InstallmentRule.transaction do
         rule = InstallmentRule.lock.find_by(installment_id:)
-        rule&.cache_version!
+        if cache_read_failed
+          rule&.version
+        else
+          begin
+            rule&.cache_version!
+          rescue Redis::BaseError, RedisClient::Error
+            rule&.version
+          end
+        end
       end
       raise RuleNotCommittedError if effective_version.nil? && pending
 

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -50,25 +50,9 @@ class SendWorkflowPostEmailsJob
     end
     return unless renew_fanout_lease(force: true)
 
-    @members.each do |member|
-      return unless renew_fanout_lease
+    return unless enqueue_all_member_jobs
 
-      if @post.seller_or_product_or_variant_type?
-        enqueue_email_job(member:, type: :purchase, id: member.purchase_id)
-      elsif @post.follower_type?
-        enqueue_email_job(member:, type: :follower, id: member.follower_id)
-      elsif @post.affiliate_type?
-        enqueue_email_job(member:, type: :affiliate, id: member.affiliate_id)
-      elsif @post.audience_type?
-        if member.follower_id
-          enqueue_email_job(member:, type: :follower, id: member.follower_id)
-        elsif member.affiliate_id
-          enqueue_email_job(member:, type: :affiliate, id: member.affiliate_id)
-        else
-          enqueue_email_job(member:, type: :purchase, id: member.purchase_id)
-        end
-      end
-    end
+    # Keep completion after the full fanout; exceptions and lost ownership leave the intent pending.
     WorkflowInstallmentScheduleIntent.mark_processed(
       schedule_intent_token,
       fanout_token: schedule_intent_fanout_token
@@ -78,6 +62,29 @@ class SendWorkflowPostEmailsJob
   end
 
   private
+    def enqueue_all_member_jobs
+      @members.each do |member|
+        return false unless renew_fanout_lease
+
+        if @post.seller_or_product_or_variant_type?
+          enqueue_email_job(member:, type: :purchase, id: member.purchase_id)
+        elsif @post.follower_type?
+          enqueue_email_job(member:, type: :follower, id: member.follower_id)
+        elsif @post.affiliate_type?
+          enqueue_email_job(member:, type: :affiliate, id: member.affiliate_id)
+        elsif @post.audience_type?
+          if member.follower_id
+            enqueue_email_job(member:, type: :follower, id: member.follower_id)
+          elsif member.affiliate_id
+            enqueue_email_job(member:, type: :affiliate, id: member.affiliate_id)
+          else
+            enqueue_email_job(member:, type: :purchase, id: member.purchase_id)
+          end
+        end
+      end
+      true
+    end
+
     def renew_fanout_lease(force: false)
       return true if @schedule_intent_token.blank? && @schedule_intent_fanout_token.blank?
 

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -1,20 +1,31 @@
 # frozen_string_literal: true
 
 class SendWorkflowPostEmailsJob
+  class RuleNotCommittedError < StandardError; end
+
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 
-  def perform(post_id, earliest_valid_time = nil)
+  def perform(post_id, earliest_valid_time = nil, _reschedule_on_stale = false, minimum_rule_version = nil, schedule_intent_token = nil)
+    WorkflowInstallmentScheduleIntent.mark_processed(schedule_intent_token)
+    primary_pinned = minimum_rule_version.present?
+    ActiveRecord::Base.connection.stick_to_primary! if primary_pinned
     @post = Installment.find(post_id)
     @workflow = @post.workflow
     return unless @workflow.alive? && @post.alive? && @post.published?
 
-    @rule_version = @post.installment_rule.version
-    @rule_delay = @post.installment_rule.delayed_delivery_time
+    rule = @post.installment_rule
+    if minimum_rule_version.present? && (rule.nil? || rule.version < minimum_rule_version)
+      raise RuleNotCommittedError
+    end
+    rule.cache_version!
+    @rule_version = rule.version
+    @rule_delay = rule.delayed_delivery_time
 
     @filters = @post.audience_members_filter_params
     @filters[:created_after] = Time.zone.parse(earliest_valid_time) if earliest_valid_time
     Makara::Context.release_all
+    primary_pinned = false
     # Same protection as SendPostBlastEmailsJob: for sellers with very large audiences the
     # filter query can exceed the database's default 5-minute statement cap, so raise it for
     # this one query.
@@ -40,6 +51,8 @@ class SendWorkflowPostEmailsJob
         end
       end
     end
+  ensure
+    Makara::Context.release_all if primary_pinned
   end
 
   private

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -8,12 +8,15 @@ class SendWorkflowPostEmailsJob
   sidekiq_options retry: 5, queue: :low
 
   def perform(post_id, earliest_valid_time = nil, _reschedule_on_stale = false, minimum_rule_version = nil, schedule_intent_token = nil, schedule_intent_fanout_token = nil)
+    @schedule_intent_token = schedule_intent_token
+    @schedule_intent_fanout_token = schedule_intent_fanout_token
     primary_pinned = minimum_rule_version.present? || schedule_intent_token.present?
     ActiveRecord::Base.connection.stick_to_primary! if primary_pinned
     return unless WorkflowInstallmentScheduleIntent.begin_fanout(
       intent_token: schedule_intent_token,
       fanout_token: schedule_intent_fanout_token
     )
+    @next_fanout_heartbeat_at = fanout_heartbeat_time + WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f
     @post = Installment.find(post_id)
     @workflow = @post.workflow
     unless @workflow.alive? && @post.alive? && @post.published?
@@ -39,12 +42,17 @@ class SendWorkflowPostEmailsJob
     # Same protection as SendPostBlastEmailsJob: for sellers with very large audiences the
     # filter query can exceed the database's default 5-minute statement cap, so raise it for
     # this one query.
-    @members = WithMaxExecutionTime.timeout_queries(seconds: audience_load_timeout_seconds) do
+    audience_timeout = audience_load_timeout_seconds
+    return unless renew_fanout_lease(force: true)
+    @members = WithMaxExecutionTime.timeout_queries(seconds: audience_timeout) do
       AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).
         select(:id, :email, :details, :purchase_id, :follower_id, :affiliate_id).to_a
     end
+    return unless renew_fanout_lease(force: true)
 
     @members.each do |member|
+      return unless renew_fanout_lease
+
       if @post.seller_or_product_or_variant_type?
         enqueue_email_job(member:, type: :purchase, id: member.purchase_id)
       elsif @post.follower_type?
@@ -70,6 +78,24 @@ class SendWorkflowPostEmailsJob
   end
 
   private
+    def renew_fanout_lease(force: false)
+      return true if @schedule_intent_token.blank? && @schedule_intent_fanout_token.blank?
+
+      now = fanout_heartbeat_time
+      return true unless force || now >= @next_fanout_heartbeat_at
+
+      renewed = WorkflowInstallmentScheduleIntent.renew_fanout(
+        intent_token: @schedule_intent_token,
+        fanout_token: @schedule_intent_fanout_token
+      )
+      @next_fanout_heartbeat_at = now + WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f if renewed
+      renewed
+    end
+
+    def fanout_heartbeat_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
     def enqueue_email_job(member:, type:, id:)
       # The id columns come from an aggregate over a JSON_TABLE join, and a row can be
       # filtered out of that join even though the member still qualifies (see the comment

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -1,18 +1,28 @@
 # frozen_string_literal: true
 
 class SendWorkflowPostEmailsJob
+  class FanoutNotEnqueuedError < StandardError; end
   class RuleNotCommittedError < StandardError; end
 
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 
-  def perform(post_id, earliest_valid_time = nil, _reschedule_on_stale = false, minimum_rule_version = nil, schedule_intent_token = nil)
-    WorkflowInstallmentScheduleIntent.mark_processed(schedule_intent_token)
-    primary_pinned = minimum_rule_version.present?
+  def perform(post_id, earliest_valid_time = nil, _reschedule_on_stale = false, minimum_rule_version = nil, schedule_intent_token = nil, schedule_intent_fanout_token = nil)
+    primary_pinned = minimum_rule_version.present? || schedule_intent_token.present?
     ActiveRecord::Base.connection.stick_to_primary! if primary_pinned
+    return unless WorkflowInstallmentScheduleIntent.begin_fanout(
+      intent_token: schedule_intent_token,
+      fanout_token: schedule_intent_fanout_token
+    )
     @post = Installment.find(post_id)
     @workflow = @post.workflow
-    return unless @workflow.alive? && @post.alive? && @post.published?
+    unless @workflow.alive? && @post.alive? && @post.published?
+      WorkflowInstallmentScheduleIntent.mark_processed(
+        schedule_intent_token,
+        fanout_token: schedule_intent_fanout_token
+      )
+      return
+    end
 
     rule = @post.installment_rule
     if minimum_rule_version.present? && (rule.nil? || rule.version < minimum_rule_version)
@@ -51,6 +61,10 @@ class SendWorkflowPostEmailsJob
         end
       end
     end
+    WorkflowInstallmentScheduleIntent.mark_processed(
+      schedule_intent_token,
+      fanout_token: schedule_intent_fanout_token
+    )
   ensure
     Makara::Context.release_all if primary_pinned
   end
@@ -66,12 +80,12 @@ class SendWorkflowPostEmailsJob
         purchase = member.details["purchases"].find { _1["id"] == id }
         return log_unresolvable_recipient(member:, type:) if purchase.nil?
         created_at = Time.zone.parse(purchase["created_at"])
-        SendWorkflowInstallmentWorker.perform_at(created_at + @rule_delay, @post.id, @rule_version, id, nil, nil)
+        enqueue_installment_worker(created_at + @rule_delay, @post.id, @rule_version, id, nil, nil)
       elsif type == :follower
         id ||= member.details.dig("follower", "id")
         return log_unresolvable_recipient(member:, type:) if id.nil?
         created_at = Time.zone.parse(member.details.dig("follower", "created_at"))
-        SendWorkflowInstallmentWorker.perform_at(created_at + @rule_delay, @post.id, @rule_version, nil, id, nil)
+        enqueue_installment_worker(created_at + @rule_delay, @post.id, @rule_version, nil, id, nil)
       elsif type == :affiliate
         affiliate = resolve_affiliate(member:, id:)
         return log_unresolvable_recipient(member:, type:) if affiliate.nil?
@@ -84,8 +98,15 @@ class SendWorkflowPostEmailsJob
         affiliate_user_id = Affiliate.where(id: affiliate["id"]).pick(:affiliate_user_id)
         return log_unresolvable_recipient(member:, type:) if affiliate_user_id.nil?
         created_at = Time.zone.parse(affiliate["created_at"])
-        SendWorkflowInstallmentWorker.perform_at(created_at + @rule_delay, @post.id, @rule_version, nil, nil, affiliate_user_id)
+        enqueue_installment_worker(created_at + @rule_delay, @post.id, @rule_version, nil, nil, affiliate_user_id)
       end
+    end
+
+    def enqueue_installment_worker(deliver_at, *args)
+      job_id = SendWorkflowInstallmentWorker.perform_at(deliver_at, *args)
+      return job_id if job_id.present?
+
+      raise FanoutNotEnqueuedError, "Sidekiq did not enqueue the workflow installment"
     end
 
     # A person can be an affiliate for several of the seller's products, and `details["affiliates"]`

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -1,4 +1,8 @@
 # Every minute
+dispatch_pending_workflow_installment_schedule_intents:
+  cron: "* * * * *" # Every minute
+  class: DispatchPendingWorkflowInstallmentScheduleIntentsJob
+  description: Re-enqueues durable workflow schedule intents whose fast-path push was lost
 find_expired_subscriptions_to_set_as_deactivated_worker:
   cron: "* * * * *" # Every minute
   class: FindExpiredSubscriptionsToSetAsDeactivatedWorker
@@ -52,6 +56,10 @@ delete_expired_oauth_device_authorizations:
   description: Deletes expired OAuth device authorizations
 
 # Daily in format: [minute] [hour] * * *
+delete_processed_workflow_installment_schedule_intents:
+  cron: "15 3 * * *" # UTC 03:15
+  class: DeleteProcessedWorkflowInstallmentScheduleIntentsJob
+  description: Deletes processed workflow schedule intents after the Sidekiq retry window
 sync_radar_value_lists:
   cron: "0 3 * * *" # UTC 03:00
   class: Radar::SyncValueListsJob

--- a/db/migrate/20260810043209_create_workflow_installment_schedule_intents.rb
+++ b/db/migrate/20260810043209_create_workflow_installment_schedule_intents.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateWorkflowInstallmentScheduleIntents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :workflow_installment_schedule_intents do |t|
+      t.string :token, null: false
+      t.integer :installment_id, null: false
+      t.integer :rule_version, null: false
+      t.integer :old_delayed_delivery_time
+      t.datetime :cutoff_reference_time, null: false
+      t.datetime :expected_published_at
+      t.string :dispatch_token
+      t.datetime :dispatch_expires_at
+      t.datetime :processed_at
+      t.timestamps
+
+      t.index :token, unique: true
+      t.index :installment_id
+      t.index [:processed_at, :dispatch_expires_at], name: "index_workflow_intent_on_processed_and_dispatch_expiry"
+    end
+  end
+end

--- a/db/migrate/20261207000001_create_workflow_installment_schedule_intents.rb
+++ b/db/migrate/20261207000001_create_workflow_installment_schedule_intents.rb
@@ -11,12 +11,14 @@ class CreateWorkflowInstallmentScheduleIntents < ActiveRecord::Migration[7.1]
       t.datetime :expected_published_at
       t.string :dispatch_token
       t.datetime :dispatch_expires_at
+      t.string :fanout_token
+      t.datetime :fanout_expires_at
       t.datetime :processed_at
       t.timestamps
 
       t.index :token, unique: true
       t.index :installment_id
-      t.index [:processed_at, :dispatch_expires_at], name: "index_workflow_intent_on_processed_and_dispatch_expiry"
+      t.index [:processed_at, :dispatch_expires_at, :fanout_expires_at], name: "index_workflow_intent_on_pending_dispatch"
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -3189,6 +3189,23 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_07_000000) do
     t.index ["user_id"], name: "index_wishlists_on_user_id"
   end
 
+  create_table "workflow_installment_schedule_intents", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "token", null: false
+    t.integer "installment_id", null: false
+    t.integer "rule_version", null: false
+    t.integer "old_delayed_delivery_time"
+    t.datetime "cutoff_reference_time", null: false
+    t.datetime "expected_published_at"
+    t.string "dispatch_token"
+    t.datetime "dispatch_expires_at"
+    t.datetime "processed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["installment_id"], name: "index_workflow_installment_schedule_intents_on_installment_id"
+    t.index ["processed_at", "dispatch_expires_at"], name: "index_workflow_intent_on_processed_and_dispatch_expiry"
+    t.index ["token"], name: "index_workflow_installment_schedule_intents_on_token", unique: true
+  end
+
   create_table "workflows", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 1024
     t.integer "seller_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_07_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_07_000001) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -3198,11 +3198,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_07_000000) do
     t.datetime "expected_published_at"
     t.string "dispatch_token"
     t.datetime "dispatch_expires_at"
+    t.string "fanout_token"
+    t.datetime "fanout_expires_at"
     t.datetime "processed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["installment_id"], name: "index_workflow_installment_schedule_intents_on_installment_id"
-    t.index ["processed_at", "dispatch_expires_at"], name: "index_workflow_intent_on_processed_and_dispatch_expiry"
+    t.index ["processed_at", "dispatch_expires_at", "fanout_expires_at"], name: "index_workflow_intent_on_pending_dispatch"
     t.index ["token"], name: "index_workflow_installment_schedule_intents_on_token", unique: true
   end
 

--- a/spec/models/installment_rule_spec.rb
+++ b/spec/models/installment_rule_spec.rb
@@ -29,6 +29,235 @@ describe InstallmentRule do
       expect(@post_rule.reload.version).to eq(2)
     end
 
+    it "publishes the new version to the shared delivery cache" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      rule.update!(delayed_delivery_time: 100)
+
+      expect(described_class.cached_version(post.id)).to eq(rule.version)
+    end
+
+    it "publishes a pending version before its transaction commits" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      pending_token_key = RedisKey.workflow_installment_rule_pending_token(post.id)
+
+      described_class.transaction do
+        rule.update!(delayed_delivery_time: 100)
+        expect(described_class.cached_version(post.id)).to eq(rule.version)
+        expect($redis.get(pending_token_key)).to be_present
+        raise ActiveRecord::Rollback
+      end
+
+      expect(described_class.cached_version(post.id)).to be_nil
+      expect($redis.get(pending_token_key)).to be_nil
+    end
+
+    it "bounds orphaned pending markers and expires the owner first" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      version_key = RedisKey.workflow_installment_rule_version(post.id)
+      owner_key = RedisKey.workflow_installment_rule_pending_token(post.id)
+
+      described_class.transaction do
+        rule.update!(delayed_delivery_time: 2.days)
+
+        expect($redis.ttl(owner_key)).to be_between(1, described_class::PENDING_OWNER_CACHE_TTL)
+        expect($redis.ttl(version_key)).to be > $redis.ttl(owner_key)
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    it "cleans pending ownership when an earlier instance only changes metadata" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      first_instance = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      pending_token_key = RedisKey.workflow_installment_rule_pending_token(post.id)
+
+      described_class.transaction do
+        first_instance.update!(time_period: "week")
+        described_class.find(first_instance.id).update!(delayed_delivery_time: 2.days)
+      end
+
+      expect($redis.get(pending_token_key)).to be_nil
+      expect(described_class.cached_version(post.id)).to eq(first_instance.reload.version)
+    end
+
+    it "promotes the highest version saved through separate instances" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      first_instance = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      pending_token_key = RedisKey.workflow_installment_rule_pending_token(post.id)
+
+      described_class.transaction do
+        first_instance.update!(delayed_delivery_time: 2.days)
+        described_class.find(first_instance.id).update!(delayed_delivery_time: 3.days)
+      end
+
+      expect($redis.get(pending_token_key)).to be_nil
+      expect(described_class.cached_version(post.id)).to eq(first_instance.reload.version)
+    end
+
+    it "keeps a same-version marker owned by a newer transaction" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      pending_version = rule.version + 1
+      old_token = SecureRandom.uuid
+      new_token = SecureRandom.uuid
+      $redis.set(RedisKey.workflow_installment_rule_version(post.id), pending_version)
+      $redis.set(RedisKey.workflow_installment_rule_pending_token(post.id), new_token)
+
+      described_class.clear_pending_version(
+        installment_id: post.id,
+        installment_rule_id: rule.id,
+        token: old_token
+      )
+
+      expect(described_class.cached_version(post.id)).to eq(pending_version)
+      expect($redis.get(RedisKey.workflow_installment_rule_pending_token(post.id))).to eq(new_token)
+    end
+
+    it "does not promote over a same-version marker owned by a newer transaction" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      pending_version = rule.version + 1
+      old_token = SecureRandom.uuid
+      new_token = SecureRandom.uuid
+      version_key = RedisKey.workflow_installment_rule_version(post.id)
+      owner_key = RedisKey.workflow_installment_rule_pending_token(post.id)
+      $redis.set(version_key, pending_version, ex: described_class::PENDING_VERSION_CACHE_TTL)
+      $redis.set(owner_key, new_token, ex: described_class::PENDING_OWNER_CACHE_TTL)
+
+      described_class.promote_pending_version(
+        installment_id: post.id,
+        installment_rule_id: rule.id,
+        version: pending_version,
+        token: old_token
+      )
+
+      expect(described_class.cached_version(post.id)).to eq(pending_version)
+      expect($redis.get(owner_key)).to eq(new_token)
+      expect($redis.ttl(version_key)).to be <= described_class::PENDING_VERSION_CACHE_TTL
+    end
+
+    it "does not let a normal cache fill clear pending ownership" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      token = SecureRandom.uuid
+      version_key = RedisKey.workflow_installment_rule_version(post.id)
+      owner_key = RedisKey.workflow_installment_rule_pending_token(post.id)
+      $redis.set(version_key, rule.version, ex: described_class::PENDING_VERSION_CACHE_TTL)
+      $redis.set(owner_key, token, ex: described_class::PENDING_OWNER_CACHE_TTL)
+
+      rule.cache_version!
+
+      expect($redis.get(owner_key)).to eq(token)
+      expect($redis.ttl(version_key)).to be <= described_class::PENDING_VERSION_CACHE_TTL
+    end
+
+    it "publishes the pending version before updating the database row" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      observed_version = nil
+      observer = lambda do |*, payload|
+        next unless payload[:name] == "InstallmentRule Update"
+
+        observed_version = described_class.cached_version(post.id)
+      end
+
+      ActiveSupport::Notifications.subscribed(observer, "sql.active_record") do
+        rule.update!(delayed_delivery_time: 2.days)
+      end
+
+      expect(observed_version).to eq(rule.version)
+    end
+
+    it "returns the newer effective version when its cache write loses" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      newer_version = rule.version + 1
+      $redis.set(RedisKey.workflow_installment_rule_version(post.id), newer_version)
+
+      expect(rule.cache_version!).to eq(newer_version)
+      expect(described_class.cached_version(post.id)).to eq(newer_version)
+    end
+
+    it "advances from the committed version when the instance is stale" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      stale_rule = described_class.find(rule.id)
+      rule.update!(delayed_delivery_time: 2.days)
+
+      stale_rule.advance_version!
+
+      expect(stale_rule.version).to eq(rule.version + 1)
+      expect(described_class.cached_version(post.id)).to eq(stale_rule.version)
+    end
+
+    it "does not fail after the database commit if Redis is unavailable" do
+      error = Redis::CannotConnectError.new("unavailable")
+      allow(@post_rule).to receive(:cache_version!).and_raise(error)
+      expect(ErrorNotifier).to receive(:notify).with(error, installment_rule_id: @post_rule.id)
+
+      expect { @post_rule.send(:cache_committed_version) }.not_to raise_error
+    end
+
+    it "does not fail after the database commit if RedisClient raises an error" do
+      error = RedisClient::Error.new("unavailable")
+      allow(@post_rule).to receive(:cache_version!).and_raise(error)
+      expect(ErrorNotifier).to receive(:notify).with(error, installment_rule_id: @post_rule.id)
+
+      expect { @post_rule.send(:cache_committed_version) }.not_to raise_error
+    end
+
+    it "does not fail database rollback cleanup if Redis is unavailable" do
+      error = Redis::CannotConnectError.new("unavailable")
+      allow($redis).to receive(:eval).and_raise(error)
+      expect(ErrorNotifier).to receive(:notify).with(error, installment_rule_id: @post_rule.id)
+
+      expect do
+        described_class.clear_pending_version(
+          installment_id: @post_rule.installment_id,
+          installment_rule_id: @post_rule.id,
+          token: SecureRandom.uuid
+        )
+      end.not_to raise_error
+    end
+
+    it "does not require Redis before committing a new rule" do
+      post = create(:installment, link: @product, installment_type: "product")
+      rule = build(:installment_rule, installment: post, to_be_published_at: 1.week.from_now)
+      expect(rule).not_to receive(:cache_version!)
+
+      expect { rule.save! }.not_to raise_error
+    end
+
+    it "does not require Redis before committing a change that keeps the version" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      error = RedisClient::Error.new("unavailable")
+      allow(rule).to receive(:cache_version!).and_raise(error)
+      expect(ErrorNotifier).to receive(:notify).with(error, installment_rule_id: rule.id)
+
+      expect { rule.update!(time_period: "week") }.not_to raise_error
+    end
+
+    it "does not cache versions for scheduled post rules" do
+      expect(@post_rule).not_to receive(:cache_version!)
+
+      @post_rule.update!(to_be_published_at: 1.month.from_now)
+    end
+
     it "does not increment the version if period is changed" do
       expect do
         @post_rule.time_period = "DAY"

--- a/spec/models/workflow_installment_schedule_intent_spec.rb
+++ b/spec/models/workflow_installment_schedule_intent_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+describe WorkflowInstallmentScheduleIntent do
+  def create_intent(**attributes)
+    described_class.create!(
+      {
+        token: SecureRandom.uuid,
+        installment_id: 1,
+        rule_version: 1,
+        cutoff_reference_time: Time.current
+      }.merge(attributes)
+    )
+  end
+
+  it "requires callers to hold a database transaction before enqueueing" do
+    connection = instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter, transaction_open?: false)
+    allow(described_class).to receive(:connection).and_return(connection)
+
+    expect do
+      described_class.enqueue!(
+        installment: instance_double(Installment, id: 1),
+        rule_version: 1,
+        old_delayed_delivery_time: nil,
+        cutoff_reference_time: Time.current
+      )
+    end.to raise_error(described_class::EnqueueError, "A database transaction is required")
+  end
+
+  it "leaves dispatch failures for the pending-intent job" do
+    intent = create_intent
+    allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_raise("Redis is unavailable")
+    expect(Rails.logger).to receive(:error).with(/Redis is unavailable/)
+
+    expect(described_class.enqueue(intent.token)).to be_nil
+    expect(intent.reload.dispatch_expires_at).to be_present
+    expect(described_class.dispatchable).not_to include(intent)
+  end
+
+  it "claims an intent before enqueueing its scheduler" do
+    intent = create_intent
+    expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(intent.token).once.and_return("jid")
+
+    expect(described_class.enqueue(intent.token)).to eq("jid")
+    expect(described_class.enqueue(intent.token)).to be_nil
+
+    expect(intent.reload.dispatch_token).to be_present
+    expect(intent.dispatch_expires_at).to be > Time.current
+  end
+
+  it "releases its claim when client middleware cancels the enqueue" do
+    intent = create_intent
+    allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_return(nil)
+
+    expect(described_class.enqueue(intent.token)).to be_nil
+
+    expect(intent.reload.dispatch_token).to be_nil
+    expect(intent.dispatch_expires_at).to be_nil
+    expect(described_class.dispatchable).to include(intent)
+  end
+
+  it "reclaims an expired dispatch lease" do
+    intent = create_intent(dispatch_token: SecureRandom.uuid, dispatch_expires_at: 1.minute.ago)
+    expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(intent.token).and_return("jid")
+
+    expect(described_class.enqueue(intent.token)).to eq("jid")
+
+    expect(intent.reload.dispatch_expires_at).to be > Time.current
+  end
+
+  it "marks only a pending matching token as processed" do
+    intent = create_intent(dispatch_token: SecureRandom.uuid, dispatch_expires_at: 1.minute.from_now)
+
+    described_class.mark_processed(intent.token)
+
+    expect(intent.reload.processed_at).to be_present
+    expect(intent.dispatch_token).to be_nil
+    expect(intent.dispatch_expires_at).to be_nil
+  end
+end

--- a/spec/models/workflow_installment_schedule_intent_spec.rb
+++ b/spec/models/workflow_installment_schedule_intent_spec.rb
@@ -68,12 +68,78 @@ describe WorkflowInstallmentScheduleIntent do
   end
 
   it "marks only a pending matching token as processed" do
-    intent = create_intent(dispatch_token: SecureRandom.uuid, dispatch_expires_at: 1.minute.from_now)
+    fanout_token = SecureRandom.uuid
+    intent = create_intent(
+      dispatch_token: SecureRandom.uuid,
+      dispatch_expires_at: 1.minute.from_now,
+      fanout_token:,
+      fanout_expires_at: 1.minute.from_now
+    )
 
-    described_class.mark_processed(intent.token)
+    described_class.mark_processed(intent.token, fanout_token:)
 
     expect(intent.reload.processed_at).to be_present
     expect(intent.dispatch_token).to be_nil
     expect(intent.dispatch_expires_at).to be_nil
+    expect(intent.fanout_token).to be_nil
+    expect(intent.fanout_expires_at).to be_nil
+  end
+
+  it "does not let a stale fanout complete another owner" do
+    intent = create_intent(fanout_token: SecureRandom.uuid, fanout_expires_at: 1.minute.from_now)
+
+    described_class.mark_processed(intent.token, fanout_token: SecureRandom.uuid)
+
+    expect(intent.reload.processed_at).to be_nil
+  end
+
+  it "claims one fanout until its lease expires" do
+    intent = create_intent
+
+    first_token = intent.claim_fanout!
+    expect(first_token).to be_present
+    expect(intent.claim_fanout!).to be_nil
+
+    intent.update!(fanout_expires_at: 1.minute.ago)
+    second_token = intent.claim_fanout!
+    expect(second_token).to be_present
+    expect(second_token).not_to eq(first_token)
+  end
+
+  it "renews a matching fanout lease" do
+    intent = create_intent
+    fanout_token = intent.claim_fanout!
+
+    expect(described_class.begin_fanout(intent_token: intent.token, fanout_token:)).to be(true)
+
+    expect(intent.reload.fanout_expires_at).to be > 119.minutes.from_now
+  end
+
+  it "rejects a stale fanout while another owner is active" do
+    intent = create_intent
+    current_token = intent.claim_fanout!
+
+    expect(
+      described_class.begin_fanout(intent_token: intent.token, fanout_token: SecureRandom.uuid)
+    ).to be(false)
+    expect(intent.reload.fanout_token).to eq(current_token)
+  end
+
+  it "lets a fetched fanout claim an expired lease" do
+    intent = create_intent(fanout_token: SecureRandom.uuid, fanout_expires_at: 1.minute.ago)
+    fetched_token = SecureRandom.uuid
+
+    expect(described_class.begin_fanout(intent_token: intent.token, fanout_token: fetched_token)).to be(true)
+
+    expect(intent.reload.fanout_token).to eq(fetched_token)
+    expect(intent.fanout_expires_at).to be > 119.minutes.from_now
+  end
+
+  it "does not start a fanout for a processed intent" do
+    intent = create_intent(processed_at: Time.current)
+
+    expect(
+      described_class.begin_fanout(intent_token: intent.token, fanout_token: SecureRandom.uuid)
+    ).to be(false)
   end
 end

--- a/spec/models/workflow_installment_schedule_intent_spec.rb
+++ b/spec/models/workflow_installment_schedule_intent_spec.rb
@@ -115,6 +115,52 @@ describe WorkflowInstallmentScheduleIntent do
     expect(intent.reload.fanout_expires_at).to be > 119.minutes.from_now
   end
 
+  it "renews only the matching fanout owner" do
+    intent = create_intent
+    fanout_token = intent.claim_fanout!
+    original_expiry = intent.fanout_expires_at
+
+    travel 10.minutes do
+      expect(
+        described_class.renew_fanout(intent_token: intent.token, fanout_token: SecureRandom.uuid)
+      ).to be(false)
+      expect(intent.reload.fanout_expires_at).to eq(original_expiry)
+
+      expect(described_class.renew_fanout(intent_token: intent.token, fanout_token:)).to be(true)
+      expect(intent.reload.fanout_token).to eq(fanout_token)
+      expect(intent.fanout_expires_at).to be > original_expiry
+    end
+  end
+
+  it "keeps direct fanouts independent of intent leases" do
+    expect(described_class.renew_fanout(intent_token: nil, fanout_token: nil)).to be(true)
+  end
+
+  it "lets an expired owner renew until another owner takes over" do
+    intent = create_intent
+    first_token = intent.claim_fanout!
+    intent.update!(fanout_expires_at: 1.minute.ago)
+
+    expect(described_class.renew_fanout(intent_token: intent.token, fanout_token: first_token)).to be(true)
+    expect(intent.with_lock { intent.claim_fanout! }).to be_nil
+
+    intent.update!(fanout_expires_at: 1.minute.ago)
+    second_token = intent.claim_fanout!
+    second_expiry = intent.fanout_expires_at
+
+    expect(described_class.renew_fanout(intent_token: intent.token, fanout_token: first_token)).to be(false)
+    expect(intent.reload.fanout_token).to eq(second_token)
+    expect(intent.fanout_expires_at).to eq(second_expiry)
+  end
+
+  it "does not renew a processed intent" do
+    intent = create_intent(processed_at: Time.current, fanout_token: SecureRandom.uuid)
+
+    expect(
+      described_class.renew_fanout(intent_token: intent.token, fanout_token: intent.fanout_token)
+    ).to be(false)
+  end
+
   it "rejects a stale fanout while another owner is active" do
     intent = create_intent
     current_token = intent.claim_fanout!

--- a/spec/models/workflow_scheduling_spec.rb
+++ b/spec/models/workflow_scheduling_spec.rb
@@ -167,13 +167,15 @@ describe Workflow do
       cutoff_reference_time = Time.current.change(usec: 0)
       minimum_rule_version = installment.installment_rule.version
       schedule_intent_token = SecureRandom.uuid
+      schedule_intent_fanout_token = SecureRandom.uuid
 
       result = workflow.schedule_installment(
         installment,
         old_delayed_delivery_time: 6.hours.to_i,
         cutoff_reference_time:,
         minimum_rule_version:,
-        schedule_intent_token:
+        schedule_intent_token:,
+        schedule_intent_fanout_token:
       )
 
       expect(result).to eq(:enqueued)
@@ -182,7 +184,8 @@ describe Workflow do
         (cutoff_reference_time - 6.hours).iso8601,
         false,
         minimum_rule_version,
-        schedule_intent_token
+        schedule_intent_token,
+        schedule_intent_fanout_token
       )
     end
 
@@ -196,8 +199,14 @@ describe Workflow do
       installment = create(:workflow_installment, workflow:, seller: workflow.seller, published_at: workflow.published_at)
       minimum_rule_version = installment.installment_rule.version
       schedule_intent_token = SecureRandom.uuid
+      schedule_intent_fanout_token = SecureRandom.uuid
 
-      result = workflow.schedule_installment(installment, minimum_rule_version:, schedule_intent_token:)
+      result = workflow.schedule_installment(
+        installment,
+        minimum_rule_version:,
+        schedule_intent_token:,
+        schedule_intent_fanout_token:
+      )
 
       expect(result).to eq(:enqueued)
       expect(SendWorkflowEmailsToPastCanceledMembersJob).to have_enqueued_sidekiq_job(
@@ -205,7 +214,8 @@ describe Workflow do
         nil,
         nil,
         minimum_rule_version,
-        schedule_intent_token
+        schedule_intent_token,
+        schedule_intent_fanout_token
       )
     end
   end

--- a/spec/models/workflow_scheduling_spec.rb
+++ b/spec/models/workflow_scheduling_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Workflow do
+  describe "#mark_deleted!" do
+    it "locks the workflow before deleting its installments" do
+      workflow = create(:workflow)
+      installment = create(:workflow_installment, workflow:, seller: workflow.seller)
+      previous_rule_version = installment.installment_rule.version
+      expect(workflow).to receive(:lock!).and_call_original
+      expect_any_instance_of(Installment).to receive(:mark_deleted!).and_wrap_original do |method|
+        expect(InstallmentRule.cached_version(installment.id)).to eq(previous_rule_version + 1)
+        method.call
+      end
+
+      workflow.mark_deleted!
+
+      expect(workflow).to be_deleted
+      expect(installment.reload).to be_deleted
+      expect(installment.installment_rule.reload).to be_deleted
+      expect(installment.installment_rule.version).to eq(previous_rule_version + 1)
+    end
+
+    it "deletes an installment without a rule" do
+      workflow = create(:workflow)
+      installment = create(:workflow_installment, workflow:, seller: workflow.seller)
+      installment.installment_rule.destroy!
+
+      workflow.mark_deleted!
+
+      expect(workflow.reload).to be_deleted
+      expect(installment.reload).to be_deleted
+    end
+  end
+
+  describe "publish transitions" do
+    it "locks the workflow before publishing installments" do
+      workflow = create(:workflow)
+      installment = create(:workflow_installment, workflow:, seller: workflow.seller)
+      allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
+      expect(workflow).to receive(:lock!).and_call_original
+
+      workflow.publish!
+
+      expect(installment.reload).to be_published
+    end
+
+    it "routes recipient scheduling through a visibility-retrying job" do
+      workflow = create(:workflow)
+      installment = create(:workflow_installment, workflow:, seller: workflow.seller)
+      previous_rule_version = installment.installment_rule.version
+      allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
+      expect_any_instance_of(Installment).to receive(:publish!).and_wrap_original do |method, **kwargs|
+        expect(InstallmentRule.cached_version(installment.id)).to eq(previous_rule_version + 1)
+        method.call(**kwargs)
+      end
+
+      workflow.publish!
+
+      installment.reload
+      expect(installment.installment_rule.version).to eq(previous_rule_version + 1)
+
+      token = ScheduleWorkflowInstallmentJob.jobs.sole.fetch("args").sole
+      intent = WorkflowInstallmentScheduleIntent.find_by!(token:)
+      expect(intent).to have_attributes(
+        installment_id: installment.id,
+        rule_version: installment.installment_rule.version,
+        old_delayed_delivery_time: nil,
+        cutoff_reference_time: workflow.published_at,
+        expected_published_at: workflow.published_at
+      )
+    end
+
+    it "publishes an installment without a rule without scheduling it" do
+      workflow = create(:workflow)
+      installment = create(:workflow_installment, workflow:, seller: workflow.seller)
+      installment.installment_rule.destroy!
+      allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
+
+      workflow.publish!
+
+      expect(workflow.reload.published_at).to be_present
+      expect(installment.reload.published_at).to eq(workflow.published_at)
+      expect(WorkflowInstallmentScheduleIntent.count).to eq(0)
+      expect(ScheduleWorkflowInstallmentJob.jobs).to be_empty
+    end
+
+    it "does not keep an intent or enqueue a job if publication rolls back" do
+      workflow = create(:workflow)
+      installment = create(:workflow_installment, workflow:, seller: workflow.seller)
+      allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
+
+      Workflow.transaction do
+        workflow.publish!
+        expect(WorkflowInstallmentScheduleIntent.count).to eq(1)
+        expect(ScheduleWorkflowInstallmentJob.jobs).to be_empty
+        raise ActiveRecord::Rollback
+      end
+
+      expect(workflow.reload.published_at).to be_nil
+      expect(installment.reload.published_at).to be_nil
+      expect(WorkflowInstallmentScheduleIntent.count).to eq(0)
+      expect(ScheduleWorkflowInstallmentJob.jobs).to be_empty
+    end
+
+    it "commits publication with a pending intent if the fast-path push returns no job id" do
+      workflow = create(:workflow)
+      installment = create(:workflow_installment, workflow:, seller: workflow.seller)
+      allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
+      allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_return(nil)
+
+      workflow.publish!
+
+      expect(workflow.reload.published_at).to be_present
+      expect(installment.reload.published_at).to eq(workflow.published_at)
+      expect(WorkflowInstallmentScheduleIntent.pending.sole.installment_id).to eq(installment.id)
+    end
+
+    it "commits every intent if a later fast-path push raises" do
+      workflow = create(:workflow)
+      installments = create_list(:workflow_installment, 2, workflow:, seller: workflow.seller)
+      allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
+      tokens = []
+      allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_wrap_original do |method, token|
+        tokens << token
+        raise "Redis is unavailable" if tokens.size == 2
+
+        method.call(token)
+      end
+
+      workflow.publish!
+
+      expect(workflow.reload.published_at).to be_present
+      expect(installments.map { _1.reload.published_at }).to all(eq(workflow.published_at))
+      expect(WorkflowInstallmentScheduleIntent.pending.pluck(:token)).to match_array(tokens)
+      expect(ScheduleWorkflowInstallmentJob.jobs.sole.fetch("args")).to eq([tokens.first])
+    end
+
+    it "locks the workflow before unpublishing installments" do
+      workflow = create(:workflow, published_at: 1.day.ago)
+      installment = create(:workflow_installment, workflow:, seller: workflow.seller, published_at: workflow.published_at)
+      previous_rule_version = installment.installment_rule.version
+      expect(workflow).to receive(:lock!).and_call_original
+      expect_any_instance_of(Installment).to receive(:unpublish!).and_wrap_original do |method|
+        expect(InstallmentRule.cached_version(installment.id)).to eq(previous_rule_version + 1)
+        method.call
+      end
+
+      workflow.unpublish!
+
+      expect(installment.reload).not_to be_published
+      expect(installment.installment_rule.reload.version).to eq(previous_rule_version + 1)
+    end
+  end
+
+  describe "#schedule_installment", :freeze_time do
+    it "carries the cutoff, rule version, and schedule intent into the recipient fanout" do
+      workflow = create(:audience_workflow, published_at: 1.day.ago)
+      installment = create(
+        :workflow_installment,
+        workflow:,
+        seller: workflow.seller,
+        published_at: workflow.published_at,
+        is_for_new_customers_of_workflow: false,
+      )
+      cutoff_reference_time = Time.current.change(usec: 0)
+      minimum_rule_version = installment.installment_rule.version
+      schedule_intent_token = SecureRandom.uuid
+
+      result = workflow.schedule_installment(
+        installment,
+        old_delayed_delivery_time: 6.hours.to_i,
+        cutoff_reference_time:,
+        minimum_rule_version:,
+        schedule_intent_token:
+      )
+
+      expect(result).to eq(:enqueued)
+      expect(SendWorkflowPostEmailsJob).to have_enqueued_sidekiq_job(
+        installment.id,
+        (cutoff_reference_time - 6.hours).iso8601,
+        false,
+        minimum_rule_version,
+        schedule_intent_token
+      )
+    end
+
+    it "carries the rule version and schedule intent into the cancellation fanout" do
+      workflow = create(
+        :workflow,
+        workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER,
+        send_to_past_customers: true,
+        published_at: 1.day.ago,
+      )
+      installment = create(:workflow_installment, workflow:, seller: workflow.seller, published_at: workflow.published_at)
+      minimum_rule_version = installment.installment_rule.version
+      schedule_intent_token = SecureRandom.uuid
+
+      result = workflow.schedule_installment(installment, minimum_rule_version:, schedule_intent_token:)
+
+      expect(result).to eq(:enqueued)
+      expect(SendWorkflowEmailsToPastCanceledMembersJob).to have_enqueued_sidekiq_job(
+        installment.id,
+        nil,
+        nil,
+        minimum_rule_version,
+        schedule_intent_token
+      )
+    end
+  end
+end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -288,9 +288,12 @@ describe Workflow do
 
     it "publishes and schedules all alive installments" do
       installment1 = create(:installment, workflow: @workflow)
+      create(:installment_rule, installment: installment1)
       installment2 = create(:installment, workflow: @workflow, deleted_at: 1.day.ago)
 
-      expect(@workflow).to receive(:schedule_installment).with(an_instance_of(Installment)).twice
+      expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(
+        kind_of(String)
+      ).twice.and_call_original
 
       expect do
         expect do

--- a/spec/requests/workflows_spec.rb
+++ b/spec/requests/workflows_spec.rb
@@ -1206,7 +1206,9 @@ describe("Workflows", js: true, type: :system) do
         visit workflows_path
         installment = create(:workflow_installment, workflow:)
 
-        expect_any_instance_of(Workflow).to receive(:schedule_installment).with(installment)
+        expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(
+          kind_of(String)
+        ).and_call_original
 
         within_section "Product workflow", section_element: :section do
           click_on "Edit workflow"
@@ -1295,7 +1297,7 @@ describe("Workflows", js: true, type: :system) do
       visit workflows_path
       create(:workflow_installment, workflow:)
 
-      expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+      expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
       allow_any_instance_of(User).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
 
       within_section "Product workflow", section_element: :section do
@@ -1575,7 +1577,7 @@ describe("Workflows", js: true, type: :system) do
     end
 
     it "allows saving and publishing workflow emails" do
-      expect_any_instance_of(Workflow).to receive(:schedule_installment).with(kind_of(Installment))
+      expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_call_original
 
       visit workflows_path
 

--- a/spec/services/workflow/manage_service_spec.rb
+++ b/spec/services/workflow/manage_service_spec.rb
@@ -247,7 +247,7 @@ describe Workflow::ManageService do
       let(:params) { { name: "Updated workflow name", permalink: product.unique_permalink, workflow_type: Workflow::AFFILIATE_TYPE, affiliate_products: [product.unique_permalink], send_to_past_customers: false } }
 
       it "updates the workflow and its installments" do
-        expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+        expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
         expect do
           expect(described_class.new(seller:, params:, product:, workflow:).process).to eq([true, nil])
@@ -367,7 +367,9 @@ describe Workflow::ManageService do
       it "updates the workflow and publishes it if the save action is 'save_and_publish'" do
         params[:save_action_name] = Workflow::SAVE_AND_PUBLISH_ACTION
         create(:payment_completed, user: seller)
-        expect_any_instance_of(Workflow).to receive(:schedule_installment).with(installment1)
+        expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(
+          kind_of(String)
+        ).and_call_original
 
         expect do
           expect(described_class.new(seller:, params:, product:, workflow:).process).to eq([true, nil])
@@ -396,7 +398,7 @@ describe Workflow::ManageService do
         params[:save_action_name] = Workflow::SAVE_AND_UNPUBLISH_ACTION
         params[:paid_less_than] = "50"
 
-        expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+        expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
         expect do
           expect do

--- a/spec/services/workflow/save_installments_service_spec.rb
+++ b/spec/services/workflow/save_installments_service_spec.rb
@@ -157,7 +157,7 @@ describe Workflow::SaveInstallmentsService do
     end
 
     it "creates installments" do
-      expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+      expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
       process_and_perform_assertions_for_created_installments
     end
@@ -165,7 +165,7 @@ describe Workflow::SaveInstallmentsService do
     it "creates installments and publishes them if save_action_name is 'save_and_publish'" do
       params[:save_action_name] = Workflow::SAVE_AND_PUBLISH_ACTION
 
-      expect_any_instance_of(Workflow).to receive(:schedule_installment).with(kind_of(Installment))
+      expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_call_original
 
       expect do
         process_and_perform_assertions_for_created_installments
@@ -175,7 +175,7 @@ describe Workflow::SaveInstallmentsService do
     end
 
     it "updates installments" do
-      expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+      expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
       process_and_perform_assertions_for_updated_installments
     end
@@ -183,7 +183,7 @@ describe Workflow::SaveInstallmentsService do
     it "updates installments and publishes them if save_action_name is 'save_and_publish'" do
       params[:save_action_name] = Workflow::SAVE_AND_PUBLISH_ACTION
 
-      expect_any_instance_of(Workflow).to receive(:schedule_installment).with(kind_of(Installment))
+      expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_call_original
 
       expect do
         process_and_perform_assertions_for_updated_installments
@@ -198,7 +198,7 @@ describe Workflow::SaveInstallmentsService do
 
       params[:save_action_name] = Workflow::SAVE_AND_UNPUBLISH_ACTION
 
-      expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+      expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
       expect do
         expect do
@@ -251,7 +251,7 @@ describe Workflow::SaveInstallmentsService do
         end
 
         it "reschedules that installment" do
-          expect(SendWorkflowPostEmailsJob).to receive(:perform_async).with(installment.id, installment.published_at.iso8601)
+          expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(kind_of(String)).and_call_original
 
           params[:installments] = [default_installment_params.merge(id: installment.external_id, time_duration: 2, time_period: "day")]
           service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
@@ -260,11 +260,54 @@ describe Workflow::SaveInstallmentsService do
             service.process
           end.to change { installment.reload.installment_rule.delayed_delivery_time }.from(1.hour.to_i).to(2.days.to_i)
              .and change { installment.reload.installment_rule.time_period }.from("hour").to("day")
+
+          intent = WorkflowInstallmentScheduleIntent.sole
+          expect(intent).to have_attributes(
+            installment_id: installment.id,
+            rule_version: installment_rule.reload.version,
+            old_delayed_delivery_time: 1.hour.to_i
+          )
+        end
+
+        it "does not keep an intent or enqueue a job if a later preview failure rolls back the delay change" do
+          params[:installments] = [
+            default_installment_params.merge(
+              id: installment.external_id,
+              time_duration: 2,
+              time_period: "day",
+              send_preview_email: true,
+            )
+          ]
+          service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
+          allow_any_instance_of(Installment).to receive(:send_preview_email).and_raise(Installment::PreviewEmailError, "Preview failed")
+
+          success, = service.process
+
+          expect(success).to be(false)
+          expect(installment_rule.reload).to have_attributes(
+            delayed_delivery_time: 1.hour.to_i,
+            time_period: "hour",
+          )
+          expect(WorkflowInstallmentScheduleIntent.count).to eq(0)
+          expect(ScheduleWorkflowInstallmentJob.jobs).to be_empty
+        end
+
+        it "commits the delay change with a pending intent if the fast-path push returns no job id" do
+          params[:installments] = [default_installment_params.merge(id: installment.external_id, time_duration: 2, time_period: "day")]
+          service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
+          allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_return(nil)
+
+          expect(service.process).to eq([true, nil])
+
+          expect(installment_rule.reload).to have_attributes(
+            delayed_delivery_time: 2.days.to_i,
+            time_period: "day"
+          )
+          expect(WorkflowInstallmentScheduleIntent.pending.sole.installment_id).to eq(installment.id)
         end
 
         it "does not reschedule that installment if save_action_name is other than 'save'" do
-          expect(SendWorkflowPostEmailsJob).not_to receive(:perform_async)
-          expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+          expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
           params[:installments] = [default_installment_params.merge(id: installment.external_id, time_duration: 2, time_period: "day", send_preview_email: true)]
           params[:save_action_name] = Workflow::SAVE_AND_PUBLISH_ACTION
@@ -280,7 +323,7 @@ describe Workflow::SaveInstallmentsService do
 
       context "when installment has not been published" do
         it "does not reschedule that installment" do
-          expect(SendWorkflowPostEmailsJob).not_to receive(:perform_async)
+          expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
           params[:installments] = [default_installment_params.merge(id: installment.external_id, time_duration: 2, time_period: "day")]
           service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
@@ -296,7 +339,7 @@ describe Workflow::SaveInstallmentsService do
     it "reschedules a newly added installment if the workflow is already published" do
       workflow.publish!
 
-      expect_any_instance_of(Workflow).to receive(:schedule_installment).with(kind_of(Installment), old_delayed_delivery_time: nil)
+      expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(kind_of(String)).and_call_original
 
       params[:installments] = [default_installment_params.merge(id: SecureRandom.uuid, time_duration: 1, time_period: "hour")]
       service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
@@ -309,10 +352,45 @@ describe Workflow::SaveInstallmentsService do
       expect(installment.installment_rule.delayed_delivery_time).to eq(1.hour.to_i)
       expect(installment.installment_rule.time_period).to eq("hour")
       expect(installment.published_at).to eq(workflow.published_at)
+      expect(WorkflowInstallmentScheduleIntent.order(:id).last).to have_attributes(
+        installment_id: installment.id,
+        rule_version: installment.installment_rule.version,
+        old_delayed_delivery_time: nil
+      )
+    end
+
+    it "does not keep an intent or enqueue a job if a later preview failure rolls back the new installment" do
+      published_at = 2.days.ago.change(usec: 0)
+      workflow.update!(published_at:, first_published_at: published_at)
+      params[:installments] = [default_installment_params.merge(id: SecureRandom.uuid, send_preview_email: true)]
+      service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
+      allow_any_instance_of(Installment).to receive(:send_preview_email).and_raise(Installment::PreviewEmailError, "Preview failed")
+
+      expect do
+        success, = service.process
+        expect(success).to be(false)
+      end.not_to change { workflow.installments.alive.count }
+      expect(WorkflowInstallmentScheduleIntent.count).to eq(0)
+      expect(ScheduleWorkflowInstallmentJob.jobs).to be_empty
+    end
+
+    it "reloads the workflow publish state after locking it" do
+      published_at = 2.days.ago.change(usec: 0)
+      workflow.update!(published_at:, first_published_at: published_at)
+      Workflow.find(workflow.id).update!(published_at: nil)
+      params[:installments] = [default_installment_params.merge(id: SecureRandom.uuid)]
+      service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
+
+      expect do
+        service.process
+      end.to change { workflow.installments.alive.count }.by(1)
+
+      expect(workflow.published_at).to be_nil
+      expect(workflow.installments.alive.last.published_at).to be_nil
     end
 
     it "does not reschedule an installment if the delayed_delivery_time does not change" do
-      expect(SendWorkflowPostEmailsJob).not_to receive(:perform_async)
+      expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
       installment = create(:installment, workflow:)
       create(:installment_rule, installment:, delayed_delivery_time: 1.hour.to_i, time_period: "hour")
@@ -324,12 +402,31 @@ describe Workflow::SaveInstallmentsService do
       end.not_to change { installment.reload.installment_rule.delayed_delivery_time }
     end
 
+    it "does not add an installment after the workflow is deleted" do
+      Workflow.where(id: workflow.id).update_all(deleted_at: Time.current)
+      params[:installments] = [default_installment_params.merge(id: SecureRandom.uuid)]
+      service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
+
+      expect do
+        success, errors = service.process
+
+        expect(success).to be(false)
+        expect(errors.full_messages.first).to eq("The workflow was not found.")
+      end.not_to change { workflow.installments.count }
+    end
+
     it "deletes installments that are missing from the params" do
-      installment = create(:installment, workflow:)
+      published_at = 1.day.ago.change(usec: 0)
+      workflow.update!(published_at:, first_published_at: published_at)
+      installment = create(:installment, workflow:, published_at:)
+      installment_rule = create(:installment_rule, installment:, delayed_delivery_time: 1.hour)
+      previous_rule_version = installment_rule.version
       attached_file = create(:product_file, installment:, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/doc.pdf", link: nil)
       service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
       expect { service.process }.to change { workflow.installments.alive.count }.by(-1)
       expect(installment.reload.deleted_at).to be_present
+      expect(installment_rule.reload.version).to eq(previous_rule_version + 1)
+      expect(InstallmentRule.cached_version(installment.id)).to eq(previous_rule_version + 1)
 
       # But keeps the attached file alive
       expect(attached_file.reload.alive?).to be(true)

--- a/spec/sidekiq/delete_processed_workflow_installment_schedule_intents_job_spec.rb
+++ b/spec/sidekiq/delete_processed_workflow_installment_schedule_intents_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe DeleteProcessedWorkflowInstallmentScheduleIntentsJob do
+  def create_intent(processed_at:, **attributes)
+    WorkflowInstallmentScheduleIntent.create!(
+      {
+        token: SecureRandom.uuid,
+        installment_id: 1,
+        rule_version: 1,
+        cutoff_reference_time: Time.current,
+        processed_at:
+      }.merge(attributes)
+    )
+  end
+
+  it "deletes only processed intents outside the retry window" do
+    old = create_intent(processed_at: 31.days.ago)
+    recent = create_intent(processed_at: 29.days.ago)
+    pending = create_intent(processed_at: nil)
+    leased = create_intent(processed_at: nil, dispatch_token: SecureRandom.uuid, dispatch_expires_at: 1.minute.from_now)
+
+    described_class.new.perform
+
+    expect(WorkflowInstallmentScheduleIntent.find_by(id: old.id)).to be_nil
+    expect(WorkflowInstallmentScheduleIntent.where(id: [recent.id, pending.id, leased.id]).count).to eq(3)
+  end
+end

--- a/spec/sidekiq/dispatch_pending_workflow_installment_schedule_intents_job_spec.rb
+++ b/spec/sidekiq/dispatch_pending_workflow_installment_schedule_intents_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe DispatchPendingWorkflowInstallmentScheduleIntentsJob do
+  def create_intent(processed_at: nil, dispatch_expires_at: nil)
+    WorkflowInstallmentScheduleIntent.create!(
+      token: SecureRandom.uuid,
+      installment_id: 1,
+      rule_version: 1,
+      cutoff_reference_time: Time.current,
+      processed_at:,
+      dispatch_expires_at:
+    )
+  end
+
+  it "dispatches available intents and skips active leases and processed intents" do
+    pending = create_intent
+    expired = create_intent(dispatch_expires_at: 1.minute.ago)
+    create_intent(dispatch_expires_at: 1.minute.from_now)
+    create_intent(processed_at: Time.current)
+    expect(WorkflowInstallmentScheduleIntent).to receive(:enqueue).with(pending.token)
+    expect(WorkflowInstallmentScheduleIntent).to receive(:enqueue).with(expired.token)
+
+    described_class.new.perform
+  end
+end

--- a/spec/sidekiq/dispatch_pending_workflow_installment_schedule_intents_job_spec.rb
+++ b/spec/sidekiq/dispatch_pending_workflow_installment_schedule_intents_job_spec.rb
@@ -1,24 +1,28 @@
 # frozen_string_literal: true
 
 describe DispatchPendingWorkflowInstallmentScheduleIntentsJob do
-  def create_intent(processed_at: nil, dispatch_expires_at: nil)
+  def create_intent(processed_at: nil, dispatch_expires_at: nil, fanout_expires_at: nil)
     WorkflowInstallmentScheduleIntent.create!(
       token: SecureRandom.uuid,
       installment_id: 1,
       rule_version: 1,
       cutoff_reference_time: Time.current,
       processed_at:,
-      dispatch_expires_at:
+      dispatch_expires_at:,
+      fanout_expires_at:
     )
   end
 
   it "dispatches available intents and skips active leases and processed intents" do
     pending = create_intent
     expired = create_intent(dispatch_expires_at: 1.minute.ago)
+    expired_fanout = create_intent(fanout_expires_at: 1.minute.ago)
     create_intent(dispatch_expires_at: 1.minute.from_now)
+    create_intent(fanout_expires_at: 1.minute.from_now)
     create_intent(processed_at: Time.current)
     expect(WorkflowInstallmentScheduleIntent).to receive(:enqueue).with(pending.token)
     expect(WorkflowInstallmentScheduleIntent).to receive(:enqueue).with(expired.token)
+    expect(WorkflowInstallmentScheduleIntent).to receive(:enqueue).with(expired_fanout.token)
 
     described_class.new.perform
   end

--- a/spec/sidekiq/schedule_workflow_installment_job_spec.rb
+++ b/spec/sidekiq/schedule_workflow_installment_job_spec.rb
@@ -20,19 +20,22 @@ describe ScheduleWorkflowInstallmentJob do
     )
   end
 
-  it "marks the intent processed after handing off the recipient fanout" do
+  it "keeps the intent pending until the recipient fanout completes" do
     intent = create_intent
     expect_any_instance_of(Workflow).to receive(:schedule_installment).with(
       kind_of(Installment),
       old_delayed_delivery_time: 1.hour.to_i,
       cutoff_reference_time:,
       minimum_rule_version: rule.version,
-      schedule_intent_token: intent.token
+      schedule_intent_token: intent.token,
+      schedule_intent_fanout_token: kind_of(String)
     ).and_return(:enqueued)
 
     described_class.new.perform(intent.token)
 
-    expect(intent.reload.processed_at).to be_present
+    expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_present
+    expect(intent.fanout_expires_at).to be > Time.current
   end
 
   it "ignores an intent that has already been cleaned up" do
@@ -56,7 +59,8 @@ describe ScheduleWorkflowInstallmentJob do
       old_delayed_delivery_time: 1.hour.to_i,
       cutoff_reference_time:,
       minimum_rule_version: rule.version,
-      schedule_intent_token: intent.token
+      schedule_intent_token: intent.token,
+      schedule_intent_fanout_token: kind_of(String)
     ).and_return(:enqueued)
 
     described_class.new.perform(intent.token)
@@ -88,7 +92,8 @@ describe ScheduleWorkflowInstallmentJob do
       old_delayed_delivery_time: nil,
       cutoff_reference_time: published_at,
       minimum_rule_version: rule.version,
-      schedule_intent_token: intent.token
+      schedule_intent_token: intent.token,
+      schedule_intent_fanout_token: kind_of(String)
     ).and_return(:enqueued)
 
     described_class.new.perform(intent.token)
@@ -121,7 +126,9 @@ describe ScheduleWorkflowInstallmentJob do
     described_class.new.perform(intent.token)
     described_class.new.perform(intent.token)
 
-    expect(intent.reload.processed_at).to be_present
+    expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_present
+    expect(intent.fanout_expires_at).to be > Time.current
   end
 
   it "keeps the intent pending if recipient scheduling fails" do
@@ -131,6 +138,8 @@ describe ScheduleWorkflowInstallmentJob do
     expect { described_class.new.perform(intent.token) }.to raise_error("Redis is unavailable")
 
     expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_nil
+    expect(intent.fanout_expires_at).to be_nil
   end
 
   it "retries when client middleware cancels the recipient fanout" do
@@ -142,6 +151,8 @@ describe ScheduleWorkflowInstallmentJob do
     end.to raise_error(ScheduleWorkflowInstallmentJob::FanoutNotEnqueuedError)
 
     expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_nil
+    expect(intent.fanout_expires_at).to be_nil
   end
 
   it "retries an unexpected recipient scheduling result" do
@@ -153,6 +164,8 @@ describe ScheduleWorkflowInstallmentJob do
     end.to raise_error(ScheduleWorkflowInstallmentJob::FanoutNotEnqueuedError, "Unexpected schedule result: nil")
 
     expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_nil
+    expect(intent.fanout_expires_at).to be_nil
   end
 
   it "marks the intent processed when no recipient fanout applies" do

--- a/spec/sidekiq/schedule_workflow_installment_job_spec.rb
+++ b/spec/sidekiq/schedule_workflow_installment_job_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ScheduleWorkflowInstallmentJob do
+  let(:workflow) { create(:audience_workflow, published_at: 1.day.ago) }
+  let(:installment) { create(:workflow_installment, workflow:, seller: workflow.seller, published_at: workflow.published_at) }
+  let(:rule) { installment.installment_rule }
+  let(:cutoff_reference_time) { Time.current.change(usec: 0) }
+
+  def create_intent(**attributes)
+    WorkflowInstallmentScheduleIntent.create!(
+      {
+        token: SecureRandom.uuid,
+        installment_id: installment.id,
+        rule_version: rule.version,
+        old_delayed_delivery_time: 1.hour.to_i,
+        cutoff_reference_time:,
+      }.merge(attributes)
+    )
+  end
+
+  it "marks the intent processed after handing off the recipient fanout" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).with(
+      kind_of(Installment),
+      old_delayed_delivery_time: 1.hour.to_i,
+      cutoff_reference_time:,
+      minimum_rule_version: rule.version,
+      schedule_intent_token: intent.token
+    ).and_return(:enqueued)
+
+    described_class.new.perform(intent.token)
+
+    expect(intent.reload.processed_at).to be_present
+  end
+
+  it "ignores an intent that has already been cleaned up" do
+    expect { described_class.new.perform(SecureRandom.uuid) }.not_to raise_error
+  end
+
+  it "retries while the expected rule version is not visible" do
+    intent = create_intent(rule_version: rule.version + 1)
+
+    expect do
+      described_class.new.perform(intent.token)
+    end.to raise_error(ScheduleWorkflowInstallmentJob::IntentNotCommittedError)
+
+    expect(intent.reload).to be_present
+  end
+
+  it "preserves the recipient window from a superseded rule version" do
+    intent = create_intent(rule_version: rule.version - 1)
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).with(
+      kind_of(Installment),
+      old_delayed_delivery_time: 1.hour.to_i,
+      cutoff_reference_time:,
+      minimum_rule_version: rule.version,
+      schedule_intent_token: intent.token
+    ).and_return(:enqueued)
+
+    described_class.new.perform(intent.token)
+  end
+
+  it "discards an intent from a rolled-back publication state" do
+    expected_published_at = cutoff_reference_time
+    workflow.update!(published_at: nil, first_published_at: expected_published_at)
+    installment.update!(published_at: nil)
+    intent = create_intent(expected_published_at:)
+    expect_any_instance_of(Workflow).not_to receive(:schedule_installment)
+
+    described_class.new.perform(intent.token)
+
+    expect(intent.reload.processed_at).to be_present
+  end
+
+  it "schedules after workflow publication becomes visible" do
+    published_at = workflow.published_at.change(usec: 0)
+    installment.update!(published_at:)
+    intent = create_intent(
+      old_delayed_delivery_time: nil,
+      cutoff_reference_time: published_at,
+      expected_published_at: published_at
+    )
+    expect_any_instance_of(Workflow).to receive(:with_lock).and_call_original
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).with(
+      kind_of(Installment),
+      old_delayed_delivery_time: nil,
+      cutoff_reference_time: published_at,
+      minimum_rule_version: rule.version,
+      schedule_intent_token: intent.token
+    ).and_return(:enqueued)
+
+    described_class.new.perform(intent.token)
+  end
+
+  it "discards the intent after the installment becomes unpublished" do
+    installment.update!(published_at: nil)
+    intent = create_intent
+    expect_any_instance_of(Workflow).not_to receive(:schedule_installment)
+
+    described_class.new.perform(intent.token)
+
+    expect(intent.reload.processed_at).to be_present
+  end
+
+  it "does not process a completed intent twice" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).and_return(:not_applicable)
+
+    described_class.new.perform(intent.token)
+    described_class.new.perform(intent.token)
+
+    expect(intent.reload.processed_at).to be_present
+  end
+
+  it "does not enqueue the recipient fanout twice" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).once.and_return(:enqueued)
+
+    described_class.new.perform(intent.token)
+    described_class.new.perform(intent.token)
+
+    expect(intent.reload.processed_at).to be_present
+  end
+
+  it "keeps the intent pending if recipient scheduling fails" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).and_raise("Redis is unavailable")
+
+    expect { described_class.new.perform(intent.token) }.to raise_error("Redis is unavailable")
+
+    expect(intent.reload.processed_at).to be_nil
+  end
+
+  it "retries when client middleware cancels the recipient fanout" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).and_return(:not_enqueued)
+
+    expect do
+      described_class.new.perform(intent.token)
+    end.to raise_error(ScheduleWorkflowInstallmentJob::FanoutNotEnqueuedError)
+
+    expect(intent.reload.processed_at).to be_nil
+  end
+
+  it "retries an unexpected recipient scheduling result" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).and_return(nil)
+
+    expect do
+      described_class.new.perform(intent.token)
+    end.to raise_error(ScheduleWorkflowInstallmentJob::FanoutNotEnqueuedError, "Unexpected schedule result: nil")
+
+    expect(intent.reload.processed_at).to be_nil
+  end
+
+  it "marks the intent processed when no recipient fanout applies" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).and_return(:not_applicable)
+
+    described_class.new.perform(intent.token)
+
+    expect(intent.reload.processed_at).to be_present
+  end
+
+  it "releases the primary connection after execution" do
+    intent = create_intent
+    expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).and_return(:not_applicable)
+    expect(Makara::Context).to receive(:release_all)
+
+    described_class.new.perform(intent.token)
+  end
+end

--- a/spec/sidekiq/send_workflow_emails_to_past_canceled_members_job_spec.rb
+++ b/spec/sidekiq/send_workflow_emails_to_past_canceled_members_job_spec.rb
@@ -30,6 +30,14 @@ describe SendWorkflowEmailsToPastCanceledMembersJob, :freeze_time do
     expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@installment.id, @rule.version, nil, nil, nil, recent.id).at(recent.deactivated_at + @rule.delayed_delivery_time)
   end
 
+  it "retries if the required rule version is not visible" do
+    expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+
+    expect do
+      described_class.new.perform(@installment.id, nil, nil, @rule.version + 1)
+    end.to raise_error(SendWorkflowEmailsToPastCanceledMembersJob::RuleNotCommittedError)
+  end
+
   it "does nothing when the workflow has been deleted" do
     @workflow.mark_deleted!
     described_class.new.perform(@installment.id)

--- a/spec/sidekiq/send_workflow_installment_worker_spec.rb
+++ b/spec/sidekiq/send_workflow_installment_worker_spec.rb
@@ -138,6 +138,32 @@ describe SendWorkflowInstallmentWorker do
       )
     end
 
+    it "uses the locked primary version if the Redis read fails" do
+      allow(PostSendgridApi).to receive(:process)
+      expect(InstallmentRule).to receive(:cached_version_state).with(@installment.id).once.and_raise(Redis::BaseError.new("read failed"))
+      expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+      expect(InstallmentRule).to receive(:lock).once.and_call_original
+      expect_any_instance_of(InstallmentRule).not_to receive(:cache_version!)
+      expect(Makara::Context).to receive(:release_all).once.and_call_original
+
+      SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+
+      expect(PostSendgridApi).to have_received(:process)
+    end
+
+    it "uses the locked primary version if the Redis cache fill fails" do
+      $redis.del(RedisKey.workflow_installment_rule_version(@installment.id))
+      allow(PostSendgridApi).to receive(:process)
+      expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+      expect(InstallmentRule).to receive(:lock).once.and_call_original
+      expect_any_instance_of(InstallmentRule).to receive(:cache_version!).once.and_raise(RedisClient::Error.new("fill failed"))
+      expect(Makara::Context).to receive(:release_all).once.and_call_original
+
+      SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+
+      expect(PostSendgridApi).to have_received(:process)
+    end
+
     it "retries if the queued version is not visible" do
       expect(PostSendgridApi).not_to receive(:process)
       expect do

--- a/spec/sidekiq/send_workflow_installment_worker_spec.rb
+++ b/spec/sidekiq/send_workflow_installment_worker_spec.rb
@@ -22,9 +22,42 @@ describe SendWorkflowInstallmentWorker do
       SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, @purchase.id, nil, nil)
     end
 
-    it "does not call mailer if different version" do
+    it "reads the primary database if the shared version expires" do
+      $redis.del(RedisKey.workflow_installment_rule_version(@installment.id))
+      allow(PostSendgridApi).to receive(:process)
+      expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+
+      SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, @purchase.id, nil, nil)
+
+      expect(PostSendgridApi).to have_received(:process)
+    end
+
+    it "retries if the queued version is not visible" do
+      pending_version = @installment_rule.version + 1
+      $redis.set(RedisKey.workflow_installment_rule_version(@installment.id), pending_version)
       expect(PostSendgridApi).not_to receive(:process)
-      SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version + 1, @purchase.id, nil, nil)
+      expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, pending_version, @purchase.id, nil, nil)
+      end.to raise_error(SendWorkflowInstallmentWorker::RuleNotCommittedError)
+    end
+
+    it "retries an old job while a publication transition is pending" do
+      $redis.set(RedisKey.workflow_installment_rule_version(@installment.id), @installment_rule.version + 1)
+      expect(PostSendgridApi).not_to receive(:process)
+
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, @purchase.id, nil, nil)
+      end.to raise_error(SendWorkflowInstallmentWorker::RuleNotCommittedError)
+    end
+
+    it "drops a queued version after a newer version commits" do
+      stale_version = @installment_rule.version
+      @installment_rule.update!(delayed_delivery_time: 2.days)
+      expect(PostSendgridApi).not_to receive(:process)
+
+      SendWorkflowInstallmentWorker.new.perform(@installment.id, stale_version, @purchase.id, nil, nil)
     end
 
     it "does not call mailer if deleted installment" do
@@ -96,6 +129,7 @@ describe SendWorkflowInstallmentWorker do
 
     it "calls follower mailer if same version" do
       allow(PostSendgridApi).to receive(:process)
+      expect(InstallmentRule).not_to receive(:find_by)
       SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
       expect(PostSendgridApi).to have_received(:process).with(
         post: @installment,
@@ -104,9 +138,67 @@ describe SendWorkflowInstallmentWorker do
       )
     end
 
-    it "does not call mailer if different version" do
+    it "retries if the queued version is not visible" do
       expect(PostSendgridApi).not_to receive(:process)
-      SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version + 1, nil, @follower.id, nil)
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version + 1, nil, @follower.id, nil)
+      end.to raise_error(SendWorkflowInstallmentWorker::RuleNotCommittedError)
+    end
+
+    it "honors a newer pending version that appears while filling a cache miss" do
+      version_key = RedisKey.workflow_installment_rule_version(@installment.id)
+      newer_version = @installment_rule.version + 1
+      $redis.del(version_key)
+      allow_any_instance_of(InstallmentRule).to receive(:cache_version!).and_wrap_original do |method, *args, **kwargs|
+        $redis.set(version_key, newer_version)
+        method.call(*args, **kwargs)
+      end
+      expect(InstallmentRule).to receive(:lock).and_call_original
+      expect(PostSendgridApi).not_to receive(:process)
+
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+      end.to raise_error(SendWorkflowInstallmentWorker::RuleNotCommittedError)
+      expect(InstallmentRule.cached_version(@installment.id)).to eq(newer_version)
+    end
+
+    it "retries while a pending version outlives its owner" do
+      version_key = RedisKey.workflow_installment_rule_version(@installment.id)
+      pending_token_key = RedisKey.workflow_installment_rule_pending_token(@installment.id)
+      $redis.set(version_key, @installment_rule.version + 1)
+      $redis.del(pending_token_key)
+      expect(PostSendgridApi).not_to receive(:process)
+
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+      end.to raise_error(SendWorkflowInstallmentWorker::RuleNotCommittedError)
+    end
+
+    it "locks the primary after pending cache protection expires" do
+      version_key = RedisKey.workflow_installment_rule_version(@installment.id)
+      pending_token_key = RedisKey.workflow_installment_rule_pending_token(@installment.id)
+      $redis.set(version_key, @installment_rule.version + 1)
+      $redis.set(pending_token_key, SecureRandom.uuid)
+      $redis.del(version_key, pending_token_key)
+      allow(PostSendgridApi).to receive(:process)
+      expect(InstallmentRule).to receive(:lock).and_call_original
+
+      SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+
+      expect(PostSendgridApi).to have_received(:process)
+      expect(InstallmentRule.cached_version(@installment.id)).to eq(@installment_rule.version)
+    end
+
+    it "retries if only pending ownership remains" do
+      version_key = RedisKey.workflow_installment_rule_version(@installment.id)
+      pending_token_key = RedisKey.workflow_installment_rule_pending_token(@installment.id)
+      $redis.del(version_key)
+      $redis.set(pending_token_key, SecureRandom.uuid)
+      expect(PostSendgridApi).not_to receive(:process)
+
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+      end.to raise_error(SendWorkflowInstallmentWorker::RuleNotCommittedError)
     end
 
     it "does not call mailer if deleted installment" do

--- a/spec/sidekiq/send_workflow_installment_worker_spec.rb
+++ b/spec/sidekiq/send_workflow_installment_worker_spec.rb
@@ -138,30 +138,41 @@ describe SendWorkflowInstallmentWorker do
       )
     end
 
-    it "uses the locked primary version if the Redis read fails" do
-      allow(PostSendgridApi).to receive(:process)
+    it "does not send if the Redis fence read fails" do
+      expect(PostSendgridApi).not_to receive(:process)
       expect(InstallmentRule).to receive(:cached_version_state).with(@installment.id).once.and_raise(Redis::BaseError.new("read failed"))
-      expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
-      expect(InstallmentRule).to receive(:lock).once.and_call_original
+      expect(ActiveRecord::Base.connection).not_to receive(:stick_to_primary!)
+      expect(InstallmentRule).not_to receive(:lock)
       expect_any_instance_of(InstallmentRule).not_to receive(:cache_version!)
-      expect(Makara::Context).to receive(:release_all).once.and_call_original
 
-      SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
-
-      expect(PostSendgridApi).to have_received(:process)
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+      end.to raise_error(Redis::BaseError, "read failed")
     end
 
-    it "uses the locked primary version if the Redis cache fill fails" do
+    it "does not send if a pending fence appears and the Redis cache fill fails" do
+      version_key = RedisKey.workflow_installment_rule_version(@installment.id)
+      pending_token_key = RedisKey.workflow_installment_rule_pending_token(@installment.id)
+      newer_version = @installment_rule.version + 1
       $redis.del(RedisKey.workflow_installment_rule_version(@installment.id))
-      allow(PostSendgridApi).to receive(:process)
+      expect(PostSendgridApi).not_to receive(:process)
       expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
       expect(InstallmentRule).to receive(:lock).once.and_call_original
-      expect_any_instance_of(InstallmentRule).to receive(:cache_version!).once.and_raise(RedisClient::Error.new("fill failed"))
+      expect_any_instance_of(InstallmentRule).to receive(:cache_version!).once do
+        InstallmentRule.cache_pending_version!(
+          installment_id: @installment.id,
+          version: newer_version,
+          token: SecureRandom.uuid
+        )
+        raise RedisClient::Error, "fill failed"
+      end
       expect(Makara::Context).to receive(:release_all).once.and_call_original
 
-      SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+      end.to raise_error(RedisClient::Error, "fill failed")
 
-      expect(PostSendgridApi).to have_received(:process)
+      expect($redis.mget(version_key, pending_token_key)).to all(be_present)
     end
 
     it "retries if the queued version is not visible" do

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -36,6 +36,18 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       expect(SendWorkflowInstallmentWorker.jobs).to be_empty
     end
 
+    it "reads the primary database for a required rule version" do
+      expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+
+      described_class.new.perform(@post.id, nil, false, @post_rule.version)
+    end
+
+    it "retries if the required rule version is not visible" do
+      expect do
+        described_class.new.perform(@post.id, nil, false, @post_rule.version + 1)
+      end.to raise_error(SendWorkflowPostEmailsJob::RuleNotCommittedError)
+    end
+
     it "only considers audience members created after the earliest_valid_time" do
       described_class.new.perform(@post.id, 1.day.ago.iso8601)
       expect(SendWorkflowInstallmentWorker.jobs).to be_empty

--- a/spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb
+++ b/spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb
@@ -11,6 +11,10 @@ describe "workflow installment schedule intent completion", :freeze_time do
     )
   end
 
+  def claim_fanout(intent)
+    intent.with_lock { intent.claim_fanout! }
+  end
+
   describe SendWorkflowPostEmailsJob do
     let(:seller) { create(:named_user) }
     let(:workflow) { create(:audience_workflow, seller:) }
@@ -18,21 +22,70 @@ describe "workflow installment schedule intent completion", :freeze_time do
     let(:rule) { create(:post_rule, installment: post, delayed_delivery_time: 1.day) }
     let!(:follower) { create(:active_follower, user: seller, created_at: 2.days.ago) }
 
-    it "marks an intent processed when the fanout starts" do
+    it "marks an intent processed after the fanout completes" do
       intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
 
-      described_class.new.perform(post.id, nil, false, rule.version, intent.token)
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
 
       expect(intent.reload.processed_at).to be_present
       expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(post.id, rule.version, nil, follower.id, nil)
     end
 
-    it "continues a retry after the intent is processed" do
+    it "keeps a partial fanout recoverable" do
+      create(:active_follower, user: seller, created_at: 1.day.ago)
+      intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
+      attempts = 0
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at) do
+        attempts += 1
+        raise "Redis is unavailable" if attempts == 2
+
+        "jid"
+      end
+
+      expect do
+        described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+      end.to raise_error("Redis is unavailable")
+
+      expect(attempts).to eq(2)
+      expect(intent.reload.processed_at).to be_nil
+
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at).and_return("jid")
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+
+      expect(intent.reload.processed_at).to be_present
+    end
+
+    it "keeps the intent pending when client middleware cancels a recipient enqueue" do
+      intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at).and_return(nil)
+
+      expect do
+        described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+      end.to raise_error(SendWorkflowPostEmailsJob::FanoutNotEnqueuedError)
+
+      expect(intent.reload.processed_at).to be_nil
+    end
+
+    it "does not rerun a completed fanout" do
       intent = create_intent(installment: post, rule:, processed_at: 1.minute.ago)
 
-      described_class.new.perform(post.id, nil, false, rule.version, intent.token)
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, SecureRandom.uuid)
 
-      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(post.id, rule.version, nil, follower.id, nil)
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+    end
+
+    it "does not run a stale copy while another fanout owns the intent" do
+      intent = create_intent(installment: post, rule:)
+      current_token = claim_fanout(intent)
+
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, SecureRandom.uuid)
+
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+      expect(intent.reload.processed_at).to be_nil
+      expect(intent.fanout_token).to eq(current_token)
     end
   end
 
@@ -68,21 +121,71 @@ describe "workflow installment schedule intent completion", :freeze_time do
       )
     end
 
-    it "marks an intent processed when the fanout starts" do
+    it "marks an intent processed after the fanout completes" do
       intent = create_intent(installment:, rule:)
+      fanout_token = claim_fanout(intent)
 
-      described_class.new.perform(installment.id, nil, nil, rule.version, intent.token)
+      described_class.new.perform(installment.id, nil, nil, rule.version, intent.token, fanout_token)
 
       expect(intent.reload.processed_at).to be_present
       expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(installment.id, rule.version, nil, nil, nil, subscription.id)
     end
 
-    it "continues a retry after the intent is processed" do
+    it "keeps a partial fanout recoverable" do
+      second_subscription = create(
+        :subscription,
+        link: product,
+        cancelled_at: 20.days.ago,
+        deactivated_at: 20.days.ago
+      )
+      create(
+        :free_purchase,
+        is_original_subscription_purchase: true,
+        link: product,
+        subscription: second_subscription,
+        created_at: 50.days.ago
+      )
+      intent = create_intent(installment:, rule:)
+      fanout_token = claim_fanout(intent)
+      attempts = 0
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at) do
+        attempts += 1
+        raise "Redis is unavailable" if attempts == 2
+
+        "jid"
+      end
+
+      expect do
+        described_class.new.perform(installment.id, nil, nil, rule.version, intent.token, fanout_token)
+      end.to raise_error("Redis is unavailable")
+
+      expect(attempts).to eq(2)
+      expect(intent.reload.processed_at).to be_nil
+
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at).and_return("jid")
+      described_class.new.perform(installment.id, nil, nil, rule.version, intent.token, fanout_token)
+
+      expect(intent.reload.processed_at).to be_present
+    end
+
+    it "keeps the intent pending when client middleware cancels a recipient enqueue" do
+      intent = create_intent(installment:, rule:)
+      fanout_token = claim_fanout(intent)
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at).and_return(nil)
+
+      expect do
+        described_class.new.perform(installment.id, nil, nil, rule.version, intent.token, fanout_token)
+      end.to raise_error(SendWorkflowEmailsToPastCanceledMembersJob::FanoutNotEnqueuedError)
+
+      expect(intent.reload.processed_at).to be_nil
+    end
+
+    it "does not rerun a completed fanout" do
       intent = create_intent(installment:, rule:, processed_at: 1.minute.ago)
 
-      described_class.new.perform(installment.id, nil, nil, rule.version, intent.token)
+      described_class.new.perform(installment.id, nil, nil, rule.version, intent.token, SecureRandom.uuid)
 
-      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(installment.id, rule.version, nil, nil, nil, subscription.id)
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
     end
   end
 end

--- a/spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb
+++ b/spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+describe "workflow installment schedule intent completion", :freeze_time do
+  def create_intent(installment:, rule:, processed_at: nil)
+    WorkflowInstallmentScheduleIntent.create!(
+      token: SecureRandom.uuid,
+      installment_id: installment.id,
+      rule_version: rule.version,
+      cutoff_reference_time: Time.current,
+      processed_at:
+    )
+  end
+
+  describe SendWorkflowPostEmailsJob do
+    let(:seller) { create(:named_user) }
+    let(:workflow) { create(:audience_workflow, seller:) }
+    let(:post) { create(:audience_post, :published, workflow:, seller:) }
+    let(:rule) { create(:post_rule, installment: post, delayed_delivery_time: 1.day) }
+    let!(:follower) { create(:active_follower, user: seller, created_at: 2.days.ago) }
+
+    it "marks an intent processed when the fanout starts" do
+      intent = create_intent(installment: post, rule:)
+
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token)
+
+      expect(intent.reload.processed_at).to be_present
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(post.id, rule.version, nil, follower.id, nil)
+    end
+
+    it "continues a retry after the intent is processed" do
+      intent = create_intent(installment: post, rule:, processed_at: 1.minute.ago)
+
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token)
+
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(post.id, rule.version, nil, follower.id, nil)
+    end
+  end
+
+  describe SendWorkflowEmailsToPastCanceledMembersJob do
+    let(:seller) { create(:user) }
+    let(:product) { create(:subscription_product, user: seller) }
+    let(:workflow) do
+      create(
+        :workflow,
+        seller:,
+        link: product,
+        workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER,
+        send_to_past_customers: true
+      )
+    end
+    let(:installment) do
+      create(
+        :published_installment,
+        link: product,
+        workflow:,
+        workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER
+      )
+    end
+    let(:rule) { create(:installment_rule, installment:, delayed_delivery_time: 14.days) }
+    let(:subscription) { create(:subscription, link: product, cancelled_at: 30.days.ago, deactivated_at: 30.days.ago) }
+    let!(:purchase) do
+      create(
+        :free_purchase,
+        is_original_subscription_purchase: true,
+        link: product,
+        subscription:,
+        created_at: 60.days.ago
+      )
+    end
+
+    it "marks an intent processed when the fanout starts" do
+      intent = create_intent(installment:, rule:)
+
+      described_class.new.perform(installment.id, nil, nil, rule.version, intent.token)
+
+      expect(intent.reload.processed_at).to be_present
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(installment.id, rule.version, nil, nil, nil, subscription.id)
+    end
+
+    it "continues a retry after the intent is processed" do
+      intent = create_intent(installment:, rule:, processed_at: 1.minute.ago)
+
+      described_class.new.perform(installment.id, nil, nil, rule.version, intent.token)
+
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(installment.id, rule.version, nil, nil, nil, subscription.id)
+    end
+  end
+end

--- a/spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb
+++ b/spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb
@@ -87,6 +87,80 @@ describe "workflow installment schedule intent completion", :freeze_time do
       expect(intent.reload.processed_at).to be_nil
       expect(intent.fanout_token).to eq(current_token)
     end
+
+    it "renews its lease before and after the audience query" do
+      intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
+      events = []
+      allow(WorkflowInstallmentScheduleIntent).to receive(:renew_fanout).and_wrap_original do |method, **kwargs|
+        events << :renew
+        method.call(**kwargs)
+      end
+      allow(WithMaxExecutionTime).to receive(:timeout_queries).and_wrap_original do |method, *args, **kwargs, &block|
+        events << :query
+        result = method.call(*args, **kwargs, &block)
+        events << :query_complete
+        result
+      end
+
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+
+      expect(events).to eq([:renew, :query, :query_complete, :renew])
+      expect(intent.reload.processed_at).to be_present
+    end
+
+    it "stops after the audience query if another fanout takes ownership" do
+      intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
+      replacement_token = nil
+      allow(WithMaxExecutionTime).to receive(:timeout_queries).and_wrap_original do |method, *args, **kwargs, &block|
+        members = method.call(*args, **kwargs, &block)
+        travel WorkflowInstallmentScheduleIntent::FANOUT_LEASE + 1.second
+        replacement_token = claim_fanout(intent)
+        members
+      end
+
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+      expect(intent.reload.processed_at).to be_nil
+      expect(intent.fanout_token).to eq(replacement_token)
+    end
+
+    it "stops its recipient loop when a later owner takes over" do
+      create(:active_follower, user: seller, created_at: 1.day.ago)
+      intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
+      replacement_token = nil
+      heartbeat_time = 0.0
+      attempts = 0
+      job = described_class.new
+      allow(job).to receive(:fanout_heartbeat_time) { heartbeat_time }
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at) do
+        attempts += 1
+        if attempts == 1
+          travel WorkflowInstallmentScheduleIntent::FANOUT_LEASE + 1.second
+          replacement_token = claim_fanout(intent)
+          heartbeat_time += WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f + 1
+        end
+        "jid"
+      end
+
+      job.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+
+      expect(attempts).to eq(1)
+      expect(intent.reload.processed_at).to be_nil
+      expect(intent.fanout_token).to eq(replacement_token)
+    end
+
+    it "runs a direct fanout without an intent lease" do
+      rule
+      expect(WorkflowInstallmentScheduleIntent).not_to receive(:renew_fanout)
+
+      described_class.new.perform(post.id)
+
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(post.id, rule.version, nil, follower.id, nil)
+    end
   end
 
   describe SendWorkflowEmailsToPastCanceledMembersJob do
@@ -186,6 +260,60 @@ describe "workflow installment schedule intent completion", :freeze_time do
       described_class.new.perform(installment.id, nil, nil, rule.version, intent.token, SecureRandom.uuid)
 
       expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+    end
+
+    it "stops its recipient loop when a later owner takes over" do
+      second_subscription = create(
+        :subscription,
+        link: product,
+        cancelled_at: 20.days.ago,
+        deactivated_at: 20.days.ago
+      )
+      create(
+        :free_purchase,
+        is_original_subscription_purchase: true,
+        link: product,
+        subscription: second_subscription,
+        created_at: 50.days.ago
+      )
+      intent = create_intent(installment:, rule:)
+      fanout_token = claim_fanout(intent)
+      replacement_token = nil
+      heartbeat_time = 0.0
+      attempts = 0
+      job = described_class.new
+      allow(job).to receive(:fanout_heartbeat_time) { heartbeat_time }
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at) do
+        attempts += 1
+        if attempts == 1
+          travel WorkflowInstallmentScheduleIntent::FANOUT_LEASE + 1.second
+          replacement_token = claim_fanout(intent)
+          heartbeat_time += WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f + 1
+        end
+        "jid"
+      end
+
+      job.perform(installment.id, nil, nil, rule.version, intent.token, fanout_token)
+
+      expect(attempts).to eq(1)
+      expect(intent.reload.processed_at).to be_nil
+      expect(intent.fanout_token).to eq(replacement_token)
+    end
+
+    it "runs a direct fanout without an intent lease" do
+      rule
+      expect(WorkflowInstallmentScheduleIntent).not_to receive(:renew_fanout)
+
+      described_class.new.perform(installment.id)
+
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(
+        installment.id,
+        rule.version,
+        nil,
+        nil,
+        nil,
+        subscription.id
+      )
     end
   end
 end


### PR DESCRIPTION
## What

- Lock workflow publish, unpublish, delete, and email-save transitions.
- Advance each rule version before a publication-state write.
- Record each schedule intent in the same database transaction as its workflow change.
- Retry lost scheduler handoffs through an expiring dispatch lease.
- Read pending rule versions from the primary database before a delivery decision.

## Why

A rolled-back workflow edit could leave a Sidekiq job that later matched a reused rule version. Replica lag could also drop or revive a delivery after a publish-state change.

This is PR 2 of the #7123 split. It depends on #7157 and contains no recipient recovery or API surface.

## Before/after

Before, database state and queued work could diverge across a rollback or replica delay. After, the database records the schedule intent and retries the Sidekiq handoff.

## QA steps

1. Publish a workflow with an existing email step.
2. Confirm that publication creates one pending schedule intent.
3. Change the step delay and save the workflow.
4. Confirm that the save creates one new intent with the committed rule version.
5. Roll back a publish or save transaction.
6. Confirm that no intent or scheduler job survives the rollback.
7. Run the pending-intent dispatcher twice within 15 minutes.
8. Confirm that it queues the scheduler once.

## Test results

- Focused workflow scheduling suite — 94 examples passed.
- RuboCop on all changed Ruby files — no offenses.
- `bin/test-confidence` — reached 99 percent.
- Autoreview — clean after fixes for ruleless steps and repeated dispatch.

---

AI disclosure: GPT-5.6 Sol implemented and reviewed this change.
