### PR TITLE
Keep workflow jobs on committed rule versions

### DIFF
--- a/app/models/installment_rule.rb
+++ b/app/models/installment_rule.rb
@@ -1,6 +1,38 @@
 # frozen_string_literal: true
 
 class InstallmentRule < ApplicationRecord
+  VERSION_CACHE_TTL = 1.day
+  PENDING_OWNER_CACHE_TTL = 5.minutes
+  PENDING_VERSION_CACHE_TTL = PENDING_OWNER_CACHE_TTL + 1.minute
+  CACHE_PENDING_VERSION_SCRIPT = <<~LUA
+    local current = redis.call("GET", KEYS[1])
+    if not current or tonumber(ARGV[1]) >= tonumber(current) then
+      redis.call("SET", KEYS[1], ARGV[1], "EX", ARGV[3])
+      redis.call("SET", KEYS[2], ARGV[2], "EX", ARGV[4])
+      return tonumber(ARGV[1])
+    end
+    return tonumber(current)
+  LUA
+  CACHE_COMMITTED_VERSION_SCRIPT = <<~LUA
+    local current = redis.call("GET", KEYS[1])
+    local owner = redis.call("GET", KEYS[2])
+    if current and tonumber(current) > tonumber(ARGV[1]) then
+      return tonumber(current)
+    end
+    if owner and (ARGV[2] == "" or owner ~= ARGV[2]) then
+      return current and tonumber(current) or false
+    end
+    redis.call("SET", KEYS[1], ARGV[1], "EX", ARGV[3])
+    redis.call("DEL", KEYS[2])
+    return tonumber(ARGV[1])
+  LUA
+  CLEAR_PENDING_VERSION_SCRIPT = <<~LUA
+    if redis.call("GET", KEYS[2]) == ARGV[1] then
+      return redis.call("DEL", KEYS[1], KEYS[2])
+    end
+    return 0
+  LUA
+
   has_paper_trail version: :paper_trail_version
 
   include Deletable
@@ -20,10 +52,68 @@ class InstallmentRule < ApplicationRecord
   validate :to_be_published_at_cannot_be_in_the_past
   validate :to_be_published_at_must_exist_for_non_workflow_posts
 
-  # We increment the version when delivery date changes so the correct job is processed, not an old one. We have the version starting
-  # at 1 even though the schema shows a default value of 0. If there is no rule to go with an installment, we pass version = 0 as a
-  # parameter so changing version to start at 0 will disrupt current installment jobs in the queue.
+  # A version change invalidates jobs that use old delivery or publication state.
+  # The version starts at 1 although the schema default is 0. Jobs use version 0 when no rule exists.
   before_save :increment_version, if: :delivery_date_changed?
+  # Publish before SQL so stale jobs cannot cross a transaction that changes delivery state.
+  before_save :cache_pending_version, if: :publish_pending_version?
+  after_commit :cache_committed_version, if: :workflow_rule?
+
+  def self.cached_version(installment_id)
+    $redis.get(RedisKey.workflow_installment_rule_version(installment_id))&.to_i
+  end
+
+  def self.cached_version_state(installment_id)
+    version, owner = $redis.mget(*cache_keys(installment_id))
+    [version&.to_i, owner.present?]
+  end
+
+  def self.cache_pending_version!(installment_id:, version:, token:)
+    $redis.eval(
+      CACHE_PENDING_VERSION_SCRIPT,
+      keys: cache_keys(installment_id),
+      argv: [version, token, PENDING_VERSION_CACHE_TTL.to_i, PENDING_OWNER_CACHE_TTL.to_i]
+    ).to_i
+  end
+
+  def self.cache_committed_version!(installment_id:, version:, expected_pending_token: nil, expires_in: VERSION_CACHE_TTL)
+    result = $redis.eval(
+      CACHE_COMMITTED_VERSION_SCRIPT,
+      keys: cache_keys(installment_id),
+      argv: [version, expected_pending_token.to_s, expires_in.to_i]
+    )
+    result&.to_i
+  end
+
+  def self.clear_pending_version!(installment_id:, token:)
+    $redis.eval(
+      CLEAR_PENDING_VERSION_SCRIPT,
+      keys: cache_keys(installment_id),
+      argv: [token]
+    )
+  end
+
+  def self.promote_pending_version(installment_id:, installment_rule_id:, version:, token:)
+    cache_committed_version!(installment_id:, version:, expected_pending_token: token)
+  rescue Redis::BaseError, RedisClient::Error => e
+    ErrorNotifier.notify(e, installment_rule_id:)
+  end
+
+  def self.clear_pending_version(installment_id:, installment_rule_id:, token:)
+    clear_pending_version!(installment_id:, token:)
+  rescue Redis::BaseError, RedisClient::Error => e
+    ErrorNotifier.notify(e, installment_rule_id:)
+  end
+
+  def cache_version!(expires_in: VERSION_CACHE_TTL)
+    return if installment_id.nil?
+
+    self.class.cache_committed_version!(installment_id:, version:, expires_in:)
+  end
+
+  def advance_version!
+    with_lock { update!(version: version + 1) }
+  end
 
   # Public: Converts the delayed_delivery_time back into the number the creator entered using the time period of the rule
   #
