### PR TITLE
Widen El Salvador plain account number floor to accept 9-digit BAC numbers

### DIFF
--- a/app/models/el_salvador_bank_account.rb
+++ b/app/models/el_salvador_bank_account.rb
@@ -4,7 +4,9 @@ class ElSalvadorBankAccount < BankAccount
   BANK_ACCOUNT_TYPE = "SV"
 
   BANK_CODE_FORMAT_REGEX = /^[a-zA-Z0-9]{8,11}$/
-  PLAIN_ACCOUNT_NUMBER_REGEX = /\A[0-9]{10,20}\z/
+  # 20-digit floor of the BBAN segment `build_iban` zero-pads into, not a real bank's account
+  # length — BAC's are 9 digits and other Salvadoran banks vary shorter still.
+  PLAIN_ACCOUNT_NUMBER_REGEX = /\A[0-9]{1,20}\z/
   IBAN_FORMAT_REGEX = /\ASV[0-9]{2}[A-Z]{4}[0-9]{20}\z/
   private_constant :BANK_CODE_FORMAT_REGEX, :PLAIN_ACCOUNT_NUMBER_REGEX, :IBAN_FORMAT_REGEX
 

--- a/spec/models/el_salvador_bank_account_spec.rb
+++ b/spec/models/el_salvador_bank_account_spec.rb
@@ -45,9 +45,13 @@ describe ElSalvadorBankAccount do
   end
 
   describe "#validate_account_number" do
-    it "accepts plain account numbers (10-20 digits)" do
+    it "accepts plain account numbers (1-20 digits)" do
       expect(build(:el_salvador_bank_account, account_number: "1234567890")).to be_valid
       expect(build(:el_salvador_bank_account, account_number: "12345678901234567890")).to be_valid
+    end
+
+    it "accepts a BAC-style 9-digit account number" do
+      expect(build(:el_salvador_bank_account, account_number: "123456789")).to be_valid
     end
 
     it "accepts valid SV IBAN format (28 chars)" do
@@ -56,7 +60,6 @@ describe ElSalvadorBankAccount do
     end
 
     it "rejects invalid formats" do
-      expect(build(:el_salvador_bank_account, account_number: "123456789")).not_to be_valid
       expect(build(:el_salvador_bank_account, account_number: "123456789012345678901")).not_to be_valid
       expect(build(:el_salvador_bank_account, account_number: "12345ABC90")).not_to be_valid
       expect(build(:el_salvador_bank_account, account_number: "SV99BCIE12345678901234567890")).not_to be_valid
@@ -86,6 +89,11 @@ describe ElSalvadorBankAccount do
     it "constructs an IBAN when a plain account number is stored" do
       ba = create(:el_salvador_bank_account, account_number: "3280602160", bank_number: "CAGRSVSS", account_number_last_four: "2160")
       expect(ba.stripe_account_number(passphrase)).to eq("SV88CAGR00000000003280602160")
+    end
+
+    it "constructs an IBAN for a BAC-style 9-digit account number" do
+      ba = create(:el_salvador_bank_account, account_number: "123456789", bank_number: "BAMCSVSS", account_number_last_four: "6789")
+      expect(ba.stripe_account_number(passphrase)).to eq("SV96BAMC00000000000123456789")
     end
 
     it "passes through a stored IBAN unchanged" do

--- a/spec/models/el_salvador_bank_account_spec.rb
+++ b/spec/models/el_salvador_bank_account_spec.rb
@@ -46,7 +46,7 @@ describe ElSalvadorBankAccount do
 
   describe "#validate_account_number" do
     it "accepts plain account numbers (1-20 digits)" do
-      expect(build(:el_salvador_bank_account, account_number: "1234567890")).to be_valid
+      expect(build(:el_salvador_bank_account, account_number: "1")).to be_valid
       expect(build(:el_salvador_bank_account, account_number: "12345678901234567890")).to be_valid
     end
 


### PR DESCRIPTION
## What

Widens `ElSalvadorBankAccount::PLAIN_ACCOUNT_NUMBER_REGEX` from `{10,20}` digits to `{1,20}` digits
so shorter (e.g. 9-digit BAC) plain account numbers reach `build_iban` instead of being rejected
outright.

## Why

`PLAIN_ACCOUNT_NUMBER_REGEX` required 10-20 digits before converting a plain account number to IBAN
via `build_iban`. That floor matches the width of the zero-padded BBAN segment `build_iban` builds,
not any real Salvadoran bank's account-number length. BAC (Banco de America Central) confirmed to a
customer their account numbers are exactly 9 digits with no 10-20 digit alternative (SWIFT
`BAMCSVSS`). `build_iban` already converts shorter numbers correctly — a live `Stripe::Token.create`
probe (country `SV`, currency `usd`) confirmed a 9-digit BAC account resolves once converted to IBAN
form, while the bare 9-digit plain number is rejected by Stripe directly (expects a full IBAN). The
model's validation floor was the only thing blocking the customer; the UI just showed "The account
number is invalid."

Ref antiwork/gumroad-private#2042.

## Before / After

- Before: `build(:el_salvador_bank_account, account_number: "123456789")` → invalid ("The account
  number is invalid.")
- After: same input → valid, and `stripe_account_number` returns `SV96BAMC00000000000123456789`
  (matches the live Stripe probe result in the linked issue).

## Test Results

`bundle exec rspec spec/models/el_salvador_bank_account_spec.rb` — 16 examples, 0 failures (local
run, 2026-08-10, at `7b44bae8`).

Mutation check: reverting the regex to `{10,20}` turns the two new examples ("accepts a BAC-style
9-digit account number" and "constructs an IBAN for a BAC-style 9-digit account number") red while
leaving the other 14 green — confirms the new specs actually pin the fix.

Addressed Greptile P2 (range example only exercised 10/20 digits, not the new 1-digit floor): the
"accepts plain account numbers (1-20 digits)" example now uses a 1-digit fixture instead of a
10-digit one. Re-verified against an `{8,20}` mutant — only that example goes red.

## QA steps

Backend-only validation/model change, no rendered surface to screenshot — confirmed via
`app/models/el_salvador_bank_account.rb` (validation-only class, no view/serializer touched) and
`app/controllers` / `app/javascript` grep for the model turning up no direct UI beyond the existing
generic bank-account form.

---

AI disclosure: this PR was authored autonomously by an AI agent (claude-sonnet-5 via Hermes Agent).



Premerge review: clean @ 7b44bae8853505140a166e719e363bff54df67c9

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ready for review — full suite green, Greptile clean, no P0/P1 outstanding. This
touches payout bank-account validation (money-path-capable), so per the current risk-branch rule
it's HIGH RISK regardless of QA cleanliness: assigned to @slavingia (matches the recent pattern of
who merges country-bank-validation PRs — Gambia/Zambia/Indonesia/BIC-country fixes), added
`awaiting-human`, removed `working`, requested review. Not auto-merging.
<!-- gumclaw-ownership-sweep -->

