### PR TITLE
Make workflow schedule handoffs durable

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -113,7 +113,7 @@ class Workflow < ApplicationRecord
     first_published_at.nil?
   end
 
-  def schedule_installment(installment, old_delayed_delivery_time: nil, cutoff_reference_time: Time.current, minimum_rule_version: nil)
+  def schedule_installment(installment, old_delayed_delivery_time: nil, cutoff_reference_time: Time.current, minimum_rule_version: nil, schedule_intent_token: nil, schedule_intent_fanout_token: nil)
     return :not_applicable if installment.abandoned_cart_type?
     return :not_applicable unless alive?
     return :not_applicable unless installment.published?
@@ -121,7 +121,9 @@ class Workflow < ApplicationRecord
     if member_cancellation_trigger?
       if send_to_past_customers?
         args = [installment.id]
-        args.concat([nil, nil, minimum_rule_version]) if minimum_rule_version.present?
+        with_intent = schedule_intent_token.present? || schedule_intent_fanout_token.present?
+        args.concat([nil, nil, minimum_rule_version]) if minimum_rule_version.present? || with_intent
+        args.concat([schedule_intent_token, schedule_intent_fanout_token]) if with_intent
         job_id = SendWorkflowEmailsToPastCanceledMembersJob.perform_async(*args)
         return job_id.present? ? :enqueued : :not_enqueued
       end
@@ -147,7 +149,9 @@ class Workflow < ApplicationRecord
     end
 
     args = [installment.id, earliest_valid_time&.iso8601]
-    args.concat([false, minimum_rule_version]) if minimum_rule_version.present?
+    with_intent = schedule_intent_token.present? || schedule_intent_fanout_token.present?
+    args.concat([false, minimum_rule_version]) if minimum_rule_version.present? || with_intent
+    args.concat([schedule_intent_token, schedule_intent_fanout_token]) if with_intent
     SendWorkflowPostEmailsJob.perform_async(*args).present? ? :enqueued : :not_enqueued
   end
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -73,14 +73,26 @@ class Workflow < ApplicationRecord
         raise ActiveRecord::RecordInvalid.new(self)
       end
 
-      self.published_at = DateTime.current
+      self.published_at = DateTime.current.change(usec: 0)
       self.first_published_at ||= published_at
+      installments_to_schedule = []
       installments.alive.find_each do |installment|
-        installment.installment_rule&.advance_version!
+        rule = installment.installment_rule
+        rule&.advance_version!
         installment.publish!(published_at:)
-        schedule_installment(installment)
+        installments_to_schedule << [installment, rule.version] if rule.present? && !installment.abandoned_cart_type?
       end
       save!
+      installments_to_schedule.each do |installment, rule_version|
+        WorkflowInstallmentScheduleIntent.enqueue!(
+          installment:,
+          rule_version:,
+          old_delayed_delivery_time: nil,
+          cutoff_reference_time: published_at,
+          expected_published_at: published_at
+        )
+      end
+      true
     end
   end
 
@@ -101,19 +113,24 @@ class Workflow < ApplicationRecord
     first_published_at.nil?
   end
 
-  def schedule_installment(installment, old_delayed_delivery_time: nil)
-    return if installment.abandoned_cart_type?
-    return unless alive?
-    return unless installment.published?
+  def schedule_installment(installment, old_delayed_delivery_time: nil, cutoff_reference_time: Time.current, minimum_rule_version: nil)
+    return :not_applicable if installment.abandoned_cart_type?
+    return :not_applicable unless alive?
+    return :not_applicable unless installment.published?
 
     if member_cancellation_trigger?
-      SendWorkflowEmailsToPastCanceledMembersJob.perform_async(installment.id) if send_to_past_customers?
-      return
+      if send_to_past_customers?
+        args = [installment.id]
+        args.concat([nil, nil, minimum_rule_version]) if minimum_rule_version.present?
+        job_id = SendWorkflowEmailsToPastCanceledMembersJob.perform_async(*args)
+        return job_id.present? ? :enqueued : :not_enqueued
+      end
+      return :not_applicable
     end
 
-    return unless new_customer_trigger?
+    return :not_applicable unless new_customer_trigger?
     # don't schedule the installment if it is only for new customers/followers and it hasn't been scheduled before (old_delayed_delivery_time is nil)
-    return if old_delayed_delivery_time.nil? && installment.is_for_new_customers_of_workflow
+    return :not_applicable if old_delayed_delivery_time.nil? && installment.is_for_new_customers_of_workflow
 
     # earliest_valid_time is:
     #   `installment.published_at` if the installment is for new customers only
@@ -123,13 +140,15 @@ class Workflow < ApplicationRecord
     # installment has not been delivered to them and needs to be (re-)scheduled.
     earliest_valid_time = if old_delayed_delivery_time.nil?
       nil
-    elsif installment.is_for_new_customers_of_workflow && installment.published_at >= old_delayed_delivery_time.seconds.ago
+    elsif installment.is_for_new_customers_of_workflow && installment.published_at >= cutoff_reference_time - old_delayed_delivery_time.seconds
       installment.published_at
     else
-      old_delayed_delivery_time.seconds.ago
+      cutoff_reference_time - old_delayed_delivery_time.seconds
     end
 
-    SendWorkflowPostEmailsJob.perform_async(installment.id, earliest_valid_time&.iso8601)
+    args = [installment.id, earliest_valid_time&.iso8601]
+    args.concat([false, minimum_rule_version]) if minimum_rule_version.present?
+    SendWorkflowPostEmailsJob.perform_async(*args).present? ? :enqueued : :not_enqueued
   end
 
   private

--- a/app/models/workflow_installment_schedule_intent.rb
+++ b/app/models/workflow_installment_schedule_intent.rb
@@ -35,32 +35,23 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
   end
 
   def self.enqueue(token)
-    dispatch_token = claim_dispatch(token)
-    return if dispatch_token.nil?
+    now = Time.current
+    transaction do
+      intent = dispatchable(now).lock.find_by(token:)
+      next if intent.nil?
 
-    enqueue_scheduler(token:, dispatch_token:)
+      job_id = ScheduleWorkflowInstallmentJob.perform_async(token)
+      raise EnqueueError, "The scheduler job was not enqueued" if job_id.blank?
+
+      intent.update!(
+        dispatch_token: SecureRandom.uuid,
+        dispatch_expires_at: now + DISPATCH_LEASE
+      )
+      job_id
+    end
   rescue => e
     Rails.logger.error("[#{name}] could not enqueue token=#{token}: #{e.class}: #{e.message}")
     nil
-  end
-
-  def self.claim_dispatch(token)
-    dispatch_token = SecureRandom.uuid
-    now = Time.current
-    claimed = dispatchable(now).where(token:).update_all(
-      dispatch_token:,
-      dispatch_expires_at: now + DISPATCH_LEASE,
-      updated_at: now
-    )
-
-    dispatch_token if claimed.positive?
-  end
-
-  def self.enqueue_scheduler(token:, dispatch_token:)
-    job_id = ScheduleWorkflowInstallmentJob.perform_async(token)
-    job_id
-  ensure
-    release_dispatch_safely(token:, dispatch_token:) if job_id.blank?
   end
 
   def self.mark_processed(token, fanout_token:)
@@ -129,24 +120,4 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
       updated_at: now
     ).positive?
   end
-
-  def self.release_dispatch(token:, dispatch_token:)
-    pending.where(token:, dispatch_token:).update_all(
-      dispatch_token: nil,
-      dispatch_expires_at: nil,
-      updated_at: Time.current
-    )
-  end
-
-  def self.release_dispatch_safely(token:, dispatch_token:)
-    release_dispatch(token:, dispatch_token:)
-  rescue
-    begin
-      release_dispatch(token:, dispatch_token:)
-    rescue => e
-      Rails.logger.error("[#{name}] could not release token=#{token}: #{e.class}: #{e.message}")
-    end
-  end
-
-  private_class_method :claim_dispatch, :enqueue_scheduler, :release_dispatch, :release_dispatch_safely
 end

--- a/app/models/workflow_installment_schedule_intent.rb
+++ b/app/models/workflow_installment_schedule_intent.rb
@@ -4,9 +4,15 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
   class EnqueueError < StandardError; end
 
   DISPATCH_LEASE = 15.minutes
+  FANOUT_LEASE = 2.hours
+  FANOUT_HEARTBEAT_INTERVAL = 5.minutes
 
   scope :pending, -> { where(processed_at: nil) }
-  scope :dispatchable, ->(at = Time.current) { pending.where("dispatch_expires_at IS NULL OR dispatch_expires_at <= ?", at) }
+  scope :dispatchable, ->(at = Time.current) do
+    pending
+      .where("dispatch_expires_at IS NULL OR dispatch_expires_at <= ?", at)
+      .where("fanout_expires_at IS NULL OR fanout_expires_at <= ?", at)
+  end
 
   validates :token, :installment_id, :rule_version, :cutoff_reference_time, presence: true
 
@@ -46,8 +52,71 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
     nil
   end
 
+  def self.mark_processed(token, fanout_token:)
+    return if token.blank? && fanout_token.blank?
+    return if token.blank? || fanout_token.blank?
+
+    now = Time.current
+    pending.where(token:, fanout_token:).update_all(
+      processed_at: now,
+      dispatch_token: nil,
+      dispatch_expires_at: nil,
+      fanout_token: nil,
+      fanout_expires_at: nil,
+      updated_at: now
+    )
+  end
+
   def mark_processed!
-    update!(processed_at: Time.current, dispatch_token: nil, dispatch_expires_at: nil)
+    update!(
+      processed_at: Time.current,
+      dispatch_token: nil,
+      dispatch_expires_at: nil,
+      fanout_token: nil,
+      fanout_expires_at: nil
+    )
+  end
+
+  def claim_fanout!
+    now = Time.current
+    return if processed_at.present? || fanout_expires_at.present? && fanout_expires_at > now
+
+    owner_token = SecureRandom.uuid
+    update!(fanout_token: owner_token, fanout_expires_at: now + FANOUT_LEASE)
+    owner_token
+  end
+
+  def self.begin_fanout(intent_token:, fanout_token:)
+    return true if intent_token.blank? && fanout_token.blank?
+    return false if intent_token.blank? || fanout_token.blank?
+
+    intent = find_by(token: intent_token)
+    return false if intent.nil?
+
+    intent.with_lock do
+      next false if intent.processed_at.present?
+
+      now = Time.current
+      another_fanout_active = intent.fanout_token.present? &&
+                              intent.fanout_token != fanout_token &&
+                              intent.fanout_expires_at.present? &&
+                              intent.fanout_expires_at > now
+      next false if another_fanout_active
+
+      intent.update!(fanout_token:, fanout_expires_at: now + FANOUT_LEASE)
+      true
+    end
+  end
+
+  def self.renew_fanout(intent_token:, fanout_token:)
+    return true if intent_token.blank? && fanout_token.blank?
+    return false if intent_token.blank? || fanout_token.blank?
+
+    now = Time.current
+    pending.where(token: intent_token, fanout_token:).update_all(
+      fanout_expires_at: now + FANOUT_LEASE,
+      updated_at: now
+    ).positive?
   end
 
   def self.release_dispatch(token:, dispatch_token:)

--- a/app/models/workflow_installment_schedule_intent.rb
+++ b/app/models/workflow_installment_schedule_intent.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class WorkflowInstallmentScheduleIntent < ApplicationRecord
+  class EnqueueError < StandardError; end
+
+  DISPATCH_LEASE = 15.minutes
+
+  scope :pending, -> { where(processed_at: nil) }
+  scope :dispatchable, ->(at = Time.current) { pending.where("dispatch_expires_at IS NULL OR dispatch_expires_at <= ?", at) }
+
+  validates :token, :installment_id, :rule_version, :cutoff_reference_time, presence: true
+
+  def self.enqueue!(installment:, rule_version:, old_delayed_delivery_time:, cutoff_reference_time:, expected_published_at: nil)
+    raise EnqueueError, "A database transaction is required" unless connection.transaction_open?
+
+    intent = create!(
+      token: SecureRandom.uuid,
+      installment_id: installment.id,
+      rule_version:,
+      old_delayed_delivery_time:,
+      cutoff_reference_time:,
+      expected_published_at:
+    )
+
+    token = intent.token
+    AfterCommitEverywhere.after_commit { enqueue(token) }
+
+    intent
+  end
+
+  def self.enqueue(token)
+    dispatch_token = SecureRandom.uuid
+    now = Time.current
+    claimed = dispatchable(now).where(token:).update_all(
+      dispatch_token:,
+      dispatch_expires_at: now + DISPATCH_LEASE,
+      updated_at: now
+    )
+    return if claimed.zero?
+
+    job_id = ScheduleWorkflowInstallmentJob.perform_async(token)
+    release_dispatch(token:, dispatch_token:) if job_id.blank?
+    job_id
+  rescue => e
+    Rails.logger.error("[#{name}] could not enqueue token=#{token}: #{e.class}: #{e.message}")
+    nil
+  end
+
+  def mark_processed!
+    update!(processed_at: Time.current, dispatch_token: nil, dispatch_expires_at: nil)
+  end
+
+  def self.release_dispatch(token:, dispatch_token:)
+    pending.where(token:, dispatch_token:).update_all(
+      dispatch_token: nil,
+      dispatch_expires_at: nil,
+      updated_at: Time.current
+    )
+  end
+  private_class_method :release_dispatch
+end

--- a/app/models/workflow_installment_schedule_intent.rb
+++ b/app/models/workflow_installment_schedule_intent.rb
@@ -35,6 +35,16 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
   end
 
   def self.enqueue(token)
+    dispatch_token = claim_dispatch(token)
+    return if dispatch_token.nil?
+
+    enqueue_scheduler(token:, dispatch_token:)
+  rescue => e
+    Rails.logger.error("[#{name}] could not enqueue token=#{token}: #{e.class}: #{e.message}")
+    nil
+  end
+
+  def self.claim_dispatch(token)
     dispatch_token = SecureRandom.uuid
     now = Time.current
     claimed = dispatchable(now).where(token:).update_all(
@@ -42,19 +52,17 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
       dispatch_expires_at: now + DISPATCH_LEASE,
       updated_at: now
     )
-    return if claimed.zero?
 
+    dispatch_token if claimed.positive?
+  end
+
+  def self.enqueue_scheduler(token:, dispatch_token:)
     job_id = ScheduleWorkflowInstallmentJob.perform_async(token)
     release_dispatch(token:, dispatch_token:) if job_id.blank?
     job_id
-  rescue => e
-    begin
-      release_dispatch(token:, dispatch_token:) if claimed.to_i.positive?
-    rescue => release_error
-      Rails.logger.error("[#{name}] could not release token=#{token}: #{release_error.class}: #{release_error.message}")
-    end
-    Rails.logger.error("[#{name}] could not enqueue token=#{token}: #{e.class}: #{e.message}")
-    nil
+  rescue
+    release_dispatch_safely(token:, dispatch_token:)
+    raise
   end
 
   def self.mark_processed(token, fanout_token:)