@@ -51,6 +141,53 @@ class InstallmentRule < ApplicationRecord
   end
 
   private
+    def cache_pending_version
+      token = SecureRandom.uuid
+      rule_class = self.class
+      pending_installment_id = installment_id
+      pending_rule_id = id
+      pending_version = version
+
+      AfterCommitEverywhere.after_commit do
+        rule_class.promote_pending_version(
+          installment_id: pending_installment_id,
+          installment_rule_id: pending_rule_id,
+          version: pending_version,
+          token:
+        )
+      end
+      AfterCommitEverywhere.after_rollback do
+        rule_class.clear_pending_version(
+          installment_id: pending_installment_id,
+          installment_rule_id: pending_rule_id,
+          token:
+        )
+      end
+      rule_class.cache_pending_version!(installment_id: pending_installment_id, version: pending_version, token:)
+    end
+
+    def publish_pending_version?
+      workflow_rule? && will_save_change_to_version? && persisted?
+    end
+
+    def workflow_rule?
+      installment&.workflow_id.present?
+    end
+
+    def cache_committed_version
+      cache_version!
+    rescue Redis::BaseError, RedisClient::Error => e
+      ErrorNotifier.notify(e, installment_rule_id: id)
+    end
+
+    def self.cache_keys(installment_id)
+      [
+        RedisKey.workflow_installment_rule_version(installment_id),
+        RedisKey.workflow_installment_rule_pending_token(installment_id),
+      ]
+    end
+    private_class_method :cache_keys
+
     # Private: Increments version of InstallmentRule. This is so PublishInstallment jobs are ignored if the version of the job does not match the
     # most recent version of the InstallmentRule. We want to update the version every time the creator changes when it is scheduled.
     def increment_version

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -51,37 +51,50 @@ class Workflow < ApplicationRecord
   end
 
   def mark_deleted!
-    self.deleted_at = Time.current
-    installments.each do |installment|
-      installment.mark_deleted!
-      installment.installment_rule.mark_deleted!
+    self.class.transaction do
+      lock!
+      self.deleted_at = Time.current
+      installments.each do |installment|
+        rule = installment.installment_rule
+        rule&.advance_version!
+        installment.mark_deleted!
+        rule&.mark_deleted!
+      end
+      save!
     end
-    save!
   end
 
   def publish!
-    return true if published_at.present?
+    with_transition_lock do
+      next true if published_at.present?
 
-    if !abandoned_cart_type? && !seller.eligible_to_send_emails?
-      errors.add(:base, "You cannot publish a workflow until you have made at least #{Money.from_cents(Installment::MINIMUM_SALES_CENTS_VALUE).format(no_cents: true)} in total earnings and received a payout")
-      raise ActiveRecord::RecordInvalid.new(self)
-    end
+      if !abandoned_cart_type? && !seller.eligible_to_send_emails?
+        errors.add(:base, "You cannot publish a workflow until you have made at least #{Money.from_cents(Installment::MINIMUM_SALES_CENTS_VALUE).format(no_cents: true)} in total earnings and received a payout")
+        raise ActiveRecord::RecordInvalid.new(self)
+      end
 
-    self.published_at = DateTime.current
-    self.first_published_at ||= published_at
-    installments.alive.find_each do |installment|
-      installment.publish!(published_at:)
-      schedule_installment(installment)
+      self.published_at = DateTime.current
+      self.first_published_at ||= published_at
+      installments.alive.find_each do |installment|
+        installment.installment_rule&.advance_version!
+        installment.publish!(published_at:)
+        schedule_installment(installment)
+      end
+      save!
     end
-    save!
   end
 
   def unpublish!
-    return true if published_at.nil?
+    with_transition_lock do
+      next true if published_at.nil?
 
-    self.published_at = nil
-    installments.alive.find_each(&:unpublish!)
-    save!
+      self.published_at = nil
+      installments.alive.find_each do |installment|
+        installment.installment_rule&.advance_version!
+        installment.unpublish!
+      end
+      save!
+    end
   end
 
   def has_never_been_published?
