### PR TITLE
Revalidate workflow email recipients before delivery

### DIFF
--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -423,7 +423,7 @@ class Installment < ApplicationRecord
     end
   end
 
-  def send_installment_from_workflow_for_purchase(purchase_id)
+  def send_installment_from_workflow_for_purchase(purchase_id, reschedule_reference_time: nil)
     sale = Purchase.find(purchase_id)
     return if sale.is_recurring_subscription_charge
     # Cancellation posts are delivered on the subscription path, which rechecks the membership
@@ -448,7 +448,10 @@ class Installment < ApplicationRecord
     if Time.current < expected_delivery_time_for_sale
       # reschedule for later if it's too soon to send (only applicable for subscriptions
       # that have been terminated and later restarted)
-      SendWorkflowInstallmentWorker.perform_at(expected_delivery_time_for_sale + 1.minute, id, installment_rule.version, sale.id, nil)
+      args = [id, installment_rule.version, sale.id, nil]
+      args.push(nil, nil, reschedule_reference_time) if reschedule_reference_time.present?
+      worker = reschedule_reference_time.present? ? SendWorkflowInstallmentRescheduleJob : SendWorkflowInstallmentWorker
+      worker.perform_at(expected_delivery_time_for_sale + 1.minute, *args)
     else
       SentPostEmail.ensure_uniqueness(post: self, email: sale.email) do
         recipient = { email: sale.email, purchase: sale }
@@ -1072,6 +1075,13 @@ class Installment < ApplicationRecord
     Time.current >= expected_delivery_time(purchase)
   end
 
+  def workflow_delivery_reference_time(purchase)
+    subscription = purchase.subscription
+    return purchase.created_at unless workflow.present? && subscription.present? && subscription.resubscribed?
+
+    purchase.created_at + (subscription.last_resubscribed_at - subscription.last_deactivated_at)
+  end
+
   class InstallmentInvalid < StandardError
   end
 
@@ -1102,12 +1112,7 @@ class Installment < ApplicationRecord
     def expected_delivery_time(sale)
       return sale.created_at unless installment_rule.present?
 
-      original_delivery_time = sale.created_at + installment_rule.delayed_delivery_time
-      subscription = sale.subscription
-      return original_delivery_time unless workflow.present? && subscription.present? && subscription.resubscribed?
-
-      send_delay = subscription.last_resubscribed_at - subscription.last_deactivated_at
-      original_delivery_time + send_delay
+      workflow_delivery_reference_time(sale) + installment_rule.delayed_delivery_time
     end
 
     def validate_sending_limit_for_sellers

--- a/app/sidekiq/send_workflow_installment_reschedule_job.rb
+++ b/app/sidekiq/send_workflow_installment_reschedule_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class SendWorkflowInstallmentRescheduleJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low
+
+  def perform(installment_id, version, purchase_id, follower_id, affiliate_user_id, subscription_id, reschedule_reference_time)
+    return unless [purchase_id, follower_id, affiliate_user_id, subscription_id].one?(&:present?)
+
+    SendWorkflowInstallmentWorker.new.perform(
+      installment_id,
+      version,
+      purchase_id,
+      follower_id,
+      affiliate_user_id,
+      subscription_id,
+      reschedule_reference_time
+    )
+  end
+end

--- a/app/sidekiq/send_workflow_installment_worker.rb
+++ b/app/sidekiq/send_workflow_installment_worker.rb
@@ -1,17 +1,20 @@
 # frozen_string_literal: true
 
 class SendWorkflowInstallmentWorker
+  class FanoutNotEnqueuedError < StandardError; end
   class RuleNotCommittedError < StandardError; end
 
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :low
 
-  def perform(installment_id, version, purchase_id, follower_id, affiliate_user_id = nil, subscription_id = nil, recipient_reference_time = nil)
+  def perform(installment_id, version, purchase_id, follower_id, affiliate_user_id = nil, subscription_id = nil, reschedule_reference_time = nil)
+    reschedule_recipient = [purchase_id, follower_id, affiliate_user_id, subscription_id].one?(&:present?)
+    reschedule_reference_time = nil unless reschedule_recipient
     primary_pinned = false
     expected_rule_version = current_rule_version(installment_id)
     return if expected_rule_version.nil?
 
-    if expected_rule_version != version || recipient_reference_time.present?
+    if expected_rule_version != version || reschedule_reference_time.present?
       ActiveRecord::Base.connection.stick_to_primary!
       primary_pinned = true
     end
