### PR TITLE
fix: keep dashboard products pagination lean; preload thumbnails on the page only

### DIFF
--- a/app/presenters/dashboard_products_page_presenter.rb
+++ b/app/presenters/dashboard_products_page_presenter.rb
@@ -8,6 +8,14 @@ class DashboardProductsPagePresenter
   include Rails.application.routes.url_helpers
 
   PER_PAGE = 50
+  # Deep ActiveStorage chain for rendering each row's thumbnail. Kept OUT of the
+  # paginated relation: `includes` turns it into ~11 LEFT JOINs on the literal,
+  # so pagy's DISTINCT/ORDER BY over a seller's full catalogue fans out and can
+  # take tens of seconds (GUMROAD-1AS). Preload it only for the returned page.
+  THUMBNAIL_INCLUDES = [
+    thumbnail: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
+    thumbnail_alive: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
+  ].freeze
 
   attr_reader :products_sort, :memberships_sort, :query
 
@@ -121,18 +129,11 @@ class DashboardProductsPagePresenter
     end
 
     def paginated_products
-      products = seller
-        .products
-        .includes([
-                    thumbnail: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
-                    thumbnail_alive: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
-                  ])
-        .non_membership
-        .visible
+      products = seller.products.non_membership.visible
       products = archived? ? products.archived : products.not_archived
       products = products.where("links.name like ?", "%#{query}%") if query.present?
 