@@ -118,4 +131,14 @@ class Workflow < ApplicationRecord
 
     SendWorkflowPostEmailsJob.perform_async(installment.id, earliest_valid_time&.iso8601)
   end
+
+  private
+    def with_transition_lock
+      self.class.transaction do
+        # An update acquires the same row lock when a callback leaves the workflow dirty.
+        save! if has_changes_to_save?
+        lock!
+        yield
+      end
+    end
 end

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -40,6 +40,8 @@ class RedisKey
     def blast_sent_emails(blast_id) = "blast:#{blast_id}:sent_emails"
     def blast_audience_snapshot(blast_id) = "blast:#{blast_id}:audience_snapshot"
     def blast_non_opener_emails(blast_id) = "blast:#{blast_id}:non_opener_emails"
+    def workflow_installment_rule_version(installment_id) = "workflow_installment_rule:#{installment_id}:version"
+    def workflow_installment_rule_pending_token(installment_id) = "workflow_installment_rule:#{installment_id}:pending_token"
     def audience_member_load_max_execution_time_seconds = "audience_member_load:max_execution_time_seconds"
     def impersonated_user(admin_user_id) = "impersonated_user_by_admin_#{admin_user_id}"
     def undeliverable_ping_subscription_notified(resource_subscription_id, reason) = "undeliverable_ping_subscription:#{resource_subscription_id}:#{reason}"

--- a/app/services/workflow/save_installments_service.rb
+++ b/app/services/workflow/save_installments_service.rb
@@ -104,6 +104,8 @@ class Workflow::SaveInstallmentsService
 
     def save_installment_rule_and_reschedule_installment(installment, installment_params)
       rule = installment.installment_rule || installment.build_installment_rule
+      # Hold the row lock before Redis marks the new version. Cache expiry then falls back to a blocked primary read.
+      rule.lock! if rule.persisted?
       rule.time_period = installment_params[:time_period]
       new_delayed_delivery_time = convert_to_seconds(installment_params[:time_duration], installment_params[:time_period])
       old_delayed_delivery_time = rule.delayed_delivery_time

--- a/app/services/workflow/save_installments_service.rb
+++ b/app/services/workflow/save_installments_service.rb
@@ -21,14 +21,21 @@ class Workflow::SaveInstallmentsService
       return [false, errors]
     end
 
-    if workflow.abandoned_cart_type? && params[:installments].size != 1
-      workflow.errors.add(:base, "An abandoned cart workflow can only have one email.")
-      @errors = workflow.errors
-      return [false, errors]
-    end
-
     begin
       ActiveRecord::Base.transaction do
+        workflow.lock!
+        unless workflow.alive?
+          workflow.errors.add(:base, "The workflow was not found.")
+          @errors = workflow.errors
+          raise ActiveRecord::Rollback
+        end
+
+        if workflow.abandoned_cart_type? && params[:installments].size != 1
+          workflow.errors.add(:base, "An abandoned cart workflow can only have one email.")
+          @errors = workflow.errors
+          raise ActiveRecord::Rollback
+        end
+
         if @workflow.has_never_been_published?
           @workflow.update!(send_to_past_customers: params[:send_to_past_customers])
         end
@@ -75,6 +82,7 @@ class Workflow::SaveInstallmentsService
     def delete_removed_installments
       deleted_external_ids = workflow.installments.alive.map(&:external_id) - params[:installments].pluck(:id)
       workflow.installments.by_external_ids(deleted_external_ids).find_each do |installment|
+        installment.installment_rule&.advance_version!
         installment.mark_deleted!
         installment.installment_rule&.mark_deleted!
       end

--- a/app/sidekiq/send_workflow_installment_worker.rb
+++ b/app/sidekiq/send_workflow_installment_worker.rb
@@ -1,20 +1,43 @@
 # frozen_string_literal: true
 
 class SendWorkflowInstallmentWorker
+  class RuleNotCommittedError < StandardError; end
+
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 
   def perform(installment_id, version, purchase_id, follower_id, affiliate_user_id = nil, subscription_id = nil)
-    installment = Installment.find_by(id: installment_id)
+    primary_pinned = false
+    expected_rule_version = current_rule_version(installment_id)
+    return if expected_rule_version.nil?
 