@@ -38,25 +41,81 @@ class SendWorkflowInstallmentWorker
     return unless installment.alive?
     return unless installment.published?
 
-    return if installment_rule.version != version
-
-    if follower_id.present? && purchase_id.nil? && affiliate_user_id.nil? && subscription_id.nil? && recipient_reference_time.present?
-      return unless follower_matches_current_audience?(
+    if installment_rule.version != version
+      current_reference_time = current_recipient_reference_time(
         installment:,
+        purchase_id:,
         follower_id:,
-        recipient_reference_time:
-      )
-    end
-    if affiliate_user_id.present? && purchase_id.nil? && follower_id.nil? && subscription_id.nil? && recipient_reference_time.present?
-      return unless affiliate_matches_current_audience?(
-        installment:,
         affiliate_user_id:,
-        recipient_reference_time:
+        subscription_id:
+      )
+      if reschedule_reference_time.nil? || purchase_id.present?
+        reschedule_reference_time = current_reference_time
+      end
+      return if reschedule_reference_time.nil?
+      return unless recipient_matches_current_audience?(
+        installment:,
+        purchase_id:,
+        follower_id:,
+        affiliate_user_id:,
+        subscription_id:,
+        reschedule_reference_time:
+      )
+      reschedule_with_current_rule(
+        installment:,
+        installment_rule:,
+        version:,
+        purchase_id:,
+        follower_id:,
+        affiliate_user_id:,
+        subscription_id:,
+        reschedule_reference_time:
+      )
+      return
+    end
+    if purchase_id.present? && reschedule_reference_time.present?
+      current_reference_time = current_recipient_reference_time(
+        installment:,
+        purchase_id:,
+        follower_id:,
+        affiliate_user_id:,
+        subscription_id:
+      )
+      if current_reference_time.present? && current_reference_time != reschedule_reference_time
+        return unless recipient_matches_current_audience?(
+          installment:,
+          purchase_id:,
+          follower_id:,
+          affiliate_user_id:,
+          subscription_id:,
+          reschedule_reference_time: current_reference_time
+        )
+        reschedule_with_current_rule(
+          installment:,
+          installment_rule:,
+          version:,
+          purchase_id:,
+          follower_id:,
+          affiliate_user_id:,
+          subscription_id:,
+          reschedule_reference_time: current_reference_time
+        )
+        return
+      end
+    end
+    if reschedule_reference_time.present?
+      return unless recipient_matches_current_audience?(
+        installment:,
+        purchase_id:,
+        follower_id:,
+        affiliate_user_id:,
+        subscription_id:,
+        reschedule_reference_time:
       )
     end
 
     if purchase_id.present? && follower_id.nil? && affiliate_user_id.nil? && subscription_id.nil?
-      installment.send_installment_from_workflow_for_purchase(purchase_id)
+      installment.send_installment_from_workflow_for_purchase(purchase_id, reschedule_reference_time:)
     elsif follower_id.present? && purchase_id.nil? && affiliate_user_id.nil? && subscription_id.nil?
       installment.send_installment_from_workflow_for_follower(follower_id)
     elsif affiliate_user_id.present? && purchase_id.nil? && follower_id.nil? && subscription_id.nil?
@@ -74,90 +133,6 @@ class SendWorkflowInstallmentWorker
   end
 
   private
-    def follower_matches_current_audience?(installment:, follower_id:, recipient_reference_time:)
-      reference_time = Time.zone.iso8601(recipient_reference_time)
-      if installment.is_for_new_customers_of_workflow && reference_time < installment.published_at
-        return false
-      end
-
-      follower = Follower.active.find_by(id: follower_id, followed_id: installment.seller_id)
-      return false if follower.nil? || follower.confirmed_at.nil?
-      return false if SentPostEmail.exists?(post: installment, email: follower.email)
-
-      filters = installment.audience_members_filter_params
-      member = AudienceMember.find_by(seller_id: installment.seller_id, email: follower.email.downcase)
-      return false if member.nil?
-
-      current_match = AudienceMember.filter(
-        seller_id: installment.seller_id,
-        params: filters.except(:created_after, :created_before),
-        with_ids: true,
-        ids: [member.id]
-      ).first
-      return false if current_match.nil?
-
-      current_follower_id = current_match.follower_id || member.details.dig("follower", "id")
-      return false unless current_follower_id == follower.id
-      return false unless follower_identity_matches_workflow_dates?(filters:, follower:)
-
-      follower.confirmed_at.change(usec: 0) == reference_time
-    end
-
-    def follower_identity_matches_workflow_dates?(filters:, follower:)
-      created_after = Time.zone.parse(filters[:created_after].to_s) if filters[:created_after]
-      created_before = Time.zone.parse(filters[:created_before].to_s) if filters[:created_before]
-      return false if created_after && follower.created_at <= created_after
-      return false if created_before && follower.created_at >= created_before
-
-      true
-    end
-
-    def affiliate_matches_current_audience?(installment:, affiliate_user_id:, recipient_reference_time:)
-      reference_time = Time.zone.iso8601(recipient_reference_time)
-      if installment.is_for_new_customers_of_workflow && reference_time < installment.published_at
-        return false
-      end
-
-      affiliate = DirectAffiliate.alive.send_posts.find_by(
-        seller_id: installment.seller_id,
-        affiliate_user_id:
-      )
-      return false if affiliate.nil?
-      return false if SentPostEmail.exists?(post: installment, email: affiliate.affiliate_user.email)
-
-      member = AudienceMember.find_by(
-        seller_id: installment.seller_id,
-        email: affiliate.affiliate_user.email.downcase
-      )
-      return false if member.nil?
-
-      filters = installment.audience_members_filter_params
-      current_match = AudienceMember.filter(
-        seller_id: installment.seller_id,
-        params: filters.except(:created_after, :created_before),
-        with_ids: true,
-        ids: [member.id]
-      ).first
-      return false if current_match.nil?
-      return false unless affiliate_identity_matches_workflow_dates?(filters:, affiliate:)
-
-      product_affiliates = affiliate.product_affiliates.where(created_at: reference_time)
-      if installment.affiliate_products.present?
-        product_affiliates = product_affiliates.joins(:product).where(links: { unique_permalink: installment.affiliate_products })
-      end
-
-      product_affiliates.exists?
-    end
-
-    def affiliate_identity_matches_workflow_dates?(filters:, affiliate:)
-      created_after = Time.zone.parse(filters[:created_after].to_s) if filters[:created_after]
-      created_before = Time.zone.parse(filters[:created_before].to_s) if filters[:created_before]
-      return false if created_after && affiliate.created_at <= created_after
-      return false if created_before && affiliate.created_at >= created_before
-
-      true
-    end
-
     def current_rule_version(installment_id)
       cache_read_failed = false
       pending = false
@@ -187,5 +162,174 @@ class SendWorkflowInstallmentWorker
       effective_version
     ensure
       Makara::Context.release_all if primary_pinned
+    end
+
+    def current_recipient_reference_time(installment:, purchase_id:, follower_id:, affiliate_user_id:, subscription_id:)
+      recipient_ids = [purchase_id, follower_id, affiliate_user_id, subscription_id]
+      return unless recipient_ids.one?(&:present?)
+
+      reference_time = if purchase_id.present?
+        purchase = Purchase.find_by(id: purchase_id)&.original_purchase
+        installment.workflow_delivery_reference_time(purchase) if purchase.present?
+      elsif follower_id.present?
+        Follower.active.where(id: follower_id, followed_id: installment.seller_id).pick(:confirmed_at)
+      elsif affiliate_user_id.present?
+        email = User.where(id: affiliate_user_id).pick(:email)
+        filters = installment.audience_members_filter_params
+        audience = current_audience_member_and_match(installment:, email:, filters: filters.except(:created_after, :created_before))
+        if audience
+          member, current_match = audience
+          affiliate_reference_times(installment:, member:, current_match:, affiliate_user_id:).max
+        end
+      elsif subscription_id.present?
+        Subscription.where(id: subscription_id).pick(:deactivated_at)
+      end
+
+      reference_time&.change(usec: 0)&.iso8601
+    end
+
+    def reschedule_with_current_rule(installment:, installment_rule:, version:, purchase_id:, follower_id:, affiliate_user_id:, subscription_id:, reschedule_reference_time:)
+      return if reschedule_reference_time.nil? || installment_rule.version < version
+
+      deliver_at = Time.zone.iso8601(reschedule_reference_time) + installment_rule.delayed_delivery_time
+      job_id = SendWorkflowInstallmentRescheduleJob.perform_at(
+        deliver_at,
+        installment.id,
+        installment_rule.version,
+        purchase_id,
+        follower_id,
+        affiliate_user_id,
+        subscription_id,
+        reschedule_reference_time
+      )
+      if job_id.blank?
+        raise FanoutNotEnqueuedError, "Sidekiq did not enqueue the workflow installment"
+      end
+    end
+
+    def recipient_matches_current_audience?(installment:, purchase_id:, follower_id:, affiliate_user_id:, subscription_id:, reschedule_reference_time:)
+      recipient_ids = [purchase_id, follower_id, affiliate_user_id, subscription_id]
+      return false unless recipient_ids.one?(&:present?)
+
+      reference_time = Time.zone.iso8601(reschedule_reference_time)
+      if installment.is_for_new_customers_of_workflow && reference_time < installment.published_at
+        return false
+      end
+      if subscription_id.present?
+        subscription = Subscription.find_by(id: subscription_id)
+        return false if subscription.nil? || !subscription.cancelled?
+
+        purchase = subscription.original_purchase
+        return false if purchase.nil? || subscription.deactivated_at.nil?
+        return false if SentPostEmail.exists?(post: installment, email: purchase.email)
+        return false if installment.workflow.present? && !installment.workflow.applies_to_purchase?(purchase)
+
+        return subscription.deactivated_at.change(usec: 0) == reference_time
+      end
+
+      if follower_id.present?
+        follower = Follower.active.find_by(id: follower_id, followed_id: installment.seller_id)
+        return false if follower.nil? || follower.confirmed_at.nil?
+        return false if SentPostEmail.exists?(post: installment, email: follower.email)
+
+        filters = installment.audience_members_filter_params
+        audience = current_audience_member_and_match(
+          installment:,
+          email: follower.email,
+          filters: filters.except(:created_after, :created_before)
+        )
+        return false if audience.nil?
+
+        member, current_match = audience
+        current_follower_id = current_match.follower_id || member.details.dig("follower", "id")
+        return false unless current_follower_id == follower.id
+        return false unless follower_identity_matches_workflow_dates?(filters:, follower:)
+
+        return follower.confirmed_at.change(usec: 0) == reference_time
+      end
+
+      if affiliate_user_id.present?
+        email = User.where(id: affiliate_user_id).pick(:email)
+        return false if email.nil? || SentPostEmail.exists?(post: installment, email:)
+
+        filters = installment.audience_members_filter_params
+        audience = current_audience_member_and_match(installment:, email:, filters: filters.except(:created_after, :created_before))
+        return false if audience.nil?
+
+        member, current_match = audience
+        reference_times = affiliate_reference_times(installment:, member:, current_match:, affiliate_user_id:)
+        return reference_times.include?(reference_time) && reference_time <= Time.current
+      end
+
+      purchase = Purchase.find_by(id: purchase_id)&.original_purchase
+      return false if purchase.nil?
+
+      email = purchase.email
+      return false if SentPostEmail.exists?(post: installment, email:)
+
+      audience = current_audience_member_and_match(installment:, email:)
+      return false if audience.nil?
+
+      member, = audience
+      purchase_is_current = member.details.fetch("purchases", []).any? { _1["id"] == purchase.id }
+      return false unless purchase_is_current && installment.workflow.applies_to_purchase?(purchase)
+
+      valid_reference_times = [
+        purchase.created_at.change(usec: 0),
+        installment.workflow_delivery_reference_time(purchase).change(usec: 0),
+      ]
+      valid_reference_times.include?(reference_time)
+    end
+
+    def current_audience_member_and_match(installment:, email:, filters: nil)
+      return if email.nil?
+
+      member = AudienceMember.find_by(seller_id: installment.seller_id, email: email.downcase)
+      return if member.nil?
+
+      current_match = AudienceMember.filter(
+        seller_id: installment.seller_id,
+        params: filters || installment.audience_members_filter_params,
+        with_ids: true,
+        ids: [member.id]
+      ).first
+      [member, current_match] if current_match.present?
+    end
+
+    def follower_identity_matches_workflow_dates?(filters:, follower:)
+      created_after = Time.zone.parse(filters[:created_after].to_s) if filters[:created_after]
+      created_before = Time.zone.parse(filters[:created_before].to_s) if filters[:created_before]
+      return false if created_after && follower.created_at <= created_after
+      return false if created_before && follower.created_at >= created_before
+
+      true
+    end
+
+    def affiliate_reference_times(installment:, member:, current_match:, affiliate_user_id:)
+      filters = installment.audience_members_filter_params
+      affiliate_ids = member.details.fetch("affiliates", []).filter_map { _1["id"] }.uniq
+      affiliates = DirectAffiliate.alive
+        .where(id: affiliate_ids, seller_id: installment.seller_id, affiliate_user_id:)
+        .to_a
+        .select(&:send_posts)
+        .select { affiliate_identity_matches_workflow_dates?(filters:, affiliate: _1) }
+      if current_match.affiliate_id.present?
+        affiliates.select! { _1.id == current_match.affiliate_id }
+      end
+      return [] if affiliates.empty?
+
+      product_affiliates = ProductAffiliate.where(affiliate_id: affiliates.map(&:id))
+      product_ids = filters[:affiliate_product_ids]
+      product_affiliates = product_affiliates.where(link_id: product_ids) if product_ids.present?
+      product_affiliates.where.not(created_at: nil).pluck(:created_at).map { _1.change(usec: 0) }
+    end
+
+    def affiliate_identity_matches_workflow_dates?(filters:, affiliate:)
+      created_after = Time.zone.parse(filters[:created_after].to_s) if filters[:created_after]
+      created_before = Time.zone.parse(filters[:created_before].to_s) if filters[:created_before]
+      return false if created_after && affiliate.created_at <= created_after
+      return false if created_before && affiliate.created_at >= created_before
+
+      true
     end
 end

--- a/spec/models/installment/installment_send_installment_spec.rb
+++ b/spec/models/installment/installment_send_installment_spec.rb
@@ -467,3 +467,39 @@ describe "InstallmentSendInstallment"  do
     end
   end
 end
+
+describe Installment, "workflow reschedule references", :freeze_time do
+  it "preserves the reschedule reference when it defers the email" do
+    seller = create(:user)
+    product = create(:subscription_product, user: seller)
+    subscription = create(:subscription, link: product)
+    purchase = create(
+      :free_purchase,
+      link: product,
+      subscription:,
+      is_original_subscription_purchase: true,
+      created_at: 1.week.ago
+    )
+    create(:subscription_event, subscription:, event_type: :deactivated, occurred_at: 6.days.ago)
+    create(:subscription_event, subscription:, event_type: :restarted, occurred_at: 1.day.ago)
+    workflow = create(:workflow, seller:, link: product)
+    installment = create(:published_installment, seller:, link: product, workflow:)
+    rule = create(:installment_rule, installment:, delayed_delivery_time: 3.days)
+    reference_time = installment.workflow_delivery_reference_time(purchase).change(usec: 0).iso8601
+
+    installment.send_installment_from_workflow_for_purchase(
+      purchase.id,
+      reschedule_reference_time: reference_time
+    )
+
+    expect(SendWorkflowInstallmentRescheduleJob).to have_enqueued_sidekiq_job(
+      installment.id,
+      rule.version,
+      purchase.id,
+      nil,
+      nil,
+      nil,
+      reference_time
+    )
+  end
+end

--- a/spec/sidekiq/send_workflow_installment_reschedule_job_spec.rb
+++ b/spec/sidekiq/send_workflow_installment_reschedule_job_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+describe SendWorkflowInstallmentRescheduleJob do
+  it "delegates the reschedule arguments to the delivery worker" do
+    delivery_worker = instance_double(SendWorkflowInstallmentWorker)
+    allow(SendWorkflowInstallmentWorker).to receive(:new).and_return(delivery_worker)
+    expect(delivery_worker).to receive(:perform).with(1, 2, 3, nil, nil, nil, "2026-08-06T12:00:00Z")
+
+    described_class.new.perform(1, 2, 3, nil, nil, nil, "2026-08-06T12:00:00Z")
+  end
+
+  it "delegates a subscription reschedule" do
+    delivery_worker = instance_double(SendWorkflowInstallmentWorker)
+    allow(SendWorkflowInstallmentWorker).to receive(:new).and_return(delivery_worker)
+    expect(delivery_worker).to receive(:perform).with(1, 2, nil, nil, nil, 3, "2026-08-06T12:00:00Z")
+
+    described_class.new.perform(1, 2, nil, nil, nil, 3, "2026-08-06T12:00:00Z")
+  end
+
+  it "delegates follower and affiliate reschedules" do
+    delivery_worker = instance_double(SendWorkflowInstallmentWorker)
+    allow(SendWorkflowInstallmentWorker).to receive(:new).and_return(delivery_worker)
+    expect(delivery_worker).to receive(:perform).with(1, 2, nil, 3, nil, nil, "2026-08-06T12:00:00Z")
+    expect(delivery_worker).to receive(:perform).with(1, 2, nil, nil, 3, nil, "2026-08-06T12:00:00Z")
+
+    described_class.new.perform(1, 2, nil, 3, nil, nil, "2026-08-06T12:00:00Z")
+    described_class.new.perform(1, 2, nil, nil, 3, nil, "2026-08-06T12:00:00Z")
+  end
+
+  it "rejects ambiguous recipient combinations" do
+    expect(SendWorkflowInstallmentWorker).not_to receive(:new)
+
+    described_class.new.perform(1, 2, 3, 4, nil, nil, "2026-08-06T12:00:00Z")
+    described_class.new.perform(1, 2, 3, nil, nil, 4, "2026-08-06T12:00:00Z")
+  end
+
+  it "does not suppress duplicate recovery jobs" do
+    arguments = [1, 2, 3, nil, nil, nil, "2026-08-06T12:00:00Z"]
+    delivery_time = 1.day.from_now
+
+    job_ids = 2.times.map { described_class.perform_at(delivery_time, *arguments) }
+
+    expect(job_ids).to all(be_present)
+    expect(described_class.jobs.size).to eq(2)
+  end
+end

--- a/spec/sidekiq/send_workflow_installment_worker_spec.rb
+++ b/spec/sidekiq/send_workflow_installment_worker_spec.rb
@@ -5,6 +5,11 @@ describe SendWorkflowInstallmentWorker do
     @product = create(:product)
   end
 
+  it "does not suppress delivery jobs at enqueue time" do
+    expect(described_class.sidekiq_options["lock"]).to be_nil
+    expect(SendWorkflowInstallmentRescheduleJob.sidekiq_options["lock"]).to be_nil
+  end
+
   describe "purchase_installment" do
     before do
       @workflow = create(:workflow, seller: @product.user, link: @product, created_at: Time.current)
@@ -84,6 +89,123 @@ describe SendWorkflowInstallmentWorker do
     it "does not call any mailer if neither purchase_id nor follower_id nor affiliate_user_id are passed" do
       expect(PostSendgridApi).not_to receive(:process)
       SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, nil, nil)
