### PR TITLE
Fix gp#2008: validate PayPal order price_cents against product price

### DIFF
--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -572,8 +572,10 @@ class PaypalChargeProcessor
                                   product_info[:vat_cents].to_i > 0 ?
                                     product_info[:exclusive_vat_cents].to_i :
                                     product_info[:exclusive_tax_cents].to_i)
+    vat_cents_usd = get_usd_cents(currency, product_info[:vat_cents].to_i)
     ensure_shipping_matches_product!(product:, quantity: product_info[:quantity].to_i, shipping_cents_usd:)
     ensure_tax_does_not_dwarf_price!(price_cents_usd:, shipping_cents_usd:, tax_cents_usd:)
+    fee_basis_cents_usd = paypal_fee_basis_cents(price_cents_usd:, tax_cents_usd:, vat_cents_usd:)
 
     purchase_unit_info = create_purchase_unit_info(permalink: product.unique_permalink,
                                                    item_name:,
@@ -584,9 +586,9 @@ class PaypalChargeProcessor
                                                    shipping_cents_usd:,
                                                    tax_cents_usd:,
                                                    fee_cents_usd: product.gumroad_amount_for_paypal_order(
-                                                     amount_cents: price_cents_usd,
+                                                     amount_cents: fee_basis_cents_usd,
                                                      affiliate_id: product_info[:affiliate_id],
-                                                     vat_cents: get_usd_cents(currency, product_info[:vat_cents].to_i),
+                                                     vat_cents: vat_cents_usd,
                                                      was_recommended: !!product_info[:was_recommended]),
                                                    total_cents_usd: get_usd_cents(currency, product_info[:total_cents].to_i),
                                                    quantity: product_info[:quantity].to_i)
@@ -612,8 +614,10 @@ class PaypalChargeProcessor
                                   product_info[:vat_cents].to_i > 0 ?
                                     product_info[:exclusive_vat_cents].to_i :
                                     product_info[:exclusive_tax_cents].to_i)
+    vat_cents_usd = get_usd_cents(currency, product_info[:vat_cents].to_i)
     ensure_shipping_matches_product!(product:, quantity: product_info[:quantity].to_i, shipping_cents_usd:)
     ensure_tax_does_not_dwarf_price!(price_cents_usd:, shipping_cents_usd:, tax_cents_usd:)
+    fee_basis_cents_usd = paypal_fee_basis_cents(price_cents_usd:, tax_cents_usd:, vat_cents_usd:)
 
     purchase_unit_info = create_purchase_unit_info(permalink: product.unique_permalink,
                                                    item_name:,
@@ -624,9 +628,9 @@ class PaypalChargeProcessor
                                                    shipping_cents_usd:,
                                                    tax_cents_usd:,
                                                    fee_cents_usd: product.gumroad_amount_for_paypal_order(
-                                                     amount_cents: price_cents_usd,
+                                                     amount_cents: fee_basis_cents_usd,
                                                      affiliate_id: product_info[:affiliate_id],
-                                                     vat_cents: get_usd_cents(currency, product_info[:vat_cents].to_i),
+                                                     vat_cents: vat_cents_usd,
                                                      was_recommended: !!product_info[:was_recommended]),
                                                    total_cents_usd: get_usd_cents(currency, product_info[:total_cents].to_i),
                                                    quantity: product_info[:quantity].to_i)
@@ -637,13 +641,12 @@ class PaypalChargeProcessor
   end
 
   # gp#1916 closed the total-preserving lower-price attack. This closes the FEE-SHIFT variant:
-  # keep the total fixed but shift cents from `price_cents` into tax/VAT, which collapses
-  # Gumroad's percentage fee (based on `price_cents` alone) without tripping the total-only
-  # guards. A hard price floor can't tell that apart from a legitimate discount (offer code,
-  # PPP, rental), so this bounds tax/VAT against price+shipping instead — real tax rates never
-  # exceed ~27% (Hungary's VAT ceiling); 0.35 leaves headroom. Known gap: the fee itself is
-  # still computed from buyer-supplied price_cents, so a ratio *inside* 0.35 still shifts some
-  # fee to tax (gp#2008 panel review tracking a fix that doesn't need buyer-location data).
+  # keep the total fixed but shift cents from `price_cents` into tax/VAT, which would collapse
+  # Gumroad's percentage fee if the fee basis stayed on buyer-supplied `price_cents` alone. A
+  # hard price floor can't tell that apart from a legitimate discount (offer code, PPP, rental),
+  # so this bounds tax/VAT against price+validated shipping and computes the fee on price plus
+  # non-VAT tax. VAT stays separate because `gumroad_amount_for_paypal_order` already adds it
+  # through the `vat_cents` argument.
   MAX_TAX_TO_PRICE_RATIO = 0.35
   private_constant :MAX_TAX_TO_PRICE_RATIO
 
@@ -673,6 +676,14 @@ class PaypalChargeProcessor
     raise ChargeProcessorError, "PayPal order tax/VAT is implausibly large relative to taxable base"
   end
   private_class_method :raise_tax_price_mismatch!
+
+  def self.paypal_fee_basis_cents(price_cents_usd:, tax_cents_usd:, vat_cents_usd:)
+    # Buyer-submitted non-VAT tax cannot reduce the PayPal partner fee by moving cents out of
+    # price_cents. VAT is already collected by gumroad_amount_for_paypal_order(vat_cents:), so
+    # do not include that passthrough in the percentage-fee basis as well.
+    price_cents_usd + [tax_cents_usd - vat_cents_usd, 0].max
+  end
+  private_class_method :paypal_fee_basis_cents
 
   def self.ensure_shipping_matches_product!(product:, quantity:, shipping_cents_usd:)
     return if shipping_cents_usd <= 0

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -575,7 +575,7 @@ class PaypalChargeProcessor
     vat_cents_usd = get_usd_cents(currency, product_info[:vat_cents].to_i)
     ensure_shipping_matches_product!(product:, quantity: product_info[:quantity].to_i, shipping_cents_usd:)
     ensure_tax_does_not_dwarf_price!(price_cents_usd:, shipping_cents_usd:, tax_cents_usd:)
