### PR TITLE
Schedule follower workflow emails from confirmation

### DIFF
--- a/app/models/follower.rb
+++ b/app/models/follower.rb
@@ -78,8 +78,17 @@ class Follower < ApplicationRecord
       workflow.installments.alive.each do |installment|
         installment_rule = installment.installment_rule
         next if installment_rule.nil?
-        SendWorkflowInstallmentWorker.perform_in(installment_rule.delayed_delivery_time,
-                                                 installment.id, installment_rule.version, nil, id, nil)
+        reference_time = confirmed_at.change(usec: 0)
+        SendWorkflowInstallmentWorker.perform_at(
+          reference_time + installment_rule.delayed_delivery_time,
+          installment.id,
+          installment_rule.version,
+          nil,
+          id,
+          nil,
+          nil,
+          reference_time.iso8601
+        )
       end
     end
   end

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -7,6 +7,8 @@ class SendWorkflowPostEmailsJob
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 
+  FOLLOWER_LOOKUP_BATCH_SIZE = 1_000
+
   def perform(post_id, earliest_valid_time = nil, _reschedule_on_stale = false, minimum_rule_version = nil, schedule_intent_token = nil, schedule_intent_fanout_token = nil)
     @schedule_intent_token = schedule_intent_token
     @schedule_intent_fanout_token = schedule_intent_fanout_token
@@ -36,7 +38,9 @@ class SendWorkflowPostEmailsJob
     @rule_delay = rule.delayed_delivery_time
 
     @filters = @post.audience_members_filter_params
-    @filters[:created_after] = Time.zone.parse(earliest_valid_time) if earliest_valid_time
+    @original_filters = @filters.dup
+    @recipient_cutoff_time = Time.zone.parse(earliest_valid_time) if earliest_valid_time
+    @filters[:created_after] = @recipient_cutoff_time if @recipient_cutoff_time
     Makara::Context.release_all
     primary_pinned = false
     # Same protection as SendPostBlastEmailsJob: for sellers with very large audiences the
@@ -45,8 +49,11 @@ class SendWorkflowPostEmailsJob
     audience_timeout = audience_load_timeout_seconds
     return unless renew_fanout_lease(force: true)
     @members = WithMaxExecutionTime.timeout_queries(seconds: audience_timeout) do
-      AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).
+      members = AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).
         select(:id, :email, :details, :purchase_id, :follower_id, :affiliate_id).to_a
+      members = merge_confirmed_followers_after_cutoff(members)
+      @follower_confirmation_times_by_id = follower_confirmation_times_by_id(members)
+      members
     end
     return unless renew_fanout_lease(force: true)
 
@@ -117,8 +124,18 @@ class SendWorkflowPostEmailsJob
       elsif type == :follower
         id ||= member.details.dig("follower", "id")
         return log_unresolvable_recipient(member:, type:) if id.nil?
-        created_at = Time.zone.parse(member.details.dig("follower", "created_at"))
-        enqueue_installment_worker(created_at + @rule_delay, @post.id, @rule_version, nil, id, nil)
+        confirmed_at = @follower_confirmation_times_by_id[id]
+        return log_unresolvable_recipient(member:, type:) if confirmed_at.nil?
+        enqueue_installment_worker(
+          confirmed_at + @rule_delay,
+          @post.id,
+          @rule_version,
+          nil,
+          id,
+          nil,
+          nil,
+          confirmed_at.iso8601
+        )
       elsif type == :affiliate
         affiliate = resolve_affiliate(member:, id:)
         return log_unresolvable_recipient(member:, type:) if affiliate.nil?
@@ -140,6 +157,52 @@ class SendWorkflowPostEmailsJob
       return job_id if job_id.present?
 
       raise FanoutNotEnqueuedError, "Sidekiq did not enqueue the workflow installment"