+    end
+  end
+
+  describe "purchase installment reschedules" do
+    before do
+      @reschedule_seller = create(:user)
+      @reschedule_product = create(:product, user: @reschedule_seller, price_cents: 0)
+      @reschedule_workflow = create(:workflow, seller: @reschedule_seller, link: @reschedule_product)
+      @reschedule_installment = create(
+        :installment,
+        seller: @reschedule_seller,
+        link: @reschedule_product,
+        workflow: @reschedule_workflow,
+        published_at: 3.days.ago,
+        installment_type: Installment::PRODUCT_TYPE
+      )
+      @reschedule_rule = create(:installment_rule, installment: @reschedule_installment, delayed_delivery_time: 1.day)
+      @reschedule_purchase = create(:free_purchase, link: @reschedule_product, created_at: 2.days.ago)
+      @reschedule_purchase.add_to_audience_member_details
+      @reschedule_reference_time = @reschedule_purchase.created_at.change(usec: 0)
+    end
+
+    it "reschedules a queued version after a newer version commits" do
+      stale_version = @reschedule_rule.version
+      @reschedule_rule.update!(delayed_delivery_time: 2.days)
+
+      described_class.new.perform(
+        @reschedule_installment.id,
+        stale_version,
+        @reschedule_purchase.id,
+        nil,
+        nil
+      )
+
+      expect(SendWorkflowInstallmentRescheduleJob).to have_enqueued_sidekiq_job(
+        @reschedule_installment.id,
+        @reschedule_rule.version,
+        @reschedule_purchase.id,
+        nil,
+        nil,
+        nil,
+        @reschedule_reference_time.iso8601
+      ).immediately
+    end
+
+    it "delivers a same-version reschedule" do
+      expect(PostSendgridApi).to receive(:process).with(
+        post: @reschedule_installment,
+        recipients: [{ email: @reschedule_purchase.email, purchase: @reschedule_purchase }],
+        cache: {}
+      )
+
+      described_class.new.perform(
+        @reschedule_installment.id,
+        @reschedule_rule.version,
+        @reschedule_purchase.id,
+        nil,
+        nil,
+        nil,
+        @reschedule_reference_time.iso8601
+      )
+    end
+
+    it "does not restore a purchase that left the audience" do
+      stale_version = @reschedule_rule.version
+      @reschedule_rule.update!(delayed_delivery_time: 2.days)
+      @reschedule_purchase.update!(stripe_refunded: true)
+
+      expect do
+        described_class.new.perform(
+          @reschedule_installment.id,
+          stale_version,
+          @reschedule_purchase.id,
+          nil,
+          nil,
+          nil,
+          @reschedule_reference_time.iso8601
+        )
+      end.not_to change(SendWorkflowInstallmentRescheduleJob.jobs, :size)
+    end
+
+    it "reschedules a resubscribed membership from its adjusted reference time" do
+      subscription = create(:subscription, link: @reschedule_product)
+      purchase = create(
+        :free_purchase,
+        link: @reschedule_product,
+        subscription:,
+        is_original_subscription_purchase: true,
+        email: "resubscribed@example.com",
+        created_at: 10.days.ago
+      )
+      create(:subscription_event, subscription:, event_type: :deactivated, occurred_at: 9.days.ago)
+      create(:subscription_event, subscription:, event_type: :restarted, occurred_at: 1.day.ago)
+      purchase.add_to_audience_member_details
+      stale_version = @reschedule_rule.version
+      @reschedule_rule.update!(delayed_delivery_time: 3.days)
+      reference_time = @reschedule_installment.workflow_delivery_reference_time(purchase).change(usec: 0)
+
+      described_class.new.perform(
+        @reschedule_installment.id,
+        stale_version,
+        purchase.id,
+        nil,
+        nil,
+        nil,
+        reference_time.iso8601
+      )
+
+      expect(SendWorkflowInstallmentRescheduleJob).to have_enqueued_sidekiq_job(
+        @reschedule_installment.id,
+        @reschedule_rule.version,
+        purchase.id,
+        nil,
+        nil,
+        nil,
+        reference_time.iso8601
+      ).at(reference_time + @reschedule_rule.delayed_delivery_time)
     end
   end
 
