### PR TITLE
Add commission-divergent pass to affiliate dedup task

### DIFF
--- a/app/services/onetime/deduplicate_product_affiliates.rb
+++ b/app/services/onetime/deduplicate_product_affiliates.rb
@@ -89,15 +89,15 @@ module Onetime
       duplicate_pairs.reject { |pair| identical?(*pair) }
     end
 
-    # Keep-rule pass for the commission-divergent pairs left after pass 2a, per Sahil
-    # (gp#2067): "Keep the row the app resolves" — the same rule pass 2a used for
-    # destination_url-only pairs, generalized to whatever a pair still diverges on.
-    # Safe to run before pass 2a too since it applies the identical rule to any
-    # remaining divergent pair.
+    # Keep-rule pass for the divergent pairs left after pass 2a, per Sahil (gp#2067):
+    # "Keep the row the app resolves" — the same rule pass 2a used for
+    # destination_url-only pairs, generalized to whatever a pair still diverges on
+    # (commission, flags, or both). Safe to run before pass 2a too since it applies
+    # the identical rule to every remaining divergent pair.
     def process_commission_divergent(dry_run: true)
       stick_to_primary unless dry_run
       pairs = divergent_pairs
-      puts "Found #{pairs.size} commission-divergent pair(s) to resolve"
+      puts "Found #{pairs.size} pair(s) to resolve to the row the app already serves"
 
       deleted = 0
       pairs.each_slice(BATCH_SIZE) do |batch|

--- a/app/services/onetime/deduplicate_product_affiliates.rb
+++ b/app/services/onetime/deduplicate_product_affiliates.rb
@@ -89,11 +89,8 @@ module Onetime
       duplicate_pairs.reject { |pair| identical?(*pair) }
     end
 
-    # Keep-rule pass for the divergent pairs left after pass 2a, per Sahil (gp#2067):
-    # "Keep the row the app resolves" — the same rule pass 2a used for
-    # destination_url-only pairs, generalized to whatever a pair still diverges on
-    # (commission, flags, or both). Safe to run before pass 2a too since it applies
-    # the identical rule to every remaining divergent pair.
+    # Resolves every remaining divergent pair (commission, flags, or both) by keeping
+    # the row the application lookup returns. Safe to run before process_url_divergent.
     def process_commission_divergent(dry_run: true)
       stick_to_primary unless dry_run
       pairs = divergent_pairs
@@ -180,9 +177,8 @@ module Onetime
           rows.map(&:destination_url).uniq.size > 1
       end
 
-      # Same unordered LIMIT 1 shape as dedupe_url_divergent_pair, generalized to any
-      # remaining divergence (commission or flags) per Sahil's ruling on gp#2067: keep
-      # whichever row the app already resolves.
+      # The keeper must come from the same unordered `.take` the app uses to resolve
+      # the pair — ordering by :id here would sometimes delete the row being served.
       def dedupe_commission_divergent_pair(affiliate_id, link_id, dry_run:)
         ProductAffiliate.transaction do
           rows = ProductAffiliate.where(affiliate_id:, link_id:).order(:id).lock(!dry_run).to_a

--- a/app/services/onetime/deduplicate_product_affiliates.rb
+++ b/app/services/onetime/deduplicate_product_affiliates.rb
@@ -14,6 +14,8 @@
 #   Onetime::DeduplicateProductAffiliates.process(dry_run: false)
 #   Onetime::DeduplicateProductAffiliates.process_url_divergent
 #   Onetime::DeduplicateProductAffiliates.process_url_divergent(dry_run: false)
+#   Onetime::DeduplicateProductAffiliates.process_commission_divergent
+#   Onetime::DeduplicateProductAffiliates.process_commission_divergent(dry_run: false)
 module Onetime
   class DeduplicateProductAffiliates
     CONTENT_COLUMNS = %w[affiliate_basis_points destination_url flags].freeze
@@ -26,6 +28,10 @@ module Onetime
 
     def self.process_url_divergent(dry_run: true)
       new.process_url_divergent(dry_run:)
+    end
+
+    def self.process_commission_divergent(dry_run: true)
+      new.process_commission_divergent(dry_run:)
     end
 
     def process(dry_run: true)
