### PR TITLE
Add commission-divergent pass to affiliate dedup task (pass 2b)

### DIFF
--- a/app/services/onetime/deduplicate_product_affiliates.rb
+++ b/app/services/onetime/deduplicate_product_affiliates.rb
@@ -14,6 +14,8 @@
 #   Onetime::DeduplicateProductAffiliates.process(dry_run: false)
 #   Onetime::DeduplicateProductAffiliates.process_url_divergent
 #   Onetime::DeduplicateProductAffiliates.process_url_divergent(dry_run: false)
+#   Onetime::DeduplicateProductAffiliates.process_commission_divergent
+#   Onetime::DeduplicateProductAffiliates.process_commission_divergent(dry_run: false)
 module Onetime
   class DeduplicateProductAffiliates
     CONTENT_COLUMNS = %w[affiliate_basis_points destination_url flags].freeze
@@ -26,6 +28,10 @@ module Onetime
 
     def self.process_url_divergent(dry_run: true)
       new.process_url_divergent(dry_run:)
+    end
+
+    def self.process_commission_divergent(dry_run: true)
+      new.process_commission_divergent(dry_run:)
     end
 
     def process(dry_run: true)
@@ -68,6 +74,33 @@ module Onetime
       eligible.each_slice(BATCH_SIZE) do |pairs|
         ReplicaLagWatcher.watch unless dry_run
         pairs.each { |affiliate_id, link_id| deleted += dedupe_url_divergent_pair(affiliate_id, link_id, dry_run:) }
+      end
+
+      if dry_run
+        puts "Dry run — no changes made. Re-run with dry_run: false to apply."
+      else
+        puts "Deleted #{deleted} surplus row(s)."
+        report_remaining_duplicates
+      end
+      deleted
+    end
+
+    # Pass 2b of the cleanup: the pairs left after passes 1 and 2a diverge on
+    # commission terms (affiliate_basis_points, flags). A human keep-rule
+    # (gumroad-private#2067) chose "keep the row the app resolves": readers resolve
+    # a pair through unordered LIMIT 1 lookups, so this pass keeps that row and
+    # deletes the rest, leaving the commission rate the app serves today unchanged.
+    # Recency was rejected as a ranking — in 61/95 pairs the newest row did not
+    # carry the highest rate, and unrelated persisted changes advance updated_at.
+    def process_commission_divergent(dry_run: true)
+      stick_to_primary unless dry_run
+      eligible, untouched = divergent_pairs.partition { |pair| commission_divergent?(*pair) }
+      puts "Found #{divergent_pairs.size} divergent pair(s): #{eligible.size} differ on commission terms, #{untouched.size} untouched"
+
+      deleted = 0
+      eligible.each_slice(BATCH_SIZE) do |pairs|
+        ReplicaLagWatcher.watch unless dry_run
+        pairs.each { |affiliate_id, link_id| deleted += dedupe_commission_divergent_pair(affiliate_id, link_id, dry_run:) }
       end
 
       if dry_run
@@ -147,6 +180,30 @@ module Onetime
       def url_only_divergent_content?(rows)
         rows.map { |row| row.attributes.values_at(*COMMISSION_COLUMNS) }.uniq.size == 1 &&
           rows.map(&:destination_url).uniq.size > 1
+      end
+
+      def commission_divergent?(affiliate_id, link_id)
+        commission_divergent_content?(ProductAffiliate.where(affiliate_id:, link_id:).to_a)
+      end
+
+      def dedupe_commission_divergent_pair(affiliate_id, link_id, dry_run:)
+        ProductAffiliate.transaction do
+          rows = ProductAffiliate.where(affiliate_id:, link_id:).order(:id).lock(!dry_run).to_a
+          next 0 if rows.size < 2 || !commission_divergent_content?(rows)
+
+          keeper = ProductAffiliate.where(affiliate_id:, link_id:).take
+          next 0 if keeper.nil?
+
+          surplus_ids = rows.map(&:id) - [keeper.id]
+          puts "Keeping ProductAffiliate #{keeper.id}; deleting #{surplus_ids.join(', ')}"
+          next 0 if dry_run
+
+          ProductAffiliate.where(id: surplus_ids).delete_all
+        end
+      end
+
+      def commission_divergent_content?(rows)
+        rows.map { |row| row.attributes.values_at(*COMMISSION_COLUMNS) }.uniq.size > 1
       end
 
       # The up-front partition can go stale mid-run (a pair skipped under lock stays

