### PR TITLE
Fix flaky RequeueTransientlyFailedPayoutsJob spec: clock/before-hook date mismatch

### DIFF
--- a/spec/sidekiq/requeue_transiently_failed_payouts_job_spec.rb
+++ b/spec/sidekiq/requeue_transiently_failed_payouts_job_spec.rb
@@ -192,10 +192,20 @@ describe RequeueTransientlyFailedPayoutsJob do
       expect(seller.reload.unpaid_balance_cents).to eq(0)
     end
 
-    it "creates a new payout for a monthly-cadence seller whose next cycle is weeks away" do
-      # The incident shape: a monthly seller's next cadence Friday is a month out, so the
-      # payout-cycle gate would reject them and their balance would sit unpaid until then.
-      travel_to Time.utc(2026, 8, 4, 14, 0, 0) do
+    context "when the seller's cadence pushes their cycle weeks past this batch" do
+      # Freezing via `around` (not `travel_to` inside the example) so the clock is fixed before
+      # the outer `before` hook runs too — that hook seeds a balance from the same
+      # `payout_period_end_date` let this example reads, and the two must agree on "today" or the
+      # balance lands outside the payout window the job actually pays out. `travel_to` scoped to
+      # just the example body left the `before` hook reading the real wall clock, so the seeded
+      # balance and the payout period disagreed on every run date except 2026-08-04 itself.
+      around do |example|
+        travel_to(Time.utc(2026, 8, 4, 14, 0, 0)) { example.run }
+      end
+
+      it "creates a new payout for a monthly-cadence seller whose next cycle is weeks away" do
+        # The incident shape: a monthly seller's next cadence Friday is a month out, so the
+        # payout-cycle gate would reject them and their balance would sit unpaid until then.
         period = User::PayoutSchedule.manual_payout_end_date
         seller.update!(payout_frequency: User::PayoutSchedule::MONTHLY)
         create_transient_failure(user: seller, bank_account: seller.active_bank_account, payout_period_end_date: period)

--- a/spec/sidekiq/requeue_transiently_failed_payouts_job_spec.rb
+++ b/spec/sidekiq/requeue_transiently_failed_payouts_job_spec.rb
@@ -193,12 +193,9 @@ describe RequeueTransientlyFailedPayoutsJob do
     end
 
     context "when the seller's cadence pushes their cycle weeks past this batch" do
-      # Freezing via `around` (not `travel_to` inside the example) so the clock is fixed before
-      # the outer `before` hook runs too — that hook seeds a balance from the same
-      # `payout_period_end_date` let this example reads, and the two must agree on "today" or the
-      # balance lands outside the payout window the job actually pays out. `travel_to` scoped to
-      # just the example body left the `before` hook reading the real wall clock, so the seeded
-      # balance and the payout period disagreed on every run date except 2026-08-04 itself.
+      # `around`, not `travel_to` inside the example, so the shared `before` hook (which seeds
+      # a balance from `payout_period_end_date`) and this example's own period computation read
+      # the same frozen clock.
       around do |example|
         travel_to(Time.utc(2026, 8, 4, 14, 0, 0)) { example.run }
       end


### PR DESCRIPTION
## What broke CI

Nearly every `Tests` CI run today (unrelated PRs, and direct `main` pushes) has been failing on the same single spec:

```
RequeueTransientlyFailedPayoutsJob end to end creates a new payout for a
monthly-cadence seller whose next cycle is weeks away
  expected `seller.payments.count` to have changed by 1, but was changed by 0
```

## Mechanism (proven, not asserted)

- `payout_period_end_date` is a `let` memoized on `User::PayoutSchedule.manual_payout_end_date`, i.e. the real wall clock at the time it's first evaluated.
- The `before` hook shared by the whole `end to end` describe block reads that `let` to seed the test balance (`date: payout_period_end_date - 3`).
- `before` hooks run before the example body. This example wrapped its own clock freeze (`travel_to Time.utc(2026, 8, 4, ...)`) *inside* the `it` block, so the `before` hook ran under the **real** date while the example body re-derived `period` under the **frozen** 2026-08-04 date.
- On any CI run date whose weekly payout cycle differs from 2026-08-04's (i.e. almost every day), the seeded balance and the payout period disagree, the balance falls outside the window `is_user_payable` pays out, and the assert-a-payout-was-created expectation fails.
- 2026-08-04 happened to be the day this spec was authored/last green locally, which is why it looked fine then and flaky everywhere else.

## Fix

Test-only change. Moved the `travel_to` freeze into an `around` hook scoped to a new `context`, so it wraps the shared `before` hook as well as the example body — both period computations now read the same frozen clock. No production code touched.

## Verification (real local run, today 2026-08-11)

- Full spec file: `bundle exec rspec spec/sidekiq/requeue_transiently_failed_payouts_job_spec.rb` → **21 examples, 0 failures** (real MySQL + Redis, no stubbed clock at the suite level).
- Mutation check: reverted the fix back to the original `main` version of this file and re-ran just this example → **1 example, 1 failure**, same `expected ... to have changed by 1, but was changed by 0` error, confirming this is exactly the bug in question and the spec still has teeth against the real behavior it covers.
- Re-applied the fix, re-ran the full file → clean again.

Premerge review: clean @ 92c1d60d8f655ebab373d98f162e611593bf0c55 (panel: codex gpt-5.6-sol + claude-fable-5, 0 findings each, "patch is correct (0.98)") — re-pinned after a comment-only fix for Greptile's P2 (simplified the context comment); diff vs prior head is comment-only, spec re-run 21/21 green.

Merges under the 2026-07-30 flakiness-automerge grant once branch CI confirms green on real shards — test-only diff, mechanism named and demonstrated, fix removes the nondeterminism rather than hiding it (no skip/sleep/loosened assertion).