@@ -131,5 +139,12 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
       updated_at: Time.current
     )
   end
-  private_class_method :release_dispatch
+
+  def self.release_dispatch_safely(token:, dispatch_token:)
+    release_dispatch(token:, dispatch_token:)
+  rescue => e
+    Rails.logger.error("[#{name}] could not release token=#{token}: #{e.class}: #{e.message}")
+  end
+
+  private_class_method :claim_dispatch, :enqueue_scheduler, :release_dispatch, :release_dispatch_safely
 end

--- a/app/models/workflow_installment_schedule_intent.rb
+++ b/app/models/workflow_installment_schedule_intent.rb
@@ -35,24 +35,45 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
   end
 
   def self.enqueue(token)
+    dispatch_token = claim_dispatch(token)
+    return if dispatch_token.nil?
+
+    job_id = ScheduleWorkflowInstallmentJob.perform_async(token, dispatch_token)
+    raise EnqueueError, "The scheduler job was not enqueued" if job_id.blank?
+
+    job_id
+  rescue => e
+    Rails.logger.error("[#{name}] could not enqueue token=#{token}: #{e.class}: #{e.message}")
+    begin
+      release_dispatch(token, dispatch_token) if dispatch_token.present?
+    rescue => release_error
+      Rails.logger.error("[#{name}] could not release token=#{token}: #{release_error.class}: #{release_error.message}")
+    end
+    nil
+  end
+
+  def self.claim_dispatch(token)
     now = Time.current
     transaction do
       intent = dispatchable(now).lock.find_by(token:)
       next if intent.nil?
 
       dispatch_token = SecureRandom.uuid
-      job_id = ScheduleWorkflowInstallmentJob.perform_async(token, dispatch_token)
-      raise EnqueueError, "The scheduler job was not enqueued" if job_id.blank?
-
       intent.update!(
         dispatch_token:,
         dispatch_expires_at: now + DISPATCH_LEASE
       )
-      job_id
+      dispatch_token
     end
-  rescue => e
-    Rails.logger.error("[#{name}] could not enqueue token=#{token}: #{e.class}: #{e.message}")
-    nil
+  end
+
+  def self.release_dispatch(token, dispatch_token)
+    now = Time.current
+    pending.where(token:, dispatch_token:).update_all(
+      dispatch_token: nil,
+      dispatch_expires_at: nil,
+      updated_at: now
+    )
   end
 
   def self.mark_processed(token, fanout_token:)

--- a/app/models/workflow_installment_schedule_intent.rb
+++ b/app/models/workflow_installment_schedule_intent.rb
@@ -58,11 +58,9 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
 
   def self.enqueue_scheduler(token:, dispatch_token:)
     job_id = ScheduleWorkflowInstallmentJob.perform_async(token)
-    release_dispatch(token:, dispatch_token:) if job_id.blank?
     job_id
-  rescue
-    release_dispatch_safely(token:, dispatch_token:)
-    raise
+  ensure
+    release_dispatch_safely(token:, dispatch_token:) if job_id.blank?
   end
 
   def self.mark_processed(token, fanout_token:)
@@ -142,8 +140,12 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
 
   def self.release_dispatch_safely(token:, dispatch_token:)
     release_dispatch(token:, dispatch_token:)
-  rescue => e
-    Rails.logger.error("[#{name}] could not release token=#{token}: #{e.class}: #{e.message}")
+  rescue
+    begin
+      release_dispatch(token:, dispatch_token:)
+    rescue => e
+      Rails.logger.error("[#{name}] could not release token=#{token}: #{e.class}: #{e.message}")
+    end
   end
 
   private_class_method :claim_dispatch, :enqueue_scheduler, :release_dispatch, :release_dispatch_safely

--- a/app/models/workflow_installment_schedule_intent.rb
+++ b/app/models/workflow_installment_schedule_intent.rb
@@ -48,6 +48,11 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
     release_dispatch(token:, dispatch_token:) if job_id.blank?
     job_id
   rescue => e
+    begin
+      release_dispatch(token:, dispatch_token:) if claimed.to_i.positive?
+    rescue => release_error
+      Rails.logger.error("[#{name}] could not release token=#{token}: #{release_error.class}: #{release_error.message}")
+    end
     Rails.logger.error("[#{name}] could not enqueue token=#{token}: #{e.class}: #{e.message}")
     nil
   end

--- a/app/models/workflow_installment_schedule_intent.rb
+++ b/app/models/workflow_installment_schedule_intent.rb
@@ -40,11 +40,12 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
       intent = dispatchable(now).lock.find_by(token:)
       next if intent.nil?
 
-      job_id = ScheduleWorkflowInstallmentJob.perform_async(token)
+      dispatch_token = SecureRandom.uuid
+      job_id = ScheduleWorkflowInstallmentJob.perform_async(token, dispatch_token)
       raise EnqueueError, "The scheduler job was not enqueued" if job_id.blank?
 
       intent.update!(
-        dispatch_token: SecureRandom.uuid,
+        dispatch_token:,
         dispatch_expires_at: now + DISPATCH_LEASE
       )
       job_id

--- a/app/services/workflow/save_installments_service.rb
+++ b/app/services/workflow/save_installments_service.rb
@@ -120,7 +120,12 @@ class Workflow::SaveInstallmentsService
       rule.save!
 
       if installment.published_at.present? && params[:save_action_name] == Workflow::SAVE_ACTION
-        installment.workflow.schedule_installment(installment, old_delayed_delivery_time:)
+        WorkflowInstallmentScheduleIntent.enqueue!(
+          installment:,
+          rule_version: rule.version,
+          old_delayed_delivery_time:,
+          cutoff_reference_time: Time.current
+        )
       end
     end
 end

--- a/app/sidekiq/delete_processed_workflow_installment_schedule_intents_job.rb
+++ b/app/sidekiq/delete_processed_workflow_installment_schedule_intents_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class DeleteProcessedWorkflowInstallmentScheduleIntentsJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low
+
+  RETENTION_PERIOD = 30.days
+
+  def perform
+    WorkflowInstallmentScheduleIntent
+      .where(processed_at: ...RETENTION_PERIOD.ago)
+      .in_batches(of: 1_000)
+      .delete_all
+  end
+end

--- a/app/sidekiq/dispatch_pending_workflow_installment_schedule_intents_job.rb
+++ b/app/sidekiq/dispatch_pending_workflow_installment_schedule_intents_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class DispatchPendingWorkflowInstallmentScheduleIntentsJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low, lock: :until_executed
+
+  include RecurringLockTtl
+  recurring_lock_ttl max_attempt: 10.minutes
+
+  def perform
+    WorkflowInstallmentScheduleIntent.dispatchable.find_each do |intent|
+      WorkflowInstallmentScheduleIntent.enqueue(intent.token)
+    end
+  end
+end

--- a/app/sidekiq/schedule_workflow_installment_job.rb
+++ b/app/sidekiq/schedule_workflow_installment_job.rb
@@ -9,10 +9,9 @@ class ScheduleWorkflowInstallmentJob
 
   def perform(intent_token, dispatch_token = nil)
     ActiveRecord::Base.connection.stick_to_primary!
-    intent = WorkflowInstallmentScheduleIntent.find_by(token: intent_token)
-    return if intent.nil?
-
-    intent.with_lock do
+    WorkflowInstallmentScheduleIntent.transaction do
+      intent = WorkflowInstallmentScheduleIntent.lock.find_by(token: intent_token)
+      next if intent.nil?
       next if intent.processed_at.present?
       next if dispatch_token.present? && intent.dispatch_token != dispatch_token
 

--- a/app/sidekiq/schedule_workflow_installment_job.rb
+++ b/app/sidekiq/schedule_workflow_installment_job.rb
@@ -13,7 +13,18 @@ class ScheduleWorkflowInstallmentJob
       intent = WorkflowInstallmentScheduleIntent.lock.find_by(token: intent_token)
       next if intent.nil?
       next if intent.processed_at.present?
-      next if dispatch_token.present? && intent.dispatch_token != dispatch_token
+      if dispatch_token.present? && intent.dispatch_token != dispatch_token
+        now = Time.current
+        another_dispatch_active = intent.dispatch_token.present? &&
+                                  intent.dispatch_expires_at.present? &&
+                                  intent.dispatch_expires_at > now
+        fanout_active = intent.fanout_token.present? &&
+                        intent.fanout_expires_at.present? &&
+                        intent.fanout_expires_at > now
+        raise IntentNotCommittedError unless another_dispatch_active || fanout_active
+
+        next
+      end
 
       installment = Installment.find_by(id: intent.installment_id)
       if installment.nil? || installment.installment_rule.nil?

--- a/app/sidekiq/schedule_workflow_installment_job.rb
+++ b/app/sidekiq/schedule_workflow_installment_job.rb
@@ -47,14 +47,21 @@ class ScheduleWorkflowInstallmentJob
         next
       end
 
+      fanout_token = intent.claim_fanout!
+      next if fanout_token.nil?
+
       result = workflow.schedule_installment(
         installment,
         old_delayed_delivery_time: intent.old_delayed_delivery_time,
         cutoff_reference_time: intent.cutoff_reference_time,
-        minimum_rule_version: current_version
+        minimum_rule_version: current_version,
+        schedule_intent_token: intent.token,
+        schedule_intent_fanout_token: fanout_token
       )
       case result
-      when :enqueued, :not_applicable
+      when :enqueued
+        next
+      when :not_applicable
         intent.mark_processed!
       when :not_enqueued
         raise FanoutNotEnqueuedError, "Recipient fanout was not enqueued"

--- a/app/sidekiq/schedule_workflow_installment_job.rb
+++ b/app/sidekiq/schedule_workflow_installment_job.rb
@@ -7,13 +7,14 @@ class ScheduleWorkflowInstallmentJob
   include Sidekiq::Job
   sidekiq_options retry: 10, queue: :low
 
-  def perform(intent_token)
+  def perform(intent_token, dispatch_token = nil)
     ActiveRecord::Base.connection.stick_to_primary!
     intent = WorkflowInstallmentScheduleIntent.find_by(token: intent_token)
     return if intent.nil?
 
     intent.with_lock do
       next if intent.processed_at.present?
+      next if dispatch_token.present? && intent.dispatch_token != dispatch_token
 
       installment = Installment.find_by(id: intent.installment_id)
       if installment.nil? || installment.installment_rule.nil?

--- a/app/sidekiq/schedule_workflow_installment_job.rb
+++ b/app/sidekiq/schedule_workflow_installment_job.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class ScheduleWorkflowInstallmentJob
+  class IntentNotCommittedError < StandardError; end
+  class FanoutNotEnqueuedError < StandardError; end
+
+  include Sidekiq::Job
+  sidekiq_options retry: 10, queue: :low
+
+  def perform(intent_token)
+    ActiveRecord::Base.connection.stick_to_primary!
+    intent = WorkflowInstallmentScheduleIntent.find_by(token: intent_token)
+    return if intent.nil?
+
+    intent.with_lock do
+      next if intent.processed_at.present?
+
+      installment = Installment.find_by(id: intent.installment_id)
+      if installment.nil? || installment.installment_rule.nil?
+        intent.mark_processed!
+        next
+      end
+
+      current_version = installment.installment_rule.version
+      raise IntentNotCommittedError if current_version < intent.rule_version
+
+      workflow = installment.workflow
+      if workflow.nil?
+        intent.mark_processed!
+        next
+      end
+
+      if intent.expected_published_at.present?
+        publication_matches = false
+        workflow.with_lock do
+          installment.reload
+          publication_matches = workflow.published_at&.change(usec: 0) == intent.expected_published_at &&
+                                installment.published_at&.change(usec: 0) == intent.expected_published_at
+        end
+        unless publication_matches
+          intent.mark_processed!
+          next
+        end
+      end
+      unless workflow.alive? && installment.alive? && installment.published?
+        intent.mark_processed!
+        next
+      end
+
+      result = workflow.schedule_installment(
+        installment,
+        old_delayed_delivery_time: intent.old_delayed_delivery_time,
+        cutoff_reference_time: intent.cutoff_reference_time,
+        minimum_rule_version: current_version
+      )
+      case result
+      when :enqueued, :not_applicable
+        intent.mark_processed!
+      when :not_enqueued
+        raise FanoutNotEnqueuedError, "Recipient fanout was not enqueued"
+      else
+        raise FanoutNotEnqueuedError, "Unexpected schedule result: #{result.inspect}"
+      end
+    end
+  ensure
+    Makara::Context.release_all
+  end
+end

--- a/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
+++ b/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
@@ -1,23 +1,49 @@
 # frozen_string_literal: true
 
 class SendWorkflowEmailsToPastCanceledMembersJob
+  class FanoutNotEnqueuedError < StandardError; end
   class RuleNotCommittedError < StandardError; end
 
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 
-  def perform(installment_id, _old_delayed_delivery_time = nil, _cutoff_reference_time = nil, minimum_rule_version = nil)
-    primary_pinned = minimum_rule_version.present?
+  def perform(installment_id, _old_delayed_delivery_time = nil, _cutoff_reference_time = nil, minimum_rule_version = nil, schedule_intent_token = nil, schedule_intent_fanout_token = nil)
+    @schedule_intent_token = schedule_intent_token
+    @schedule_intent_fanout_token = schedule_intent_fanout_token
+    primary_pinned = minimum_rule_version.present? || schedule_intent_token.present? || schedule_intent_fanout_token.present?
     ActiveRecord::Base.connection.stick_to_primary! if primary_pinned
-    installment = Installment.find(installment_id)
+    return unless WorkflowInstallmentScheduleIntent.begin_fanout(
+      intent_token: schedule_intent_token,
+      fanout_token: schedule_intent_fanout_token
+    )
+    @next_fanout_heartbeat_at = fanout_heartbeat_time + WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f
+    installment = Installment.find_by(id: installment_id)
+    if installment.nil?
+      WorkflowInstallmentScheduleIntent.mark_processed(
+        schedule_intent_token,
+        fanout_token: schedule_intent_fanout_token
+      )
+      return
+    end
     workflow = installment.workflow
-    return unless workflow&.alive? && installment.alive? && installment.published?
-    return unless workflow.member_cancellation_trigger?
-    return unless workflow.send_to_past_customers?
-    return unless workflow.seller_or_product_or_variant_type?
+    unless workflow&.alive? && installment.alive? && installment.published? &&
+           workflow.member_cancellation_trigger? && workflow.send_to_past_customers? &&
+           workflow.seller_or_product_or_variant_type?
+      WorkflowInstallmentScheduleIntent.mark_processed(
+        schedule_intent_token,
+        fanout_token: schedule_intent_fanout_token
+      )
+      return
+    end
 
     rule = installment.installment_rule