-    return if installment.nil?
+    if expected_rule_version != version
+      ActiveRecord::Base.connection.stick_to_primary!
+      primary_pinned = true
+    end
+
+    installment = Installment.find_by(id: installment_id)
+    installment_rule = installment&.installment_rule
+    if installment.nil? || installment_rule.nil? || installment_rule.version != version
+      unless primary_pinned
+        ActiveRecord::Base.connection.stick_to_primary!
+        primary_pinned = true
+      end
+      installment = Installment.find_by(id: installment_id)
+      return if installment.nil?
+
+      installment_rule = installment.installment_rule
+      return if installment_rule.nil?
+    end
+    if installment_rule.version < expected_rule_version || installment_rule.version < version
+      raise RuleNotCommittedError
+    end
+
     return if installment.seller&.suspended?
     return unless installment.workflow.alive?
     return unless installment.alive?
     return unless installment.published?
 
-    installment_rule = installment.installment_rule
-    return if installment_rule.nil?
     return if installment_rule.version != version
 
     if purchase_id.present? && follower_id.nil? && affiliate_user_id.nil? && subscription_id.nil?
@@ -31,5 +54,39 @@ class SendWorkflowInstallmentWorker
       # a whole class of workflows could deliver nothing at all without anyone noticing.
       Rails.logger.error("[#{self.class.name}] installment_id=#{installment_id} got an unusable recipient combination (purchase=#{purchase_id.inspect} follower=#{follower_id.inspect} affiliate=#{affiliate_user_id.inspect} subscription=#{subscription_id.inspect}); nothing sent")
     end
+  ensure
+    Makara::Context.release_all if primary_pinned
   end
+
+  private
+    def current_rule_version(installment_id)
+      cache_read_failed = false
+      pending = false
+      begin
+        cached_version, pending = InstallmentRule.cached_version_state(installment_id)
+        return cached_version if cached_version.present? && !pending
+      rescue Redis::BaseError, RedisClient::Error
+        cache_read_failed = true
+      end
+
+      primary_pinned = true
+      ActiveRecord::Base.connection.stick_to_primary!
+      effective_version = InstallmentRule.transaction do
+        rule = InstallmentRule.lock.find_by(installment_id:)
+        if cache_read_failed
+          rule&.version
+        else
+          begin
+            rule&.cache_version!
+          rescue Redis::BaseError, RedisClient::Error
+            rule&.version
+          end
+        end
+      end
+      raise RuleNotCommittedError if effective_version.nil? && pending
+
+      effective_version
+    ensure
+      Makara::Context.release_all if primary_pinned
+    end
 end

--- a/spec/models/installment_rule_spec.rb
+++ b/spec/models/installment_rule_spec.rb
@@ -29,6 +29,233 @@ describe InstallmentRule do
       expect(@post_rule.reload.version).to eq(2)
     end
 