--- a/app/services/onetime/deduplicate_product_affiliates.rb
+++ b/app/services/onetime/deduplicate_product_affiliates.rb
@@ -85,13 +85,10 @@ module Onetime
       deleted
     end
 
-    # Pass 2b of the cleanup: the pairs left after passes 1 and 2a diverge on
-    # commission terms (affiliate_basis_points, flags). A human keep-rule
-    # (gumroad-private#2067) chose "keep the row the app resolves": readers resolve
-    # a pair through unordered LIMIT 1 lookups, so this pass keeps that row and
-    # deletes the rest, leaving the commission rate the app serves today unchanged.
-    # Recency was rejected as a ranking — in 61/95 pairs the newest row did not
-    # carry the highest rate, and unrelated persisted changes advance updated_at.
+    # Collapses pairs that still diverge on commission terms, keeping the row
+    # unordered LIMIT 1 lookups already resolve so the rate the app serves does
+    # not change. Recency is not a safe ranking here: updated_at advances on
+    # unrelated writes.
     def process_commission_divergent(dry_run: true)
       stick_to_primary unless dry_run
       eligible, untouched = divergent_pairs.partition { |pair| commission_divergent?(*pair) }

--- a/spec/services/onetime/deduplicate_product_affiliates_spec.rb
+++ b/spec/services/onetime/deduplicate_product_affiliates_spec.rb
@@ -225,4 +225,88 @@ describe Onetime::DeduplicateProductAffiliates do
       end.not_to change { ProductAffiliate.exists?(identical_pair_surplus.id) }
     end
   end
+
+  describe ".process_commission_divergent" do
+    it "does not delete anything on a dry run" do
+      expect do
+        described_class.process_commission_divergent
+      end.not_to change { ProductAffiliate.count }
+    end
+
+    it "skips row locks on a dry run so it works against a read-only replica" do
+      expect(locking_queries_during { described_class.process_commission_divergent }).to be_empty
+    end
+
+    it "locks the pair's rows so the content re-check and the delete are atomic" do
+      expect(locking_queries_during { described_class.process_commission_divergent(dry_run: false) }).not_to be_empty
+    end
+
+    it "sticks a live run to the primary so discovery cannot read a lagging replica" do
+      expect(ActiveRecord::Base.connection).to receive(:stick_to_primary!).at_least(:once).and_call_original
+      described_class.process_commission_divergent(dry_run: false)
+    end
+
+    it "keeps the row the application lookup returns for a basis-points-divergent pair" do
+      resolved_id = ProductAffiliate.where(affiliate_id: divergent_pair_row_one.affiliate_id,
+                                           link_id: divergent_pair_row_one.link_id).take.id
+
+      expect do
+        described_class.process_commission_divergent(dry_run: false)
+      end.to change { ProductAffiliate.count }.by(-1)
+
+      remaining_ids = ProductAffiliate.where(affiliate_id: divergent_pair_row_one.affiliate_id,
+                                             link_id: divergent_pair_row_one.link_id).pluck(:id)
+      expect(remaining_ids).to eq([resolved_id])
+    end
+
+    it "serves the same basis points the app resolved before the collapse" do
+      pair = create(:product_affiliate, affiliate_basis_points: 1000).tap { _1.update_columns(updated_at: 3.days.ago) }
+      create_duplicate_of(pair, affiliate_basis_points: 4000)
+      affiliate = pair.affiliate
+
+      basis_before = affiliate.product_affiliates.find_by(link_id: pair.link_id).affiliate_basis_points
+
+      described_class.process_commission_divergent(dry_run: false)
+
+      expect(affiliate.product_affiliates.find_by(link_id: pair.link_id).affiliate_basis_points).to eq(basis_before)
+    end
+
+    it "deletes every surplus row in a pair with more than two commission-divergent rows" do
+      create_duplicate_of(divergent_pair_row_one, affiliate_basis_points: 3000)
+      create_duplicate_of(divergent_pair_row_one, affiliate_basis_points: 5000)
+
+      described_class.process_commission_divergent(dry_run: false)
+
+      remaining = ProductAffiliate.where(affiliate_id: divergent_pair_row_one.affiliate_id,
+                                         link_id: divergent_pair_row_one.link_id).pluck(:id)
+      expect(remaining.size).to eq(1)
+    end
+
+    it "collapses a pair that diverges only on flags" do
+      flags_pair_row_one = create(:product_affiliate, affiliate_basis_points: 1000)
+      flags_pair_row_two = create_duplicate_of(flags_pair_row_one, dont_show_as_co_creator: true)
+
+      described_class.process_commission_divergent(dry_run: false)
+
+      remaining = ProductAffiliate.where(affiliate_id: flags_pair_row_one.affiliate_id,
+                                         link_id: flags_pair_row_one.link_id).pluck(:id)
+      expect(remaining.size).to eq(1)
+      expect(remaining).not_to include(flags_pair_row_two.id)
+    end
+
+    it "leaves identical pairs for the first pass" do
+      expect do
+        described_class.process_commission_divergent(dry_run: false)
+      end.not_to change { ProductAffiliate.exists?(identical_pair_surplus.id) }
+    end
+
+    it "leaves a destination_url-only pair for the second pass" do
+      url_pair = create(:product_affiliate, destination_url: "https://example.com/one")
+      create_duplicate_of(url_pair, destination_url: "https://example.com/two")
+
+      expect do
+        described_class.process_commission_divergent(dry_run: false)
+      end.not_to change { ProductAffiliate.where(affiliate_id: url_pair.affiliate_id, link_id: url_pair.link_id).count }
+    end
+  end
 end