-    return if rule.nil?
+    if rule.nil?
+      WorkflowInstallmentScheduleIntent.mark_processed(
+        schedule_intent_token,
+        fanout_token: schedule_intent_fanout_token
+      )
+      return
+    end
     raise RuleNotCommittedError if minimum_rule_version.present? && rule.version < minimum_rule_version
     cache_rule_version(rule)
 
@@ -26,16 +52,16 @@ class SendWorkflowEmailsToPastCanceledMembersJob
     Makara::Context.release_all
     primary_pinned = false
 
-    candidate_subscriptions(workflow).includes(:original_purchase).find_each do |subscription|
-      next unless subscription.cancelled?
-      original_purchase = subscription.original_purchase
-      next if original_purchase.nil?
-      next unless workflow.applies_to_purchase?(original_purchase)
-
-      SendWorkflowInstallmentWorker.perform_at(
-        subscription.deactivated_at + delay,
-        installment.id, rule_version, nil, nil, nil, subscription.id
+    case enqueue_all_member_jobs(workflow:, installment:, delay:, rule_version:)
+    when :complete
+      WorkflowInstallmentScheduleIntent.mark_processed(
+        schedule_intent_token,
+        fanout_token: schedule_intent_fanout_token
       )
+    when :ownership_lost
+      nil
+    else
+      raise FanoutNotEnqueuedError, "Unexpected fanout result"
     end
   ensure
     Makara::Context.release_all if primary_pinned
@@ -46,6 +72,45 @@ class SendWorkflowEmailsToPastCanceledMembersJob
       rule.cache_version!
     rescue Redis::BaseError, RedisClient::Error => e
       ErrorNotifier.notify(e, installment_rule_id: rule.id)
+    end
+
+    def enqueue_all_member_jobs(workflow:, installment:, delay:, rule_version:)
+      candidate_subscriptions(workflow).includes(:original_purchase).find_each do |subscription|
+        return :ownership_lost unless renew_fanout_lease
+
+        next unless subscription.cancelled?
+        original_purchase = subscription.original_purchase
+        next if original_purchase.nil?
+        next unless workflow.applies_to_purchase?(original_purchase)
+
+        job_id = SendWorkflowInstallmentWorker.perform_at(
+          subscription.deactivated_at + delay,
+          installment.id, rule_version, nil, nil, nil, subscription.id
+        )
+        if job_id.blank?
+          raise FanoutNotEnqueuedError, "Sidekiq did not enqueue the workflow installment"
+        end
+      end
+      :complete
+    end
+
+    def renew_fanout_lease
+      return true if @schedule_intent_token.blank? && @schedule_intent_fanout_token.blank?
+
+      now = fanout_heartbeat_time
+      return true if now < @next_fanout_heartbeat_at
+
+      renewed = WorkflowInstallmentScheduleIntent.renew_fanout(
+        intent_token: @schedule_intent_token,
+        fanout_token: @schedule_intent_fanout_token
+      )
+      Makara::Context.release_all
+      @next_fanout_heartbeat_at = now + WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f if renewed
+      renewed
+    end
+
+    def fanout_heartbeat_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     def candidate_subscriptions(workflow)

--- a/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
+++ b/app/sidekiq/send_workflow_emails_to_past_canceled_members_job.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class SendWorkflowEmailsToPastCanceledMembersJob
+  class RuleNotCommittedError < StandardError; end
+
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 
-  def perform(installment_id)
+  def perform(installment_id, _old_delayed_delivery_time = nil, _cutoff_reference_time = nil, minimum_rule_version = nil)
+    primary_pinned = minimum_rule_version.present?
+    ActiveRecord::Base.connection.stick_to_primary! if primary_pinned
     installment = Installment.find(installment_id)
     workflow = installment.workflow
     return unless workflow&.alive? && installment.alive? && installment.published?
@@ -14,9 +18,13 @@ class SendWorkflowEmailsToPastCanceledMembersJob
 
     rule = installment.installment_rule
     return if rule.nil?
+    raise RuleNotCommittedError if minimum_rule_version.present? && rule.version < minimum_rule_version
+    cache_rule_version(rule)
 
     delay = rule.delayed_delivery_time
     rule_version = rule.version
+    Makara::Context.release_all
+    primary_pinned = false
 
     candidate_subscriptions(workflow).includes(:original_purchase).find_each do |subscription|
       next unless subscription.cancelled?
@@ -29,9 +37,17 @@ class SendWorkflowEmailsToPastCanceledMembersJob
         installment.id, rule_version, nil, nil, nil, subscription.id
       )
     end
+  ensure
+    Makara::Context.release_all if primary_pinned
   end
 
   private
+    def cache_rule_version(rule)
+      rule.cache_version!
+    rescue Redis::BaseError, RedisClient::Error => e
+      ErrorNotifier.notify(e, installment_rule_id: rule.id)
+    end
+
     def candidate_subscriptions(workflow)
       scope = Subscription.where.not(deactivated_at: nil).where.not(cancelled_at: nil)
       if workflow.product_or_variant_type?

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -1,22 +1,48 @@
 # frozen_string_literal: true
 
 class SendWorkflowPostEmailsJob
+  class FanoutNotEnqueuedError < StandardError; end
   class RuleNotCommittedError < StandardError; end
 
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 
-  def perform(post_id, earliest_valid_time = nil, _reschedule_on_stale = false, minimum_rule_version = nil)
-    primary_pinned = minimum_rule_version.present?
+  def perform(post_id, earliest_valid_time = nil, _reschedule_on_stale = false, minimum_rule_version = nil, schedule_intent_token = nil, schedule_intent_fanout_token = nil)
+    @schedule_intent_token = schedule_intent_token
+    @schedule_intent_fanout_token = schedule_intent_fanout_token
+    primary_pinned = minimum_rule_version.present? || schedule_intent_token.present? || schedule_intent_fanout_token.present?
     ActiveRecord::Base.connection.stick_to_primary! if primary_pinned
-    @post = Installment.find(post_id)
+    return unless WorkflowInstallmentScheduleIntent.begin_fanout(
+      intent_token: schedule_intent_token,
+      fanout_token: schedule_intent_fanout_token
+    )
+    @next_fanout_heartbeat_at = fanout_heartbeat_time + WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f
+    @post = Installment.find_by(id: post_id)
+    if @post.nil?
+      WorkflowInstallmentScheduleIntent.mark_processed(
+        schedule_intent_token,
+        fanout_token: schedule_intent_fanout_token
+      )
+      return
+    end
     @workflow = @post.workflow
-    return unless @workflow.alive? && @post.alive? && @post.published?
+    unless @workflow&.alive? && @post.alive? && @post.published?
+      WorkflowInstallmentScheduleIntent.mark_processed(
+        schedule_intent_token,
+        fanout_token: schedule_intent_fanout_token
+      )
+      return
+    end
 
     rule = @post.installment_rule
-    if minimum_rule_version.present? && (rule.nil? || rule.version < minimum_rule_version)
-      raise RuleNotCommittedError
+    if rule.nil?
+      WorkflowInstallmentScheduleIntent.mark_processed(
+        schedule_intent_token,
+        fanout_token: schedule_intent_fanout_token
+      )
+      return
     end
+    raise RuleNotCommittedError if minimum_rule_version.present? && rule.version < minimum_rule_version
     cache_rule_version(rule)
     @rule_version = rule.version
     @rule_delay = rule.delayed_delivery_time
@@ -28,27 +54,24 @@ class SendWorkflowPostEmailsJob
     # Same protection as SendPostBlastEmailsJob: for sellers with very large audiences the
     # filter query can exceed the database's default 5-minute statement cap, so raise it for
     # this one query.
-    @members = WithMaxExecutionTime.timeout_queries(seconds: audience_load_timeout_seconds) do
+    audience_timeout = audience_load_timeout_seconds
+    return unless renew_fanout_lease(force: true)
+    @members = WithMaxExecutionTime.timeout_queries(seconds: audience_timeout) do
       AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).
         select(:id, :email, :details, :purchase_id, :follower_id, :affiliate_id).to_a
     end
+    return unless renew_fanout_lease(force: true)
 
-    @members.each do |member|
-      if @post.seller_or_product_or_variant_type?
-        enqueue_email_job(member:, type: :purchase, id: member.purchase_id)
-      elsif @post.follower_type?
-        enqueue_email_job(member:, type: :follower, id: member.follower_id)
-      elsif @post.affiliate_type?
-        enqueue_email_job(member:, type: :affiliate, id: member.affiliate_id)
-      elsif @post.audience_type?
-        if member.follower_id
-          enqueue_email_job(member:, type: :follower, id: member.follower_id)
-        elsif member.affiliate_id
-          enqueue_email_job(member:, type: :affiliate, id: member.affiliate_id)
-        else
-          enqueue_email_job(member:, type: :purchase, id: member.purchase_id)
-        end
-      end
+    case enqueue_all_member_jobs
+    when :complete
+      WorkflowInstallmentScheduleIntent.mark_processed(
+        schedule_intent_token,
+        fanout_token: schedule_intent_fanout_token
+      )
+    when :ownership_lost
+      nil
+    else
+      raise FanoutNotEnqueuedError, "Unexpected fanout result"
     end
   ensure
     Makara::Context.release_all if primary_pinned
@@ -61,22 +84,62 @@ class SendWorkflowPostEmailsJob
       ErrorNotifier.notify(e, installment_rule_id: rule.id)
     end
 
+    def enqueue_all_member_jobs
+      @members.each do |member|
+        return :ownership_lost unless renew_fanout_lease
+
+        if @post.seller_or_product_or_variant_type?
+          enqueue_email_job(member:, type: :purchase, id: member.purchase_id)
+        elsif @post.follower_type?
+          enqueue_email_job(member:, type: :follower, id: member.follower_id)
+        elsif @post.affiliate_type?
+          enqueue_email_job(member:, type: :affiliate, id: member.affiliate_id)
+        elsif @post.audience_type?
+          if member.follower_id
+            enqueue_email_job(member:, type: :follower, id: member.follower_id)
+          elsif member.affiliate_id
+            enqueue_email_job(member:, type: :affiliate, id: member.affiliate_id)
+          else
+            enqueue_email_job(member:, type: :purchase, id: member.purchase_id)
+          end
+        end
+      end
+      :complete
+    end
+
+    def renew_fanout_lease(force: false)
+      return true if @schedule_intent_token.blank? && @schedule_intent_fanout_token.blank?
+
+      now = fanout_heartbeat_time
+      return true unless force || now >= @next_fanout_heartbeat_at
+
+      renewed = WorkflowInstallmentScheduleIntent.renew_fanout(
+        intent_token: @schedule_intent_token,
+        fanout_token: @schedule_intent_fanout_token
+      )
+      Makara::Context.release_all
+      @next_fanout_heartbeat_at = now + WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f if renewed
+      renewed
+    end
+
+    def fanout_heartbeat_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
     def enqueue_email_job(member:, type:, id:)
-      # The id columns come from an aggregate over a JSON_TABLE join, and a row can be
-      # filtered out of that join even though the member still qualifies (see the comment
-      # on the `with_ids` select in AudienceMember.filter). If that happens the id arrives
-      # nil and the worker below would have nothing to send to, so fall back to reading it
-      # out of the same `details` JSON the timestamps are already read from.
       if type == :purchase
+        # `with_ids` supplies the matching purchase. Another embedded purchase can bypass the workflow filters.
+        return log_unresolvable_recipient(member:, type:) if id.nil?
+
         purchase = member.details["purchases"].find { _1["id"] == id }
         return log_unresolvable_recipient(member:, type:) if purchase.nil?
         created_at = Time.zone.parse(purchase["created_at"])
-        SendWorkflowInstallmentWorker.perform_at(created_at + @rule_delay, @post.id, @rule_version, id, nil, nil)
+        enqueue_installment_worker(created_at + @rule_delay, @post.id, @rule_version, id, nil, nil)
       elsif type == :follower
         id ||= member.details.dig("follower", "id")
         return log_unresolvable_recipient(member:, type:) if id.nil?
         created_at = Time.zone.parse(member.details.dig("follower", "created_at"))
-        SendWorkflowInstallmentWorker.perform_at(created_at + @rule_delay, @post.id, @rule_version, nil, id, nil)
+        enqueue_installment_worker(created_at + @rule_delay, @post.id, @rule_version, nil, id, nil)
       elsif type == :affiliate
         affiliate = resolve_affiliate(member:, id:)
         return log_unresolvable_recipient(member:, type:) if affiliate.nil?
@@ -89,8 +152,15 @@ class SendWorkflowPostEmailsJob
         affiliate_user_id = Affiliate.where(id: affiliate["id"]).pick(:affiliate_user_id)
         return log_unresolvable_recipient(member:, type:) if affiliate_user_id.nil?
         created_at = Time.zone.parse(affiliate["created_at"])
-        SendWorkflowInstallmentWorker.perform_at(created_at + @rule_delay, @post.id, @rule_version, nil, nil, affiliate_user_id)
+        enqueue_installment_worker(created_at + @rule_delay, @post.id, @rule_version, nil, nil, affiliate_user_id)
       end
+    end
+
+    def enqueue_installment_worker(deliver_at, *args)
+      job_id = SendWorkflowInstallmentWorker.perform_at(deliver_at, *args)
+      return job_id if job_id.present?
+
+      raise FanoutNotEnqueuedError, "Sidekiq did not enqueue the workflow installment"
     end
 
     # A person can be an affiliate for several of the seller's products, and `details["affiliates"]`

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -1,20 +1,30 @@
 # frozen_string_literal: true
 
 class SendWorkflowPostEmailsJob
+  class RuleNotCommittedError < StandardError; end
+
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 
-  def perform(post_id, earliest_valid_time = nil)
+  def perform(post_id, earliest_valid_time = nil, _reschedule_on_stale = false, minimum_rule_version = nil)
+    primary_pinned = minimum_rule_version.present?
+    ActiveRecord::Base.connection.stick_to_primary! if primary_pinned
     @post = Installment.find(post_id)
     @workflow = @post.workflow
     return unless @workflow.alive? && @post.alive? && @post.published?
 
-    @rule_version = @post.installment_rule.version
-    @rule_delay = @post.installment_rule.delayed_delivery_time
+    rule = @post.installment_rule
+    if minimum_rule_version.present? && (rule.nil? || rule.version < minimum_rule_version)
+      raise RuleNotCommittedError
+    end
+    cache_rule_version(rule)
+    @rule_version = rule.version
+    @rule_delay = rule.delayed_delivery_time
 
     @filters = @post.audience_members_filter_params
     @filters[:created_after] = Time.zone.parse(earliest_valid_time) if earliest_valid_time
     Makara::Context.release_all
+    primary_pinned = false
     # Same protection as SendPostBlastEmailsJob: for sellers with very large audiences the
     # filter query can exceed the database's default 5-minute statement cap, so raise it for
     # this one query.
@@ -40,9 +50,17 @@ class SendWorkflowPostEmailsJob
         end
       end
     end
+  ensure
+    Makara::Context.release_all if primary_pinned
   end
 
   private