-    fee_basis_cents_usd = paypal_fee_basis_cents(price_cents_usd:, tax_cents_usd:, vat_cents_usd:)
+    fee_basis_cents_usd = paypal_fee_basis_cents(price_cents_usd:, shipping_cents_usd:, tax_cents_usd:, vat_cents_usd:)
 
     purchase_unit_info = create_purchase_unit_info(permalink: product.unique_permalink,
                                                    item_name:,
@@ -617,7 +617,7 @@ class PaypalChargeProcessor
     vat_cents_usd = get_usd_cents(currency, product_info[:vat_cents].to_i)
     ensure_shipping_matches_product!(product:, quantity: product_info[:quantity].to_i, shipping_cents_usd:)
     ensure_tax_does_not_dwarf_price!(price_cents_usd:, shipping_cents_usd:, tax_cents_usd:)
-    fee_basis_cents_usd = paypal_fee_basis_cents(price_cents_usd:, tax_cents_usd:, vat_cents_usd:)
+    fee_basis_cents_usd = paypal_fee_basis_cents(price_cents_usd:, shipping_cents_usd:, tax_cents_usd:, vat_cents_usd:)
 
     purchase_unit_info = create_purchase_unit_info(permalink: product.unique_permalink,
                                                    item_name:,
@@ -645,8 +645,8 @@ class PaypalChargeProcessor
   # Gumroad's percentage fee if the fee basis stayed on buyer-supplied `price_cents` alone. A
   # hard price floor can't tell that apart from a legitimate discount (offer code, PPP, rental),
   # so this bounds tax/VAT against price+validated shipping and computes the fee on price plus
-  # non-VAT tax. VAT stays separate because `gumroad_amount_for_paypal_order` already adds it
-  # through the `vat_cents` argument.
+  # validated shipping plus non-VAT tax. VAT stays separate because `gumroad_amount_for_paypal_order`
+  # already adds it through the `vat_cents` argument.
   MAX_TAX_TO_PRICE_RATIO = 0.35
   private_constant :MAX_TAX_TO_PRICE_RATIO
 
@@ -677,11 +677,13 @@ class PaypalChargeProcessor
   end
   private_class_method :raise_tax_price_mismatch!
 
-  def self.paypal_fee_basis_cents(price_cents_usd:, tax_cents_usd:, vat_cents_usd:)
-    # Buyer-submitted non-VAT tax cannot reduce the PayPal partner fee by moving cents out of
-    # price_cents. VAT is already collected by gumroad_amount_for_paypal_order(vat_cents:), so
-    # do not include that passthrough in the percentage-fee basis as well.
-    price_cents_usd + [tax_cents_usd - vat_cents_usd, 0].max
+  def self.paypal_fee_basis_cents(price_cents_usd:, shipping_cents_usd:, tax_cents_usd:, vat_cents_usd:)
+    # Buyer-submitted shipping and non-VAT tax cannot reduce the PayPal partner fee by moving
+    # cents out of price_cents. Shipping has already been validated against the product's
+    # configured rates before this method runs. VAT is already collected by
+    # gumroad_amount_for_paypal_order(vat_cents:), so do not include that passthrough in the
+    # percentage-fee basis as well.
+    price_cents_usd + shipping_cents_usd + [tax_cents_usd - vat_cents_usd, 0].max
   end
   private_class_method :paypal_fee_basis_cents
 

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -566,24 +566,28 @@ class PaypalChargeProcessor
     item_name = sanitize_for_paypal(product.name, MAXIMUM_ITEM_NAME_LENGTH).presence ||
         sanitize_for_paypal(product.general_permalink, MAXIMUM_ITEM_NAME_LENGTH)
 
+    quantity = product_info[:quantity].to_i
+    price_cents_usd = get_usd_cents(currency, product_info[:price_cents].to_i)
+    ensure_price_matches_product!(product:, quantity:, price_cents_usd:)
+
     purchase_unit_info = create_purchase_unit_info(permalink: product.unique_permalink,
                                                    item_name:,
                                                    currency: merchant_account.currency,
                                                    merchant_id: merchant_account.charge_processor_merchant_id,
                                                    descriptor: sanitize_for_paypal(product.statement_description, MAXIMUM_DESCRIPTOR_LENGTH),
-                                                   price_cents_usd: get_usd_cents(currency, product_info[:price_cents].to_i),
+                                                   price_cents_usd:,
                                                    shipping_cents_usd: get_usd_cents(currency, product_info[:shipping_cents].to_i),
                                                    tax_cents_usd: get_usd_cents(currency,
                                                                                 product_info[:vat_cents].to_i > 0 ?
                                                                                   product_info[:exclusive_vat_cents].to_i :
                                                                                   product_info[:exclusive_tax_cents].to_i),
                                                    fee_cents_usd: product.gumroad_amount_for_paypal_order(
-                                                     amount_cents: get_usd_cents(currency, product_info[:price_cents].to_i),
+                                                     amount_cents: price_cents_usd,
                                                      affiliate_id: product_info[:affiliate_id],
                                                      vat_cents: get_usd_cents(currency, product_info[:vat_cents].to_i),
                                                      was_recommended: !!product_info[:was_recommended]),
                                                    total_cents_usd: get_usd_cents(currency, product_info[:total_cents].to_i),
-                                                   quantity: product_info[:quantity].to_i)
+                                                   quantity:)
 
     create_order(purchase_unit_info)
   end
@@ -600,29 +604,66 @@ class PaypalChargeProcessor
     item_name = sanitize_for_paypal(product.name, MAXIMUM_ITEM_NAME_LENGTH).presence ||
         sanitize_for_paypal(product.general_permalink, MAXIMUM_ITEM_NAME_LENGTH)
 
+    quantity = product_info[:quantity].to_i
+    price_cents_usd = get_usd_cents(currency, product_info[:price_cents].to_i)
+    ensure_price_matches_product!(product:, quantity:, price_cents_usd:)
+
     purchase_unit_info = create_purchase_unit_info(permalink: product.unique_permalink,
                                                    item_name:,
                                                    currency: merchant_account.currency,
                                                    merchant_id: merchant_account.charge_processor_merchant_id,
                                                    descriptor: sanitize_for_paypal(product.statement_description, MAXIMUM_DESCRIPTOR_LENGTH),
-                                                   price_cents_usd: get_usd_cents(currency, product_info[:price_cents].to_i),
+                                                   price_cents_usd:,
                                                    shipping_cents_usd: get_usd_cents(currency, product_info[:shipping_cents].to_i),
                                                    tax_cents_usd: get_usd_cents(currency,
                                                                                 product_info[:vat_cents].to_i > 0 ?
                                                                                     product_info[:exclusive_vat_cents].to_i :
                                                                                     product_info[:exclusive_tax_cents].to_i),
                                                    fee_cents_usd: product.gumroad_amount_for_paypal_order(
-                                                     amount_cents: get_usd_cents(currency, product_info[:price_cents].to_i),
+                                                     amount_cents: price_cents_usd,
                                                      affiliate_id: product_info[:affiliate_id],
                                                      vat_cents: get_usd_cents(currency, product_info[:vat_cents].to_i),
                                                      was_recommended: !!product_info[:was_recommended]),
                                                    total_cents_usd: get_usd_cents(currency, product_info[:total_cents].to_i),
-                                                   quantity: product_info[:quantity].to_i)
+                                                   quantity:)
 
     ensure_order_update_does_not_lower_total!(paypal_order_id, purchase_unit_info)
 
     update_order(paypal_order_id, purchase_unit_info)
   end
+
+  # gp#1916 closed the total-preserving version of this (a lower total was rejected outright);
+  # this closes the FEE-SHIFT variant, where an attacker keeps the total unchanged but shifts
+  # cents from `price_cents` into `exclusive_tax_cents`/`exclusive_vat_cents`. The platform fee
+  # (`Link#gumroad_amount_for_paypal_order`) is a percentage of `price_cents` alone, so an
+  # artificially low `price_cents` collapses Gumroad's fee toward zero without tripping the
+  # total-lower guard or `ensure_captured_amount_matches!` (both total-only checks). Tax/VAT are
+  # buyer-supplied and vary by jurisdiction, so they can't be re-derived here — but the ITEM PRICE
+  # is not: it is the product's own live `price_cents` (variant-aware would be a further
+  # improvement; not-yet-tiered products are the immediate risk this closes) converted through the
+  # same USD-cents helper used everywhere else in this class, so FX rounding matches on both sides.
+  def self.ensure_price_matches_product!(product:, quantity:, price_cents_usd:)
+    quantity = 1 if quantity <= 0
+    minimum_price_cents_usd = get_usd_cents(product.price_currency_type, product.price_cents.to_i) * quantity
+
+    # Rounding tolerance for cross-currency conversion, not a security carve-out — a deliberate
+    # multi-cent shift like the reported price_cents=1 case is still caught below.
+    tolerance = quantity
+
+    # PWYW ("name a fair price") products let the buyer pay MORE than price_cents, so only a
+    # submitted price BELOW the product's own floor is a violation — same rule cart_item uses
+    # ([params[:price], price_cents].max) for the same product.
+    return if price_cents_usd >= minimum_price_cents_usd - tolerance
+
+    ErrorNotifier.notify(
+      "PayPal order price is below Gumroad product's minimum price",
+      product_id: product.id,
+      submitted_price_cents_usd: price_cents_usd,
+      minimum_price_cents_usd:
+    )
+    raise ChargeProcessorError, "PayPal order price is below Gumroad product's minimum price"
+  end
+  private_class_method :ensure_price_matches_product!
 
   def self.ensure_order_update_does_not_lower_total!(paypal_order_id, purchase_unit_info)
     order_details = fetch_order(order_id: paypal_order_id)

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -566,9 +566,12 @@ class PaypalChargeProcessor
     item_name = sanitize_for_paypal(product.name, MAXIMUM_ITEM_NAME_LENGTH).presence ||
         sanitize_for_paypal(product.general_permalink, MAXIMUM_ITEM_NAME_LENGTH)
 
-    quantity = product_info[:quantity].to_i
     price_cents_usd = get_usd_cents(currency, product_info[:price_cents].to_i)
-    ensure_price_matches_product!(product:, quantity:, price_cents_usd:)
+    tax_cents_usd = get_usd_cents(currency,
+                                  product_info[:vat_cents].to_i > 0 ?
+                                    product_info[:exclusive_vat_cents].to_i :
+                                    product_info[:exclusive_tax_cents].to_i)
+    ensure_tax_does_not_dwarf_price!(price_cents_usd:, tax_cents_usd:)
 
     purchase_unit_info = create_purchase_unit_info(permalink: product.unique_permalink,
                                                    item_name:,
@@ -577,17 +580,14 @@ class PaypalChargeProcessor
                                                    descriptor: sanitize_for_paypal(product.statement_description, MAXIMUM_DESCRIPTOR_LENGTH),
                                                    price_cents_usd:,
                                                    shipping_cents_usd: get_usd_cents(currency, product_info[:shipping_cents].to_i),
-                                                   tax_cents_usd: get_usd_cents(currency,
-                                                                                product_info[:vat_cents].to_i > 0 ?
-                                                                                  product_info[:exclusive_vat_cents].to_i :
-                                                                                  product_info[:exclusive_tax_cents].to_i),
+                                                   tax_cents_usd:,
                                                    fee_cents_usd: product.gumroad_amount_for_paypal_order(
                                                      amount_cents: price_cents_usd,
                                                      affiliate_id: product_info[:affiliate_id],
                                                      vat_cents: get_usd_cents(currency, product_info[:vat_cents].to_i),
                                                      was_recommended: !!product_info[:was_recommended]),
                                                    total_cents_usd: get_usd_cents(currency, product_info[:total_cents].to_i),
-                                                   quantity:)
+                                                   quantity: product_info[:quantity].to_i)
 
     create_order(purchase_unit_info)
   end
@@ -604,9 +604,12 @@ class PaypalChargeProcessor
     item_name = sanitize_for_paypal(product.name, MAXIMUM_ITEM_NAME_LENGTH).presence ||
         sanitize_for_paypal(product.general_permalink, MAXIMUM_ITEM_NAME_LENGTH)
 
-    quantity = product_info[:quantity].to_i
     price_cents_usd = get_usd_cents(currency, product_info[:price_cents].to_i)