@@ -290,6 +412,37 @@ describe SendWorkflowInstallmentWorker do
       end.to raise_error(SendWorkflowInstallmentWorker::RuleNotCommittedError)
     end
 
+    it "reschedules a stale follower job from its confirmation time" do
+      @follower.update_columns(created_at: 3.days.ago, confirmed_at: 2.hours.ago)
+      reference_time = @follower.confirmed_at.change(usec: 0)
+      stale_version = @installment_rule.version
+      @installment_rule.update!(delayed_delivery_time: 2.days)
+
+      expect do
+        described_class.new.perform(@installment.id, stale_version, nil, @follower.id, nil)
+      end.to change(SendWorkflowInstallmentRescheduleJob.jobs, :size).by(1)
+
+      expect(SendWorkflowInstallmentRescheduleJob).to have_enqueued_sidekiq_job(
+        @installment.id,
+        @installment_rule.version,
+        nil,
+        @follower.id,
+        nil,
+        nil,
+        reference_time.iso8601
+      ).at(reference_time + @installment_rule.delayed_delivery_time)
+    end
+
+    it "does not restore a deleted follower" do
+      stale_version = @installment_rule.version
+      @installment_rule.update!(delayed_delivery_time: 2.days)
+      @follower.mark_deleted!
+
+      expect do
+        described_class.new.perform(@installment.id, stale_version, nil, @follower.id, nil)
+      end.not_to change(SendWorkflowInstallmentRescheduleJob.jobs, :size)
+    end
+
     it "does not call mailer if different version" do
       expect(PostSendgridApi).not_to receive(:process)
       expect do