+    def cache_rule_version(rule)
+      rule.cache_version!
+    rescue Redis::BaseError, RedisClient::Error => e
+      ErrorNotifier.notify(e, installment_rule_id: rule.id)
+    end
+
     def enqueue_email_job(member:, type:, id:)
       # The id columns come from an aggregate over a JSON_TABLE join, and a row can be
       # filtered out of that join even though the member still qualifies (see the comment

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -1,4 +1,8 @@
 # Every minute
+dispatch_pending_workflow_installment_schedule_intents:
+  cron: "* * * * *" # Every minute
+  class: DispatchPendingWorkflowInstallmentScheduleIntentsJob
+  description: Re-enqueues durable workflow schedule intents whose fast-path push was lost
 find_expired_subscriptions_to_set_as_deactivated_worker:
   cron: "* * * * *" # Every minute
   class: FindExpiredSubscriptionsToSetAsDeactivatedWorker
@@ -52,6 +56,10 @@ delete_expired_oauth_device_authorizations:
   description: Deletes expired OAuth device authorizations
 
 # Daily in format: [minute] [hour] * * *
+delete_processed_workflow_installment_schedule_intents:
+  cron: "15 3 * * *" # UTC 03:15
+  class: DeleteProcessedWorkflowInstallmentScheduleIntentsJob
+  description: Deletes processed workflow schedule intents after the Sidekiq retry window
 sync_radar_value_lists:
   cron: "0 3 * * *" # UTC 03:00
   class: Radar::SyncValueListsJob

--- a/db/migrate/20261207122600_create_workflow_installment_schedule_intents.rb
+++ b/db/migrate/20261207122600_create_workflow_installment_schedule_intents.rb
@@ -12,12 +12,14 @@ class CreateWorkflowInstallmentScheduleIntents < ActiveRecord::Migration[7.1]
       t.datetime :expected_published_at
       t.string :dispatch_token
       t.datetime :dispatch_expires_at
+      t.string :fanout_token
+      t.datetime :fanout_expires_at
       t.datetime :processed_at
       t.timestamps
 
       t.index :token, unique: true
       t.index :installment_id
-      t.index [:processed_at, :dispatch_expires_at], name: "index_workflow_intent_on_processed_and_dispatch_expiry"
+      t.index [:processed_at, :dispatch_expires_at, :fanout_expires_at], name: "index_workflow_intent_on_pending_dispatch"
     end
   end
 end

--- a/db/migrate/20261207122600_create_workflow_installment_schedule_intents.rb
+++ b/db/migrate/20261207122600_create_workflow_installment_schedule_intents.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Main already records a future schema version, so this timestamp must sort after it.
+class CreateWorkflowInstallmentScheduleIntents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :workflow_installment_schedule_intents do |t|
+      t.string :token, null: false
+      t.integer :installment_id, null: false
+      t.integer :rule_version, null: false
+      t.integer :old_delayed_delivery_time
+      t.datetime :cutoff_reference_time, null: false
+      t.datetime :expected_published_at
+      t.string :dispatch_token
+      t.datetime :dispatch_expires_at
+      t.datetime :processed_at
+      t.timestamps
+
+      t.index :token, unique: true
+      t.index :installment_id
+      t.index [:processed_at, :dispatch_expires_at], name: "index_workflow_intent_on_processed_and_dispatch_expiry"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_07_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_07_122600) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -3187,6 +3187,23 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_07_000000) do
     t.integer "recent_follower_count", default: 0, null: false
     t.index ["recommendable", "recent_follower_count"], name: "index_wishlists_on_recommendable_and_recent_follower_count"
     t.index ["user_id"], name: "index_wishlists_on_user_id"
+  end
+
+  create_table "workflow_installment_schedule_intents", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "token", null: false
+    t.integer "installment_id", null: false
+    t.integer "rule_version", null: false
+    t.integer "old_delayed_delivery_time"
+    t.datetime "cutoff_reference_time", null: false
+    t.datetime "expected_published_at"
+    t.string "dispatch_token"
+    t.datetime "dispatch_expires_at"
+    t.datetime "processed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["installment_id"], name: "index_workflow_installment_schedule_intents_on_installment_id"
+    t.index ["processed_at", "dispatch_expires_at"], name: "index_workflow_intent_on_processed_and_dispatch_expiry"
+    t.index ["token"], name: "index_workflow_installment_schedule_intents_on_token", unique: true
   end
 
   create_table "workflows", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -3198,11 +3198,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_07_122600) do
     t.datetime "expected_published_at"
     t.string "dispatch_token"
     t.datetime "dispatch_expires_at"
+    t.string "fanout_token"
+    t.datetime "fanout_expires_at"
     t.datetime "processed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["installment_id"], name: "index_workflow_installment_schedule_intents_on_installment_id"
-    t.index ["processed_at", "dispatch_expires_at"], name: "index_workflow_intent_on_processed_and_dispatch_expiry"
+    t.index ["processed_at", "dispatch_expires_at", "fanout_expires_at"], name: "index_workflow_intent_on_pending_dispatch"
     t.index ["token"], name: "index_workflow_installment_schedule_intents_on_token", unique: true
   end
 

--- a/spec/models/workflow_installment_schedule_intent_spec.rb
+++ b/spec/models/workflow_installment_schedule_intent_spec.rb
@@ -26,7 +26,7 @@ describe WorkflowInstallmentScheduleIntent do
     end.to raise_error(described_class::EnqueueError, "A database transaction is required")
   end
 
-  it "releases dispatch failures for the pending intent job" do
+  it "does not persist a claim when the scheduler enqueue raises" do
     intent = create_intent
     allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_raise("Redis is unavailable")
     expect(Rails.logger).to receive(:error).with(/Redis is unavailable/)
@@ -37,44 +37,26 @@ describe WorkflowInstallmentScheduleIntent do
     expect(described_class.dispatchable).to include(intent)
   end
 
-  it "does not release a dispatch claim that failed to persist" do
+  it "contains a dispatch query failure" do
     intent = create_intent
     allow(described_class).to receive(:dispatchable).and_raise("database is unavailable")
-    expect(described_class).not_to receive(:release_dispatch)
     expect(Rails.logger).to receive(:error).with(/database is unavailable/)
 
     expect(described_class.enqueue(intent.token)).to be_nil
   end
 
-  it "contains a failure while releasing a dispatch claim" do
+  it "does not persist a claim when middleware cancels the enqueue" do
     intent = create_intent
-    allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_raise("Redis is unavailable")
-    allow(described_class).to receive(:release_dispatch).and_raise("database is unavailable")
-    expect(Rails.logger).to receive(:error).with(/could not release.*database is unavailable/)
-    expect(Rails.logger).to receive(:error).with(/could not enqueue.*Redis is unavailable/)
+    allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_return(nil)
+    expect(Rails.logger).to receive(:error).with(/scheduler job was not enqueued/i)
 
     expect(described_class.enqueue(intent.token)).to be_nil
-  end
-
-  it "retries a transient failure while releasing a dispatch claim" do
-    intent = create_intent
-    allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_raise("Redis is unavailable")
-    expect(Rails.logger).to receive(:error).with(/could not enqueue.*Redis is unavailable/)
-    attempts = 0
-    allow(described_class).to receive(:release_dispatch).and_wrap_original do |method, **kwargs|
-      attempts += 1
-      raise "database is unavailable" if attempts == 1
-
-      method.call(**kwargs)
-    end
-
-    expect(described_class.enqueue(intent.token)).to be_nil
-    expect(attempts).to eq(2)
     expect(intent.reload.dispatch_token).to be_nil
     expect(intent.dispatch_expires_at).to be_nil
+    expect(described_class.dispatchable).to include(intent)
   end
 
-  it "claims an intent before enqueueing its scheduler" do
+  it "records a claim after enqueueing its scheduler" do
     intent = create_intent
     expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(intent.token).once.and_return("jid")
 
@@ -83,17 +65,6 @@ describe WorkflowInstallmentScheduleIntent do
 
     expect(intent.reload.dispatch_token).to be_present
     expect(intent.dispatch_expires_at).to be > Time.current
-  end
-
-  it "releases its claim when middleware cancels the enqueue" do
-    intent = create_intent
-    allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_return(nil)
-
-    expect(described_class.enqueue(intent.token)).to be_nil
-
-    expect(intent.reload.dispatch_token).to be_nil
-    expect(intent.dispatch_expires_at).to be_nil
-    expect(described_class.dispatchable).to include(intent)
   end
 
   it "reclaims an expired dispatch lease" do

--- a/spec/models/workflow_installment_schedule_intent_spec.rb
+++ b/spec/models/workflow_installment_schedule_intent_spec.rb
@@ -58,18 +58,22 @@ describe WorkflowInstallmentScheduleIntent do
 
   it "records a claim after enqueueing its scheduler" do
     intent = create_intent
-    expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(intent.token).once.and_return("jid")
+    enqueued_dispatch_token = nil
+    expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(intent.token, kind_of(String)).once do |_, dispatch_token|
+      enqueued_dispatch_token = dispatch_token
+      "jid"
+    end
 
     expect(described_class.enqueue(intent.token)).to eq("jid")
     expect(described_class.enqueue(intent.token)).to be_nil
 
-    expect(intent.reload.dispatch_token).to be_present
+    expect(intent.reload.dispatch_token).to eq(enqueued_dispatch_token)
     expect(intent.dispatch_expires_at).to be > Time.current
   end
 
   it "reclaims an expired dispatch lease" do
     intent = create_intent(dispatch_token: SecureRandom.uuid, dispatch_expires_at: 1.minute.ago)
-    expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(intent.token).and_return("jid")
+    expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(intent.token, kind_of(String)).and_return("jid")
 
     expect(described_class.enqueue(intent.token)).to eq("jid")
 

--- a/spec/models/workflow_installment_schedule_intent_spec.rb
+++ b/spec/models/workflow_installment_schedule_intent_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+describe WorkflowInstallmentScheduleIntent do
+  def create_intent(**attributes)
+    described_class.create!(
+      {
+        token: SecureRandom.uuid,
+        installment_id: 1,
+        rule_version: 1,
+        cutoff_reference_time: Time.current
+      }.merge(attributes)
+    )
+  end
+
+  it "requires a database transaction before enqueueing" do
+    connection = instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter, transaction_open?: false)
+    allow(described_class).to receive(:connection).and_return(connection)
+
+    expect do
+      described_class.enqueue!(
+        installment: instance_double(Installment, id: 1),
+        rule_version: 1,
+        old_delayed_delivery_time: nil,
+        cutoff_reference_time: Time.current
+      )
+    end.to raise_error(described_class::EnqueueError, "A database transaction is required")
+  end
+
+  it "leaves dispatch failures for the pending intent job" do
+    intent = create_intent
+    allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_raise("Redis is unavailable")
+    expect(Rails.logger).to receive(:error).with(/Redis is unavailable/)
+
+    expect(described_class.enqueue(intent.token)).to be_nil
+    expect(intent.reload.dispatch_expires_at).to be_present
+    expect(described_class.dispatchable).not_to include(intent)
+  end
+
+  it "claims an intent before enqueueing its scheduler" do
+    intent = create_intent
+    expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(intent.token).once.and_return("jid")
+
+    expect(described_class.enqueue(intent.token)).to eq("jid")
+    expect(described_class.enqueue(intent.token)).to be_nil
+
+    expect(intent.reload.dispatch_token).to be_present
+    expect(intent.dispatch_expires_at).to be > Time.current
+  end
+
+  it "releases its claim when middleware cancels the enqueue" do
+    intent = create_intent
+    allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_return(nil)
+
+    expect(described_class.enqueue(intent.token)).to be_nil
+
+    expect(intent.reload.dispatch_token).to be_nil
+    expect(intent.dispatch_expires_at).to be_nil
+    expect(described_class.dispatchable).to include(intent)
+  end
+
+  it "reclaims an expired dispatch lease" do
+    intent = create_intent(dispatch_token: SecureRandom.uuid, dispatch_expires_at: 1.minute.ago)
+    expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(intent.token).and_return("jid")
+
+    expect(described_class.enqueue(intent.token)).to eq("jid")
+
+    expect(intent.reload.dispatch_expires_at).to be > Time.current
+  end
+end

--- a/spec/models/workflow_installment_schedule_intent_spec.rb
+++ b/spec/models/workflow_installment_schedule_intent_spec.rb
@@ -56,6 +56,24 @@ describe WorkflowInstallmentScheduleIntent do
     expect(described_class.enqueue(intent.token)).to be_nil
   end
 
+  it "retries a transient failure while releasing a dispatch claim" do
+    intent = create_intent
+    allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_raise("Redis is unavailable")
+    expect(Rails.logger).to receive(:error).with(/could not enqueue.*Redis is unavailable/)
+    attempts = 0
+    allow(described_class).to receive(:release_dispatch).and_wrap_original do |method, **kwargs|
+      attempts += 1
+      raise "database is unavailable" if attempts == 1
+
+      method.call(**kwargs)
+    end
+
+    expect(described_class.enqueue(intent.token)).to be_nil
+    expect(attempts).to eq(2)
+    expect(intent.reload.dispatch_token).to be_nil
+    expect(intent.dispatch_expires_at).to be_nil
+  end
+
   it "claims an intent before enqueueing its scheduler" do
     intent = create_intent
     expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(intent.token).once.and_return("jid")

--- a/spec/models/workflow_installment_schedule_intent_spec.rb
+++ b/spec/models/workflow_installment_schedule_intent_spec.rb
@@ -66,4 +66,134 @@ describe WorkflowInstallmentScheduleIntent do
 
     expect(intent.reload.dispatch_expires_at).to be > Time.current
   end