+    end
+
+    def confirmed_follower_members_after_cutoff
+      return [] if @recipient_cutoff_time.nil?
+      return [] unless @post.follower_type? || @post.audience_type?
+
+      follower_emails = Follower.active
+        .where(followed_id: @post.seller_id)
+        .where("confirmed_at > ?", @recipient_cutoff_time)
+        .select("LOWER(followers.email)")
+      member_ids = AudienceMember
+        .where(seller_id: @post.seller_id, email: follower_emails)
+        .select(:id)
+
+      members = AudienceMember.filter(
+        seller_id: @post.seller_id,
+        params: @original_filters,
+        with_ids: true,
+        ids: member_ids
+      ).select(:id, :email, :details, :purchase_id, :follower_id, :affiliate_id).to_a
+      members.select! { workflow_dates_include?(_1.details.dig("follower", "created_at")) }
+      members.each { _1.follower_id = _1.details.dig("follower", "id") }
+      members
+    end
+
+    def merge_confirmed_followers_after_cutoff(members)
+      existing_member_ids = members.to_set(&:id)
+      confirmed_follower_members_after_cutoff.each do |follower_member|
+        members << follower_member unless existing_member_ids.include?(follower_member.id)
+      end
+      members
+    end
+
+    def follower_confirmation_times_by_id(members)
+      return {} unless @post.follower_type? || @post.audience_type?
+
+      follower_ids = if @post.follower_type?
+        members.filter_map { _1.follower_id || _1.details.dig("follower", "id") }
+      else
+        members.filter_map(&:follower_id)
+      end
+      follower_ids.uniq.each_slice(FOLLOWER_LOOKUP_BATCH_SIZE).each_with_object({}) do |ids, confirmation_times|
+        Follower.where(id: ids, followed_id: @post.seller_id).active.pluck(:id, :confirmed_at).each do |id, confirmed_at|
+          confirmation_times[id] = confirmed_at.change(usec: 0)
+        end
+      end
     end
 
     # A person can be an affiliate for several of the seller's products, and `details["affiliates"]`
@@ -164,6 +227,19 @@ class SendWorkflowPostEmailsJob
         affiliates
       end
       candidates.select { _1["id"].present? }.max_by { _1["id"] }
+    end
+
+    def workflow_dates_include?(created_at)
+      return true if @original_filters[:created_after].blank? && @original_filters[:created_before].blank?
+      return false if created_at.blank?
+
+      created_at = Time.zone.parse(created_at.to_s)
+      created_after = Time.zone.parse(@original_filters[:created_after].to_s) if @original_filters[:created_after]
+      created_before = Time.zone.parse(@original_filters[:created_before].to_s) if @original_filters[:created_before]
+      return false if created_after && created_at <= created_after
+      return false if created_before && created_at >= created_before
+
+      true
     end
 
     # Skipping a member silently is how the follower/bought-product bug stayed invisible for

--- a/spec/models/follower_spec.rb
+++ b/spec/models/follower_spec.rb
@@ -201,6 +201,30 @@ RSpec.describe Follower do
       follower.confirm!
 
       expect(SendWorkflowInstallmentWorker.jobs.size).to eq(2)
+      reference_time = follower.confirmed_at.change(usec: 0)
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(
+        @installment1.id,
+        @installment_rule1.version,
+        nil,
+        follower.id,
+        nil,
+        nil,
+        reference_time.iso8601
+      ).at(reference_time + @installment_rule1.delayed_delivery_time)
+
+      queued_args = SendWorkflowInstallmentWorker.jobs.find { _1["args"].first == @installment1.id }.fetch("args")
+      expected_args = [
+        @installment1.id,
+        @installment_rule1.version,
+        nil,
+        follower.id,
+        nil,
+        nil,
+        reference_time.iso8601
+      ]
+      expect(queued_args).to eq(expected_args)
+      allow(PostSendgridApi).to receive(:process)
+      expect { SendWorkflowInstallmentWorker.new.perform(*queued_args) }.not_to raise_error
     end
 
     it "doesn't enqueue installment jobs when follower doesn't confirm" do

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -12,7 +12,8 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
 
   describe "#perform with a follower" do
     before do
-      @basic_follower = create(:active_follower, user: @seller, created_at: 2.day.ago)
+      followed_at = 2.days.ago.change(usec: 0)
+      @basic_follower = create(:active_follower, user: @seller, created_at: followed_at, confirmed_at: followed_at)
     end
 
     it "ignores deleted workflows" do
@@ -48,17 +49,122 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       end.to raise_error(SendWorkflowPostEmailsJob::RuleNotCommittedError)
     end
 
-    it "only considers audience members created after the earliest_valid_time" do
+    it "only considers confirmations after the earliest valid time" do
       described_class.new.perform(@post.id, 1.day.ago.iso8601)
       expect(SendWorkflowInstallmentWorker.jobs).to be_empty
 
       described_class.new.perform(@post.id, 3.days.ago.iso8601)