@@ -398,6 +551,35 @@ describe SendWorkflowInstallmentWorker do
       perform_affiliate_job
     end
 
+    it "reschedules a stale affiliate job from its product assignment time" do
+      stale_version = @installment_rule.version
+      @installment_rule.update!(delayed_delivery_time: 2.days)
+
+      expect do
+        described_class.new.perform(@installment.id, stale_version, nil, nil, @affiliate.affiliate_user_id)
+      end.to change(SendWorkflowInstallmentRescheduleJob.jobs, :size).by(1)
+
+      expect(SendWorkflowInstallmentRescheduleJob).to have_enqueued_sidekiq_job(
+        @installment.id,
+        @installment_rule.version,
+        nil,
+        nil,
+        @affiliate.affiliate_user_id,
+        nil,
+        @reference_time.iso8601
+      ).at(@reference_time + @installment_rule.delayed_delivery_time)
+    end
+
+    it "does not restore a removed product assignment" do
+      stale_version = @installment_rule.version
+      @installment_rule.update!(delayed_delivery_time: 2.days)
+      @product_affiliate.destroy!
+
+      expect do
+        described_class.new.perform(@installment.id, stale_version, nil, nil, @affiliate.affiliate_user_id)
+      end.not_to change(SendWorkflowInstallmentRescheduleJob.jobs, :size)
+    end
+
     def perform_affiliate_job
       described_class.new.perform(
         @installment.id,
@@ -429,6 +611,48 @@ describe SendWorkflowInstallmentWorker do
         cache: {}
       )
       SendWorkflowInstallmentWorker.new.perform(@installment.id, @installment_rule.version, nil, nil, nil, @subscription.id)