+
+  it "marks only the matching fanout owner as processed" do
+    fanout_token = SecureRandom.uuid
+    intent = create_intent(
+      dispatch_token: SecureRandom.uuid,
+      dispatch_expires_at: 1.minute.from_now,
+      fanout_token:,
+      fanout_expires_at: 1.minute.from_now
+    )
+
+    described_class.mark_processed(intent.token, fanout_token:)
+
+    expect(intent.reload.processed_at).to be_present
+    expect(intent.dispatch_token).to be_nil
+    expect(intent.dispatch_expires_at).to be_nil
+    expect(intent.fanout_token).to be_nil
+    expect(intent.fanout_expires_at).to be_nil
+  end
+
+  it "does not complete an intent without its fanout owner" do
+    intent = create_intent(fanout_token: SecureRandom.uuid, fanout_expires_at: 1.minute.from_now)
+
+    described_class.mark_processed(intent.token, fanout_token: nil)
+
+    expect(intent.reload.processed_at).to be_nil
+  end
+
+  it "does not let a stale fanout complete another owner" do
+    intent = create_intent(fanout_token: SecureRandom.uuid, fanout_expires_at: 1.minute.from_now)
+
+    described_class.mark_processed(intent.token, fanout_token: SecureRandom.uuid)
+
+    expect(intent.reload.processed_at).to be_nil
+  end
+
+  it "claims one fanout until its lease expires" do
+    intent = create_intent
+
+    first_token = intent.claim_fanout!
+    expect(first_token).to be_present
+    expect(intent.claim_fanout!).to be_nil
+
+    intent.update!(fanout_expires_at: 1.minute.ago)
+    second_token = intent.claim_fanout!
+    expect(second_token).to be_present
+    expect(second_token).not_to eq(first_token)
+  end
+
+  it "starts a matching fanout and renews its lease" do
+    intent = create_intent
+    fanout_token = intent.claim_fanout!
+
+    expect(described_class.begin_fanout(intent_token: intent.token, fanout_token:)).to be(true)
+
+    expect(intent.reload.fanout_expires_at).to be > 119.minutes.from_now
+  end
+
+  it "renews only the matching fanout owner" do
+    intent = create_intent
+    fanout_token = intent.claim_fanout!
+    original_expiry = intent.fanout_expires_at
+
+    travel 10.minutes do
+      expect(
+        described_class.renew_fanout(intent_token: intent.token, fanout_token: SecureRandom.uuid)
+      ).to be(false)
+      expect(intent.reload.fanout_expires_at).to eq(original_expiry)
+
+      expect(described_class.renew_fanout(intent_token: intent.token, fanout_token:)).to be(true)
+      expect(intent.reload.fanout_token).to eq(fanout_token)
+      expect(intent.fanout_expires_at).to be > original_expiry
+    end
+  end
+
+  it "keeps direct fanouts independent of intent leases" do
+    expect(described_class.renew_fanout(intent_token: nil, fanout_token: nil)).to be(true)
+  end
+
+  it "lets an expired owner renew until another owner takes over" do
+    intent = create_intent
+    first_token = intent.claim_fanout!
+    intent.update!(fanout_expires_at: 1.minute.ago)
+
+    expect(described_class.renew_fanout(intent_token: intent.token, fanout_token: first_token)).to be(true)
+    expect(intent.with_lock { intent.claim_fanout! }).to be_nil
+
+    intent.update!(fanout_expires_at: 1.minute.ago)
+    second_token = intent.claim_fanout!
+    second_expiry = intent.fanout_expires_at
+
+    expect(described_class.renew_fanout(intent_token: intent.token, fanout_token: first_token)).to be(false)
+    expect(intent.reload.fanout_token).to eq(second_token)
+    expect(intent.fanout_expires_at).to eq(second_expiry)
+  end
+
+  it "does not renew a processed intent" do
+    intent = create_intent(processed_at: Time.current, fanout_token: SecureRandom.uuid)
+
+    expect(
+      described_class.renew_fanout(intent_token: intent.token, fanout_token: intent.fanout_token)
+    ).to be(false)
+  end
+
+  it "rejects a stale fanout while another owner is active" do
+    intent = create_intent
+    current_token = intent.claim_fanout!
+
+    expect(
+      described_class.begin_fanout(intent_token: intent.token, fanout_token: SecureRandom.uuid)
+    ).to be(false)
+    expect(intent.reload.fanout_token).to eq(current_token)
+  end
+
+  it "lets a fetched fanout claim an expired lease" do
+    intent = create_intent(fanout_token: SecureRandom.uuid, fanout_expires_at: 1.minute.ago)
+    fetched_token = SecureRandom.uuid
+
+    expect(described_class.begin_fanout(intent_token: intent.token, fanout_token: fetched_token)).to be(true)
+
+    expect(intent.reload.fanout_token).to eq(fetched_token)
+    expect(intent.fanout_expires_at).to be > 119.minutes.from_now
+  end
+
+  it "does not start a fanout for a processed intent" do
+    intent = create_intent(processed_at: Time.current)
+
+    expect(
+      described_class.begin_fanout(intent_token: intent.token, fanout_token: SecureRandom.uuid)
+    ).to be(false)
+  end
 end

--- a/spec/models/workflow_installment_schedule_intent_spec.rb
+++ b/spec/models/workflow_installment_schedule_intent_spec.rb
@@ -26,7 +26,7 @@ describe WorkflowInstallmentScheduleIntent do
     end.to raise_error(described_class::EnqueueError, "A database transaction is required")
   end
 
-  it "does not persist a claim when the scheduler enqueue raises" do
+  it "releases the claim when the scheduler enqueue raises" do
     intent = create_intent
     allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_raise("Redis is unavailable")
     expect(Rails.logger).to receive(:error).with(/Redis is unavailable/)
@@ -37,6 +37,16 @@ describe WorkflowInstallmentScheduleIntent do
     expect(described_class.dispatchable).to include(intent)
   end
 
+  it "contains a claim release failure after the scheduler enqueue raises" do
+    intent = create_intent
+    allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_raise("Redis is unavailable")
+    allow(described_class).to receive(:release_dispatch).and_raise("database is unavailable")
+    expect(Rails.logger).to receive(:error).with(/Redis is unavailable/)
+    expect(Rails.logger).to receive(:error).with(/database is unavailable/)
+
+    expect(described_class.enqueue(intent.token)).to be_nil
+  end
+
   it "contains a dispatch query failure" do
     intent = create_intent
     allow(described_class).to receive(:dispatchable).and_raise("database is unavailable")
@@ -45,7 +55,7 @@ describe WorkflowInstallmentScheduleIntent do
     expect(described_class.enqueue(intent.token)).to be_nil
   end
 
-  it "does not persist a claim when middleware cancels the enqueue" do
+  it "releases the claim when middleware cancels the enqueue" do
     intent = create_intent
     allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_return(nil)
     expect(Rails.logger).to receive(:error).with(/scheduler job was not enqueued/i)
@@ -56,11 +66,13 @@ describe WorkflowInstallmentScheduleIntent do
     expect(described_class.dispatchable).to include(intent)
   end
 
-  it "records a claim after enqueueing its scheduler" do
+  it "commits the claim before enqueueing its scheduler" do
     intent = create_intent
     enqueued_dispatch_token = nil
     expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(intent.token, kind_of(String)).once do |_, dispatch_token|
       enqueued_dispatch_token = dispatch_token
+      expect(intent.reload.dispatch_token).to eq(dispatch_token)
+      expect(intent.dispatch_expires_at).to be > Time.current
       "jid"
     end
 

--- a/spec/models/workflow_installment_schedule_intent_spec.rb
+++ b/spec/models/workflow_installment_schedule_intent_spec.rb
@@ -26,14 +26,34 @@ describe WorkflowInstallmentScheduleIntent do
     end.to raise_error(described_class::EnqueueError, "A database transaction is required")
   end
 
-  it "leaves dispatch failures for the pending intent job" do
+  it "releases dispatch failures for the pending intent job" do
     intent = create_intent
     allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_raise("Redis is unavailable")
     expect(Rails.logger).to receive(:error).with(/Redis is unavailable/)
 
     expect(described_class.enqueue(intent.token)).to be_nil
-    expect(intent.reload.dispatch_expires_at).to be_present
-    expect(described_class.dispatchable).not_to include(intent)
+    expect(intent.reload.dispatch_token).to be_nil
+    expect(intent.dispatch_expires_at).to be_nil
+    expect(described_class.dispatchable).to include(intent)
+  end
+
+  it "does not release a dispatch claim that failed to persist" do
+    intent = create_intent
+    allow(described_class).to receive(:dispatchable).and_raise("database is unavailable")
+    expect(described_class).not_to receive(:release_dispatch)
+    expect(Rails.logger).to receive(:error).with(/database is unavailable/)
+
+    expect(described_class.enqueue(intent.token)).to be_nil
+  end
+
+  it "contains a failure while releasing a dispatch claim" do
+    intent = create_intent
+    allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_raise("Redis is unavailable")
+    allow(described_class).to receive(:release_dispatch).and_raise("database is unavailable")
+    expect(Rails.logger).to receive(:error).with(/could not release.*database is unavailable/)
+    expect(Rails.logger).to receive(:error).with(/could not enqueue.*Redis is unavailable/)
+
+    expect(described_class.enqueue(intent.token)).to be_nil
   end
 
   it "claims an intent before enqueueing its scheduler" do

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -288,9 +288,12 @@ describe Workflow do
 
     it "publishes and schedules all alive installments" do
       installment1 = create(:installment, workflow: @workflow)
+      create(:installment_rule, installment: installment1)
       installment2 = create(:installment, workflow: @workflow, deleted_at: 1.day.ago)
 
-      expect(@workflow).to receive(:schedule_installment).with(an_instance_of(Installment)).twice
+      expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(
+        kind_of(String)
+      ).twice.and_call_original
 
       expect do
         expect do

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -292,6 +292,7 @@ describe Workflow do
       installment2 = create(:installment, workflow: @workflow, deleted_at: 1.day.ago)
 
       expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(
+        kind_of(String),
         kind_of(String)
       ).twice.and_call_original
 

--- a/spec/models/workflow_transition_spec.rb
+++ b/spec/models/workflow_transition_spec.rb
@@ -60,12 +60,16 @@ describe Workflow do
     workflow.update!(published_at:)
     installment.update!(published_at:)
     cutoff_reference_time = Time.current.change(usec: 0)
+    schedule_intent_token = SecureRandom.uuid
+    schedule_intent_fanout_token = SecureRandom.uuid
 
     result = workflow.schedule_installment(
       installment,
       old_delayed_delivery_time: 6.hours.to_i,
       cutoff_reference_time:,
-      minimum_rule_version: rule.version
+      minimum_rule_version: rule.version,
+      schedule_intent_token:,
+      schedule_intent_fanout_token:
     )
 
     expect(result).to eq(:enqueued)
@@ -73,7 +77,9 @@ describe Workflow do
       installment.id,
       (cutoff_reference_time - 6.hours).iso8601,
       false,
-      rule.version
+      rule.version,
+      schedule_intent_token,
+      schedule_intent_fanout_token
     )
   end
 
@@ -94,15 +100,24 @@ describe Workflow do
       send_to_past_customers: true
     )
     installment.update!(published_at:)
+    schedule_intent_token = SecureRandom.uuid
+    schedule_intent_fanout_token = SecureRandom.uuid
 
-    result = workflow.schedule_installment(installment, minimum_rule_version: rule.version)
+    result = workflow.schedule_installment(
+      installment,
+      minimum_rule_version: rule.version,
+      schedule_intent_token:,
+      schedule_intent_fanout_token:
+    )
 
     expect(result).to eq(:enqueued)
     expect(SendWorkflowEmailsToPastCanceledMembersJob).to have_enqueued_sidekiq_job(
       installment.id,
       nil,
       nil,
-      rule.version
+      rule.version,
+      schedule_intent_token,
+      schedule_intent_fanout_token
     )
   end
 

--- a/spec/models/workflow_transition_spec.rb
+++ b/spec/models/workflow_transition_spec.rb
@@ -19,11 +19,91 @@ describe Workflow do
       method.call(**kwargs)
     end
 
-    workflow.publish!
+    expect(workflow.publish!).to be(true)
 
     expect(installment.reload).to be_published
     expect(rule.reload.version).to eq(previous_version + 1)
-    expect(SendWorkflowPostEmailsJob).to have_enqueued_sidekiq_job(installment.id, nil)
+    token = ScheduleWorkflowInstallmentJob.jobs.sole.fetch("args").sole
+    expect(WorkflowInstallmentScheduleIntent.find_by!(token:)).to have_attributes(
+      installment_id: installment.id,
+      rule_version: rule.version,
+      cutoff_reference_time: workflow.published_at,
+      expected_published_at: workflow.published_at
+    )
+    expect(SendWorkflowPostEmailsJob.jobs).to be_empty
+  end
+
+  it "rolls back a publish schedule intent with its transaction" do
+    Workflow.transaction do
+      workflow.publish!
+      expect(WorkflowInstallmentScheduleIntent.count).to eq(1)
+      expect(ScheduleWorkflowInstallmentJob.jobs).to be_empty
+      raise ActiveRecord::Rollback
+    end
+
+    expect(workflow.reload.published_at).to be_nil
+    expect(WorkflowInstallmentScheduleIntent.count).to eq(0)
+    expect(ScheduleWorkflowInstallmentJob.jobs).to be_empty
+  end
+
+  it "keeps a committed publish intent when the fast path returns no job ID" do
+    allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_return(nil)
+
+    workflow.publish!
+
+    expect(workflow.reload.published_at).to be_present
+    expect(WorkflowInstallmentScheduleIntent.pending.sole.installment_id).to eq(installment.id)
+  end
+
+  it "hands the saved cutoff and minimum rule version to the recipient fanout" do
+    published_at = 1.day.ago
+    workflow.update!(published_at:)
+    installment.update!(published_at:)
+    cutoff_reference_time = Time.current.change(usec: 0)
+
+    result = workflow.schedule_installment(
+      installment,
+      old_delayed_delivery_time: 6.hours.to_i,
+      cutoff_reference_time:,
+      minimum_rule_version: rule.version
+    )
+
+    expect(result).to eq(:enqueued)
+    expect(SendWorkflowPostEmailsJob).to have_enqueued_sidekiq_job(
+      installment.id,
+      (cutoff_reference_time - 6.hours).iso8601,
+      false,
+      rule.version
+    )
+  end
+
+  it "returns not_enqueued when middleware cancels the recipient fanout" do
+    published_at = 1.day.ago
+    workflow.update!(published_at:)
+    installment.update!(published_at:)
+    allow(SendWorkflowPostEmailsJob).to receive(:perform_async).and_return(nil)
+
+    expect(workflow.schedule_installment(installment)).to eq(:not_enqueued)
+  end
+
+  it "hands the minimum rule version to the cancellation fanout" do
+    published_at = 1.day.ago
+    workflow.update!(
+      published_at:,
+      workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER,
+      send_to_past_customers: true
+    )
+    installment.update!(published_at:)
+
+    result = workflow.schedule_installment(installment, minimum_rule_version: rule.version)
+
+    expect(result).to eq(:enqueued)
+    expect(SendWorkflowEmailsToPastCanceledMembersJob).to have_enqueued_sidekiq_job(
+      installment.id,
+      nil,
+      nil,
+      rule.version
+    )
   end
 
   it "locks the workflow and advances the rule version before unpublishing" do

--- a/spec/models/workflow_transition_spec.rb
+++ b/spec/models/workflow_transition_spec.rb
@@ -23,11 +23,12 @@ describe Workflow do
 
     expect(installment.reload).to be_published
     expect(rule.reload.version).to eq(previous_version + 1)
-    token = ScheduleWorkflowInstallmentJob.jobs.sole.fetch("args").sole
+    token, dispatch_token = ScheduleWorkflowInstallmentJob.jobs.sole.fetch("args")
     expect(WorkflowInstallmentScheduleIntent.find_by!(token:)).to have_attributes(
       installment_id: installment.id,
       rule_version: rule.version,
       cutoff_reference_time: workflow.published_at,
+      dispatch_token:,
       expected_published_at: workflow.published_at
     )
     expect(SendWorkflowPostEmailsJob.jobs).to be_empty