+    it "publishes the new version to the shared delivery cache" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      rule.update!(delayed_delivery_time: 100)
+
+      expect(described_class.cached_version(post.id)).to eq(rule.version)
+    end
+
+    it "publishes the pending version before updating the database row" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      observed_state = nil
+      observer = lambda do |*, payload|
+        next unless payload[:name] == "InstallmentRule Update"
+
+        observed_state = described_class.cached_version_state(post.id)
+      end
+
+      ActiveSupport::Notifications.subscribed(observer, "sql.active_record") do
+        rule.update!(delayed_delivery_time: 2.days)
+      end
+
+      expect(observed_state).to eq([rule.version, true])
+      expect(described_class.cached_version_state(post.id)).to eq([rule.version, false])
+    end
+
+    it "clears its pending version when the transaction rolls back" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+
+      described_class.transaction do
+        rule.update!(delayed_delivery_time: 2.days)
+        expect(described_class.cached_version_state(post.id)).to eq([rule.version, true])
+        raise ActiveRecord::Rollback
+      end
+
+      expect(described_class.cached_version_state(post.id)).to eq([nil, false])
+    end
+
+    it "expires an orphaned pending version after its owner" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      version_key = RedisKey.workflow_installment_rule_version(post.id)
+      owner_key = RedisKey.workflow_installment_rule_pending_token(post.id)
+
+      described_class.transaction do
+        rule.update!(delayed_delivery_time: 2.days)
+
+        expect($redis.ttl(owner_key)).to be_between(1, described_class::PENDING_OWNER_CACHE_TTL)
+        expect($redis.ttl(version_key)).to be > $redis.ttl(owner_key)
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    it "cleans pending ownership when an earlier instance only changes metadata" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      first_instance = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      owner_key = RedisKey.workflow_installment_rule_pending_token(post.id)
+
+      described_class.transaction do
+        first_instance.update!(time_period: "week")
+        described_class.find(first_instance.id).update!(delayed_delivery_time: 2.days)
+      end
+
+      expect($redis.get(owner_key)).to be_nil
+      expect(described_class.cached_version(post.id)).to eq(first_instance.reload.version)
+    end
+
+    it "promotes the highest version saved through separate instances" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      first_instance = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+
+      described_class.transaction do
+        first_instance.update!(delayed_delivery_time: 2.days)
+        described_class.find(first_instance.id).update!(delayed_delivery_time: 3.days)
+      end
+
+      expect(described_class.cached_version_state(post.id)).to eq([first_instance.reload.version, false])
+    end
+
+    it "keeps a same-version marker owned by a newer transaction" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      pending_version = rule.version + 1
+      old_token = SecureRandom.uuid
+      new_token = SecureRandom.uuid
+      version_key = RedisKey.workflow_installment_rule_version(post.id)
+      owner_key = RedisKey.workflow_installment_rule_pending_token(post.id)
+      $redis.set(version_key, pending_version)
+      $redis.set(owner_key, new_token)
+
+      described_class.clear_pending_version(
+        installment_id: post.id,
+        installment_rule_id: rule.id,
+        token: old_token
+      )
+
+      expect(described_class.cached_version(post.id)).to eq(pending_version)
+      expect($redis.get(owner_key)).to eq(new_token)
+    end
+
+    it "does not promote over a same-version marker owned by a newer transaction" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      pending_version = rule.version + 1
+      old_token = SecureRandom.uuid
+      new_token = SecureRandom.uuid
+      version_key = RedisKey.workflow_installment_rule_version(post.id)
+      owner_key = RedisKey.workflow_installment_rule_pending_token(post.id)
+      $redis.set(version_key, pending_version, ex: described_class::PENDING_VERSION_CACHE_TTL)
+      $redis.set(owner_key, new_token, ex: described_class::PENDING_OWNER_CACHE_TTL)
+
+      described_class.promote_pending_version(
+        installment_id: post.id,
+        installment_rule_id: rule.id,
+        version: pending_version,
+        token: old_token
+      )
+
+      expect(described_class.cached_version(post.id)).to eq(pending_version)
+      expect($redis.get(owner_key)).to eq(new_token)
+      expect($redis.ttl(version_key)).to be <= described_class::PENDING_VERSION_CACHE_TTL
+    end
+
+    it "does not let a normal cache fill clear pending ownership" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      token = SecureRandom.uuid
+      version_key = RedisKey.workflow_installment_rule_version(post.id)
+      owner_key = RedisKey.workflow_installment_rule_pending_token(post.id)
+      $redis.set(version_key, rule.version, ex: described_class::PENDING_VERSION_CACHE_TTL)
+      $redis.set(owner_key, token, ex: described_class::PENDING_OWNER_CACHE_TTL)
+
+      rule.cache_version!
+
+      expect($redis.get(owner_key)).to eq(token)
+      expect($redis.ttl(version_key)).to be <= described_class::PENDING_VERSION_CACHE_TTL
+    end
+
+    it "returns the newer effective version when its cache write loses" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      newer_version = rule.version + 1
+      $redis.set(RedisKey.workflow_installment_rule_version(post.id), newer_version)
+
+      expect(rule.cache_version!).to eq(newer_version)
+      expect(described_class.cached_version(post.id)).to eq(newer_version)
+    end
+
+    it "advances from the committed version when the instance is stale" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      stale_rule = described_class.find(rule.id)
+      rule.update!(delayed_delivery_time: 2.days)
+
+      stale_rule.advance_version!
+
+      expect(stale_rule.version).to eq(rule.version + 1)
+      expect(described_class.cached_version(post.id)).to eq(stale_rule.version)
+    end
+
+    it "reports a Redis failure after the database commit" do
+      error = Redis::CannotConnectError.new("unavailable")
+      allow(@post_rule).to receive(:cache_version!).and_raise(error)
+      expect(ErrorNotifier).to receive(:notify).with(error, installment_rule_id: @post_rule.id)
+
+      expect { @post_rule.send(:cache_committed_version) }.not_to raise_error
+    end
+
+    it "reports a RedisClient failure after the database commit" do
+      error = RedisClient::Error.new("unavailable")
+      allow(@post_rule).to receive(:cache_version!).and_raise(error)
+      expect(ErrorNotifier).to receive(:notify).with(error, installment_rule_id: @post_rule.id)
+
+      expect { @post_rule.send(:cache_committed_version) }.not_to raise_error
+    end
+
+    it "reports a Redis failure during rollback cleanup" do
+      error = Redis::CannotConnectError.new("unavailable")
+      allow($redis).to receive(:eval).and_raise(error)
+      expect(ErrorNotifier).to receive(:notify).with(error, installment_rule_id: @post_rule.id)
+
+      expect do
+        described_class.clear_pending_version(
+          installment_id: @post_rule.installment_id,
+          installment_rule_id: @post_rule.id,
+          token: SecureRandom.uuid
+        )
+      end.not_to raise_error
+    end
+
+    it "does not require Redis before committing a new rule" do
+      post = create(:installment, link: @product, installment_type: "product")
+      rule = build(:installment_rule, installment: post, to_be_published_at: 1.week.from_now)
+      expect(rule).not_to receive(:cache_version!)
+
+      expect { rule.save! }.not_to raise_error
+    end
+
+    it "reports a cache failure after a change that keeps the version" do
+      workflow = create(:workflow, seller: @product.user, link: @product)
+      post = create(:installment, link: @product, workflow:)
+      rule = create(:installment_rule, installment: post, delayed_delivery_time: 1.day)
+      error = RedisClient::Error.new("unavailable")
+      allow(rule).to receive(:cache_version!).and_raise(error)
+      expect(ErrorNotifier).to receive(:notify).with(error, installment_rule_id: rule.id)
+
+      expect { rule.update!(time_period: "week") }.not_to raise_error
+    end
+
+    it "does not cache versions for scheduled post rules" do
+      expect(@post_rule).not_to receive(:cache_version!)
+
+      @post_rule.update!(to_be_published_at: 1.month.from_now)
+    end
+
     it "does not increment the version if period is changed" do
       expect do
         @post_rule.time_period = "DAY"