+    end
+  end
+
+  describe "member cancellation reschedules" do
+    it "uses the membership deactivation time" do
+      product = create(:subscription_product)
+      subscription = create(:subscription, link: product, cancelled_by_buyer: true, cancelled_at: 2.days.ago, deactivated_at: 1.day.ago)
+      create(:free_purchase, is_original_subscription_purchase: true, link: product, subscription:, created_at: 1.week.ago)
+      workflow = create(:workflow, seller: product.user, link: product, workflow_trigger: "member_cancellation")
+      installment = create(:published_installment, link: product, workflow:, workflow_trigger: "member_cancellation")
+      rule = create(:installment_rule, installment:, delayed_delivery_time: 1.day)
+      stale_version = rule.version
+      rule.update!(delayed_delivery_time: 3.days)
+      reference_time = subscription.deactivated_at.change(usec: 0)
+
+      described_class.new.perform(installment.id, stale_version, nil, nil, nil, subscription.id, reference_time.iso8601)
+
+      expect(SendWorkflowInstallmentRescheduleJob).to have_enqueued_sidekiq_job(
+        installment.id,
+        rule.version,
+        nil,
+        nil,
+        nil,
+        subscription.id,
+        reference_time.iso8601
+      ).at(reference_time + rule.delayed_delivery_time)
+    end
+
+    it "does not restore a cancellation job after the membership ends for another reason" do
+      product = create(:subscription_product)
+      subscription = create(:subscription, link: product, ended_at: 1.day.ago, deactivated_at: 1.day.ago)
+      create(:free_purchase, is_original_subscription_purchase: true, link: product, subscription:, created_at: 1.week.ago)
+      workflow = create(:workflow, seller: product.user, link: product, workflow_trigger: "member_cancellation")
+      installment = create(:published_installment, link: product, workflow:, workflow_trigger: "member_cancellation")
+      rule = create(:installment_rule, installment:, delayed_delivery_time: 1.day)
+      stale_version = rule.version
+      rule.update!(delayed_delivery_time: 3.days)
+      reference_time = subscription.deactivated_at.change(usec: 0)
+
+      expect do
+        described_class.new.perform(installment.id, stale_version, nil, nil, nil, subscription.id, reference_time.iso8601)
+      end.not_to change(SendWorkflowInstallmentRescheduleJob.jobs, :size)
     end
   end
 


### PR DESCRIPTION
## What

- Revalidate workflow recipients before delivery.
- Retry stale jobs with the latest committed rule version.
- Preserve purchase, subscription, follower, and affiliate trigger times.
- Reject recipients who left the current audience.

## Why

A queued workflow job can become stale after a rule change. Sending it unchanged can use an old delay or an invalid recipient.

The delivery worker must resolve the current recipient and trigger before it retries the email.

## Before/After

Before, stale jobs stopped when their rule version changed. Some recipients remained queued at an old time.

After, the worker rechecks the current recipient. It schedules an eligible recipient with the current rule and trigger time.

This PR has no user-visible interface change.

## Test Results

- Focused RSpec runs: 40 examples, 0 failures.
- `bin/test-confidence`: 99%; 23 tests passed.
- RuboCop: 0 offenses.
- Migration version check: passed.
- Premerge review: clean @ fe304e6de05b260761cbff63537e4ffffbd882e2
- Greptile: pending.

## Stack

- Builds on #7169.
- Prompt delay repair follows this change.
- Partial workflow saves follow both delay changes.

---

AI disclosure: GPT-5.6 Sol implemented and reviewed this change.