--- a/spec/requests/workflows_spec.rb
+++ b/spec/requests/workflows_spec.rb
@@ -1207,6 +1207,7 @@ describe("Workflows", js: true, type: :system) do
         installment = create(:workflow_installment, workflow:)
 
         expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(
+          kind_of(String),
           kind_of(String)
         ).and_call_original
 

--- a/spec/requests/workflows_spec.rb
+++ b/spec/requests/workflows_spec.rb
@@ -1206,7 +1206,9 @@ describe("Workflows", js: true, type: :system) do
         visit workflows_path
         installment = create(:workflow_installment, workflow:)
 
-        expect_any_instance_of(Workflow).to receive(:schedule_installment).with(installment)
+        expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(
+          kind_of(String)
+        ).and_call_original
 
         within_section "Product workflow", section_element: :section do
           click_on "Edit workflow"
@@ -1295,7 +1297,7 @@ describe("Workflows", js: true, type: :system) do
       visit workflows_path
       create(:workflow_installment, workflow:)
 
-      expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+      expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
       allow_any_instance_of(User).to receive(:sales_cents_total).and_return(Installment::MINIMUM_SALES_CENTS_VALUE - 1)
 
       within_section "Product workflow", section_element: :section do
@@ -1575,7 +1577,7 @@ describe("Workflows", js: true, type: :system) do
     end
 
     it "allows saving and publishing workflow emails" do
-      expect_any_instance_of(Workflow).to receive(:schedule_installment).with(kind_of(Installment))
+      expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_call_original
 
       visit workflows_path
 

--- a/spec/services/workflow/manage_service_spec.rb
+++ b/spec/services/workflow/manage_service_spec.rb
@@ -368,6 +368,7 @@ describe Workflow::ManageService do
         params[:save_action_name] = Workflow::SAVE_AND_PUBLISH_ACTION
         create(:payment_completed, user: seller)
         expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(
+          kind_of(String),
           kind_of(String)
         ).and_call_original
 

--- a/spec/services/workflow/manage_service_spec.rb
+++ b/spec/services/workflow/manage_service_spec.rb
@@ -247,7 +247,7 @@ describe Workflow::ManageService do
       let(:params) { { name: "Updated workflow name", permalink: product.unique_permalink, workflow_type: Workflow::AFFILIATE_TYPE, affiliate_products: [product.unique_permalink], send_to_past_customers: false } }
 
       it "updates the workflow and its installments" do
-        expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+        expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
         expect do
           expect(described_class.new(seller:, params:, product:, workflow:).process).to eq([true, nil])
@@ -367,7 +367,9 @@ describe Workflow::ManageService do
       it "updates the workflow and publishes it if the save action is 'save_and_publish'" do
         params[:save_action_name] = Workflow::SAVE_AND_PUBLISH_ACTION
         create(:payment_completed, user: seller)
-        expect_any_instance_of(Workflow).to receive(:schedule_installment).with(installment1)
+        expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(
+          kind_of(String)
+        ).and_call_original
 
         expect do
           expect(described_class.new(seller:, params:, product:, workflow:).process).to eq([true, nil])
@@ -396,7 +398,7 @@ describe Workflow::ManageService do
         params[:save_action_name] = Workflow::SAVE_AND_UNPUBLISH_ACTION
         params[:paid_less_than] = "50"
 
-        expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+        expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
         expect do
           expect do

--- a/spec/services/workflow/save_installments_service_spec.rb
+++ b/spec/services/workflow/save_installments_service_spec.rb
@@ -291,7 +291,7 @@ describe Workflow::SaveInstallmentsService do
         end
 
         it "reschedules that installment" do
-          expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(kind_of(String)).and_call_original
+          expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(kind_of(String), kind_of(String)).and_call_original
 
           params[:installments] = [default_installment_params.merge(id: installment.external_id, time_duration: 2, time_period: "day")]
           service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
@@ -378,7 +378,7 @@ describe Workflow::SaveInstallmentsService do
     it "reschedules a newly added installment if the workflow is already published" do
       workflow.publish!
 
-      expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(kind_of(String)).and_call_original
+      expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(kind_of(String), kind_of(String)).and_call_original
 
       params[:installments] = [default_installment_params.merge(id: SecureRandom.uuid, time_duration: 1, time_period: "hour")]
       service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)

--- a/spec/services/workflow/save_installments_service_spec.rb
+++ b/spec/services/workflow/save_installments_service_spec.rb
@@ -178,7 +178,7 @@ describe Workflow::SaveInstallmentsService do
     end
 
     it "creates installments" do
-      expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+      expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
       process_and_perform_assertions_for_created_installments
     end
@@ -186,7 +186,7 @@ describe Workflow::SaveInstallmentsService do
     it "creates installments and publishes them if save_action_name is 'save_and_publish'" do
       params[:save_action_name] = Workflow::SAVE_AND_PUBLISH_ACTION
 
-      expect_any_instance_of(Workflow).to receive(:schedule_installment).with(kind_of(Installment))
+      expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_call_original
 
       expect do
         process_and_perform_assertions_for_created_installments
@@ -196,7 +196,7 @@ describe Workflow::SaveInstallmentsService do
     end
 
     it "updates installments" do
-      expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+      expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
       process_and_perform_assertions_for_updated_installments
     end
@@ -204,7 +204,7 @@ describe Workflow::SaveInstallmentsService do
     it "updates installments and publishes them if save_action_name is 'save_and_publish'" do
       params[:save_action_name] = Workflow::SAVE_AND_PUBLISH_ACTION
 
-      expect_any_instance_of(Workflow).to receive(:schedule_installment).with(kind_of(Installment))
+      expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_call_original
 
       expect do
         process_and_perform_assertions_for_updated_installments
@@ -219,7 +219,7 @@ describe Workflow::SaveInstallmentsService do
 
       params[:save_action_name] = Workflow::SAVE_AND_UNPUBLISH_ACTION
 
-      expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+      expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
       expect do
         expect do
@@ -291,7 +291,7 @@ describe Workflow::SaveInstallmentsService do
         end
 
         it "reschedules that installment" do
-          expect(SendWorkflowPostEmailsJob).to receive(:perform_async).with(installment.id, installment.published_at.iso8601)
+          expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(kind_of(String)).and_call_original
 
           params[:installments] = [default_installment_params.merge(id: installment.external_id, time_duration: 2, time_period: "day")]
           service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
@@ -300,11 +300,53 @@ describe Workflow::SaveInstallmentsService do
             service.process
           end.to change { installment.reload.installment_rule.delayed_delivery_time }.from(1.hour.to_i).to(2.days.to_i)
              .and change { installment.reload.installment_rule.time_period }.from("hour").to("day")
+
+          expect(WorkflowInstallmentScheduleIntent.sole).to have_attributes(
+            installment_id: installment.id,
+            rule_version: installment_rule.reload.version,
+            old_delayed_delivery_time: 1.hour.to_i
+          )
+        end
+
+        it "rolls back the schedule intent when a later preview fails" do
+          params[:installments] = [
+            default_installment_params.merge(
+              id: installment.external_id,
+              time_duration: 2,
+              time_period: "day",
+              send_preview_email: true,
+            )
+          ]
+          service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
+          allow_any_instance_of(Installment).to receive(:send_preview_email).and_raise(Installment::PreviewEmailError, "Preview failed")
+
+          success, = service.process
+
+          expect(success).to be(false)
+          expect(installment_rule.reload).to have_attributes(
+            delayed_delivery_time: 1.hour.to_i,
+            time_period: "hour",
+          )
+          expect(WorkflowInstallmentScheduleIntent.count).to eq(0)
+          expect(ScheduleWorkflowInstallmentJob.jobs).to be_empty
+        end
+
+        it "keeps a pending intent when the fast path returns no job ID" do
+          params[:installments] = [default_installment_params.merge(id: installment.external_id, time_duration: 2, time_period: "day")]
+          service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
+          allow(ScheduleWorkflowInstallmentJob).to receive(:perform_async).and_return(nil)
+
+          expect(service.process).to eq([true, nil])
+
+          expect(installment_rule.reload).to have_attributes(
+            delayed_delivery_time: 2.days.to_i,
+            time_period: "day"
+          )
+          expect(WorkflowInstallmentScheduleIntent.pending.sole.installment_id).to eq(installment.id)
         end
 
         it "does not reschedule that installment if save_action_name is other than 'save'" do
-          expect(SendWorkflowPostEmailsJob).not_to receive(:perform_async)
-          expect_any_instance_of(Workflow).to_not receive(:schedule_installment)
+          expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
           params[:installments] = [default_installment_params.merge(id: installment.external_id, time_duration: 2, time_period: "day", send_preview_email: true)]
           params[:save_action_name] = Workflow::SAVE_AND_PUBLISH_ACTION
@@ -320,7 +362,7 @@ describe Workflow::SaveInstallmentsService do
 
       context "when installment has not been published" do
         it "does not reschedule that installment" do
-          expect(SendWorkflowPostEmailsJob).not_to receive(:perform_async)
+          expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
           params[:installments] = [default_installment_params.merge(id: installment.external_id, time_duration: 2, time_period: "day")]
           service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
@@ -336,7 +378,7 @@ describe Workflow::SaveInstallmentsService do
     it "reschedules a newly added installment if the workflow is already published" do
       workflow.publish!
 
-      expect_any_instance_of(Workflow).to receive(:schedule_installment).with(kind_of(Installment), old_delayed_delivery_time: nil)
+      expect(ScheduleWorkflowInstallmentJob).to receive(:perform_async).with(kind_of(String)).and_call_original
 
       params[:installments] = [default_installment_params.merge(id: SecureRandom.uuid, time_duration: 1, time_period: "hour")]
       service = described_class.new(seller:, params:, workflow:, preview_email_recipient:)
@@ -349,10 +391,15 @@ describe Workflow::SaveInstallmentsService do
       expect(installment.installment_rule.delayed_delivery_time).to eq(1.hour.to_i)
       expect(installment.installment_rule.time_period).to eq("hour")
       expect(installment.published_at).to eq(workflow.published_at)
+      expect(WorkflowInstallmentScheduleIntent.order(:id).last).to have_attributes(
+        installment_id: installment.id,
+        rule_version: installment.installment_rule.version,
+        old_delayed_delivery_time: nil
+      )
     end
 
     it "does not reschedule an installment if the delayed_delivery_time does not change" do
-      expect(SendWorkflowPostEmailsJob).not_to receive(:perform_async)
+      expect(ScheduleWorkflowInstallmentJob).not_to receive(:perform_async)
 
       installment = create(:installment, workflow:)
       create(:installment_rule, installment:, delayed_delivery_time: 1.hour.to_i, time_period: "hour")

--- a/spec/sidekiq/delete_processed_workflow_installment_schedule_intents_job_spec.rb
+++ b/spec/sidekiq/delete_processed_workflow_installment_schedule_intents_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe DeleteProcessedWorkflowInstallmentScheduleIntentsJob do
+  def create_intent(processed_at:, **attributes)
+    WorkflowInstallmentScheduleIntent.create!(
+      {
+        token: SecureRandom.uuid,
+        installment_id: 1,
+        rule_version: 1,
+        cutoff_reference_time: Time.current,
+        processed_at:
+      }.merge(attributes)
+    )
+  end
+
+  it "deletes only old processed intents" do
+    old = create_intent(processed_at: 31.days.ago)
+    recent = create_intent(processed_at: 29.days.ago)
+    pending = create_intent(processed_at: nil)
+    leased = create_intent(processed_at: nil, dispatch_token: SecureRandom.uuid, dispatch_expires_at: 1.minute.from_now)
+
+    described_class.new.perform
+
+    expect(WorkflowInstallmentScheduleIntent.find_by(id: old.id)).to be_nil
+    expect(WorkflowInstallmentScheduleIntent.where(id: [recent.id, pending.id, leased.id]).count).to eq(3)
+  end
+end

--- a/spec/sidekiq/dispatch_pending_workflow_installment_schedule_intents_job_spec.rb
+++ b/spec/sidekiq/dispatch_pending_workflow_installment_schedule_intents_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe DispatchPendingWorkflowInstallmentScheduleIntentsJob do
+  def create_intent(processed_at: nil, dispatch_expires_at: nil)
+    WorkflowInstallmentScheduleIntent.create!(
+      token: SecureRandom.uuid,
+      installment_id: 1,
+      rule_version: 1,
+      cutoff_reference_time: Time.current,
+      processed_at:,
+      dispatch_expires_at:
+    )
+  end
+
+  it "dispatches pending intents without an active lease" do
+    pending = create_intent
+    expired = create_intent(dispatch_expires_at: 1.minute.ago)
+    create_intent(dispatch_expires_at: 1.minute.from_now)
+    create_intent(processed_at: Time.current)
+    expect(WorkflowInstallmentScheduleIntent).to receive(:enqueue).with(pending.token)
+    expect(WorkflowInstallmentScheduleIntent).to receive(:enqueue).with(expired.token)
+
+    described_class.new.perform
+  end
+end

--- a/spec/sidekiq/dispatch_pending_workflow_installment_schedule_intents_job_spec.rb
+++ b/spec/sidekiq/dispatch_pending_workflow_installment_schedule_intents_job_spec.rb
@@ -1,24 +1,28 @@
 # frozen_string_literal: true
 
 describe DispatchPendingWorkflowInstallmentScheduleIntentsJob do
-  def create_intent(processed_at: nil, dispatch_expires_at: nil)
+  def create_intent(processed_at: nil, dispatch_expires_at: nil, fanout_expires_at: nil)
     WorkflowInstallmentScheduleIntent.create!(
       token: SecureRandom.uuid,
       installment_id: 1,
       rule_version: 1,
       cutoff_reference_time: Time.current,
       processed_at:,
-      dispatch_expires_at:
+      dispatch_expires_at:,
+      fanout_expires_at:
     )
   end
 
   it "dispatches pending intents without an active lease" do
     pending = create_intent
     expired = create_intent(dispatch_expires_at: 1.minute.ago)
+    expired_fanout = create_intent(fanout_expires_at: 1.minute.ago)
     create_intent(dispatch_expires_at: 1.minute.from_now)
+    create_intent(fanout_expires_at: 1.minute.from_now)
     create_intent(processed_at: Time.current)
     expect(WorkflowInstallmentScheduleIntent).to receive(:enqueue).with(pending.token)
     expect(WorkflowInstallmentScheduleIntent).to receive(:enqueue).with(expired.token)
+    expect(WorkflowInstallmentScheduleIntent).to receive(:enqueue).with(expired_fanout.token)
 
     described_class.new.perform
   end

--- a/spec/sidekiq/schedule_workflow_installment_job_spec.rb
+++ b/spec/sidekiq/schedule_workflow_installment_job_spec.rb
@@ -55,6 +55,7 @@ describe ScheduleWorkflowInstallmentJob do
   it "accepts the scheduler job whose dispatch token committed" do
     dispatch_token = SecureRandom.uuid
     intent = create_intent(dispatch_token:)