--- a/spec/models/workflow_transition_spec.rb
+++ b/spec/models/workflow_transition_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Workflow do
+  let(:workflow) { create(:workflow) }
+  let!(:installment) { create(:workflow_installment, workflow:, seller: workflow.seller, is_for_new_customers_of_workflow: false) }
+  let(:rule) { installment.installment_rule }
+
+  before do
+    allow_any_instance_of(User).to receive(:eligible_to_send_emails?).and_return(true)
+  end
+
+  it "locks the workflow and advances the rule version before publishing" do
+    previous_version = rule.version
+    expect(workflow).to receive(:lock!).and_call_original
+    expect_any_instance_of(Installment).to receive(:publish!).and_wrap_original do |method, **kwargs|
+      expect(InstallmentRule.cached_version(installment.id)).to eq(previous_version + 1)
+      method.call(**kwargs)
+    end
+
+    workflow.publish!
+
+    expect(installment.reload).to be_published
+    expect(rule.reload.version).to eq(previous_version + 1)
+    expect(SendWorkflowPostEmailsJob).to have_enqueued_sidekiq_job(installment.id, nil)
+  end
+
+  it "locks the workflow and advances the rule version before unpublishing" do
+    workflow.update!(published_at: 1.day.ago)
+    installment.update!(published_at: workflow.published_at)
+    previous_version = rule.version
+    expect(workflow).to receive(:lock!).and_call_original
+    expect_any_instance_of(Installment).to receive(:unpublish!).and_wrap_original do |method|
+      expect(InstallmentRule.cached_version(installment.id)).to eq(previous_version + 1)
+      method.call
+    end
+
+    workflow.unpublish!
+
+    expect(installment.reload).not_to be_published
+    expect(rule.reload.version).to eq(previous_version + 1)
+  end
+
+  it "locks the workflow and advances the rule version before deletion" do
+    previous_version = rule.version
+    expect(workflow).to receive(:lock!).and_call_original
+    expect_any_instance_of(Installment).to receive(:mark_deleted!).and_wrap_original do |method|
+      expect(InstallmentRule.cached_version(installment.id)).to eq(previous_version + 1)
+      method.call
+    end
+
+    workflow.mark_deleted!
+
+    expect(workflow).to be_deleted
+    expect(installment.reload).to be_deleted
+    expect(rule.reload).to be_deleted
+    expect(rule.version).to eq(previous_version + 1)
+  end
+end

--- a/spec/services/workflow/save_installments_service_spec.rb
+++ b/spec/services/workflow/save_installments_service_spec.rb
@@ -271,6 +271,25 @@ describe Workflow::SaveInstallmentsService do
           installment.update!(published_at: workflow.published_at)
         end
 
+        it "locks the rule before publishing its pending cache version" do
+          params[:installments] = [default_installment_params.merge(id: installment.external_id, time_duration: 2, time_period: "day")]
+          service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
+          events = []
+          allow_any_instance_of(InstallmentRule).to receive(:lock!).and_wrap_original do |method, *args|
+            events << :lock
+            method.call(*args)
+          end
+          allow(InstallmentRule).to receive(:cache_pending_version!).and_wrap_original do |method, **kwargs|
+            events << :cache
+            method.call(**kwargs)
+          end
+
+          service.process
+
+          expect(events).to include(:lock, :cache)
+          expect(events.index(:lock)).to be < events.index(:cache)
+        end
+
         it "reschedules that installment" do
           expect(SendWorkflowPostEmailsJob).to receive(:perform_async).with(installment.id, installment.published_at.iso8601)
 

