### PR TITLE
Remove the dead one-time PayPal frontend flow (gp#2008 follow-up)

### DIFF
--- a/app/javascript/data/payment_method_params.ts
+++ b/app/javascript/data/payment_method_params.ts
@@ -57,21 +57,6 @@ export type PaymentRequestPaymentMethodParams = {
   email: string | null;
   zip_code: string | null;
 };
-export type PayPalNativePaymentMethodParams = {
-  status: "success";
-  type: "paypal-native";
-  reusable: false;
-  paypal_order_id: string;
-  visual: string;
-  card_country: string;
-  // PayPal params never carry Payment Element wallet details or element-collected billing
-  // details; declaring the keys as always-undefined lets serializeCardParamsIntoQueryParamsObject
-  // strip them from the whole AnyPaymentMethodParams union type-safely.
-  wallet?: undefined;
-  elementBillingAddress?: undefined;
-  elementBillingFullName?: undefined;
-};
-
 export type ReusableCardPaymentMethodParams = { stripe_customer_id: string; stripe_setup_intent_id: string } & Omit<
   CardPaymentMethodParams,
   "reusable"
@@ -90,7 +75,7 @@ export type ReusablePayPalBraintreePaymentMethodParams = {
   reusable: true;
   braintree_transient_customer_store_key: string | null;
   braintree_device_data: string | null;
-  // Same as PayPalNativePaymentMethodParams above: never present, declared for union safety.
+  // PayPal never carries Payment Element wallet/billing details; declared always-undefined for union safety.
   wallet?: undefined;
   elementBillingAddress?: undefined;
   elementBillingFullName?: undefined;
@@ -103,7 +88,7 @@ export type ReusablePayPalNativePaymentMethodParams = {
   billing_agreement_id: string;
   visual: string;
   card_country: string;
-  // Same as PayPalNativePaymentMethodParams above: never present, declared for union safety.
+  // PayPal never carries Payment Element wallet/billing details; declared always-undefined for union safety.
   wallet?: undefined;
   elementBillingAddress?: undefined;
   elementBillingFullName?: undefined;
@@ -111,8 +96,7 @@ export type ReusablePayPalNativePaymentMethodParams = {
 
 export type AnyPayPalMethodParams =
   | ReusablePayPalBraintreePaymentMethodParams
-  | ReusablePayPalNativePaymentMethodParams
-  | PayPalNativePaymentMethodParams;
+  | ReusablePayPalNativePaymentMethodParams;
 
 export type StripeErrorParams = { status: "error"; stripe_error: StripeError };
 

--- a/app/javascript/data/payment_method_result.ts
+++ b/app/javascript/data/payment_method_result.ts
@@ -164,16 +164,6 @@ export async function getPaymentMethodResult(
       };
     }
     case "paypal-native": {
-      if (selected.info.kind === "oneTime") {
-        return {
-          type: "new",
-          cardParamsResult: {
-            type: "paypal",
-            cardParams: preparePaypalPaymentMethodData(selected.info),
-            keepOnFile: selected.keepOnFile,
-          },
-        };
-      }
       return {
         type: "new",
         cardParamsResult: {

--- a/app/javascript/data/paypal_payment_method_data.ts
+++ b/app/javascript/data/paypal_payment_method_data.ts
@@ -1,38 +1,21 @@
-import {
-  PayPalNativePaymentMethodParams,
-  ReusablePayPalNativePaymentMethodParams,
-} from "$app/data/payment_method_params";
+import { ReusablePayPalNativePaymentMethodParams } from "$app/data/payment_method_params";
 
-export type PayPalNativeResultInfo =
-  | {
-      kind: "billingAgreement";
-      billingToken: string;
-      agreementId: string;
-      email: string;
-      country: string;
-    }
-  | { kind: "oneTime"; orderId: string; email: string; country: string };
+export type PayPalNativeResultInfo = {
+  kind: "billingAgreement";
+  billingToken: string;
+  agreementId: string;
+  email: string;
+  country: string;
+};
 
 export const preparePaypalPaymentMethodData = (
   info: PayPalNativeResultInfo,
-): PayPalNativePaymentMethodParams | ReusablePayPalNativePaymentMethodParams => {
-  if (info.kind === "oneTime") {
-    return {
-      status: "success",
-      type: "paypal-native",
-      reusable: false,
-      paypal_order_id: info.orderId,
-      visual: info.email,
-      card_country: info.country,
-    };
-  }
-  return {
-    status: "success",
-    type: "paypal-native",
-    reusable: true,
-    billingToken: info.billingToken,
-    billing_agreement_id: info.agreementId,
-    visual: info.email,
-    card_country: info.country,
-  };
-};
+): ReusablePayPalNativePaymentMethodParams => ({
+  status: "success",
+  type: "paypal-native",
+  reusable: true,
+  billingToken: info.billingToken,
+  billing_agreement_id: info.agreementId,
+  visual: info.email,
+  card_country: info.country,
+});

--- a/app/javascript/data/purchase.test.ts
+++ b/app/javascript/data/purchase.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   type CardPaymentMethodParams,
   type PaymentRequestPaymentMethodParams,
-  type PayPalNativePaymentMethodParams,
+  type ReusablePayPalNativePaymentMethodParams,
   type StripeErrorParams,
 } from "$app/data/payment_method_params";
 import {
@@ -34,11 +34,12 @@ const paymentRequestParams: PaymentRequestPaymentMethodParams = {
   wallet_type: "apple_pay",
 };
 
-const paypalParams: PayPalNativePaymentMethodParams = {
+const paypalParams: ReusablePayPalNativePaymentMethodParams = {
   status: "success",
   type: "paypal-native",
-  reusable: false,
-  paypal_order_id: "PAY-123",
+  reusable: true,
+  billingToken: "BA-TOKEN",
+  billing_agreement_id: "BA-123",
   visual: "buyer@example.com",
   card_country: "US",
 };

--- a/app/javascript/data/purchase.ts
+++ b/app/javascript/data/purchase.ts
@@ -379,11 +379,7 @@ export const createPurchasesRequestData = (
       }
 
       if (paymentParams.type === "paypal-native") {
-        if (paymentParams.reusable) {
-          data.billing_agreement_id = paymentParams.billing_agreement_id;
-        } else {
-          data.paypal_order_id = paymentParams.paypal_order_id;
-        }
+        data.billing_agreement_id = paymentParams.billing_agreement_id;
         data.visual = paymentParams.visual;
         data.card_country = paymentParams.card_country;
       }


### PR DESCRIPTION
## What

Removes the dead one-time PayPal frontend flow:

- The `oneTime` variant of `PayPalNativeResultInfo` and its branch in `preparePaypalPaymentMethodData`
- The non-reusable `PayPalNativePaymentMethodParams` type (which carried `paypal_order_id`) and its union member in `AnyPayPalMethodParams`
- The redundant `oneTime` branch in `getPaymentMethodResult` (it returned exactly what the fallthrough already returns)
- The `paypal_order_id` submission in `createPurchasesRequestData`
- Converts the one affected test fixture to the surviving reusable (billing-agreement) type

PayPal native is now billing-agreement-only in the type system, matching what actually runs.

## Why

The one-time PayPal order flow (`createOrder` → `/paypal/order`) was removed from checkout in 2022 ([gumroad-old#24576](https://github.com/antiwork/gumroad-old/pull/24576)); the native PayPal button has produced only billing agreements since. #7184 removed the dead server endpoints; this removes the matching dead frontend branch, which has had no producer for ~2.5 years. Housekeeping follow-up to antiwork/gumroad-private#2008.

**Deliberately left for a separate change:** the server-side `PaypalApprovedOrderChargeable` / `paypal_order_id` chargeable handling. It's inert now (nothing submits `paypal_order_id`), but removing it cascades into the live capture flow (`create_payment_intent_or_charge!`, `capture_order`) and would drop the #7126 `ensure_captured_amount_matches!` check — a charge-path change whose specs can't be verified locally (the `MerchantAccount.gumroad` factory gap), so it deserves its own reviewed PR.

## Before/After

Frontend type / dead-code change with no user-facing behavior change (the removed branch had no producer). Walkthrough video: _pending_.

## Test Results

- `npm run typecheck` (`tsc --noEmit`) — exit 0.
- `npx eslint` on the changed files — clean.
- `npx vitest run app/javascript/data/purchase.test.ts` — 15 passed.

---
AI disclosure: authored with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
