### PR TITLE
Dedupe repeated product name in combined receipt subject

### DIFF
--- a/app/presenters/receipt_presenter/mail_subject.rb
+++ b/app/presenters/receipt_presenter/mail_subject.rb
@@ -41,7 +41,12 @@ class ReceiptPresenter::MailSubject
     end
 
     def build_for_two_purchases
-      "You bought #{purchases.first.link_name.truncate(PRODUCT_NAME_CHARACTER_LIMIT)} and #{purchases.last.link_name.truncate(PRODUCT_NAME_CHARACTER_LIMIT)}"
+      first_name = purchases.first.link_name.truncate(PRODUCT_NAME_CHARACTER_LIMIT)
+      last_name = purchases.last.link_name.truncate(PRODUCT_NAME_CHARACTER_LIMIT)
+
+      return "You bought #{first_name}!" if first_name == last_name
+
+      "You bought #{first_name} and #{last_name}"
     end
 
     def build_for_more_than_two_purchases

--- a/app/presenters/receipt_presenter/mail_subject.rb
+++ b/app/presenters/receipt_presenter/mail_subject.rb
@@ -41,12 +41,12 @@ class ReceiptPresenter::MailSubject
     end
 
     def build_for_two_purchases
-      first_name = purchases.first.link_name.truncate(PRODUCT_NAME_CHARACTER_LIMIT)
-      last_name = purchases.last.link_name.truncate(PRODUCT_NAME_CHARACTER_LIMIT)
+      first_name = purchases.first.link_name
+      last_name = purchases.last.link_name
 
-      return "You bought #{first_name}!" if first_name == last_name
+      return "You bought #{first_name.truncate(PRODUCT_NAME_CHARACTER_LIMIT)}!" if first_name == last_name
 
-      "You bought #{first_name} and #{last_name}"
+      "You bought #{first_name.truncate(PRODUCT_NAME_CHARACTER_LIMIT)} and #{last_name.truncate(PRODUCT_NAME_CHARACTER_LIMIT)}"
     end
 
     def build_for_more_than_two_purchases

--- a/spec/presenters/receipt_presenter/mail_subject_spec.rb
+++ b/spec/presenters/receipt_presenter/mail_subject_spec.rb
@@ -139,6 +139,14 @@ describe ReceiptPresenter::MailSubject, :vcr do
       it "returns subject for two purchases" do
         expect(mail_subject).to eq("You bought Product One and Product Two")
       end
+
+      context "when both purchases are the same product" do
+        let(:purchase_two) { create(:purchase, link: product_one) }
+
+        it "dedupes the repeated product name in the subject" do
+          expect(mail_subject).to eq("You bought Product One!")
+        end
+      end
     end
 
     describe "with more than two purchases" do

--- a/spec/presenters/receipt_presenter/mail_subject_spec.rb
+++ b/spec/presenters/receipt_presenter/mail_subject_spec.rb
@@ -147,6 +147,17 @@ describe ReceiptPresenter::MailSubject, :vcr do
           expect(mail_subject).to eq("You bought Product One!")
         end
       end
+
+      context "when two distinct products share the same truncated prefix" do
+        let(:product_one) { create(:product, name: "Advanced Marketing Course Bundle A") }
+        let(:product_two) { create(:product, name: "Advanced Marketing Course Bundle B") }
+
+        it "does not collapse them into a single-product subject" do
+          expect(mail_subject).to eq(
+            "You bought Advanced Marketing Cours... and Advanced Marketing Cours..."
+          )
+        end
+      end
     end
 
     describe "with more than two purchases" do


### PR DESCRIPTION
## What

Fix the combined (two-purchase) receipt email subject so it doesn't repeat the product name when a buyer purchases the free and paid variants of the *same* product in one checkout. Today that produces `"You bought MacWhisper and MacWhisper!"`.

## Why

antiwork/gumroad-private#2025: a seller (MacWhisper) reported differences in the receipt emails customers receive when buying the free + paid version of one product together. The investigation (completed on that issue) found the delivery itself is correct — a single combined charge-level receipt is sent/opened with both line items and the right total. But it also surfaced a real cosmetic defect in the subject line: `ReceiptPresenter::MailSubject#build_for_two_purchases` concatenates each purchase's `link_name`, so a free + paid purchase of the same product yields "You bought MacWhisper and MacWhisper!". Fixing the subject makes the receipt clearer and removes the confusion that prompted the ticket.

## Before-After

- **Before:** `"You bought MacWhisper and MacWhisper!"` (two different products still render as `"You bought Product One and Product Two"` — unchanged)
- **After:** `"You bought MacWhisper!"` when both purchases share the same product name.

Two distinct products in one checkout still produce the existing two-name subject; only the duplicate-name case is deduped.

**Round 2 (Greptile P2):** the first version compared *truncated* display strings, so two distinct products whose names share the same first 27 characters (e.g. `"Advanced Marketing Course Bundle A"` vs `"...Bundle B"`) both truncated to `"Advanced Marketing Cours..."` and collapsed into a false-singular subject. Fixed by comparing the full `link_name` values and only truncating for display.

## Test Results

- `bundle exec rspec spec/presenters/receipt_presenter/mail_subject_spec.rb` — 24 examples, 0 failures (fresh worktree, seeded DB, no environmental noise).
- Mutation proof: reverting to the truncate-then-compare comparison reddens exactly the new "two distinct products share the same truncated prefix" example (1 failure, all 23 others green) — confirms the new spec has teeth against the Greptile-reported collision.
- `ruby -c` clean on the changed source file.

## QA steps

- Read the diff in `app/presenters/receipt_presenter/mail_subject.rb` — dedup compares full `link_name`s, truncation is applied only when building the display string.
- Ran the spec file per Test Results; both the same-product dedupe example and the distinct-truncated-prefix example pass at head.

## Not done here

- This is cosmetic subject copy only. It does not change which receipts are sent, or the combined-receipt grouping itself, which the gp#2025 investigation confirmed is working as designed.

---
AI disclosure: authored autonomously by an AI agent (deepseek/deepseek-v4-flash-0731) under the autonomous-product-dev skill.

### Status boxes

- [x] **Scope** — dedupe duplicate product name in combined receipt subject (gp#2025 finding), fixed to compare full names not truncated display strings (Greptile P2)
- [x] **Design** — compare full `link_name`s for equality; truncate only for display
- [x] **Build** — pushed (`8c636eba5`)
- [x] **QA** — 24/24 spec examples green; mutation-proved the new truncation-collision example
- [ ] **Shipped** — pending CI green + merge
- [ ] **Market** — n/a, cosmetic email-subject fix, no announcement needed
- [ ] **Sell** — n/a, internal defect fix, not a sellable feature

Premerge review: clean @ 8c636eba545713ca33bd00a128170400e5ca393b