--- a/spec/services/workflow/save_installments_service_spec.rb
+++ b/spec/services/workflow/save_installments_service_spec.rb
@@ -101,6 +101,27 @@ describe Workflow::SaveInstallmentsService do
       expect(audio.reload.alive?).to be(false)
     end
 
+    it "locks the workflow before checking that it is alive" do
+      service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
+      expect(workflow).to receive(:lock!).ordered.and_call_original
+      expect(workflow).to receive(:alive?).ordered.and_call_original
+
+      expect(service.process).to eq([true, nil])
+    end
+
+    it "does not add an installment after the workflow is deleted" do
+      Workflow.where(id: workflow.id).update_all(deleted_at: Time.current)
+      params[:installments] = [default_installment_params.merge(id: SecureRandom.uuid)]
+      service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
+
+      expect do
+        success, errors = service.process
+
+        expect(success).to be(false)
+        expect(errors.full_messages.first).to eq("The workflow was not found.")
+      end.not_to change { workflow.installments.count }
+    end
+
     describe "for an abandoned cart workflow" do
       let!(:workflow) { create(:workflow, seller:, link: product, workflow_type: Workflow::ABANDONED_CART_TYPE) }
 
@@ -326,10 +347,14 @@ describe Workflow::SaveInstallmentsService do
 
     it "deletes installments that are missing from the params" do
       installment = create(:installment, workflow:)
+      installment_rule = create(:installment_rule, installment:, delayed_delivery_time: 1.hour)
+      previous_rule_version = installment_rule.version
       attached_file = create(:product_file, installment:, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/doc.pdf", link: nil)
       service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
       expect { service.process }.to change { workflow.installments.alive.count }.by(-1)
       expect(installment.reload.deleted_at).to be_present
+      expect(installment_rule.reload.version).to eq(previous_rule_version + 1)
+      expect(InstallmentRule.cached_version(installment.id)).to eq(previous_rule_version + 1)
 
       # But keeps the attached file alive
       expect(attached_file.reload.alive?).to be(true)

--- a/spec/sidekiq/send_workflow_installment_worker_spec.rb
+++ b/spec/sidekiq/send_workflow_installment_worker_spec.rb
@@ -24,7 +24,9 @@ describe SendWorkflowInstallmentWorker do
 
     it "does not call mailer if different version" do
       expect(PostSendgridApi).not_to receive(:process)
-      SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version + 1, @purchase.id, nil, nil)
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version + 1, @purchase.id, nil, nil)
+      end.to raise_error(SendWorkflowInstallmentWorker::RuleNotCommittedError)
     end
 
     it "does not call mailer if deleted installment" do
@@ -104,9 +106,123 @@ describe SendWorkflowInstallmentWorker do
       )
     end
 