-    ensure_price_matches_product!(product:, quantity:, price_cents_usd:)
+    tax_cents_usd = get_usd_cents(currency,
+                                  product_info[:vat_cents].to_i > 0 ?
+                                    product_info[:exclusive_vat_cents].to_i :
+                                    product_info[:exclusive_tax_cents].to_i)
+    ensure_tax_does_not_dwarf_price!(price_cents_usd:, tax_cents_usd:)
 
     purchase_unit_info = create_purchase_unit_info(permalink: product.unique_permalink,
                                                    item_name:,
@@ -615,17 +618,14 @@ class PaypalChargeProcessor
                                                    descriptor: sanitize_for_paypal(product.statement_description, MAXIMUM_DESCRIPTOR_LENGTH),
                                                    price_cents_usd:,
                                                    shipping_cents_usd: get_usd_cents(currency, product_info[:shipping_cents].to_i),
-                                                   tax_cents_usd: get_usd_cents(currency,
-                                                                                product_info[:vat_cents].to_i > 0 ?
-                                                                                    product_info[:exclusive_vat_cents].to_i :
-                                                                                    product_info[:exclusive_tax_cents].to_i),
+                                                   tax_cents_usd:,
                                                    fee_cents_usd: product.gumroad_amount_for_paypal_order(
                                                      amount_cents: price_cents_usd,
                                                      affiliate_id: product_info[:affiliate_id],
                                                      vat_cents: get_usd_cents(currency, product_info[:vat_cents].to_i),
                                                      was_recommended: !!product_info[:was_recommended]),
                                                    total_cents_usd: get_usd_cents(currency, product_info[:total_cents].to_i),
-                                                   quantity:)
+                                                   quantity: product_info[:quantity].to_i)
 
     ensure_order_update_does_not_lower_total!(paypal_order_id, purchase_unit_info)
 
@@ -637,33 +637,47 @@ class PaypalChargeProcessor
   # cents from `price_cents` into `exclusive_tax_cents`/`exclusive_vat_cents`. The platform fee
   # (`Link#gumroad_amount_for_paypal_order`) is a percentage of `price_cents` alone, so an
   # artificially low `price_cents` collapses Gumroad's fee toward zero without tripping the
-  # total-lower guard or `ensure_captured_amount_matches!` (both total-only checks). Tax/VAT are
-  # buyer-supplied and vary by jurisdiction, so they can't be re-derived here — but the ITEM PRICE
-  # is not: it is the product's own live `price_cents` (variant-aware would be a further
-  # improvement; not-yet-tiered products are the immediate risk this closes) converted through the
-  # same USD-cents helper used everywhere else in this class, so FX rounding matches on both sides.
-  def self.ensure_price_matches_product!(product:, quantity:, price_cents_usd:)
-    quantity = 1 if quantity <= 0
-    minimum_price_cents_usd = get_usd_cents(product.price_currency_type, product.price_cents.to_i) * quantity
+  # total-lower guard or `ensure_captured_amount_matches!` (both total-only checks).
+  #
+  # A hard floor on price_cents against the product's live price (an earlier version of this
+  # guard) is wrong: this endpoint's product_info has no signal for which legitimate discount
+  # produced the submitted price — offer codes, PPP, rentals, and cheaper tiers/recurrences all
+  # send a price_cents below the product's base price by design, and the guard can't tell those
+  # apart from an attack (caught in review before merge).
+  #
+  # Instead, bound the ratio that IS attack-specific: real-world VAT/sales tax rates top out
+  # around 27% of the pre-tax price (Hungary's 27% VAT is the ceiling case), so tax/VAT
+  # legitimately exceeding roughly a third of the price never happens for an actual purchase —
+  # only for the fee-shift attack, which relies on tax_cents dwarfing price_cents while the total
+  # stays fixed. This is invariant to how price_cents was legitimately discounted, so it doesn't
+  # need to know the product's base price at all. 0.35 leaves headroom above the highest real
+  # rate without meaningfully widening the attack window: it caps how much of the total an
+  # attacker can still shift out of price_cents (at most ~26% of the total, vs. ~100% before this
+  # guard existed).
+  MAX_TAX_TO_PRICE_RATIO = 0.35
+  private_constant :MAX_TAX_TO_PRICE_RATIO
 
-    # Rounding tolerance for cross-currency conversion, not a security carve-out — a deliberate
-    # multi-cent shift like the reported price_cents=1 case is still caught below.
-    tolerance = quantity
+  def self.ensure_tax_does_not_dwarf_price!(price_cents_usd:, tax_cents_usd:)
+    return if tax_cents_usd <= 0
+    # A $0 (or near-$0) price with any positive tax is exactly the reported attack shape and
+    # can't be a legitimate ratio no matter how small tax_cents_usd is, so guard the zero case
+    # explicitly rather than dividing by it.
+    return raise_tax_price_mismatch!(price_cents_usd:, tax_cents_usd:) if price_cents_usd <= 0
+    return if tax_cents_usd <= price_cents_usd * MAX_TAX_TO_PRICE_RATIO
 
-    # PWYW ("name a fair price") products let the buyer pay MORE than price_cents, so only a
-    # submitted price BELOW the product's own floor is a violation — same rule cart_item uses
-    # ([params[:price], price_cents].max) for the same product.
-    return if price_cents_usd >= minimum_price_cents_usd - tolerance
-
-    ErrorNotifier.notify(
-      "PayPal order price is below Gumroad product's minimum price",
-      product_id: product.id,
-      submitted_price_cents_usd: price_cents_usd,
-      minimum_price_cents_usd:
-    )
-    raise ChargeProcessorError, "PayPal order price is below Gumroad product's minimum price"
+    raise_tax_price_mismatch!(price_cents_usd:, tax_cents_usd:)
   end
-  private_class_method :ensure_price_matches_product!
+  private_class_method :ensure_tax_does_not_dwarf_price!
+
+  def self.raise_tax_price_mismatch!(price_cents_usd:, tax_cents_usd:)
+    ErrorNotifier.notify(
+      "PayPal order tax/VAT is implausibly large relative to price",
+      submitted_price_cents_usd: price_cents_usd,
+      submitted_tax_cents_usd: tax_cents_usd
+    )
+    raise ChargeProcessorError, "PayPal order tax/VAT is implausibly large relative to price"
+  end
+  private_class_method :raise_tax_price_mismatch!
 
   def self.ensure_order_update_does_not_lower_total!(paypal_order_id, purchase_unit_info)
     order_details = fetch_order(order_id: paypal_order_id)

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -636,27 +636,14 @@ class PaypalChargeProcessor
     update_order(paypal_order_id, purchase_unit_info)
   end
 
-  # gp#1916 closed the total-preserving version of this (a lower total was rejected outright);
-  # this closes the FEE-SHIFT variant, where an attacker keeps the total unchanged but shifts
-  # cents from `price_cents` into other buyer-supplied breakdown fields. The platform fee
-  # (`Link#gumroad_amount_for_paypal_order`) is a percentage of `price_cents` alone, so an
-  # artificially low `price_cents` collapses Gumroad's fee toward zero without tripping the
-  # total-lower guard or `ensure_captured_amount_matches!` (both total-only checks).
-  #
-  # A hard floor on price_cents against the product's live price (an earlier version of this
-  # guard) is wrong: this endpoint's product_info has no signal for which legitimate discount
-  # produced the submitted price — offer codes, PPP, rentals, and cheaper tiers/recurrences all
-  # send a price_cents below the product's base price by design, and the guard can't tell those
-  # apart from an attack (caught in review before merge).
-  #
-  # Instead, bound the ratio that IS attack-specific: real-world VAT/sales tax rates top out
-  # around 27% of the taxable base (Hungary's 27% VAT is the ceiling case), so tax/VAT
-  # legitimately exceeding roughly a third of price + validated shipping never happens for an
-  # actual purchase — only for the fee-shift attack, which relies on tax_cents dwarfing the
-  # server-valid subtotal while the total stays fixed. This is invariant to how price_cents was
-  # legitimately discounted, so it doesn't need to know the product's base price at all. Shipping
-  # is included because physical-product shipping can itself be taxable, but it is safe to include
-  # only after `ensure_shipping_matches_product!` has independently rejected fake shipping.
+  # gp#1916 closed the total-preserving lower-price attack. This closes the FEE-SHIFT variant:
+  # keep the total fixed but shift cents from `price_cents` into tax/VAT, which collapses
+  # Gumroad's percentage fee (based on `price_cents` alone) without tripping the total-only
+  # guards. A hard price floor can't tell that apart from a legitimate discount (offer code,
+  # PPP, rental), so this bounds tax/VAT against price+shipping instead — real tax rates never
+  # exceed ~27% (Hungary's VAT ceiling); 0.35 leaves headroom. Known gap: the fee itself is
+  # still computed from buyer-supplied price_cents, so a ratio *inside* 0.35 still shifts some
+  # fee to tax (gp#2008 panel review tracking a fix that doesn't need buyer-location data).
   MAX_TAX_TO_PRICE_RATIO = 0.35
   private_constant :MAX_TAX_TO_PRICE_RATIO
 

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -573,7 +573,7 @@ class PaypalChargeProcessor
                                     product_info[:exclusive_vat_cents].to_i :
                                     product_info[:exclusive_tax_cents].to_i)
     ensure_shipping_matches_product!(product:, quantity: product_info[:quantity].to_i, shipping_cents_usd:)
-    ensure_tax_does_not_dwarf_price!(price_cents_usd:, tax_cents_usd:)
+    ensure_tax_does_not_dwarf_price!(price_cents_usd:, shipping_cents_usd:, tax_cents_usd:)
 
     purchase_unit_info = create_purchase_unit_info(permalink: product.unique_permalink,
                                                    item_name:,
@@ -613,7 +613,7 @@ class PaypalChargeProcessor
                                     product_info[:exclusive_vat_cents].to_i :
                                     product_info[:exclusive_tax_cents].to_i)
     ensure_shipping_matches_product!(product:, quantity: product_info[:quantity].to_i, shipping_cents_usd:)