-      sort_and_paginate_products(
+      pagination, products = sort_and_paginate_products(
         key: products_sort&.dig(:key),
         direction: products_sort&.dig(:direction),
         page: products_page,
@@ -140,6 +141,9 @@ class DashboardProductsPagePresenter
         per_page: PER_PAGE,
         user_id: seller.id
       )
+      # Paginate lean (no thumbnail JOINs), then load thumbnails only for the page rows.
+      ActiveRecord::Associations::Preloader.new(records: products, associations: THUMBNAIL_INCLUDES).call
+      [pagination, products]
     end
 
     def memberships_data(memberships)

--- a/test/presenters/dashboard_products_page_presenter_test.rb
+++ b/test/presenters/dashboard_products_page_presenter_test.rb
@@ -153,6 +153,36 @@ class DashboardProductsPagePresenterTest < ActiveSupport::TestCase
     assert_empty presenter(query: "nonexistent_xyz").products_table_props[:products]
   end
 
+  test "paginates the lean product relation without eager-loading thumbnails into it (GUMROAD-1AS)" do
+    create_product(user: @seller, name: "p")
+
+    paginated_collection = nil
+    presenter = self.presenter
+    presenter.stub(:sort_and_paginate_products, ->(**kwargs) {
+      paginated_collection = kwargs[:collection]
+      [{ page: 1, pages: 1 }, []]
+    }) do
+      presenter.send(:paginated_products)
+    end
+
+    refute_nil paginated_collection
+    # The thumbnail chain must be preloaded AFTER pagination, never eager-loaded
+    # into the paginated relation. `includes` here turns into an 11-way LEFT JOIN
+    # over a large catalogue and times the request out (GUMROAD-1AS, 73s span).
+    assert_empty paginated_collection.includes_values
+    assert_empty paginated_collection.eager_load_values
+  end
+
+  test "page products still render their thumbnail via the post-pagination preload (GUMROAD-1AS)" do
+    product = create_product(user: @seller, name: "thumbnailed_product")
+    create_thumbnail(product:)
+
+    thumbnail_prop = presenter.products_table_props[:products].sole["thumbnail"]
+
+    assert thumbnail_prop.present?, "expected the page product's thumbnail to be preloaded and rendered"
+    assert_equal product.thumbnail.alive.as_json, thumbnail_prop
+  end
+
   test "#products_table_props denies every product action for a read-only team member" do
     create_product(user: @seller, name: "normal_product")
 

--- a/test/presenters/dashboard_products_page_presenter_test.rb
+++ b/test/presenters/dashboard_products_page_presenter_test.rb
@@ -165,7 +165,7 @@ class DashboardProductsPagePresenterTest < ActiveSupport::TestCase
       presenter.send(:paginated_products)
     end
 
-    refute_nil paginated_collection
+    assert_not_nil paginated_collection
     # The thumbnail chain must be preloaded AFTER pagination, never eager-loaded
     # into the paginated relation. `includes` here turns into an 11-way LEFT JOIN
     # over a large catalogue and times the request out (GUMROAD-1AS, 73s span).


### PR DESCRIPTION
## What

- [x] **Scope** — root cause confirmed (73.3s pagy page query from eager-loading thumbnails into the paginated relation)
- [x] **Design** — paginate lean, preload thumbnails on the page only
- [x] **Build** — done
- [x] **QA** — full presenter suite 62/0, EXPLAIN ANALYZE before/after, independent review clean
- [ ] **Ship** — pending merge + deploy
- [ ] **Market/Sell** — N/A (internal perf fix)

Stop the seller Products dashboard (`LinksController#index`) timing out on sellers with large catalogues. GUMROAD-1AS (187 events / 14 users, production `Rack::Timeout` at 120s) is pinned to a single 73.3s query: the pagy page query for the **Products** section.

Root cause is in `DashboardProductsPagePresenter#paginated_products`: it eager-loads the thumbnail/ActiveStorage chain via `.includes([thumbnail: {...}, thumbnail_alive: {...}])` (an 11-way `LEFT JOIN` through `thumbnails` + `active_storage_attachments/blobs/variant_records`) **into the paginated relation**. For a large catalogue that make pagy's `SELECT DISTINCT ... ORDER BY created_at DESC LIMIT 50` page query fan out across every row (with a leading-wildcard `name LIKE '%query%'` scan) and blow past the 120s budget.

The fix paginates the plain `links` relation (lean, no thumbnail JOINs) and then preloads the thumbnail chain **only for the 50 returned page rows**.

## Why

`#paginated_products` was the only dashboard presenter carrying the includes (the collab presenter and `#paginated_memberships` do not), and a 74s Sentry span shows 73.3s of it is that one DISTINCT page query. After the fix, that same query is ~60ms and the count ~46ms.

## Before-After

Seller 14235752 (8,364 products; 20 match the `template` filter). Measured against the read replica via `EXPLAIN ANALYZE`; the "before" is the actual Sentry span from the timeout event.

| Query | Before | After |
|---|---|---|
| Products DISTINCT page query (`name LIKE '%…%'`, `ORDER BY created_at DESC LIMIT 50`) | 73,343 ms (Sentry span, GUMROAD-1AS) | 60 ms |
| Products `COUNT(*)` | 54 ms | 46 ms |
| Thumbnail preload (page rows only) | n/a (was part of the 73s join) | ~0 ms (bounded to 50 rows) |

Request end-to-end drops from >120 s to well under 1 s for this seller.

## Test Results

- `test/presenters/dashboard_products_page_presenter_test.rb` — full file: **62 runs, 166 assertions, 0 failures**.
- New regression test asserts the collection handed to `sort_and_paginate_products` carries **no** `includes`/`eager_load` thumbnail values (mutation-verified: reintroducing the old `.includes` turns it RED).
- New test asserts a page product's thumbnail still renders via the post-pagination preload (behavior preserved).
- Full Actions suite (run-all-specs) + Buildkite green at head `7cec1c3f2`; `ci/green` pass.
- `ruby -c`/rubocop clean on both changed files.

## QA steps

N/A — no visible UI change. Thumbnails render identically (verified by the preload spec); the change is purely the query shape behind the Products dashboard pagination. Evidence is the `EXPLAIN ANALYZE` before/after above, measured on the same seller who timed out in production. Phrasing/behavior of the dashboard is unchanged.

---
Generated with claude-sonnet-5.

Premerge review: clean @ 7cec1c3f2caef06ed089d540020322f1c42df05d
