### PR TITLE
Trim AI-slop comments in customer_mailer and stripe_payout_processor

### DIFF
--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -133,17 +133,9 @@ class StripePayoutProcessor
     balances_held_by_gumroad = balances_by_holder_of_funds[HolderOfFunds::GUMROAD] || []
     balances_held_by_stripe = balances_by_holder_of_funds[HolderOfFunds::STRIPE] || []
 
-    # If user has a Stripe standard account connected and there are no balances_held_by_stripe, we issue payout to the
-    # connected Stripe standard account.
-    #
-    # If there is no Stripe Connect account or if there is balances_held_by_stripe,
-    # that means the custom Stripe connect account (which is managed by gumroad) is still in use and there's some amount
-    # in the custom Stripe connect account that needs to be paid out.
-    # We issue payout via the custom Stripe connect account in that case.
-    #
-    # Once a standard Stripe account is connected, balances_held_by_stripe will eventually come down to zero as
-    # new sales will go directly to the connected Stripe account and no new balance will be generated
-    # against the custom Stripe connect account.
+    # Prefer the connected Stripe standard account once there's nothing left on the custom
+    # connect account; balances_held_by_stripe drains to zero over time as new sales route
+    # directly to the standard account.
     merchant_account = if user.has_stripe_account_connected? && balances_held_by_stripe.blank?
       user.stripe_connect_account
     else

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -48,11 +48,8 @@ class CustomerMailer < ApplicationMailer
     )
   end
 
-  # Note that the first argument is purchase_id, while the 2nd is charge_id
-  # charge_id needs to be passed to the mailer only when the initial customer order is placed (via SendChargeReceiptJob)
-  # For duplicate receipts (post-purchase), the purchase_id is passed, and the mailer will determine if it should use the
-  # purchase, or the charge associated (via Charge::Chargeable.find_by_purchase_or_charge!)
-  #
+  # charge_id is only passed for the initial order (SendChargeReceiptJob); duplicate/post-purchase
+  # receipts pass purchase_id alone and let find_by_purchase_or_charge! resolve the charge.
   def receipt(purchase_id = nil, charge_id = nil, for_email: true)
     @chargeable = Charge::Chargeable.find_by_purchase_or_charge!(
       purchase: Purchase.find_by(id: purchase_id),


### PR DESCRIPTION
## What
Comment-only trim of two flagged blocks that restated the code directly below them:

- `app/mailers/customer_mailer.rb#receipt`: 5-line "note that" preamble → 2-line summary of the actual non-obvious fact (which caller passes which arg).
- `app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb#get_payout_details`: 11-line paragraph restating the if/else verbatim → 3-line note on the one fact worth keeping (balances_held_by_stripe drains to zero over time).

## Why
Both blocks re-explained the code immediately below them line-by-line instead of adding information a maintainer can't get by reading the code. Per AGENTS.md code-comments guidance: keep the non-obvious why, cut narration/restatement.

## Before/after line counts
- customer_mailer.rb: 417 → 414 lines (-5, comment shrunk from 5 to 2 lines)
- stripe_payout_processor.rb: 872 → 864 lines (-11, comment shrunk from 11 to 3 lines)

Total: -16 lines / +5 lines net.

## No behaviour change
Comments only. No logic, renames, or reordering touched.

## What I deliberately KEPT (checked, not slop)
Scan also flagged, and I rejected, these blocks as carrying real non-re-derivable domain knowledge:
- paypal_charge_processor.rb capture/sibling-ambiguity comments (real incident + MySQL query-plan tradeoff) — already trimmed in a prior PR (#7153); scan was stale against origin/main.
- config/test_redis_isolation.rb — dense concurrency/isolation invariants for parallel test runs; genuinely hard to rederive.
- stripe_payout_processor.rb L25, L72, L142 (Brazilian-account carve-out), L756 (Stripe payout-reversal edge case) — each states a real invariant or vendor quirk that would take real effort to rediscover.
- users_controller.rb all four blocks — sandboxed-iframe security rationale (cookie/origin isolation, XSS boundary) and cross-controller mirroring notes; deleting these would remove exactly the reasoning that keeps the next editor from breaking the sandbox.
- alert_on_negative_destination_balances_job.rb all three blocks — FX-residue reconciliation math and pagination-cursor correctness notes; compressing further risks losing a real invariant.
- customer_mailer.rb L133 (presentment-currency race) and L217 (stamped-PDF fallback safety) — describe genuine races/traps, kept as-is.

## Test Results
- ruby -c on both changed files: syntax OK.
- bundle exec rubocop on both changed files: no offenses.
- Full rspec run blocked locally by pre-existing infra issues unrelated to this change (missing Vite build artifacts, no free Redis test-isolation block) — same failures occur on a clean origin/main checkout, confirming they're environmental, not caused by this diff. This is a comment-only, zero-logic-touched change; the class's behavior is unchanged.

Premerge review: exempt (comments-only diff, no logic/behaviour change — not a money-path or risk fix)

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (CI still running (8 checks) — settle before handing off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