-    ensure_tax_does_not_dwarf_price!(price_cents_usd:, tax_cents_usd:)
+    ensure_tax_does_not_dwarf_price!(price_cents_usd:, shipping_cents_usd:, tax_cents_usd:)
 
     purchase_unit_info = create_purchase_unit_info(permalink: product.unique_permalink,
                                                    item_name:,
@@ -650,36 +650,40 @@ class PaypalChargeProcessor
   # apart from an attack (caught in review before merge).
   #
   # Instead, bound the ratio that IS attack-specific: real-world VAT/sales tax rates top out
-  # around 27% of the pre-tax price (Hungary's 27% VAT is the ceiling case), so tax/VAT
-  # legitimately exceeding roughly a third of the price never happens for an actual purchase —
-  # only for the fee-shift attack, which relies on tax_cents dwarfing price_cents while the total
-  # stays fixed. This is invariant to how price_cents was legitimately discounted, so it doesn't
-  # need to know the product's base price at all. 0.35 leaves headroom above the highest real
-  # rate without meaningfully widening the attack window: it caps how much of the total an
-  # attacker can still shift out of price_cents (at most ~26% of the total, vs. ~100% before this
-  # guard existed).
+  # around 27% of the taxable base (Hungary's 27% VAT is the ceiling case), so tax/VAT
+  # legitimately exceeding roughly a third of price + validated shipping never happens for an
+  # actual purchase — only for the fee-shift attack, which relies on tax_cents dwarfing the
+  # server-valid subtotal while the total stays fixed. This is invariant to how price_cents was
+  # legitimately discounted, so it doesn't need to know the product's base price at all. Shipping
+  # is included because physical-product shipping can itself be taxable, but it is safe to include
+  # only after `ensure_shipping_matches_product!` has independently rejected fake shipping.
   MAX_TAX_TO_PRICE_RATIO = 0.35
   private_constant :MAX_TAX_TO_PRICE_RATIO
 
-  def self.ensure_tax_does_not_dwarf_price!(price_cents_usd:, tax_cents_usd:)
+  def self.ensure_tax_does_not_dwarf_price!(price_cents_usd:, shipping_cents_usd:, tax_cents_usd:)
     return if tax_cents_usd <= 0
-    # A $0 (or near-$0) price with any positive tax is exactly the reported attack shape and
-    # can't be a legitimate ratio no matter how small tax_cents_usd is, so guard the zero case
-    # explicitly rather than dividing by it.
-    return raise_tax_price_mismatch!(price_cents_usd:, tax_cents_usd:) if price_cents_usd <= 0
-    return if tax_cents_usd <= price_cents_usd * MAX_TAX_TO_PRICE_RATIO
 
-    raise_tax_price_mismatch!(price_cents_usd:, tax_cents_usd:)
+    taxable_base_cents_usd = price_cents_usd + shipping_cents_usd
+    # A $0 (or near-$0) taxable base with any positive tax is exactly the reported attack shape
+    # and can't be a legitimate ratio no matter how small tax_cents_usd is, so guard the zero
+    # case explicitly rather than dividing by it.
+    if taxable_base_cents_usd <= 0
+      return raise_tax_price_mismatch!(price_cents_usd:, shipping_cents_usd:, tax_cents_usd:)
+    end
+    return if tax_cents_usd <= taxable_base_cents_usd * MAX_TAX_TO_PRICE_RATIO
+
+    raise_tax_price_mismatch!(price_cents_usd:, shipping_cents_usd:, tax_cents_usd:)
   end
   private_class_method :ensure_tax_does_not_dwarf_price!
 
-  def self.raise_tax_price_mismatch!(price_cents_usd:, tax_cents_usd:)
+  def self.raise_tax_price_mismatch!(price_cents_usd:, shipping_cents_usd:, tax_cents_usd:)
     ErrorNotifier.notify(
-      "PayPal order tax/VAT is implausibly large relative to price",
+      "PayPal order tax/VAT is implausibly large relative to taxable base",
       submitted_price_cents_usd: price_cents_usd,
+      submitted_shipping_cents_usd: shipping_cents_usd,
       submitted_tax_cents_usd: tax_cents_usd
     )
-    raise ChargeProcessorError, "PayPal order tax/VAT is implausibly large relative to price"
+    raise ChargeProcessorError, "PayPal order tax/VAT is implausibly large relative to taxable base"
   end
   private_class_method :raise_tax_price_mismatch!
 

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -694,27 +694,30 @@ class PaypalChargeProcessor
     return raise_shipping_mismatch!(product:, quantity:, shipping_cents_usd:) unless product.is_physical
 
     tolerance = quantity
-    valid_shipping_rates = product.shipping_destinations.alive.map do |shipping_destination|
+    valid_shipping_rates_usd = product.shipping_destinations.alive.map do |shipping_destination|
+      # ShippingDestination#calculate_shipping_rate returns USD cents after converting each
+      # product-currency rate term with CurrencyHelper#get_usd_cents, so this compares USD cents
+      # to USD cents even for non-USD physical products.
       shipping_destination.calculate_shipping_rate(
         quantity:,
         currency_type: product.price_currency_type
       )
     end.compact
 
-    return if valid_shipping_rates.any? { |rate| (shipping_cents_usd - rate).abs <= tolerance }
+    return if valid_shipping_rates_usd.any? { |rate| (shipping_cents_usd - rate).abs <= tolerance }
 
-    raise_shipping_mismatch!(product:, quantity:, shipping_cents_usd:, valid_shipping_rates:)
+    raise_shipping_mismatch!(product:, quantity:, shipping_cents_usd:, valid_shipping_rates_usd:)
   end
   private_class_method :ensure_shipping_matches_product!
 
-  def self.raise_shipping_mismatch!(product:, quantity:, shipping_cents_usd:, valid_shipping_rates: [])
+  def self.raise_shipping_mismatch!(product:, quantity:, shipping_cents_usd:, valid_shipping_rates_usd: [])
     ErrorNotifier.notify(
       "PayPal order shipping does not match Gumroad product shipping",
       product_id: product.id,
       is_physical: product.is_physical,
       submitted_shipping_cents_usd: shipping_cents_usd,
       quantity:,
-      valid_shipping_rates_usd: valid_shipping_rates
+      valid_shipping_rates_usd:
     )
     raise ChargeProcessorError, "PayPal order shipping does not match Gumroad product shipping"
   end

--- a/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
+++ b/app/business/payments/charging/implementations/paypal/paypal_charge_processor.rb
@@ -567,10 +567,12 @@ class PaypalChargeProcessor
         sanitize_for_paypal(product.general_permalink, MAXIMUM_ITEM_NAME_LENGTH)
 
     price_cents_usd = get_usd_cents(currency, product_info[:price_cents].to_i)
+    shipping_cents_usd = get_usd_cents(currency, product_info[:shipping_cents].to_i)
     tax_cents_usd = get_usd_cents(currency,
                                   product_info[:vat_cents].to_i > 0 ?
                                     product_info[:exclusive_vat_cents].to_i :
                                     product_info[:exclusive_tax_cents].to_i)
+    ensure_shipping_matches_product!(product:, quantity: product_info[:quantity].to_i, shipping_cents_usd:)
     ensure_tax_does_not_dwarf_price!(price_cents_usd:, tax_cents_usd:)
 
     purchase_unit_info = create_purchase_unit_info(permalink: product.unique_permalink,
@@ -579,7 +581,7 @@ class PaypalChargeProcessor
                                                    merchant_id: merchant_account.charge_processor_merchant_id,
                                                    descriptor: sanitize_for_paypal(product.statement_description, MAXIMUM_DESCRIPTOR_LENGTH),
                                                    price_cents_usd:,
-                                                   shipping_cents_usd: get_usd_cents(currency, product_info[:shipping_cents].to_i),
+                                                   shipping_cents_usd:,
                                                    tax_cents_usd:,
                                                    fee_cents_usd: product.gumroad_amount_for_paypal_order(
                                                      amount_cents: price_cents_usd,
@@ -605,10 +607,12 @@ class PaypalChargeProcessor
         sanitize_for_paypal(product.general_permalink, MAXIMUM_ITEM_NAME_LENGTH)
 
     price_cents_usd = get_usd_cents(currency, product_info[:price_cents].to_i)
+    shipping_cents_usd = get_usd_cents(currency, product_info[:shipping_cents].to_i)
     tax_cents_usd = get_usd_cents(currency,
                                   product_info[:vat_cents].to_i > 0 ?
                                     product_info[:exclusive_vat_cents].to_i :
                                     product_info[:exclusive_tax_cents].to_i)
+    ensure_shipping_matches_product!(product:, quantity: product_info[:quantity].to_i, shipping_cents_usd:)
     ensure_tax_does_not_dwarf_price!(price_cents_usd:, tax_cents_usd:)
 
     purchase_unit_info = create_purchase_unit_info(permalink: product.unique_permalink,
@@ -617,7 +621,7 @@ class PaypalChargeProcessor
                                                    merchant_id: merchant_account.charge_processor_merchant_id,
                                                    descriptor: sanitize_for_paypal(product.statement_description, MAXIMUM_DESCRIPTOR_LENGTH),
                                                    price_cents_usd:,
-                                                   shipping_cents_usd: get_usd_cents(currency, product_info[:shipping_cents].to_i),
+                                                   shipping_cents_usd:,
                                                    tax_cents_usd:,
                                                    fee_cents_usd: product.gumroad_amount_for_paypal_order(
                                                      amount_cents: price_cents_usd,
@@ -634,7 +638,7 @@ class PaypalChargeProcessor
 
   # gp#1916 closed the total-preserving version of this (a lower total was rejected outright);
   # this closes the FEE-SHIFT variant, where an attacker keeps the total unchanged but shifts
-  # cents from `price_cents` into `exclusive_tax_cents`/`exclusive_vat_cents`. The platform fee
+  # cents from `price_cents` into other buyer-supplied breakdown fields. The platform fee
   # (`Link#gumroad_amount_for_paypal_order`) is a percentage of `price_cents` alone, so an
   # artificially low `price_cents` collapses Gumroad's fee toward zero without tripping the
   # total-lower guard or `ensure_captured_amount_matches!` (both total-only checks).
@@ -678,6 +682,39 @@ class PaypalChargeProcessor
     raise ChargeProcessorError, "PayPal order tax/VAT is implausibly large relative to price"
   end
   private_class_method :raise_tax_price_mismatch!
+
+  def self.ensure_shipping_matches_product!(product:, quantity:, shipping_cents_usd:)
+    return if shipping_cents_usd <= 0
+
+    quantity = 1 if quantity <= 0
+    return raise_shipping_mismatch!(product:, quantity:, shipping_cents_usd:) unless product.is_physical
+
+    tolerance = quantity
+    valid_shipping_rates = product.shipping_destinations.alive.map do |shipping_destination|
+      shipping_destination.calculate_shipping_rate(
+        quantity:,
+        currency_type: product.price_currency_type
+      )
+    end.compact
+
+    return if valid_shipping_rates.any? { |rate| (shipping_cents_usd - rate).abs <= tolerance }
+
+    raise_shipping_mismatch!(product:, quantity:, shipping_cents_usd:, valid_shipping_rates:)
+  end
+  private_class_method :ensure_shipping_matches_product!
+
+  def self.raise_shipping_mismatch!(product:, quantity:, shipping_cents_usd:, valid_shipping_rates: [])
+    ErrorNotifier.notify(
+      "PayPal order shipping does not match Gumroad product shipping",
+      product_id: product.id,
+      is_physical: product.is_physical,
+      submitted_shipping_cents_usd: shipping_cents_usd,
+      quantity:,
+      valid_shipping_rates_usd: valid_shipping_rates
+    )
+    raise ChargeProcessorError, "PayPal order shipping does not match Gumroad product shipping"
+  end
+  private_class_method :raise_shipping_mismatch!
 
   def self.ensure_order_update_does_not_lower_total!(paypal_order_id, purchase_unit_info)
     order_details = fetch_order(order_id: paypal_order_id)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -230,6 +230,20 @@ class Rack::Attack
       req.remote_ip if req.path.match?(path_regexp)
     end
   end
+  # /paypal/order and /paypal/update_order are unauthenticated by design (a buyer checking out
+  # via PayPal is not logged in), which is exactly what gp#2008 abused to hammer the fee-shift
+  # exploit an unbounded number of times per IP. price_cents is now re-validated against the
+  # live product server-side (see PaypalChargeProcessor.ensure_price_matches_product!), so this
+  # throttle is defense-in-depth against brute-forcing rounding/currency edge cases and general
+  # abuse of a route that legitimately has no session to key off of.
+  PAYPAL_ORDER_PATHS = %w[/paypal/order /paypal/update_order /paypal/fetch_order].index_with do |path|
+    /\A#{Regexp.escape(path)}(?:\.[^\/]+)?\z/
+  end.freeze
+  PAYPAL_ORDER_PATHS.each do |path, path_regexp|
+    throttle_with_exponential_backoff(name: "/ip:#{path}", requests: 20, period: 20.seconds) do |req|
+      req.remote_ip if req.path.match?(path_regexp)
+    end
+  end
   # One shared per-recipient budget across both grouped-receipt endpoints — they send the
   # same email, so separate budgets would double the ceiling. Initial: 6rpm, Max: 36
   # requests/3 days — roomy enough for a buyer retrying a lookup, still a hard ceiling on

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -230,12 +230,10 @@ class Rack::Attack
       req.remote_ip if req.path.match?(path_regexp)
     end
   end
-  # /paypal/order and /paypal/update_order are unauthenticated by design (a buyer checking out
-  # via PayPal is not logged in), which is exactly what gp#2008 abused to hammer the fee-shift
-  # exploit an unbounded number of times per IP. The submitted breakdown is now bounded against
-  # server-side product facts in PaypalChargeProcessor, so this throttle is defense-in-depth
-  # against brute-forcing rounding/currency edge cases and general abuse of a route that
-  # legitimately has no session to key off of.
+  # Unauthenticated by design (buyer checking out via PayPal isn't logged in yet) — exactly
+  # what gp#2008's fee-shift exploit relied on to hammer the endpoint per IP. The submitted
+  # breakdown is now bounded server-side in PaypalChargeProcessor; this is defense-in-depth
+  # against brute-forcing rounding/currency edge cases.
   PAYPAL_ORDER_PATHS = %w[/paypal/order /paypal/update_order /paypal/fetch_order].index_with do |path|
     /\A#{Regexp.escape(path)}(?:\.[^\/]+)?\z/
   end.freeze

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -232,10 +232,10 @@ class Rack::Attack
   end
   # /paypal/order and /paypal/update_order are unauthenticated by design (a buyer checking out
   # via PayPal is not logged in), which is exactly what gp#2008 abused to hammer the fee-shift
-  # exploit an unbounded number of times per IP. price_cents is now re-validated against the
-  # live product server-side (see PaypalChargeProcessor.ensure_price_matches_product!), so this
-  # throttle is defense-in-depth against brute-forcing rounding/currency edge cases and general
-  # abuse of a route that legitimately has no session to key off of.
+  # exploit an unbounded number of times per IP. The submitted breakdown is now bounded against
+  # server-side product facts in PaypalChargeProcessor, so this throttle is defense-in-depth
+  # against brute-forcing rounding/currency edge cases and general abuse of a route that
+  # legitimately has no session to key off of.
   PAYPAL_ORDER_PATHS = %w[/paypal/order /paypal/update_order /paypal/fetch_order].index_with do |path|
     /\A#{Regexp.escape(path)}(?:\.[^\/]+)?\z/
   end.freeze

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -2418,7 +2418,7 @@ describe PaypalChargeProcessor, :vcr do
                         price_cents_usd: 15_00,
                         shipping_cents_usd: 1_50,
                         tax_cents_usd: 2_00,
-                        fee_cents_usd: 150,
+                        fee_cents_usd: 170,
                         total_cents_usd: 18_50,
                         quantity: 2 }
 
@@ -2453,7 +2453,7 @@ describe PaypalChargeProcessor, :vcr do
                         price_cents_usd: 15_47,
                         shipping_cents_usd: 1_55,
                         tax_cents_usd: 2_06,
-                        fee_cents_usd: 154,
+                        fee_cents_usd: 175,
                         total_cents_usd: 19_08,
                         quantity: 2 }
 
@@ -2488,7 +2488,7 @@ describe PaypalChargeProcessor, :vcr do
                         price_cents_usd: 15_47,
                         shipping_cents_usd: 1_55,
                         tax_cents_usd: 2_06,
-                        fee_cents_usd: 154,
+                        fee_cents_usd: 175,
                         total_cents_usd: 19_08,
                         quantity: 2 }
 
@@ -2526,7 +2526,7 @@ describe PaypalChargeProcessor, :vcr do
                         price_cents_usd: 15_47,
                         shipping_cents_usd: 1_55,
                         tax_cents_usd: 2_06,
-                        fee_cents_usd: 154,
+                        fee_cents_usd: 175,
                         total_cents_usd: 19_08,
                         quantity: 2 }
 
@@ -2565,7 +2565,7 @@ describe PaypalChargeProcessor, :vcr do
           price_cents_usd: 15_47,
           shipping_cents_usd: 1_55,
           tax_cents_usd: 2_06,
-          fee_cents_usd: 154,
+          fee_cents_usd: 175,
           total_cents_usd: 19_08,
           quantity: 2 }).and_call_original
 