### PR DESCRIPTION
## What

Adds pass 2b to `Onetime::DeduplicateProductAffiliates`: `process_commission_divergent` collapses the pairs left after passes 1 (`process`) and 2a (`process_url_divergent`) — those that diverge on commission terms (`affiliate_basis_points`, `flags`) — keeping the row the application resolves (`ProductAffiliate.where(affiliate_id:, link_id:).take`).

## Why

gumroad-private#2067's cleanup reached convergence at **95 remaining duplicate `(affiliate_id, link_id)` pairs**, all commission-divergent, which were intentionally held for a human keep-rule. Sahil chose **"keep the row the app resolves"** (2026-08-11) — the same rule pass 2a already uses. Recency was rejected (in 61/95 pairs the newest row did not carry the highest rate, and unrelated persisted changes advance `updated_at`).

Since the keeper is exactly the row an unordered `LIMIT 1` lookup serves today, the commission rate each affiliate sees does not observably change — this is the conservative reading of Sahil's rule.

## Before-After

Before: 95 duplicate pairs remain; `affiliates_links` still has no composite unique index, so the write race (#7167 serializes it, but the index is the durable guard).

After this pass runs (once merged + deployed, then invoked in the prod console with a dry run then `dry_run: false`): zero duplicate pairs, satisfying the unique-index migration's gate condition #1.

## Test Results

- `bin/rspec spec/services/onetime/deduplicate_product_affiliates_spec.rb` — **34 examples, 0 failures** (includes the new `.process_commission_divergent` block + all prior pass tests).
- `ruby -c` on both files — clean.
- Mutation proof: flipping `commission_divergent_content?` to `>= 1` (making it collapse any divergent pair, stealing url-only pairs from pass 2a) killed the `"leaves a destination_url-only pair for the second pass"` spec (2→1 count change). The `"leaves identical pairs"` spec is structurally guarded upstream by `divergent_pairs` (identical pairs are rejected via `identical?`, so this pass can never see them).

## QA steps

No rendered surface (backend onetime task). When merged + deployed: `Onetime::DeduplicateProductAffiliates.process_commission_divergent` (dry run on replica) then `(...dry_run: false)` on the primary, verifying `Remaining duplicate pair(s) after this run: 0`, then the unique-index migration PR (gp#2067 gate conditions 1–3).

## Gate / sequencing

Pass 2b must be **deployed** before the prod console run clears the 95 pairs (the console boots deployed code). The unique-index migration PR is a separate follow-up, gated on this pass producing zero duplicates.
---

**AI disclosure:** this change was authored by Hermes Agent (model default: claude-sonnet-5) under the autonomous-product-dev workflow, reviewed via the pre-merge QA audit.

## Status

- [x] **Scope** — 95 commission-divergent duplicate pairs; keep-rule from Sahil ("keep the row the app resolves")
- [x] **Design** — pass 2b mirrors pass 2a's keeper logic on a new `process_commission_divergent`
- [x] **Build** — service method + 10 new specs; local run green (34/0); mutation proof on the load-bearing guard
- [ ] **QA** — prod dry run then live run after this PR merges + deploys; verify `Remaining duplicate pair(s): 0`
- [ ] **Shipped** — blocked on merge + deploy of this PR, then the prod console run, then the unique-index migration PR
- [ ] **Market / Sell** — n/a (internal data-integrity cleanup)



Premerge review: clean @ 0b04f37625b4762ab330de4630b78884d464748d