+    it "fills an expired cache from the locked primary" do
+      $redis.del(
+        RedisKey.workflow_installment_rule_version(@installment.id),
+        RedisKey.workflow_installment_rule_pending_token(@installment.id)
+      )
+      allow(PostSendgridApi).to receive(:process)
+      expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+      expect(InstallmentRule).to receive(:lock).once.and_call_original
+
+      SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+
+      expect(PostSendgridApi).to have_received(:process)
+      expect(InstallmentRule.cached_version(@installment.id)).to eq(@installment_rule.version)
+    end
+
+    it "uses the locked primary version if the Redis read fails" do
+      allow(PostSendgridApi).to receive(:process)
+      expect(InstallmentRule).to receive(:cached_version_state).with(@installment.id).once.and_raise(Redis::BaseError.new("read failed"))
+      expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+      expect(InstallmentRule).to receive(:lock).once.and_call_original
+      expect_any_instance_of(InstallmentRule).not_to receive(:cache_version!)
+      expect(Makara::Context).to receive(:release_all).once.and_call_original
+
+      SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+
+      expect(PostSendgridApi).to have_received(:process)
+    end
+
+    it "uses the locked primary version if the Redis cache fill fails" do
+      $redis.del(
+        RedisKey.workflow_installment_rule_version(@installment.id),
+        RedisKey.workflow_installment_rule_pending_token(@installment.id)
+      )
+      allow(PostSendgridApi).to receive(:process)
+      expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+      expect(InstallmentRule).to receive(:lock).once.and_call_original
+      expect_any_instance_of(InstallmentRule).to receive(:cache_version!).once.and_raise(RedisClient::Error.new("fill failed"))
+      expect(Makara::Context).to receive(:release_all).once.and_call_original
+
+      SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+
+      expect(PostSendgridApi).to have_received(:process)
+    end
+
+    it "retries an old job while a publication transition is pending" do
+      InstallmentRule.cache_pending_version!(
+        installment_id: @installment.id,
+        version: @installment_rule.version + 1,
+        token: SecureRandom.uuid
+      )
+      expect(PostSendgridApi).not_to receive(:process)
+
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+      end.to raise_error(SendWorkflowInstallmentWorker::RuleNotCommittedError)
+    end
+
+    it "drops an old job after a newer version commits" do
+      stale_version = @installment_rule.version
+      @installment_rule.update!(delayed_delivery_time: 2.days)
+      expect(PostSendgridApi).not_to receive(:process)
+
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, stale_version, nil, @follower.id, nil)
+      end.not_to raise_error
+    end
+
+    it "honors a newer pending version that appears during a cache fill" do
+      version_key = RedisKey.workflow_installment_rule_version(@installment.id)
+      owner_key = RedisKey.workflow_installment_rule_pending_token(@installment.id)
+      newer_version = @installment_rule.version + 1
+      $redis.del(version_key, owner_key)
+      allow_any_instance_of(InstallmentRule).to receive(:cache_version!).and_wrap_original do |method, *args, **kwargs|
+        InstallmentRule.cache_pending_version!(
+          installment_id: @installment.id,
+          version: newer_version,
+          token: SecureRandom.uuid
+        )
+        method.call(*args, **kwargs)
+      end
+      expect(PostSendgridApi).not_to receive(:process)
+
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+      end.to raise_error(SendWorkflowInstallmentWorker::RuleNotCommittedError)
+      expect(InstallmentRule.cached_version(@installment.id)).to eq(newer_version)
+    end
+
+    it "retries while a pending version outlives its owner" do
+      version_key = RedisKey.workflow_installment_rule_version(@installment.id)
+      owner_key = RedisKey.workflow_installment_rule_pending_token(@installment.id)
+      $redis.set(version_key, @installment_rule.version + 1)
+      $redis.del(owner_key)
+      expect(PostSendgridApi).not_to receive(:process)
+
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+      end.to raise_error(SendWorkflowInstallmentWorker::RuleNotCommittedError)
+    end
+
+    it "retries while only pending ownership remains" do
+      version_key = RedisKey.workflow_installment_rule_version(@installment.id)
+      owner_key = RedisKey.workflow_installment_rule_pending_token(@installment.id)
+      $redis.del(version_key)
+      $redis.set(owner_key, SecureRandom.uuid)
+      expect(PostSendgridApi).not_to receive(:process)
+
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, @follower.id, nil)
+      end.to raise_error(SendWorkflowInstallmentWorker::RuleNotCommittedError)
+    end
+
     it "does not call mailer if different version" do
       expect(PostSendgridApi).not_to receive(:process)
-      SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version + 1, nil, @follower.id, nil)
+      expect do
+        SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version + 1, nil, @follower.id, nil)
+      end.to raise_error(SendWorkflowInstallmentWorker::RuleNotCommittedError)
     end
 
     it "does not call mailer if deleted installment" do


### PR DESCRIPTION
## What

- Serialize workflow publish, unpublish, and delete transitions under a row lock.
- Advance each email rule version before its delivery state changes.
- Fence pending and committed rule versions in Redis.
- Use a locked primary read when Redis or replica state is uncertain.

## Why

A queued delivery can run while a workflow transaction changes its rule or publication state. The job must not trust a version that the database has not committed.

This PR contains only the commit barrier. Later PRs add durable schedule handoffs and fanout recovery.

## Before/after

Before, a worker could accept stale replica state during a rule or publication transition. After, it waits for the committed rule version or retries safely.

## QA steps

1. Publish a workflow while a delivery worker reads the prior rule version.
2. Confirm that the worker waits for the committed version.
3. Roll back a rule edit.
4. Confirm that the pending Redis marker does not replace the committed version.
5. Simulate a Redis read or write failure.
6. Confirm that the worker reads the locked primary row.

## Test results

- Focused RSpec suite — 46 examples passed.
- `bundle exec rubocop` — 9 files passed with no offenses.
- `bin/test-confidence` — reached 99 percent with 11 tests passed.
- Autoreview — clean on the exact commit with GPT-5.6 Sol.

---

AI disclosure: GPT-5.6 Sol implemented and reviewed this change.