@@ -2628,6 +2628,32 @@ describe PaypalChargeProcessor, :vcr do
       expect do
         PaypalChargeProcessor.update_order_from_product_info(order_id, attack_purchase_unit_info)
       end.to raise_error(ChargeProcessorError, /implausibly large/)
+    end
+
+    it "computes the platform fee on non-VAT tax so an in-ratio tax shift cannot reduce it" do
+      creator = create(:user)
+      product = create(:product, user: creator, price_cents: 17_50)
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+
+      in_ratio_shift_purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "usd",
+        price_cents: 12_97,
+        shipping_cents: 0,
+        tax_cents: 4_53,
+        exclusive_tax_cents: 4_53,
+        total_cents: 17_50,
+        quantity: 1,
+      }
+
+      expect(PaypalChargeProcessor).to receive(:create_purchase_unit_info).with(
+        hash_including(fee_cents_usd: 1_75)
+      ).and_call_original
+      expect(PaypalChargeProcessor).to receive(:create_order).and_return("FAKE_ORDER_ID")
+
+      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(in_ratio_shift_purchase_unit_info)
+      expect(paypal_order_id).to eq("FAKE_ORDER_ID")
     end
 
     it "rejects create_order_from_product_info when shipping_cents carries the fee-shift on a non-physical product" do

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -2369,7 +2369,8 @@ describe PaypalChargeProcessor, :vcr do
   describe ".create_order_from_product_info" do
     it "creates a new paypal order with the given product info" do
       creator = create(:user)