@@ -81,6 +87,31 @@ module Onetime
 
     def divergent_pairs
       duplicate_pairs.reject { |pair| identical?(*pair) }
+    end
+
+    # Keep-rule pass for the commission-divergent pairs left after pass 2a, per Sahil
+    # (gp#2067): "Keep the row the app resolves" — the same rule pass 2a used for
+    # destination_url-only pairs, generalized to whatever a pair still diverges on.
+    # Safe to run before pass 2a too since it applies the identical rule to any
+    # remaining divergent pair.
+    def process_commission_divergent(dry_run: true)
+      stick_to_primary unless dry_run
+      pairs = divergent_pairs
+      puts "Found #{pairs.size} commission-divergent pair(s) to resolve"
+
+      deleted = 0
+      pairs.each_slice(BATCH_SIZE) do |batch|
+        ReplicaLagWatcher.watch unless dry_run
+        batch.each { |affiliate_id, link_id| deleted += dedupe_commission_divergent_pair(affiliate_id, link_id, dry_run:) }
+      end
+
+      if dry_run
+        puts "Dry run — no changes made. Re-run with dry_run: false to apply."
+      else
+        puts "Deleted #{deleted} surplus row(s)."
+        report_remaining_duplicates
+      end
+      deleted
     end
 
     private
@@ -147,6 +178,25 @@ module Onetime
       def url_only_divergent_content?(rows)
         rows.map { |row| row.attributes.values_at(*COMMISSION_COLUMNS) }.uniq.size == 1 &&
           rows.map(&:destination_url).uniq.size > 1
+      end
+
+      # Same unordered LIMIT 1 shape as dedupe_url_divergent_pair, generalized to any
+      # remaining divergence (commission or flags) per Sahil's ruling on gp#2067: keep
+      # whichever row the app already resolves.
+      def dedupe_commission_divergent_pair(affiliate_id, link_id, dry_run:)
+        ProductAffiliate.transaction do
+          rows = ProductAffiliate.where(affiliate_id:, link_id:).order(:id).lock(!dry_run).to_a
+          next 0 if rows.size < 2
+
+          keeper = ProductAffiliate.where(affiliate_id:, link_id:).take
+          next 0 if keeper.nil?
+
+          surplus_ids = rows.map(&:id) - [keeper.id]
+          puts "Keeping ProductAffiliate #{keeper.id}; deleting #{surplus_ids.join(', ')}"
+          next 0 if dry_run
+
+          ProductAffiliate.where(id: surplus_ids).delete_all
+        end
       end
 
       # The up-front partition can go stale mid-run (a pair skipped under lock stays

--- a/spec/services/onetime/deduplicate_product_affiliates_spec.rb
+++ b/spec/services/onetime/deduplicate_product_affiliates_spec.rb
@@ -261,7 +261,7 @@ describe Onetime::DeduplicateProductAffiliates do
 
     it "resolves a pair that mixes url and basis_points divergence too" do
       mixed_row_one = create(:product_affiliate, affiliate_basis_points: 1000, destination_url: "https://example.com/one")
-      mixed_row_two = create_duplicate_of(mixed_row_one, affiliate_basis_points: 2500, destination_url: "https://example.com/two")
+      create_duplicate_of(mixed_row_one, affiliate_basis_points: 2500, destination_url: "https://example.com/two")
       resolved_id = ProductAffiliate.where(affiliate_id: mixed_row_one.affiliate_id, link_id: mixed_row_one.link_id).take.id
 
       described_class.process_commission_divergent(dry_run: false)
@@ -273,7 +273,7 @@ describe Onetime::DeduplicateProductAffiliates do
 
     it "resolves a pair that diverges only on flags, not just affiliate_basis_points" do
       flags_row_one = create(:product_affiliate, affiliate_basis_points: 1000)
-      flags_row_two = create_duplicate_of(flags_row_one, dont_show_as_co_creator: true)
+      create_duplicate_of(flags_row_one, dont_show_as_co_creator: true)
       resolved_id = ProductAffiliate.where(affiliate_id: flags_row_one.affiliate_id, link_id: flags_row_one.link_id).take.id
 
       described_class.process_commission_divergent(dry_run: false)

