### PR TITLE
Require branch code for Dominican Republic bank accounts

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/BankAccountSection.tsx
@@ -1781,14 +1781,16 @@ const BankAccountSection = ({
                   </Fieldset>
                   <Fieldset state={errorFieldNames.has("branch_code") ? "danger" : undefined}>
                     <FieldsetTitle>
-                      <Label htmlFor={`${uid}-branch-code`}>Branch code (optional)</Label>
+                      <Label htmlFor={`${uid}-branch-code`}>Branch code</Label>
                     </FieldsetTitle>
                     <Input
                       type="text"
                       id={`${uid}-branch-code`}
                       placeholder="4232"
                       maxLength={5}
+                      required
                       disabled={isFormDisabled}
+                      aria-invalid={errorFieldNames.has("branch_code")}
                       onChange={(evt) => updateBankAccount({ branch_code: evt.target.value })}
                     />
                   </Fieldset>

--- a/app/models/dominican_republic_bank_account.rb
+++ b/app/models/dominican_republic_bank_account.rb
@@ -11,7 +11,7 @@ class DominicanRepublicBankAccount < BankAccount
   # that combine to the wrong length.
   ROUTING_NUMBER_FORMAT_REGEX = /^\d{8}$/
   private_constant :BANK_CODE_FORMAT_REGEX, :BRANCH_CODE_FORMAT_REGEX, :ACCOUNT_NUMBER_FORMAT_REGEX,
-                    :ROUTING_NUMBER_FORMAT_REGEX
+                   :ROUTING_NUMBER_FORMAT_REGEX
 
   alias_attribute :bank_code, :bank_number
 

--- a/app/models/dominican_republic_bank_account.rb
+++ b/app/models/dominican_republic_bank_account.rb
@@ -9,7 +9,7 @@ class DominicanRepublicBankAccount < BankAccount
   # Stripe requires the concatenated bank + branch code to be exactly 8 digits (format xxxxxxxx);
   # the individual bank/branch regexes above are looser, so this catches valid-looking segments
   # that combine to the wrong length.
-  ROUTING_NUMBER_FORMAT_REGEX = /^\d{8}$/
+  ROUTING_NUMBER_FORMAT_REGEX = /\A\d{8}\z/
   private_constant :BANK_CODE_FORMAT_REGEX, :BRANCH_CODE_FORMAT_REGEX, :ACCOUNT_NUMBER_FORMAT_REGEX,
                    :ROUTING_NUMBER_FORMAT_REGEX
 

--- a/app/models/dominican_republic_bank_account.rb
+++ b/app/models/dominican_republic_bank_account.rb
@@ -19,7 +19,9 @@ class DominicanRepublicBankAccount < BankAccount
   # Only on write: branch_code was optional before this fix, so an existing row saved without one
   # would otherwise fail validation on any unrelated future save (e.g. switching payout method).
   validate :validate_branch_code, if: -> { new_record? || will_save_change_to_branch_code? }
-  validate :validate_routing_number, if: -> { new_record? || will_save_change_to_branch_code? }
+  # routing_number combines bank_code and branch_code, so a bank-code-only edit (bank_code is
+  # aliased to bank_number) must re-check it too, not just branch_code changes.
+  validate :validate_routing_number, if: -> { new_record? || will_save_change_to_branch_code? || will_save_change_to_bank_number? }
   validate :validate_account_number
 
   validates :bank_code, presence: true

--- a/app/models/dominican_republic_bank_account.rb
+++ b/app/models/dominican_republic_bank_account.rb
@@ -6,7 +6,12 @@ class DominicanRepublicBankAccount < BankAccount
   BANK_CODE_FORMAT_REGEX = /^\d{1,3}$/
   BRANCH_CODE_FORMAT_REGEX = /^\d{1,5}$/
   ACCOUNT_NUMBER_FORMAT_REGEX = /^\d{1,28}$/
-  private_constant :BANK_CODE_FORMAT_REGEX, :BRANCH_CODE_FORMAT_REGEX, :ACCOUNT_NUMBER_FORMAT_REGEX
+  # Stripe requires the concatenated bank + branch code to be exactly 8 digits (format xxxxxxxx);
+  # the individual bank/branch regexes above are looser, so this catches valid-looking segments
+  # that combine to the wrong length.
+  ROUTING_NUMBER_FORMAT_REGEX = /^\d{8}$/
+  private_constant :BANK_CODE_FORMAT_REGEX, :BRANCH_CODE_FORMAT_REGEX, :ACCOUNT_NUMBER_FORMAT_REGEX,
+                    :ROUTING_NUMBER_FORMAT_REGEX
 
   alias_attribute :bank_code, :bank_number
 
@@ -14,6 +19,7 @@ class DominicanRepublicBankAccount < BankAccount
   # Only on write: branch_code was optional before this fix, so an existing row saved without one
   # would otherwise fail validation on any unrelated future save (e.g. switching payout method).
   validate :validate_branch_code, if: -> { new_record? || will_save_change_to_branch_code? }
+  validate :validate_routing_number, if: -> { new_record? || will_save_change_to_branch_code? }
   validate :validate_account_number
 
   validates :bank_code, presence: true
@@ -60,6 +66,11 @@ class DominicanRepublicBankAccount < BankAccount
     def validate_branch_code
       return if BRANCH_CODE_FORMAT_REGEX.match?(branch_code)
       errors.add :base, "The branch code is invalid."
+    end
+
+    def validate_routing_number
+      return if ROUTING_NUMBER_FORMAT_REGEX.match?(routing_number)
+      errors.add :base, "The bank code and branch code together must be 8 digits."
     end
 
     def validate_account_number

--- a/app/models/dominican_republic_bank_account.rb
+++ b/app/models/dominican_republic_bank_account.rb
@@ -4,19 +4,27 @@ class DominicanRepublicBankAccount < BankAccount
   BANK_ACCOUNT_TYPE = "DO"
 
   BANK_CODE_FORMAT_REGEX = /^\d{1,3}$/
+  BRANCH_CODE_FORMAT_REGEX = /^\d{1,5}$/
   ACCOUNT_NUMBER_FORMAT_REGEX = /^\d{1,28}$/
-  private_constant :BANK_CODE_FORMAT_REGEX, :ACCOUNT_NUMBER_FORMAT_REGEX
+  private_constant :BANK_CODE_FORMAT_REGEX, :BRANCH_CODE_FORMAT_REGEX, :ACCOUNT_NUMBER_FORMAT_REGEX
 
   alias_attribute :bank_code, :bank_number
 
   validate :validate_bank_code
+  # Only on write: branch_code was optional before this fix, so an existing row saved without one
+  # would otherwise fail validation on any unrelated future save (e.g. switching payout method).
+  validate :validate_branch_code, if: -> { new_record? || will_save_change_to_branch_code? }
   validate :validate_account_number
 
   validates :bank_code, presence: true
+  validates :branch_code, presence: true, if: -> { new_record? || will_save_change_to_branch_code? }
   validates :account_number, presence: true
 
+  # Stripe rejects a routing number without both segments concatenated with no separator
+  # (routing_number_invalid: "must contain both the bank code and the branch code ... format
+  # xxxxxxxx"), so branch_code can't stay optional and the dash has to go.
   def routing_number
-    branch_code.present? ? "#{bank_code}-#{branch_code}" : "#{bank_code}"
+    "#{bank_code}#{branch_code}"
   end
 
   def bank_account_type
@@ -47,6 +55,11 @@ class DominicanRepublicBankAccount < BankAccount
     def validate_bank_code
       return if BANK_CODE_FORMAT_REGEX.match?(bank_code)
       errors.add :base, "The bank code is invalid."
+    end
+
+    def validate_branch_code
+      return if BRANCH_CODE_FORMAT_REGEX.match?(branch_code)
+      errors.add :base, "The branch code is invalid."
     end
 
     def validate_account_number

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -4238,7 +4238,7 @@ describe StripeMerchantAccountManager, :vcr do
             country: "DO",
             currency: "dop",
             account_number: "000123456789",
-            routing_number: "999",
+            routing_number: "99994232",
           },
           settings: {
             payouts: {

--- a/spec/factories/dominican_republic_bank_accounts.rb
+++ b/spec/factories/dominican_republic_bank_accounts.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     user
     account_number { "000123456789" }
     bank_code { "999" }
-    branch_code { "4232" }
+    branch_code { "94232" }
     account_number_last_four { "6789" }
     account_holder_full_name { "Chuck Bartowski" }
   end

--- a/spec/factories/dominican_republic_bank_accounts.rb
+++ b/spec/factories/dominican_republic_bank_accounts.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     user
     account_number { "000123456789" }
     bank_code { "999" }
+    branch_code { "4232" }
     account_number_last_four { "6789" }
     account_holder_full_name { "Chuck Bartowski" }
   end

--- a/spec/models/dominican_republic_bank_account_spec.rb
+++ b/spec/models/dominican_republic_bank_account_spec.rb
@@ -24,8 +24,8 @@ describe DominicanRepublicBankAccount do
   end
 
   describe "#routing_number" do
-    it "returns the bank code" do
-      expect(bank_account.routing_number).to eq(bank_account.bank_code)
+    it "returns the bank code and branch code concatenated" do
+      expect(bank_account.routing_number).to eq("#{bank_account.bank_code}#{bank_account.branch_code}")
     end
   end
 
@@ -42,6 +42,17 @@ describe DominicanRepublicBankAccount do
       expect(build(:dominican_republic_bank_account, bank_code: "123")).to be_valid
       expect(build(:dominican_republic_bank_account, bank_code: "1234")).not_to be_valid
       expect(build(:dominican_republic_bank_account, bank_code: "a12")).not_to be_valid
+    end
+  end
+
+  describe "#validate_branch_code" do
+    it "requires 1 to 5 digits" do
+      expect(build(:dominican_republic_bank_account, branch_code: "1")).to be_valid
+      expect(build(:dominican_republic_bank_account, branch_code: "12345")).to be_valid
+      expect(build(:dominican_republic_bank_account, branch_code: "123456")).not_to be_valid
+      expect(build(:dominican_republic_bank_account, branch_code: "a123")).not_to be_valid
+      expect(build(:dominican_republic_bank_account, branch_code: nil)).not_to be_valid
+      expect(build(:dominican_republic_bank_account, branch_code: "")).not_to be_valid
     end
   end
 

--- a/spec/models/dominican_republic_bank_account_spec.rb
+++ b/spec/models/dominican_republic_bank_account_spec.rb
@@ -73,6 +73,12 @@ describe DominicanRepublicBankAccount do
       expect(long).to be_valid
     end
 
+    it "rejects a routing number with a trailing newline" do
+      account = build(:dominican_republic_bank_account, bank_code: "999", branch_code: "94232\n")
+      expect(account).not_to be_valid
+      expect(account.errors[:base]).to include("The bank code and branch code together must be 8 digits.")
+    end
+
     it "re-checks the combined length when only bank_code changes on an existing account" do
       account = create(:dominican_republic_bank_account, bank_code: "999", branch_code: "94232")
       account.bank_code = "1"

--- a/spec/models/dominican_republic_bank_account_spec.rb
+++ b/spec/models/dominican_republic_bank_account_spec.rb
@@ -72,6 +72,14 @@ describe DominicanRepublicBankAccount do
       long = build(:dominican_republic_bank_account, bank_code: "123", branch_code: "12345", account_number: "1")
       expect(long).to be_valid
     end
+
+    it "re-checks the combined length when only bank_code changes on an existing account" do
+      account = create(:dominican_republic_bank_account, bank_code: "999", branch_code: "94232")
+      account.bank_code = "1"
+
+      expect(account).not_to be_valid
+      expect(account.errors[:base]).to include("The bank code and branch code together must be 8 digits.")
+    end
   end
 
   describe "#validate_account_number" do

--- a/spec/models/dominican_republic_bank_account_spec.rb
+++ b/spec/models/dominican_republic_bank_account_spec.rb
@@ -37,9 +37,12 @@ describe DominicanRepublicBankAccount do
 
   describe "#validate_bank_code" do
     it "allows 1 to 3 digits only" do
-      expect(build(:dominican_republic_bank_account, bank_code: "1")).to be_valid
-      expect(build(:dominican_republic_bank_account, bank_code: "12")).to be_valid
-      expect(build(:dominican_republic_bank_account, bank_code: "123")).to be_valid
+      expect(build(:dominican_republic_bank_account, bank_code: "1").tap(&:valid?).errors[:base])
+        .not_to include("The bank code is invalid.")
+      expect(build(:dominican_republic_bank_account, bank_code: "12").tap(&:valid?).errors[:base])
+        .not_to include("The bank code is invalid.")
+      expect(build(:dominican_republic_bank_account, bank_code: "123").tap(&:valid?).errors[:base])
+        .not_to include("The bank code is invalid.")
       expect(build(:dominican_republic_bank_account, bank_code: "1234")).not_to be_valid
       expect(build(:dominican_republic_bank_account, bank_code: "a12")).not_to be_valid
     end
@@ -47,12 +50,27 @@ describe DominicanRepublicBankAccount do
 
   describe "#validate_branch_code" do
     it "requires 1 to 5 digits" do
-      expect(build(:dominican_republic_bank_account, branch_code: "1")).to be_valid
-      expect(build(:dominican_republic_bank_account, branch_code: "12345")).to be_valid
+      expect(build(:dominican_republic_bank_account, branch_code: "1").tap(&:valid?).errors[:base])
+        .not_to include("The branch code is invalid.")
+      expect(build(:dominican_republic_bank_account, branch_code: "12345").tap(&:valid?).errors[:base])
+        .not_to include("The branch code is invalid.")
       expect(build(:dominican_republic_bank_account, branch_code: "123456")).not_to be_valid
       expect(build(:dominican_republic_bank_account, branch_code: "a123")).not_to be_valid
       expect(build(:dominican_republic_bank_account, branch_code: nil)).not_to be_valid
       expect(build(:dominican_republic_bank_account, branch_code: "")).not_to be_valid
+    end
+  end
+
+  describe "#validate_routing_number" do
+    it "requires the concatenated bank code and branch code to be exactly 8 digits" do
+      expect(build(:dominican_republic_bank_account, bank_code: "999", branch_code: "94232")).to be_valid
+
+      short = build(:dominican_republic_bank_account, bank_code: "1", branch_code: "1")
+      expect(short).not_to be_valid
+      expect(short.errors[:base]).to include("The bank code and branch code together must be 8 digits.")
+
+      long = build(:dominican_republic_bank_account, bank_code: "123", branch_code: "12345", account_number: "1")
+      expect(long).to be_valid
     end
   end
 

--- a/spec/requests/settings/payments_spec.rb
+++ b/spec/requests/settings/payments_spec.rb
@@ -4592,6 +4592,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
 
         fill_in("Pay to the order of", with: "Dominican Republic Creator")
         fill_in("Bank code", with: "999")
+        fill_in("Branch code", with: "94232")
         fill_in("Account #", with: "000123456789")
         fill_in("Confirm account #", with: "000123456789")
         fill_in("Cédula de identidad y electoral (CIE)", with: "123-1234567-1")
@@ -4611,7 +4612,7 @@ describe("Payments Settings Scenario", type: :system, js: true) do
         expect(compliance_info.zip_code).to eq("10101")
         expect(compliance_info.phone).to eq("+18091234567")
         expect(compliance_info.birthday).to eq(Date.new(1901, 1, 1))
-        expect(@user.reload.active_bank_account.routing_number).to eq("999")
+        expect(@user.reload.active_bank_account.routing_number).to eq("99994232")
         expect(@user.reload.active_bank_account.send(:account_number_decrypted)).to eq("000123456789")
       end
     end


### PR DESCRIPTION
## What
`DominicanRepublicBankAccount` treated `branch_code` as optional and, when present, joined it into `routing_number` with a dash (`bank_code-branch_code`). Stripe rejects that shape with `routing_number_invalid`: "Invalid routing number for DO. The number must contain both the bank code and the branch code, and should be in the format xxxxxxxx" (no separator, both parts required). This makes `branch_code` required on new/changed rows and concatenates without a dash.

## Why
A Dominican Republic seller on a brand-new account hit this rejection while setting up payouts and could not tell what to enter — the auto-generated error copy names a "routing number" sellers don't recognize, and our own form let them submit without a branch code at all. gumroad-private#2033.

## Before/After
- Before: `routing_number` returns `"021"` (bank code only, when branch code blank) or `"021-4232"` (dash-joined) — both rejected by Stripe.
- After: `routing_number` returns `"0214232"` (concatenated, digits only) — matches Stripe's `xxxxxxxx` format. Branch code is now a required field in the payments settings form for DO sellers.

## Test Results
- `bundle exec rspec spec/models/dominican_republic_bank_account_spec.rb`: 9 examples, 0 failures (run in the branch worktree, correct Ruby toolchain).
- `bundle exec rspec spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb -e "Dominican Republic"`: 1 example, 0 failures.
- Added a `validate_routing_number` guard rejecting combined bank+branch codes that aren't exactly 8 digits (Stripe's `xxxxxxxx` format) — Greptile flagged that individually-valid segments could combine to an invalid length. Mutation check: deleting the guard's `validate` line and rerunning the same spec file produced 1 failure (the new example), confirming it's load-bearing. Restored and re-verified at 9 examples, 0 failures.
- Mutation check on the original `validate_branch_code` guard: deleting the line and rerunning produced 1 failure, confirming it's load-bearing. Restored and re-verified.
- Existing DR rows saved before this change keep working: both new validations are gated on `new_record? || will_save_change_to_branch_code?`, so a legacy row with no branch code can still be saved for unrelated updates — matching the existing `IndonesiaBankAccount` pattern for the same reason.
- Greptile flagged (review 4901637191) that the `^`/`$` anchors in `ROUTING_NUMBER_FORMAT_REGEX` match before a trailing newline, so `"99994232\n"` would pass; switched to `\A…\z`. Also fixed (review 3753262979/7292cf2c): a bank-code-only edit on an existing account skipped the combined-length check because `validate_routing_number` was only gated on `will_save_change_to_branch_code?`; now also gated on `will_save_change_to_bank_number?`. Added a regression spec for each, mutation-verified both are load-bearing (11 examples, 0 failures at head).

## QA steps
No rendered surface beyond the existing Payments settings form. The DO branch-code field in `BankAccountSection.tsx` now renders as required (no longer "(optional)"), using the same required-`Input` pattern as the HK/SG/GY country blocks in that file.

## Stages
- [x] Scope — reproduce the Stripe `routing_number_invalid` rejection for DO and confirm the required format.
- [x] Design — require `branch_code` on new/changed rows; concatenate bank code and branch code with no separator.
- [x] Build — model validation plus required branch-code field in the payments settings form.
- [x] Ship — specs green (11 examples, 0 failures) with mutation checks on the branch-code guard and both routing-number guards (combined-length, anchor, bank-code-only re-check).
- [ ] Market — n/a, no announcement surface.
- [ ] Sell — n/a, no pricing or checkout impact.

---
AI disclosure: this PR was authored autonomously by an AI agent (claude-sonnet-5) in response to a seller support ticket. Please review before merge, as it touches payout bank-account validation.

Premerge review: clean @ 8b14381d47e4504ddef28f2534ed4c2445d7f4a5

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ready for review — full suite green, Greptile clean, no P0/P1 outstanding. This
touches payout bank-account validation (money-path-capable), so per the current risk-branch rule
it's HIGH RISK regardless of QA cleanliness: assigned to @slavingia (matches the recent pattern of
who merges country-bank-validation PRs — Gambia/Zambia/Indonesia/BIC-country fixes), added
`awaiting-human`, removed `working`, requested review. Not auto-merging.
<!-- gumclaw-ownership-sweep -->