-      product = create(:product, user: creator)
+      product = create(:product, user: creator, price_currency_type: "gbp", is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "GB", one_item_rate_cents: 1_00, multiple_items_rate_cents: 50)])
       paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "CJS32DZ7NDN5L",
                                                                  user: creator, country: "GB", currency: "gbp")
 
@@ -2392,7 +2393,8 @@ describe PaypalChargeProcessor, :vcr do
       creator = create(:user)
       product_name = "🚧 MDE.TV High-Roller Paywall 🚧 (INCLUDES ALL NEW 🍖 VIDEO CONTENT & NICK ROCHEFORT) " \
                      "and you also get......... 💥 THE GREAT WAR!!! 💥 Your Favourite!!!"
-      product = create(:product, user: creator, name: product_name)
+      product = create(:product, user: creator, name: product_name, is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "US", one_item_rate_cents: 1_00, multiple_items_rate_cents: 50)])
       paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "CJS32DZ7NDN5L",
                                                                  user: creator, country: "GB", currency: "gbp")
 
@@ -2427,7 +2429,8 @@ describe PaypalChargeProcessor, :vcr do
 
     it "creates a new paypal order if merchant account currency is usd but product currency is not" do
       creator = create(:user)
-      product = create(:product, user: creator, price_currency_type: "aud")
+      product = create(:product, user: creator, price_currency_type: "aud", is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "US", one_item_rate_cents: 1_00, multiple_items_rate_cents: 50)])
       paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "B66YJBBNCRW6L",
                                                                  user: creator, country: "US", currency: "usd")
 
@@ -2461,7 +2464,8 @@ describe PaypalChargeProcessor, :vcr do
 
     it "creates a new paypal order if merchant account currency and product currency are different and none is usd" do
       creator = create(:user)
-      product = create(:product, user: creator, price_currency_type: "aud")
+      product = create(:product, user: creator, price_currency_type: "aud", is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "US", one_item_rate_cents: 1_00, multiple_items_rate_cents: 50)])
       paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "CJS32DZ7NDN5L",
                                                                  user: creator, country: "GB", currency: "gbp")
 
@@ -2498,7 +2502,8 @@ describe PaypalChargeProcessor, :vcr do
        "sanitization" do
       creator = create(:user)
       product = create(:product, user: creator, price_currency_type: "aud", name: "🚧 🚧 🍖 💥 💥",
-                                 custom_permalink: "custom")
+                                 custom_permalink: "custom", is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "US", one_item_rate_cents: 1_00, multiple_items_rate_cents: 50)])
       paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "CJS32DZ7NDN5L",
                                                                  user: creator, country: "GB", currency: "gbp")
 
@@ -2534,7 +2539,8 @@ describe PaypalChargeProcessor, :vcr do
     it "creates a new paypal order with item name as product's unique_permalink if the product's name becomes empty " \
        "on sanitization and there's no custom_permalink" do
       creator = create(:user)
-      product = create(:product, user: creator, price_currency_type: "aud", name: "🚧 🚧 🍖 💥 💥")
+      product = create(:product, user: creator, price_currency_type: "aud", name: "🚧 🚧 🍖 💥 💥", is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "US", one_item_rate_cents: 1_00, multiple_items_rate_cents: 50)])
       paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "CJS32DZ7NDN5L",
                                                                  user: creator, country: "GB", currency: "gbp")
 
@@ -2624,6 +2630,57 @@ describe PaypalChargeProcessor, :vcr do
       end.to raise_error(ChargeProcessorError, /implausibly large/)
     end
 
+    it "rejects create_order_from_product_info when shipping_cents carries the fee-shift on a non-physical product" do
+      creator = create(:user)
+      product = create(:product, user: creator, price_cents: 17_50)
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+
+      attack_purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "usd",
+        price_cents: 1,
+        shipping_cents: 17_49,
+        tax_cents: 0,
+        exclusive_tax_cents: 0,
+        total_cents: 17_50,
+        quantity: 1,
+      }
+
+      expect(PaypalChargeProcessor).not_to receive(:create_order)
+      expect do
+        PaypalChargeProcessor.create_order_from_product_info(attack_purchase_unit_info)
+      end.to raise_error(ChargeProcessorError, /shipping does not match/)
+    end
+
+    it "rejects update_order_from_product_info when shipping_cents carries the fee-shift on a non-physical product" do
+      creator = create(:user)
+      product = create(:product, user: creator, price_cents: 17_50)
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+      order_id = "27B71908FM8616631"
+
+      attack_purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "usd",
+        price_cents: 1,
+        shipping_cents: 17_49,
+        tax_cents: 0,
+        exclusive_tax_cents: 0,
+        total_cents: 17_50,
+        quantity: 1,
+      }
+
+      allow(PaypalChargeProcessor).to receive(:fetch_order).with(order_id:).and_return(
+        "purchase_units" => [{ "amount" => { "value" => "17.50", "currency_code" => "USD" } }]
+      )
+
+      expect(PaypalChargeProcessor).not_to receive(:update_order)
+      expect do
+        PaypalChargeProcessor.update_order_from_product_info(order_id, attack_purchase_unit_info)
+      end.to raise_error(ChargeProcessorError, /shipping does not match/)
+    end
+
     it "rejects a $0 price with any positive tax without dividing by zero" do
       creator = create(:user)
       product = create(:product, user: creator, price_cents: 17_50)
@@ -2645,6 +2702,53 @@ describe PaypalChargeProcessor, :vcr do
       expect do
         PaypalChargeProcessor.create_order_from_product_info(attack_purchase_unit_info)
       end.to raise_error(ChargeProcessorError, /implausibly large/)
+    end
+
+    it "allows configured shipping for a physical product" do
+      creator = create(:user)
+      product = create(:product, user: creator, price_cents: 5_00, is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "US", one_item_rate_cents: 20_00, multiple_items_rate_cents: 15_00)])
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+
+      physical_purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "usd",
+        price_cents: 5_00,
+        shipping_cents: 20_00,
+        tax_cents: 0,
+        exclusive_tax_cents: 0,
+        total_cents: 25_00,
+        quantity: 1,
+      }
+
+      expect(PaypalChargeProcessor).to receive(:create_order).and_return("FAKE_ORDER_ID")
+      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(physical_purchase_unit_info)
+      expect(paypal_order_id).to eq("FAKE_ORDER_ID")
+    end
+
+    it "rejects unconfigured shipping for a physical product" do
+      creator = create(:user)
+      product = create(:product, user: creator, price_cents: 5_00, is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "US", one_item_rate_cents: 20_00, multiple_items_rate_cents: 15_00)])
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+
+      inflated_shipping_purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "usd",
+        price_cents: 1,
+        shipping_cents: 17_49,
+        tax_cents: 0,
+        exclusive_tax_cents: 0,
+        total_cents: 17_50,
+        quantity: 1,
+      }
+
+      expect(PaypalChargeProcessor).not_to receive(:create_order)
+      expect do
+        PaypalChargeProcessor.create_order_from_product_info(inflated_shipping_purchase_unit_info)
+      end.to raise_error(ChargeProcessorError, /shipping does not match/)
     end
 
     it "allows a discounted (offer code) price with proportionally discounted tax" do
@@ -2768,7 +2872,8 @@ describe PaypalChargeProcessor, :vcr do
   describe ".update_order_from_product_info" do
     it "updates the paypal order when the requested total is not lower than the current total" do
       creator = create(:user)
-      product = create(:product, user: creator)
+      product = create(:product, user: creator, is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "US", one_item_rate_cents: 1_00, multiple_items_rate_cents: 50)])
       paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
                                                                  user: creator, country: "US", currency: "usd")
       paypal_order_id = "27B71908FM8616631"
@@ -2798,7 +2903,8 @@ describe PaypalChargeProcessor, :vcr do
 
     it "rejects updates that would lower the PayPal order total" do
       creator = create(:user)
-      product = create(:product, user: creator)
+      product = create(:product, user: creator, is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "US", one_item_rate_cents: 50, multiple_items_rate_cents: 25)])
       paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
                                                                  user: creator, country: "US", currency: "usd")
       original_order_id = "27B71908FM8616631"
@@ -2825,7 +2931,8 @@ describe PaypalChargeProcessor, :vcr do
 
     it "rejects updates when PayPal's current order total is not numeric" do
       creator = create(:user)
-      product = create(:product, user: creator)
+      product = create(:product, user: creator, is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "US", one_item_rate_cents: 1_00, multiple_items_rate_cents: 50)])
       paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
                                                                  user: creator, country: "US", currency: "usd")
       order_id = "27B71908FM8616631"
@@ -2852,7 +2959,8 @@ describe PaypalChargeProcessor, :vcr do
 
     it "rejects updates when PayPal's current order total is NaN" do
       creator = create(:user)
-      product = create(:product, user: creator)
+      product = create(:product, user: creator, is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "US", one_item_rate_cents: 50, multiple_items_rate_cents: 25)])
       paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
                                                                  user: creator, country: "US", currency: "usd")
       order_id = "27B71908FM8616631"
@@ -2906,7 +3014,8 @@ describe PaypalChargeProcessor, :vcr do
   describe "#update_invoice_id" do
     it "updates the invoice id for paypal order" do
       creator = create(:user)