--- a/spec/services/onetime/deduplicate_product_affiliates_spec.rb
+++ b/spec/services/onetime/deduplicate_product_affiliates_spec.rb
@@ -225,4 +225,74 @@ describe Onetime::DeduplicateProductAffiliates do
       end.not_to change { ProductAffiliate.exists?(identical_pair_surplus.id) }
     end
   end
+
+  describe ".process_commission_divergent" do
+    it "does not delete anything on a dry run" do
+      expect do
+        described_class.process_commission_divergent
+      end.not_to change { ProductAffiliate.count }
+    end
+
+    it "skips row locks on a dry run so it works against a read-only replica" do
+      expect(locking_queries_during { described_class.process_commission_divergent }).to be_empty
+    end
+
+    it "locks the pair's rows so the re-check and the delete are atomic" do
+      expect(locking_queries_during { described_class.process_commission_divergent(dry_run: false) }).not_to be_empty
+    end
+
+    it "sticks a live run to the primary so discovery cannot read a lagging replica" do
+      expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+      described_class.process_commission_divergent(dry_run: false)
+    end
+
+    it "keeps the row the application lookup returns for a commission-divergent pair" do
+      resolved_id = ProductAffiliate.where(affiliate_id: divergent_pair_row_one.affiliate_id,
+                                           link_id: divergent_pair_row_one.link_id).take.id
+
+      expect do
+        described_class.process_commission_divergent(dry_run: false)
+      end.to change { ProductAffiliate.count }.by(-1)
+
+      remaining_ids = ProductAffiliate.where(affiliate_id: divergent_pair_row_one.affiliate_id,
+                                             link_id: divergent_pair_row_one.link_id).pluck(:id)
+      expect(remaining_ids).to eq([resolved_id])
+    end
+
+    it "resolves a pair that mixes url and basis_points divergence too" do
+      mixed_row_one = create(:product_affiliate, affiliate_basis_points: 1000, destination_url: "https://example.com/one")
+      mixed_row_two = create_duplicate_of(mixed_row_one, affiliate_basis_points: 2500, destination_url: "https://example.com/two")
+      resolved_id = ProductAffiliate.where(affiliate_id: mixed_row_one.affiliate_id, link_id: mixed_row_one.link_id).take.id
+
+      described_class.process_commission_divergent(dry_run: false)
+
+      remaining_ids = ProductAffiliate.where(affiliate_id: mixed_row_one.affiliate_id,
+                                             link_id: mixed_row_one.link_id).pluck(:id)
+      expect(remaining_ids).to eq([resolved_id])
+    end
+
+    it "resolves a pair that diverges only on flags, not just affiliate_basis_points" do
+      flags_row_one = create(:product_affiliate, affiliate_basis_points: 1000)
+      flags_row_two = create_duplicate_of(flags_row_one, dont_show_as_co_creator: true)
+      resolved_id = ProductAffiliate.where(affiliate_id: flags_row_one.affiliate_id, link_id: flags_row_one.link_id).take.id
+
+      described_class.process_commission_divergent(dry_run: false)
+
+      remaining_ids = ProductAffiliate.where(affiliate_id: flags_row_one.affiliate_id,
+                                             link_id: flags_row_one.link_id).pluck(:id)
+      expect(remaining_ids).to eq([resolved_id])
+    end
+
+    it "leaves identical pairs untouched — they need pass 1 first" do
+      expect do
+        described_class.process_commission_divergent(dry_run: false)
+      end.not_to change { ProductAffiliate.exists?(identical_pair_surplus.id) }
+    end
+
+    it "leaves non-duplicated rows untouched" do
+      described_class.process_commission_divergent(dry_run: false)
+
+      expect(ProductAffiliate.exists?(unique_row.id)).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
# Add commission-divergent pass to affiliate dedup task

> Draft status: build complete, premerge review clean at head; awaiting CI green before ready. Production run of this pass and the follow-up unique-index PR stay separate, gated steps per gp#2067's issue body.