+    expect(WorkflowInstallmentScheduleIntent).to receive(:lock).and_call_original
     expect_any_instance_of(Workflow).to receive(:schedule_installment).and_return(:enqueued)
 
     described_class.new.perform(intent.token, dispatch_token)

--- a/spec/sidekiq/schedule_workflow_installment_job_spec.rb
+++ b/spec/sidekiq/schedule_workflow_installment_job_spec.rb
@@ -42,6 +42,26 @@ describe ScheduleWorkflowInstallmentJob do
     expect { described_class.new.perform(SecureRandom.uuid) }.not_to raise_error
   end
 
+  it "ignores a scheduler job whose dispatch token did not commit" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).not_to receive(:schedule_installment)
+
+    described_class.new.perform(intent.token, SecureRandom.uuid)
+
+    expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_nil
+  end
+
+  it "accepts the scheduler job whose dispatch token committed" do
+    dispatch_token = SecureRandom.uuid
+    intent = create_intent(dispatch_token:)
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).and_return(:enqueued)
+
+    described_class.new.perform(intent.token, dispatch_token)
+
+    expect(intent.reload.fanout_token).to be_present
+  end
+
   it "retries while the required rule version is not visible" do
     intent = create_intent(rule_version: rule.version + 1)
 

--- a/spec/sidekiq/schedule_workflow_installment_job_spec.rb
+++ b/spec/sidekiq/schedule_workflow_installment_job_spec.rb
@@ -20,18 +20,22 @@ describe ScheduleWorkflowInstallmentJob do
     )
   end
 
-  it "marks the intent processed after handing off the recipient fanout" do
+  it "keeps the intent pending until the recipient fanout completes" do
     intent = create_intent
     expect_any_instance_of(Workflow).to receive(:schedule_installment).with(
       kind_of(Installment),
       old_delayed_delivery_time: 1.hour.to_i,
       cutoff_reference_time:,
-      minimum_rule_version: rule.version
+      minimum_rule_version: rule.version,
+      schedule_intent_token: intent.token,
+      schedule_intent_fanout_token: kind_of(String)
     ).and_return(:enqueued)
 
     described_class.new.perform(intent.token)
 
-    expect(intent.reload.processed_at).to be_present
+    expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_present
+    expect(intent.fanout_expires_at).to be > Time.current
   end
 
   it "ignores an intent that has already been cleaned up" do
@@ -54,7 +58,9 @@ describe ScheduleWorkflowInstallmentJob do
       kind_of(Installment),
       old_delayed_delivery_time: 1.hour.to_i,
       cutoff_reference_time:,
-      minimum_rule_version: rule.version
+      minimum_rule_version: rule.version,
+      schedule_intent_token: intent.token,
+      schedule_intent_fanout_token: kind_of(String)
     ).and_return(:enqueued)
 
     described_class.new.perform(intent.token)
@@ -85,7 +91,9 @@ describe ScheduleWorkflowInstallmentJob do
       kind_of(Installment),
       old_delayed_delivery_time: nil,
       cutoff_reference_time: published_at,
-      minimum_rule_version: rule.version
+      minimum_rule_version: rule.version,
+      schedule_intent_token: intent.token,
+      schedule_intent_fanout_token: kind_of(String)
     ).and_return(:enqueued)
 
     described_class.new.perform(intent.token)
@@ -101,14 +109,16 @@ describe ScheduleWorkflowInstallmentJob do
     expect(intent.reload.processed_at).to be_present
   end
 
-  it "does not process an intent twice" do
+  it "does not enqueue a recipient fanout twice" do
     intent = create_intent
     expect_any_instance_of(Workflow).to receive(:schedule_installment).once.and_return(:enqueued)
 
     described_class.new.perform(intent.token)
     described_class.new.perform(intent.token)
 
-    expect(intent.reload.processed_at).to be_present
+    expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_present
+    expect(intent.fanout_expires_at).to be > Time.current
   end
 
   it "keeps the intent pending when recipient scheduling raises" do
@@ -118,6 +128,8 @@ describe ScheduleWorkflowInstallmentJob do
     expect { described_class.new.perform(intent.token) }.to raise_error("Redis is unavailable")
 
     expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_nil
+    expect(intent.fanout_expires_at).to be_nil
   end
 
   it "keeps the intent pending when middleware cancels the fanout" do
@@ -129,6 +141,8 @@ describe ScheduleWorkflowInstallmentJob do
     end.to raise_error(described_class::FanoutNotEnqueuedError, "Recipient fanout was not enqueued")
 
     expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_nil
+    expect(intent.fanout_expires_at).to be_nil
   end
 
   it "keeps the intent pending for an unexpected fanout result" do
@@ -140,6 +154,8 @@ describe ScheduleWorkflowInstallmentJob do
     end.to raise_error(described_class::FanoutNotEnqueuedError, "Unexpected schedule result: nil")
 
     expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_nil
+    expect(intent.fanout_expires_at).to be_nil
   end
 
   it "marks the intent processed when no fanout applies" do

--- a/spec/sidekiq/schedule_workflow_installment_job_spec.rb
+++ b/spec/sidekiq/schedule_workflow_installment_job_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ScheduleWorkflowInstallmentJob do
+  let(:workflow) { create(:audience_workflow, published_at: 1.day.ago) }
+  let(:installment) { create(:workflow_installment, workflow:, seller: workflow.seller, published_at: workflow.published_at) }
+  let(:rule) { installment.installment_rule }
+  let(:cutoff_reference_time) { Time.current.change(usec: 0) }
+
+  def create_intent(**attributes)
+    WorkflowInstallmentScheduleIntent.create!(
+      {
+        token: SecureRandom.uuid,
+        installment_id: installment.id,
+        rule_version: rule.version,
+        old_delayed_delivery_time: 1.hour.to_i,
+        cutoff_reference_time:,
+      }.merge(attributes)
+    )
+  end
+
+  it "marks the intent processed after handing off the recipient fanout" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).with(
+      kind_of(Installment),
+      old_delayed_delivery_time: 1.hour.to_i,
+      cutoff_reference_time:,
+      minimum_rule_version: rule.version
+    ).and_return(:enqueued)
+
+    described_class.new.perform(intent.token)
+
+    expect(intent.reload.processed_at).to be_present
+  end
+
+  it "ignores an intent that has already been cleaned up" do
+    expect { described_class.new.perform(SecureRandom.uuid) }.not_to raise_error
+  end
+
+  it "retries while the required rule version is not visible" do
+    intent = create_intent(rule_version: rule.version + 1)
+
+    expect do
+      described_class.new.perform(intent.token)
+    end.to raise_error(described_class::IntentNotCommittedError)
+
+    expect(intent.reload.processed_at).to be_nil
+  end
+
+  it "preserves the recipient window from a superseded rule version" do
+    intent = create_intent(rule_version: rule.version - 1)
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).with(
+      kind_of(Installment),
+      old_delayed_delivery_time: 1.hour.to_i,
+      cutoff_reference_time:,
+      minimum_rule_version: rule.version
+    ).and_return(:enqueued)
+
+    described_class.new.perform(intent.token)
+  end
+
+  it "discards an intent from a stale publication state" do
+    expected_published_at = cutoff_reference_time
+    workflow.update!(published_at: nil, first_published_at: expected_published_at)
+    installment.update!(published_at: nil)
+    intent = create_intent(expected_published_at:)
+    expect_any_instance_of(Workflow).not_to receive(:schedule_installment)
+
+    described_class.new.perform(intent.token)
+
+    expect(intent.reload.processed_at).to be_present
+  end
+
+  it "schedules after the publication state becomes visible" do
+    published_at = workflow.published_at.change(usec: 0)
+    installment.update!(published_at:)
+    intent = create_intent(
+      old_delayed_delivery_time: nil,
+      cutoff_reference_time: published_at,
+      expected_published_at: published_at
+    )
+    expect_any_instance_of(Workflow).to receive(:with_lock).and_call_original
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).with(
+      kind_of(Installment),
+      old_delayed_delivery_time: nil,
+      cutoff_reference_time: published_at,
+      minimum_rule_version: rule.version
+    ).and_return(:enqueued)
+
+    described_class.new.perform(intent.token)
+  end
+
+  it "discards an intent after the installment becomes unpublished" do
+    installment.update!(published_at: nil)
+    intent = create_intent
+    expect_any_instance_of(Workflow).not_to receive(:schedule_installment)
+
+    described_class.new.perform(intent.token)
+
+    expect(intent.reload.processed_at).to be_present
+  end
+
+  it "does not process an intent twice" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).once.and_return(:enqueued)
+
+    described_class.new.perform(intent.token)
+    described_class.new.perform(intent.token)
+
+    expect(intent.reload.processed_at).to be_present
+  end
+
+  it "keeps the intent pending when recipient scheduling raises" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).and_raise("Redis is unavailable")
+
+    expect { described_class.new.perform(intent.token) }.to raise_error("Redis is unavailable")
+
+    expect(intent.reload.processed_at).to be_nil
+  end
+
+  it "keeps the intent pending when middleware cancels the fanout" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).and_return(:not_enqueued)
+
+    expect do
+      described_class.new.perform(intent.token)
+    end.to raise_error(described_class::FanoutNotEnqueuedError, "Recipient fanout was not enqueued")
+
+    expect(intent.reload.processed_at).to be_nil
+  end
+
+  it "keeps the intent pending for an unexpected fanout result" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).and_return(nil)
+
+    expect do
+      described_class.new.perform(intent.token)
+    end.to raise_error(described_class::FanoutNotEnqueuedError, "Unexpected schedule result: nil")
+
+    expect(intent.reload.processed_at).to be_nil
+  end
+
+  it "marks the intent processed when no fanout applies" do
+    intent = create_intent
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).and_return(:not_applicable)
+
+    described_class.new.perform(intent.token)
+
+    expect(intent.reload.processed_at).to be_present
+  end
+
+  it "releases the primary connection after execution" do
+    intent = create_intent
+    expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+    expect_any_instance_of(Workflow).to receive(:schedule_installment).and_return(:not_applicable)
+    expect(Makara::Context).to receive(:release_all)
+
+    described_class.new.perform(intent.token)
+  end
+end

--- a/spec/sidekiq/schedule_workflow_installment_job_spec.rb
+++ b/spec/sidekiq/schedule_workflow_installment_job_spec.rb
@@ -42,14 +42,55 @@ describe ScheduleWorkflowInstallmentJob do
     expect { described_class.new.perform(SecureRandom.uuid) }.not_to raise_error
   end
 
-  it "ignores a scheduler job whose dispatch token did not commit" do
+  it "retries a scheduler job whose dispatch token is not visible" do
     intent = create_intent
+    expect_any_instance_of(Workflow).not_to receive(:schedule_installment)
+
+    expect do
+      described_class.new.perform(intent.token, SecureRandom.uuid)
+    end.to raise_error(described_class::IntentNotCommittedError)
+
+    expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_nil
+  end
+
+  it "ignores a scheduler job whose dispatch lease was replaced" do
+    intent = create_intent(dispatch_token: SecureRandom.uuid, dispatch_expires_at: 1.minute.from_now)
     expect_any_instance_of(Workflow).not_to receive(:schedule_installment)
 
     described_class.new.perform(intent.token, SecureRandom.uuid)
 
     expect(intent.reload.processed_at).to be_nil
     expect(intent.fanout_token).to be_nil
+  end
+
+  it "retries a scheduler job after the previous dispatch lease expires" do
+    intent = create_intent(dispatch_token: SecureRandom.uuid, dispatch_expires_at: 1.minute.ago)
+    expect_any_instance_of(Workflow).not_to receive(:schedule_installment)
+
+    expect do
+      described_class.new.perform(intent.token, SecureRandom.uuid)
+    end.to raise_error(described_class::IntentNotCommittedError)
+
+    expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_nil
+  end
+
+  it "ignores a stale scheduler job while a fanout owns the intent" do
+    intent = create_intent(
+      dispatch_token: SecureRandom.uuid,
+      dispatch_expires_at: 1.minute.ago,
+      fanout_token: SecureRandom.uuid,
+      fanout_expires_at: 1.minute.from_now
+    )
+    expect_any_instance_of(Workflow).not_to receive(:schedule_installment)
+
+    expect do
+      described_class.new.perform(intent.token, SecureRandom.uuid)
+    end.not_to raise_error
+
+    expect(intent.reload.processed_at).to be_nil
+    expect(intent.fanout_token).to be_present
   end
 
   it "accepts the scheduler job whose dispatch token committed" do

--- a/spec/sidekiq/send_workflow_emails_to_past_canceled_members_job_spec.rb
+++ b/spec/sidekiq/send_workflow_emails_to_past_canceled_members_job_spec.rb
@@ -10,8 +10,10 @@ describe SendWorkflowEmailsToPastCanceledMembersJob, :freeze_time do
     @installment = create(:published_installment, link: @product, workflow: @workflow, workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER)
     @rule = create(:installment_rule, installment: @installment, delayed_delivery_time: 14.days)
 
-    @canceled_subscription = create(:subscription, link: @product, cancelled_at: 30.days.ago, deactivated_at: 30.days.ago)
-    create(:purchase, is_original_subscription_purchase: true, link: @product, subscription: @canceled_subscription, created_at: 60.days.ago)
+    unless RSpec.current_example.metadata[:rule_version_only]
+      @canceled_subscription = create(:subscription, link: @product, cancelled_at: 30.days.ago, deactivated_at: 30.days.ago)
+      create(:purchase, is_original_subscription_purchase: true, link: @product, subscription: @canceled_subscription, created_at: 60.days.ago)
+    end
   end
 
   it "schedules a worker immediately for past cancellations whose deactivated_at + delay is in the past" do
@@ -28,6 +30,26 @@ describe SendWorkflowEmailsToPastCanceledMembersJob, :freeze_time do
     described_class.new.perform(@installment.id)
 
     expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@installment.id, @rule.version, nil, nil, nil, recent.id).at(recent.deactivated_at + @rule.delayed_delivery_time)
+  end
+
+  it "retries if the required rule version is not visible", :rule_version_only do
+    expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+
+    expect do
+      described_class.new.perform(@installment.id, nil, nil, @rule.version + 1)
+    end.to raise_error(described_class::RuleNotCommittedError)
+  end
+
+  it "continues when the version cache is unavailable", :rule_version_only do
+    subscription = create(:subscription, link: @product, cancelled_at: 30.days.ago, deactivated_at: 30.days.ago)
+    create(:free_purchase, is_original_subscription_purchase: true, link: @product, subscription:, created_at: 60.days.ago)
+    error = RedisClient::Error.new("cache unavailable")
+    allow_any_instance_of(InstallmentRule).to receive(:cache_version!).and_raise(error)
+    expect(ErrorNotifier).to receive(:notify).with(error, installment_rule_id: @rule.id)
+
+    described_class.new.perform(@installment.id)
+
+    expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@installment.id, @rule.version, nil, nil, nil, subscription.id)
   end
 
   it "does nothing when the workflow has been deleted" do

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -36,6 +36,28 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       expect(SendWorkflowInstallmentWorker.jobs).to be_empty
     end
 