-      product = create(:product, user: creator)
+      product = create(:product, user: creator, price_currency_type: "gbp", is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "GB", one_item_rate_cents: 1_00, multiple_items_rate_cents: 50)])
       paypal_merchant_account = create(:merchant_account_paypal, charge_processor_merchant_id: "CJS32DZ7NDN5L",
                                                                  user: creator, country: "GB", currency: "gbp")
 

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -2727,6 +2727,30 @@ describe PaypalChargeProcessor, :vcr do
       expect(paypal_order_id).to eq("FAKE_ORDER_ID")
     end
 
+    it "allows configured shipping for a non-USD physical product" do
+      creator = create(:user)
+      product = create(:product, user: creator, price_currency_type: "aud", price_cents: 5_00,
+                                 is_physical: true, require_shipping: true,
+                                 shipping_destinations: [ShippingDestination.new(country_code: "AU", one_item_rate_cents: 1_00, multiple_items_rate_cents: 50)])
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+
+      physical_purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "aud",
+        price_cents: 5_00,
+        shipping_cents: 1_50,
+        tax_cents: 0,
+        exclusive_tax_cents: 0,
+        total_cents: 6_50,
+        quantity: 2,
+      }
+
+      expect(PaypalChargeProcessor).to receive(:create_order).and_return("FAKE_ORDER_ID")
+      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(physical_purchase_unit_info)
+      expect(paypal_order_id).to eq("FAKE_ORDER_ID")
+    end
+
     it "rejects unconfigured shipping for a physical product" do
       creator = create(:user)
       product = create(:product, user: creator, price_cents: 5_00, is_physical: true, require_shipping: true,

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -2418,7 +2418,7 @@ describe PaypalChargeProcessor, :vcr do
                         price_cents_usd: 15_00,
                         shipping_cents_usd: 1_50,
                         tax_cents_usd: 2_00,
-                        fee_cents_usd: 170,
+                        fee_cents_usd: 185,
                         total_cents_usd: 18_50,
                         quantity: 2 }
 
@@ -2453,7 +2453,7 @@ describe PaypalChargeProcessor, :vcr do
                         price_cents_usd: 15_47,
                         shipping_cents_usd: 1_55,
                         tax_cents_usd: 2_06,
-                        fee_cents_usd: 175,
+                        fee_cents_usd: 190,
                         total_cents_usd: 19_08,
                         quantity: 2 }
 
@@ -2488,7 +2488,7 @@ describe PaypalChargeProcessor, :vcr do
                         price_cents_usd: 15_47,
                         shipping_cents_usd: 1_55,
                         tax_cents_usd: 2_06,
-                        fee_cents_usd: 175,
+                        fee_cents_usd: 190,
                         total_cents_usd: 19_08,
                         quantity: 2 }
 
@@ -2526,7 +2526,7 @@ describe PaypalChargeProcessor, :vcr do
                         price_cents_usd: 15_47,
                         shipping_cents_usd: 1_55,
                         tax_cents_usd: 2_06,
-                        fee_cents_usd: 175,
+                        fee_cents_usd: 190,
                         total_cents_usd: 19_08,
                         quantity: 2 }
 
@@ -2565,7 +2565,7 @@ describe PaypalChargeProcessor, :vcr do
           price_cents_usd: 15_47,
           shipping_cents_usd: 1_55,
           tax_cents_usd: 2_06,
-          fee_cents_usd: 175,
+          fee_cents_usd: 190,
           total_cents_usd: 19_08,
           quantity: 2 }).and_call_original
 
@@ -2748,7 +2748,11 @@ describe PaypalChargeProcessor, :vcr do
         quantity: 1,
       }
 
+      expect(PaypalChargeProcessor).to receive(:create_purchase_unit_info).with(
+        hash_including(fee_cents_usd: 2_72)
+      ).and_call_original
       expect(PaypalChargeProcessor).to receive(:create_order).and_return("FAKE_ORDER_ID")
+
       paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(physical_purchase_unit_info)
       expect(paypal_order_id).to eq("FAKE_ORDER_ID")
     end

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -2569,7 +2569,7 @@ describe PaypalChargeProcessor, :vcr do
   end
 
   describe "gp#2008 fee-shift guard" do
-    it "rejects create_order_from_product_info when price_cents is shifted below the product's price" do
+    it "rejects create_order_from_product_info when tax_cents dwarfs price_cents at a fixed total" do
       creator = create(:user)
       product = create(:product, user: creator, price_cents: 17_50)
       create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
@@ -2591,10 +2591,10 @@ describe PaypalChargeProcessor, :vcr do
       expect(PaypalChargeProcessor).not_to receive(:create_order)
       expect do
         PaypalChargeProcessor.create_order_from_product_info(attack_purchase_unit_info)
-      end.to raise_error(ChargeProcessorError, /minimum price/)
+      end.to raise_error(ChargeProcessorError, /implausibly large/)
     end
 
-    it "rejects update_order_from_product_info when price_cents is shifted below the product's price" do
+    it "rejects update_order_from_product_info when tax_cents dwarfs price_cents at a fixed total" do
       creator = create(:user)
       product = create(:product, user: creator, price_cents: 17_50)
       create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
@@ -2621,7 +2621,79 @@ describe PaypalChargeProcessor, :vcr do
       expect(PaypalChargeProcessor).not_to receive(:update_order)
       expect do
         PaypalChargeProcessor.update_order_from_product_info(order_id, attack_purchase_unit_info)
-      end.to raise_error(ChargeProcessorError, /minimum price/)
+      end.to raise_error(ChargeProcessorError, /implausibly large/)
+    end
+
+    it "rejects a $0 price with any positive tax without dividing by zero" do
+      creator = create(:user)
+      product = create(:product, user: creator, price_cents: 17_50)
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+
+      attack_purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "usd",
+        price_cents: 0,
+        shipping_cents: 0,
+        tax_cents: 17_50,
+        exclusive_tax_cents: 17_50,
+        total_cents: 17_50,
+        quantity: 1,
+      }
+
+      expect(PaypalChargeProcessor).not_to receive(:create_order)
+      expect do
+        PaypalChargeProcessor.create_order_from_product_info(attack_purchase_unit_info)
+      end.to raise_error(ChargeProcessorError, /implausibly large/)
+    end
+
+    it "allows a discounted (offer code) price with proportionally discounted tax" do
+      creator = create(:user)
+      # Base price $17.50; an offer code has discounted it to $10 with tax recalculated on the
+      # discounted amount — a legitimate flow the guard must not break (the P0 caught in review).
+      product = create(:product, user: creator, price_cents: 17_50)
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+
+      discounted_purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "usd",
+        price_cents: 10_00,
+        shipping_cents: 0,
+        tax_cents: 87,
+        exclusive_tax_cents: 87,
+        total_cents: 10_87,
+        quantity: 1,
+      }
+
+      expect(PaypalChargeProcessor).to receive(:create_order).and_return("FAKE_ORDER_ID")
+      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(discounted_purchase_unit_info)
+      expect(paypal_order_id).to eq("FAKE_ORDER_ID")
+    end
+
+    it "allows a rental price well below the product's buy price" do
+      creator = create(:user)
+      # Rentals are legitimately priced far below price_cents; the guard only bounds tax/price,
+      # so a rental with no tax at all must still be allowed through untouched.
+      product = create(:product, user: creator, price_cents: 20_00, purchase_type: "buy_and_rent",
+                                 rental_price_cents: 3_00)
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+
+      rental_purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "usd",
+        price_cents: 3_00,
+        shipping_cents: 0,
+        tax_cents: 0,
+        exclusive_tax_cents: 0,
+        total_cents: 3_00,
+        quantity: 1,
+      }
+
+      expect(PaypalChargeProcessor).to receive(:create_order).and_return("FAKE_ORDER_ID")
+      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(rental_purchase_unit_info)
+      expect(paypal_order_id).to eq("FAKE_ORDER_ID")
     end
 
     it "allows a pay-what-you-want price above the product's price" do
@@ -2665,6 +2737,30 @@ describe PaypalChargeProcessor, :vcr do
 
       expect(PaypalChargeProcessor).to receive(:create_order).and_return("FAKE_ORDER_ID")
       paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(purchase_unit_info)
+      expect(paypal_order_id).to eq("FAKE_ORDER_ID")
+    end
+
+    it "allows a high but real-world VAT rate (Hungary, 27%) just under the guard's ceiling" do
+      creator = create(:user)
+      product = create(:product, user: creator, price_cents: 10_00)
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+
+      hungary_vat_purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "usd",
+        price_cents: 10_00,
+        shipping_cents: 0,
+        vat_cents: 2_70,
+        exclusive_vat_cents: 2_70,
+        tax_cents: 2_70,
+        exclusive_tax_cents: 2_70,
+        total_cents: 12_70,
+        quantity: 1,
+      }
+
+      expect(PaypalChargeProcessor).to receive(:create_order).and_return("FAKE_ORDER_ID")
+      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(hungary_vat_purchase_unit_info)
       expect(paypal_order_id).to eq("FAKE_ORDER_ID")
     end
   end

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -2568,6 +2568,107 @@ describe PaypalChargeProcessor, :vcr do
     end
   end
 