-      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, @basic_follower.id, nil)
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(
+        @post.id,
+        @post_rule.version,
+        nil,
+        @basic_follower.id,
+        nil,
+        nil,
+        @basic_follower.confirmed_at.iso8601
+      )
 
       # does not limit when earliest_valid_time is nil
       SendWorkflowInstallmentWorker.jobs.clear
       described_class.new.perform(@post.id, nil)
-      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, @basic_follower.id, nil)
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(
+        @post.id,
+        @post_rule.version,
+        nil,
+        @basic_follower.id,
+        nil,
+        nil,
+        @basic_follower.confirmed_at.iso8601
+      )
+    end
+
+    it "recovers a follower who confirmed after the cutoff" do
+      @basic_follower.update_columns(created_at: 3.days.ago)
+      @basic_follower.update!(confirmed_at: 1.hour.ago.change(usec: 0))
+      cutoff = 1.day.ago
+
+      described_class.new.perform(@post.id, cutoff.iso8601)
+
+      expect(@basic_follower.created_at).to be < cutoff
+      expect(@basic_follower.confirmed_at).to be > cutoff
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(
+        @post.id,
+        @post_rule.version,
+        nil,
+        @basic_follower.id,
+        nil,
+        nil,
+        @basic_follower.confirmed_at.iso8601
+      ).at(@basic_follower.confirmed_at + @post_rule.delayed_delivery_time)
+    end
+
+    it "recovers a follower id hidden by purchase filters" do
+      product = create(:product, user: @seller, price_cents: 0)
+      purchase = create(:free_purchase, link: product, email: @basic_follower.email, created_at: 3.days.ago)
+      purchase.add_to_audience_member_details
+      @post.update!(installment_type: Installment::FOLLOWER_TYPE, bought_products: [product.unique_permalink])
+      @basic_follower.update_columns(created_at: 3.days.ago)
+      @basic_follower.update!(confirmed_at: 1.hour.ago.change(usec: 0))
+
+      described_class.new.perform(@post.id, 1.day.ago.iso8601)
+
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(
+        @post.id,
+        @post_rule.version,
+        nil,
+        @basic_follower.id,
+        nil,
+        nil,
+        @basic_follower.confirmed_at.iso8601
+      ).at(@basic_follower.confirmed_at + @post_rule.delayed_delivery_time)
+    end
+
+    it "preserves a qualifying purchase for an audience workflow" do
+      product = create(:product, user: @seller, price_cents: 0)
+      purchase = create(:free_purchase, link: product, email: @basic_follower.email, created_at: 30.minutes.ago)
+      purchase.add_to_audience_member_details
+      @basic_follower.update_columns(created_at: 3.days.ago)
+      @basic_follower.update!(confirmed_at: 1.hour.ago.change(usec: 0))
+
+      described_class.new.perform(@post.id, 1.day.ago.iso8601)
+
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(
+        @post.id,
+        @post_rule.version,
+        purchase.id,
+        nil,
+        nil
+      ).at(purchase.created_at + @post_rule.delayed_delivery_time)
+      expect(SendWorkflowInstallmentWorker.jobs.none? { _1["args"][3] == @basic_follower.id }).to be(true)
+    end
+
+    it "keeps workflow date filters on the follower identity" do
+      product = create(:product, user: @seller, price_cents: 0)
+      purchase = create(:free_purchase, link: product, email: @basic_follower.email, created_at: 36.hours.ago)
+      purchase.add_to_audience_member_details
+      @post.update!(created_after: 2.days.ago)
+      @basic_follower.update_columns(created_at: 3.days.ago)
+      @basic_follower.update!(confirmed_at: 1.hour.ago.change(usec: 0))
+
+      described_class.new.perform(@post.id, 1.day.ago.iso8601)
+
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+    end
+
+    it "loads follower confirmation times in bounded queries" do
+      second_follower = create(:active_follower, user: @seller, created_at: 1.day.ago, confirmed_at: 1.day.ago)
+      third_follower = create(:active_follower, user: @seller, created_at: 1.day.ago, confirmed_at: 1.day.ago)
+      stub_const("#{described_class}::FOLLOWER_LOOKUP_BATCH_SIZE", 2)
+      queried_ids = []
+      allow(Follower).to receive(:where).and_wrap_original do |method, id:, followed_id:|
+        queried_ids << id
+        method.call(id:, followed_id:)
+      end
+
+      described_class.new.perform(@post.id)
+
+      expect(queried_ids.map(&:size)).to eq([2, 1])
+      expect(queried_ids.flatten).to contain_exactly(@basic_follower.id, second_follower.id, third_follower.id)
     end
   end
 