+    it "reads the primary database for a required rule version" do
+      expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+
+      described_class.new.perform(@post.id, nil, false, @post_rule.version)
+    end
+
+    it "retries if the required rule version is not visible" do
+      expect do
+        described_class.new.perform(@post.id, nil, false, @post_rule.version + 1)
+      end.to raise_error(described_class::RuleNotCommittedError)
+    end
+
+    it "continues when the version cache is unavailable" do
+      error = Redis::BaseError.new("cache unavailable")
+      allow_any_instance_of(InstallmentRule).to receive(:cache_version!).and_raise(error)
+      expect(ErrorNotifier).to receive(:notify).with(error, installment_rule_id: @post_rule.id)
+
+      described_class.new.perform(@post.id)
+
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(@post.id, @post_rule.version, nil, @basic_follower.id, nil)
+    end
+
     it "only considers audience members created after the earliest_valid_time" do
       described_class.new.perform(@post.id, 1.day.ago.iso8601)
       expect(SendWorkflowInstallmentWorker.jobs).to be_empty

--- a/spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb
+++ b/spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb
@@ -1,0 +1,390 @@
+# frozen_string_literal: true
+
+describe "workflow installment schedule intent completion", :freeze_time do
+  def create_intent(installment:, rule:, processed_at: nil)
+    WorkflowInstallmentScheduleIntent.create!(
+      token: SecureRandom.uuid,
+      installment_id: installment.id,
+      rule_version: rule.version,
+      cutoff_reference_time: Time.current,
+      processed_at:
+    )
+  end
+
+  def claim_fanout(intent)
+    intent.with_lock { intent.claim_fanout! }
+  end
+
+  describe SendWorkflowPostEmailsJob do
+    let(:seller) { create(:named_user) }
+    let(:workflow) { create(:audience_workflow, seller:) }
+    let(:post) { create(:audience_post, :published, workflow:, seller:) }
+    let(:rule) { create(:post_rule, installment: post, delayed_delivery_time: 1.day) }
+    let!(:follower) { create(:active_follower, user: seller, created_at: 2.days.ago) }
+
+    it "marks an intent processed after the fanout completes" do
+      intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
+
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+
+      expect(intent.reload.processed_at).to be_present
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(post.id, rule.version, nil, follower.id, nil)
+    end
+
+    it "keeps a partial fanout recoverable" do
+      create(:active_follower, user: seller, created_at: 1.day.ago)
+      intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
+      attempts = 0
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at) do
+        attempts += 1
+        raise "Redis is unavailable" if attempts == 2
+
+        "jid"
+      end
+
+      expect do
+        described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+      end.to raise_error("Redis is unavailable")
+
+      expect(attempts).to eq(2)
+      expect(intent.reload.processed_at).to be_nil
+
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at).and_return("jid")
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+
+      expect(intent.reload.processed_at).to be_present
+    end
+
+    it "keeps the intent pending when middleware cancels a recipient enqueue" do
+      intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at).and_return(nil)
+
+      expect do
+        described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+      end.to raise_error(SendWorkflowPostEmailsJob::FanoutNotEnqueuedError)
+
+      expect(intent.reload.processed_at).to be_nil
+    end
+
+    it "does not rerun a completed fanout" do
+      intent = create_intent(installment: post, rule:, processed_at: 1.minute.ago)
+
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, SecureRandom.uuid)
+
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+    end
+
+    it "completes an intent when the installment no longer exists" do
+      intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
+      post.delete
+
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+
+      expect(intent.reload.processed_at).to be_present
+    end
+
+    it "completes an intent when the rule no longer exists" do
+      intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
+      rule.delete
+
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+
+      expect(intent.reload.processed_at).to be_present
+    end
+
+    it "does not run a stale copy while another fanout owns the intent" do
+      intent = create_intent(installment: post, rule:)
+      current_token = claim_fanout(intent)
+
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, SecureRandom.uuid)
+
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+      expect(intent.reload.processed_at).to be_nil
+      expect(intent.fanout_token).to eq(current_token)
+    end
+
+    it "renews its lease before and after the audience query" do
+      intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
+      events = []
+      allow(WorkflowInstallmentScheduleIntent).to receive(:renew_fanout).and_wrap_original do |method, **kwargs|
+        events << :renew
+        method.call(**kwargs)
+      end
+      allow(Makara::Context).to receive(:release_all).and_wrap_original do |method|
+        events << :release
+        method.call
+      end
+      allow(WithMaxExecutionTime).to receive(:timeout_queries).and_wrap_original do |method, *args, **kwargs, &block|
+        events << :query
+        result = method.call(*args, **kwargs, &block)
+        events << :query_complete
+        result
+      end
+
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+
+      expect(events).to eq([:release, :renew, :release, :query, :query_complete, :renew, :release])
+      expect(intent.reload.processed_at).to be_present
+    end
+
+    it "stops after the audience query if another fanout takes ownership" do
+      intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
+      replacement_token = nil
+      allow(WithMaxExecutionTime).to receive(:timeout_queries).and_wrap_original do |method, *args, **kwargs, &block|
+        members = method.call(*args, **kwargs, &block)
+        travel WorkflowInstallmentScheduleIntent::FANOUT_LEASE + 1.second
+        replacement_token = claim_fanout(intent)
+        members
+      end
+
+      described_class.new.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+      expect(intent.reload.processed_at).to be_nil
+      expect(intent.fanout_token).to eq(replacement_token)
+    end
+
+    it "stops its recipient loop when a later owner takes over" do
+      create(:active_follower, user: seller, created_at: 1.day.ago)
+      intent = create_intent(installment: post, rule:)
+      fanout_token = claim_fanout(intent)
+      replacement_token = nil
+      heartbeat_time = 0.0
+      attempts = 0
+      job = described_class.new
+      allow(job).to receive(:fanout_heartbeat_time) { heartbeat_time }
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at) do
+        attempts += 1
+        if attempts == 1
+          travel WorkflowInstallmentScheduleIntent::FANOUT_LEASE + 1.second
+          replacement_token = claim_fanout(intent)
+          heartbeat_time += WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f + 1
+        end
+        "jid"
+      end
+
+      job.perform(post.id, nil, false, rule.version, intent.token, fanout_token)
+
+      expect(attempts).to eq(1)
+      expect(intent.reload.processed_at).to be_nil
+      expect(intent.fanout_token).to eq(replacement_token)
+    end
+
+    it "runs a direct fanout without an intent lease" do
+      rule
+      expect(WorkflowInstallmentScheduleIntent).not_to receive(:renew_fanout)
+
+      described_class.new.perform(post.id)
+
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(post.id, rule.version, nil, follower.id, nil)
+    end
+
+    it "does not replace a missing matching purchase with another embedded purchase" do
+      job = described_class.new
+      job.instance_variable_set(:@post, post)
+      job.instance_variable_set(:@rule_version, rule.version)
+      job.instance_variable_set(:@rule_delay, rule.delayed_delivery_time)
+      member = instance_double(
+        AudienceMember,
+        id: 1,
+        details: { "purchases" => [{ "id" => 99, "created_at" => 1.day.ago.iso8601 }] }
+      )
+
+      job.send(:enqueue_email_job, member:, type: :purchase, id: nil)
+
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+    end
+  end
+
+  describe SendWorkflowEmailsToPastCanceledMembersJob do
+    let(:seller) { create(:user) }
+    let(:product) { create(:subscription_product, user: seller) }
+    let(:workflow) do
+      create(
+        :workflow,
+        seller:,
+        link: product,
+        workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER,
+        send_to_past_customers: true
+      )
+    end
+    let(:installment) do
+      create(
+        :published_installment,
+        link: product,
+        workflow:,
+        workflow_trigger: Workflow::MEMBER_CANCELLATION_WORKFLOW_TRIGGER
+      )
+    end
+    let(:rule) { create(:installment_rule, installment:, delayed_delivery_time: 14.days) }
+    let(:subscription) { create(:subscription, link: product, cancelled_at: 30.days.ago, deactivated_at: 30.days.ago) }
+    let!(:purchase) do
+      create(
+        :free_purchase,
+        is_original_subscription_purchase: true,
+        link: product,
+        subscription:,
+        created_at: 60.days.ago
+      )
+    end
+
+    it "marks an intent processed after the fanout completes" do
+      intent = create_intent(installment:, rule:)
+      fanout_token = claim_fanout(intent)
+
+      described_class.new.perform(installment.id, nil, nil, rule.version, intent.token, fanout_token)
+
+      expect(intent.reload.processed_at).to be_present
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(installment.id, rule.version, nil, nil, nil, subscription.id)
+    end
+
+    it "releases Makara after renewing its lease" do
+      intent = create_intent(installment:, rule:)
+      fanout_token = claim_fanout(intent)
+      events = []
+      job = described_class.new
+      allow(job).to receive(:fanout_heartbeat_time).and_return(0.0, 301.0)
+      allow(WorkflowInstallmentScheduleIntent).to receive(:renew_fanout).and_wrap_original do |method, **kwargs|
+        events << :renew
+        method.call(**kwargs)
+      end
+      allow(Makara::Context).to receive(:release_all).and_wrap_original do |method|
+        events << :release
+        method.call
+      end
+
+      job.perform(installment.id, nil, nil, rule.version, intent.token, fanout_token)
+
+      expect(events).to eq([:release, :renew, :release])
+      expect(intent.reload.processed_at).to be_present
+    end
+
+    it "keeps a partial fanout recoverable" do
+      second_subscription = create(
+        :subscription,
+        link: product,
+        cancelled_at: 20.days.ago,
+        deactivated_at: 20.days.ago
+      )
+      create(
+        :free_purchase,
+        is_original_subscription_purchase: true,
+        link: product,
+        subscription: second_subscription,
+        created_at: 50.days.ago
+      )
+      intent = create_intent(installment:, rule:)
+      fanout_token = claim_fanout(intent)
+      attempts = 0
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at) do
+        attempts += 1
+        raise "Redis is unavailable" if attempts == 2
+
+        "jid"
+      end
+
+      expect do
+        described_class.new.perform(installment.id, nil, nil, rule.version, intent.token, fanout_token)
+      end.to raise_error("Redis is unavailable")
+
+      expect(attempts).to eq(2)
+      expect(intent.reload.processed_at).to be_nil
+
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at).and_return("jid")
+      described_class.new.perform(installment.id, nil, nil, rule.version, intent.token, fanout_token)
+
+      expect(intent.reload.processed_at).to be_present
+    end
+
+    it "keeps the intent pending when middleware cancels a recipient enqueue" do
+      intent = create_intent(installment:, rule:)
+      fanout_token = claim_fanout(intent)
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at).and_return(nil)
+
+      expect do
+        described_class.new.perform(installment.id, nil, nil, rule.version, intent.token, fanout_token)
+      end.to raise_error(SendWorkflowEmailsToPastCanceledMembersJob::FanoutNotEnqueuedError)
+
+      expect(intent.reload.processed_at).to be_nil
+    end
+
+    it "does not rerun a completed fanout" do
+      intent = create_intent(installment:, rule:, processed_at: 1.minute.ago)
+
+      described_class.new.perform(installment.id, nil, nil, rule.version, intent.token, SecureRandom.uuid)
+
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+    end
+
+    it "completes an intent when the installment no longer exists" do
+      intent = create_intent(installment:, rule:)
+      fanout_token = claim_fanout(intent)
+      installment.delete
+
+      described_class.new.perform(installment.id, nil, nil, rule.version, intent.token, fanout_token)
+
+      expect(intent.reload.processed_at).to be_present
+    end
+
+    it "stops its recipient loop when a later owner takes over" do
+      second_subscription = create(
+        :subscription,
+        link: product,
+        cancelled_at: 20.days.ago,
+        deactivated_at: 20.days.ago
+      )
+      create(
+        :free_purchase,
+        is_original_subscription_purchase: true,
+        link: product,
+        subscription: second_subscription,
+        created_at: 50.days.ago
+      )
+      intent = create_intent(installment:, rule:)
+      fanout_token = claim_fanout(intent)
+      replacement_token = nil
+      heartbeat_time = 0.0
+      attempts = 0
+      job = described_class.new
+      allow(job).to receive(:fanout_heartbeat_time) { heartbeat_time }
+      allow(SendWorkflowInstallmentWorker).to receive(:perform_at) do
+        attempts += 1
+        if attempts == 1
+          travel WorkflowInstallmentScheduleIntent::FANOUT_LEASE + 1.second
+          replacement_token = claim_fanout(intent)
+          heartbeat_time += WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f + 1
+        end
+        "jid"
+      end
+
+      job.perform(installment.id, nil, nil, rule.version, intent.token, fanout_token)
+
+      expect(attempts).to eq(1)
+      expect(intent.reload.processed_at).to be_nil
+      expect(intent.fanout_token).to eq(replacement_token)
+    end
+
+    it "runs a direct fanout without an intent lease" do
+      rule
+      expect(WorkflowInstallmentScheduleIntent).not_to receive(:renew_fanout)
+
+      described_class.new.perform(installment.id)
+
+      expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(
+        installment.id,
+        rule.version,
+        nil,
+        nil,
+        nil,
+        subscription.id
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What

- Store workflow schedule requests inside the workflow transaction.
- Dispatch each request after commit.
- Keep each request pending until recipient fanout completes.
- Recover failed or partial fanout with leases, heartbeats, and owner tokens.
- Record a dispatch lease only after Sidekiq accepts the scheduler job.
- Reject blank Sidekiq job IDs and stale fanout owners.

## Why

Database writes and Sidekiq pushes cannot share one transaction. A direct push can run before commit or fail after the database commits.

A durable intent records the required work before commit. The dispatcher can then retry any request that does not complete.

The handoff and fanout recovery must remain in one PR. If the handoff completes after the first fanout job starts, a later failure can strand recipients.

## Before/After

Before, workflow publish and delay changes handed scheduling work directly to Sidekiq. A failed or partial handoff could leave pending workflow emails unscheduled.

After, the database keeps each request until fanout completes. Row locks serialize dispatch, while fanout leases and owner tokens recover interrupted work.

This PR has no user-visible interface change.

## Test Results

- Focused scheduling RSpec run: 38 examples, 0 failures.
- `bin/test-confidence`: 99%; 15 tests passed.
- RuboCop on the changed Ruby files: 0 offenses.
- `bin/check-migration-versions`: passed.
- GPT-5.6 Sol autoreview: clean.
- Greptile: 5/5.

## Stack

- Builds on #7162, which is merged.
- #7165 adds follower confirmation scheduling.

---

AI disclosure: GPT-5.6 Sol implemented and reviewed this change.