+  describe "gp#2008 fee-shift guard" do
+    it "rejects create_order_from_product_info when price_cents is shifted below the product's price" do
+      creator = create(:user)
+      product = create(:product, user: creator, price_cents: 17_50)
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+
+      # Same total ($17.50) as a legitimate purchase, but price_cents is shifted down to 1 cent
+      # and the difference moved into exclusive_tax_cents — the gp#2008 fee-shift attack.
+      attack_purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "usd",
+        price_cents: 1,
+        shipping_cents: 0,
+        tax_cents: 17_49,
+        exclusive_tax_cents: 17_49,
+        total_cents: 17_50,
+        quantity: 1,
+      }
+
+      expect(PaypalChargeProcessor).not_to receive(:create_order)
+      expect do
+        PaypalChargeProcessor.create_order_from_product_info(attack_purchase_unit_info)
+      end.to raise_error(ChargeProcessorError, /minimum price/)
+    end
+
+    it "rejects update_order_from_product_info when price_cents is shifted below the product's price" do
+      creator = create(:user)
+      product = create(:product, user: creator, price_cents: 17_50)
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+      order_id = "27B71908FM8616631"
+
+      attack_purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "usd",
+        price_cents: 1,
+        shipping_cents: 0,
+        tax_cents: 17_49,
+        exclusive_tax_cents: 17_49,
+        total_cents: 17_50,
+        quantity: 1,
+      }
+
+      # The total-only guard would pass this (total is unchanged at $17.50), proving this is a
+      # distinct check from "rejects updates that would lower the PayPal order total" above.
+      allow(PaypalChargeProcessor).to receive(:fetch_order).with(order_id:).and_return(
+        "purchase_units" => [{ "amount" => { "value" => "17.50", "currency_code" => "USD" } }]
+      )
+
+      expect(PaypalChargeProcessor).not_to receive(:update_order)
+      expect do
+        PaypalChargeProcessor.update_order_from_product_info(order_id, attack_purchase_unit_info)
+      end.to raise_error(ChargeProcessorError, /minimum price/)
+    end
+
+    it "allows a pay-what-you-want price above the product's price" do
+      creator = create(:user)
+      product = create(:product, user: creator, price_cents: 1_00, customizable_price: true)
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+
+      generous_purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "usd",
+        price_cents: 50_00,
+        shipping_cents: 0,
+        tax_cents: 0,
+        exclusive_tax_cents: 0,
+        total_cents: 50_00,
+        quantity: 1,
+      }
+
+      expect(PaypalChargeProcessor).to receive(:create_order).and_return("FAKE_ORDER_ID")
+      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(generous_purchase_unit_info)
+      expect(paypal_order_id).to eq("FAKE_ORDER_ID")
+    end
+
+    it "allows a quantity purchase priced at exactly quantity * price_cents" do
+      creator = create(:user)
+      product = create(:product, user: creator, price_cents: 5_00)
+      create(:merchant_account_paypal, charge_processor_merchant_id: "MN7CSWD6RCNJ8",
+                                       user: creator, country: "US", currency: "usd")
+
+      purchase_unit_info = {
+        external_id: product.external_id,
+        currency_code: "usd",
+        price_cents: 15_00,
+        shipping_cents: 0,
+        tax_cents: 0,
+        exclusive_tax_cents: 0,
+        total_cents: 15_00,
+        quantity: 3,
+      }
+
+      expect(PaypalChargeProcessor).to receive(:create_order).and_return("FAKE_ORDER_ID")
+      paypal_order_id = PaypalChargeProcessor.create_order_from_product_info(purchase_unit_info)
+      expect(paypal_order_id).to eq("FAKE_ORDER_ID")
+    end
+  end
+
   describe ".update_order_from_product_info" do
     it "updates the paypal order when the requested total is not lower than the current total" do
       creator = create(:user)

--- a/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb
@@ -2704,7 +2704,7 @@ describe PaypalChargeProcessor, :vcr do
       end.to raise_error(ChargeProcessorError, /implausibly large/)
     end
 
-    it "allows configured shipping for a physical product" do
+    it "allows configured shipping and tax assessed on shipping for a physical product" do
       creator = create(:user)
       product = create(:product, user: creator, price_cents: 5_00, is_physical: true, require_shipping: true,
                                  shipping_destinations: [ShippingDestination.new(country_code: "US", one_item_rate_cents: 20_00, multiple_items_rate_cents: 15_00)])
@@ -2716,9 +2716,9 @@ describe PaypalChargeProcessor, :vcr do
         currency_code: "usd",
         price_cents: 5_00,
         shipping_cents: 20_00,
-        tax_cents: 0,
-        exclusive_tax_cents: 0,
-        total_cents: 25_00,
+        tax_cents: 2_25,
+        exclusive_tax_cents: 2_25,
+        total_cents: 27_25,
         quantity: 1,
       }
 

--- a/spec/controllers/paypal_controller_spec.rb
+++ b/spec/controllers/paypal_controller_spec.rb
@@ -247,7 +247,7 @@ describe PaypalController, :vcr do
     context "for affiliate sales" do
       let(:purchase_info) do
         {
-          amount_cents: product_info[:price_cents].to_i + product_info[:exclusive_tax_cents].to_i,
+          amount_cents: product_info[:price_cents].to_i + product_info[:shipping_cents].to_i + product_info[:exclusive_tax_cents].to_i,
           vat_cents: 0,
           affiliate_id: nil,
           was_recommended: false,

--- a/spec/controllers/paypal_controller_spec.rb
+++ b/spec/controllers/paypal_controller_spec.rb
@@ -247,7 +247,7 @@ describe PaypalController, :vcr do
     context "for affiliate sales" do
       let(:purchase_info) do
         {
-          amount_cents: product_info[:price_cents].to_i,
+          amount_cents: product_info[:price_cents].to_i + product_info[:exclusive_tax_cents].to_i,
           vat_cents: 0,
           affiliate_id: nil,
           was_recommended: false,

--- a/spec/controllers/paypal_controller_spec.rb
+++ b/spec/controllers/paypal_controller_spec.rb
@@ -225,10 +225,10 @@ describe PaypalController, :vcr do
         external_id: product.external_id,
         currency_code: "usd",
         price_cents: "1500",
-        shipping_cents: "150",
+        shipping_cents: "0",
         tax_cents: "100",
         exclusive_tax_cents: "100",
-        total_cents: "1750",
+        total_cents: "1600",
         quantity: 3
       }
     end


### PR DESCRIPTION
## Stages

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

## Problem

`PaypalChargeProcessor`'s platform fee is computed from the client-supplied `price_cents` field (`Link#gumroad_amount_for_paypal_order`), not from the order total. The `/paypal/order` and `/paypal/update_order` endpoints are unauthenticated by design (buyers checking out via PayPal aren't logged in yet), and the only existing guards (`ensure_order_update_does_not_lower_total!`, `ensure_captured_amount_matches!`) check the **total only**.

An attacker can submit `price_cents: 1`, move the rest of the price into `exclusive_tax_cents`/`exclusive_vat_cents`, keep the total unchanged, pass both total-only guards, and collapse Gumroad's platform fee toward $0. Verified against `origin/main` (a9d0dd8) before this fix — reproduced the reported $17.50 order (`price_cents=1`, `exclusive_tax_cents=1749`) computing a $0 fee instead of $1.75.

## Fix

- `PaypalChargeProcessor.ensure_tax_does_not_dwarf_price!`: bounds submitted tax/VAT to at most 35% of (price + validated shipping), run in both `create_order_from_product_info` and `update_order_from_product_info` before the existing total-only guard. Real-world VAT/sales tax never exceeds ~27% of the taxable base (Hungary's 27% VAT is the ceiling), so this rejects the reported attack shape without a hard price floor — a floor was tried first and reverted (autoreview P0) because it breaks offer codes, PPP, rentals, and cheaper tiers that legitimately submit `price_cents` below the product's base price.
- `PaypalChargeProcessor.paypal_fee_basis_cents`: the percentage-fee basis now adds validated shipping and submitted non-VAT tax back to price (`price_cents_usd + shipping_cents_usd + max(tax_cents_usd - vat_cents_usd, 0)`) instead of using `price_cents_usd` alone, so neither configured shipping nor tax shifted into the 35% band can shrink the fee — `price_cents=1297, tax=453` now computes a 1750-cent basis, not 1297, and physical shipping is included after validation.
- `PaypalChargeProcessor.ensure_shipping_matches_product!`: rejects submitted shipping that doesn't match a configured shipping rate, closing the sibling fee-shift variant that routes cents through `shipping_cents` instead of tax on non-physical products.
- Added a rack-attack throttle on `/paypal/order`, `/paypal/update_order`, `/paypal/fetch_order` (20 req/20s per IP with exponential backoff), matching the existing pattern for other unauthenticated receipt-lookup endpoints.

## Tests

219 examples, 0 failures:
- `spec/business/payments/charging/implementations/paypal/paypal_charge_processor_spec.rb` (gp#2008 fee-shift guard: rejects tax-dwarfs-price on create/update, rejects shipping-carried fee-shift on non-physical products, rejects a $0 price with positive tax, allows configured shipping + tax-on-shipping, allows non-USD configured shipping, proves non-VAT tax and validated shipping are included in the fee basis, allows offer-code/rental/PWYW/quantity purchases, allows the Hungary 27% VAT edge case)
- `spec/controllers/paypal_controller_spec.rb`
- `spec/requests/rack_attack_spec.rb`

Premerge review: clean @ 1e81de760b197de9e3b87e86dd89b6419d0bb572

Ref: antiwork/gumroad-private#2008

🤖 Generated by gumclaw



