### PR TITLE
Stop escalating branch-specs on test/ diffs

### DIFF
--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -112,6 +112,8 @@ ESCALATE_PATTERNS = [
 
 # Paths that never affect the rspec suite.
 IGNORED_PATTERNS = [
+  # Minitest suite; test_minitest runs all of it on every PR, unfiltered.
+  %r{\Atest/},
   %r{\Aqa-media/},
   %r{\Adocs?/},
   %r{\.md\z},


### PR DESCRIPTION
## What

`bin/branch-specs` now ignores paths under `test/`. The directory joins `IGNORED_PATTERNS` alongside the vitest carve-out for files that another CI lane already covers.

## Why

The `test_minitest` job runs the full Minitest suite on every PR with no path filter, so `test/` files never need RSpec selection. The selector still treated them as a mapping gap and exited 3, which failed the "Compute relevant specs" job on test-only diffs. [PR #7192](https://github.com/antiwork/gumroad/pull/7192) hit this ([failed run](https://github.com/antiwork/gumroad/actions/runs/31525047552/job/93891399447)).

## Before/After

Running `ruby bin/branch-specs` against a diff that only touches `test/foo_test.rb`:

- Before: `ESCALATE — diff touches test/foo_test.rb but no specs were selected for it (mapping gap)`, exit 3.
- After: empty selection, exit 0. CI then runs the floor spec (`spec/models/user_spec.rb`).

The pattern is anchored to the `test/` directory. Unmapped paths elsewhere still escalate, including top-level files whose names start with "test".

## Test Results

- Verified in a scratch repo: the previous script exits 3 on a `test/`-only diff; the patched script exits 0. A mixed diff with an unmapped `app/models` file still exits 3.
- `bundle exec rubocop bin/branch-specs` — no offenses.
- Codex structured review — clean, no findings.

This PR carries the `run-all-specs` label because `bin/branch-specs` cannot attribute specs to itself.

---

This PR was implemented with AI assistance using Claude Fable 5. Prompts: fix `bin/branch-specs` so `test/**` paths stop escalating to the full RSpec suite, since `test_minitest` already runs the whole Minitest suite on every PR; verify with a `test/`-only diff; rebase, run autoreview, and open a draft PR.