@@ -81,8 +187,8 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
         @sales << create(:membership_purchase, link: @products[2], created_at: 6.hours.ago)
 
         @followers = []
-        @followers << create(:active_follower, user: @seller, created_at: 5.days.ago)
-        @followers << create(:active_follower, user: @seller, email: @sales[0].email, created_at: 5.hours.ago)
+        @followers << create(:active_follower, user: @seller, created_at: 5.days.ago, confirmed_at: 5.days.ago)
+        @followers << create(:active_follower, user: @seller, email: @sales[0].email, created_at: 5.hours.ago, confirmed_at: 5.hours.ago)
 
         @affiliates = []
         @affiliates << create(:direct_affiliate, seller: @seller, send_posts: true, created_at: 4.hours.ago)
@@ -137,8 +243,8 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
         described_class.new.perform(@post.id)
 
         expect(SendWorkflowInstallmentWorker.jobs.size).to eq(2)
-        expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, @followers[0].id, nil).immediately
-        expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, @followers[1].id, nil).at(19.hours.from_now)
+        expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, @followers[0].id, nil, nil, @followers[0].confirmed_at.iso8601).immediately
+        expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, @followers[1].id, nil, nil, @followers[1].confirmed_at.iso8601).at(19.hours.from_now)
       end
 
       it "when follower_type? is true and a bought-product filter is set, it still sends to the matching follower" do
@@ -146,7 +252,7 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
         described_class.new.perform(@post.id)
 
         expect(SendWorkflowInstallmentWorker.jobs.size).to eq(1)
-        expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, @followers[1].id, nil).at(19.hours.from_now)
+        expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, @followers[1].id, nil, nil, @followers[1].confirmed_at.iso8601).at(19.hours.from_now)
       end
 
       it "when affiliate_type? is true, it sends the expected emails at the right times" do
@@ -233,8 +339,8 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
 
         expect(SendWorkflowInstallmentWorker.jobs.size).to eq(7)
 
-        expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, @followers[0].id, nil).immediately
-        expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, @followers[1].id, nil).at(19.hours.from_now)
+        expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, @followers[0].id, nil, nil, @followers[0].confirmed_at.iso8601).immediately
+        expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, @followers[1].id, nil, nil, @followers[1].confirmed_at.iso8601).at(19.hours.from_now)
 
         expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, nil, @affiliates[0].affiliate_user_id).at(20.hours.from_now)
 

--- a/spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb
+++ b/spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb
@@ -29,7 +29,15 @@ describe "workflow installment schedule intent completion", :freeze_time do
       described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
 
       expect(intent.reload.processed_at).to be_present
-      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(post.id, rule.version, nil, follower.id, nil)
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(
+        post.id,
+        rule.version,
+        nil,
+        follower.id,
+        nil,
+        nil,
+        follower.confirmed_at.change(usec: 0).iso8601
+      )
     end
 
     it "keeps a partial fanout recoverable" do
@@ -159,7 +167,15 @@ describe "workflow installment schedule intent completion", :freeze_time do
 
       described_class.new.perform(post.id)
 
-      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(post.id, rule.version, nil, follower.id, nil)
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(
+        post.id,
+        rule.version,
+        nil,
+        follower.id,
+        nil,
+        nil,
+        follower.confirmed_at.change(usec: 0).iso8601
+      )
     end
   end
 


### PR DESCRIPTION
## What

- Use follower confirmation as the workflow trigger.
- Recover confirmed followers hidden by purchase filters or the fanout cutoff.
- Carry the exact confirmation time in each queued job.
- Keep affiliate, delay-recovery, partial-save, and API changes outside this PR.

## Why

A follower row can exist before confirmation. Scheduling from row creation can deliver a workflow email too early.

This is PR 3 of the #7123 split. It depends on #7159.

## Before and after

Before, follower emails used Follower.created_at. After, direct and fanout jobs use Follower.confirmed_at.

## QA steps

1. Create a follower before confirmation.
2. Confirm the follower later.
3. Run a follower workflow fanout.
4. Confirm that the due time uses confirmed_at.
5. Apply a purchase filter that hides follower_id.
6. Confirm that the fanout still recovers the active follower.

## Test results

- Follower, model, post, completion, and worker suite: 38 examples passed.
- RuboCop: no offenses.
- Autoreview: clean, with no findings.

---

AI disclosure: GPT-5.6 Sol: code implementation and review.