Premerge review: clean @ c50cb5794124b0a823438d0f9ca2925fc1fbabb5

## What

Adds `Onetime::DeduplicateProductAffiliates.process_commission_divergent` — a keep-rule
pass resolving the affiliate assignment duplicate pairs left after passes 1 and 2a. Same
shape as the existing `process_url_divergent` pass, generalized to any remaining
divergence (commission rate and/or flags), so it also resolves the small number of
pairs that mix URL and commission divergence.

## Why

gp#2067 tracks cleanup of duplicate `(affiliate_id, link_id)` rows ahead of a unique-index
migration. Passes 1 (#7189) and 2a (#7191) are merged/deployed; 95 pairs remained,
diverging on `affiliate_basis_points`/`flags`, held for a human keep-rule decision. Sahil
ruled on the issue: "Keep the row the app resolves."

## Before / after

- Before: 95 commission-divergent pairs sit undeleted; no code path resolves them.
- After: the new pass deletes every row in a pair except the one
  `ProductAffiliate.where(affiliate_id:, link_id:).take` already returns — the same
  lookup shape the app's own `find_by`/`take` call sites use — so the commission rate
  and flags an affiliate sees does not change.

## Checklist

- [x] Scope — resolves any remaining divergent pair (commission, flags, or mixed with
  url); identical pairs are still pass 1's job.
- [x] Design — mirrors `process_url_divergent`'s "keep what the app resolves" shape
  rather than a new rule (e.g. keep-highest-rate); this was the option Sahil picked.
- [x] Build — `gumclaw/gp2067-commission-divergent-dedup`, 3 commits (feature + a
  review-round log-message fix + a lint/comment fix round, see Rounds 2-3 below).
- [x] QA — see Tests below; ran locally, no rendered surface to screenshot.
- [ ] Shipped — draft; needs CI green before ready. Production execution stays gated
  per gp#2067 (zero-duplicate check immediately before the unique index migration).
- [x] Market — n/a, internal cleanup task.
- [x] Sell — n/a, no customer-facing change.

## Tests

```text
DISABLE_SPRING=1 RAILS_ENV=test bundle exec rspec spec/services/onetime/deduplicate_product_affiliates_spec.rb
33 examples, 0 failures
```
(re-run and green at head `c50cb57` after the Round 3 fix below)

Mutation-proved the new guard: replacing `ProductAffiliate.where(...).take` with
`rows.first`/`rows.last` (bypassing the app-resolves lookup) reddened 3 of the 9 new
examples; reverted after confirming the kill.

## QA

Backend-only onetime service, no rendered surface — the 9 new specs are the evidence:
dry-run no-op, primary stick, row locking, keep-the-resolved-row, mixed url+commission
divergence, flags-only divergence, and leaves-identical/unique-pairs-untouched. Not run
against production; per the issue's gate conditions any live run needs a fresh
zero-duplicate check immediately before the unique-index migration, which stays a
separate step.

## Review rounds

- Round 1 at `1514b9d` — subagent adversarial review (fresh clone, independently
  re-ran specs and the `.take`→`.first`/`.last` mutation): 1 P2 — the operator log line
  said "commission-divergent pair(s)" but the method resolves every remaining
  divergent pair (url-only + mixed too), which is misleading for anyone reading the
  console output during a live run. No P1s, no data-safety issues.
- Round 2 at `b492192` — fixed: log line now reads "pair(s) to resolve to the row the
  app already serves". Re-ran the full spec file (33/0) after the fix.
- Round 3 at `c50cb57` — CI's Lint Ruby flagged two `Lint/UselessAssignment` offenses in
  the new specs (unused `mixed_row_two`/`flags_row_two` locals), and Greptile's P2 asked
  to condense the decision-history comments on the new pass. Fixed both; the app delta is
  comment-only (verified: zero non-comment lines in the app diff), the spec delta removes
  the two unused assignments. Rubocop clean on both files and full spec file re-run green
  (33/0) at this head.

---

AI disclosure: claude-sonnet-5. Prompt/instructions: autonomous-product-dev workflow, responding to Sahil's keep-rule ruling on gumroad-private#2067.

