### PR TITLE
Add mixed url+commission divergence spec to affiliate dedup task

### DIFF
--- a/spec/services/onetime/deduplicate_product_affiliates_spec.rb
+++ b/spec/services/onetime/deduplicate_product_affiliates_spec.rb
@@ -300,6 +300,19 @@ describe Onetime::DeduplicateProductAffiliates do
       end.not_to change { ProductAffiliate.exists?(identical_pair_surplus.id) }
     end
 
+    it "resolves a pair that mixes url and commission divergence to the row the app serves" do
+      mixed_row_one = create(:product_affiliate, affiliate_basis_points: 1000, destination_url: "https://example.com/one")
+      create_duplicate_of(mixed_row_one, affiliate_basis_points: 2500, destination_url: "https://example.com/two")
+      resolved_id = ProductAffiliate.where(affiliate_id: mixed_row_one.affiliate_id,
+                                           link_id: mixed_row_one.link_id).take.id
+
+      described_class.process_commission_divergent(dry_run: false)
+
+      remaining_ids = ProductAffiliate.where(affiliate_id: mixed_row_one.affiliate_id,
+                                             link_id: mixed_row_one.link_id).pluck(:id)
+      expect(remaining_ids).to eq([resolved_id])
+    end
+
     it "leaves a destination_url-only pair for the second pass" do
       url_pair = create(:product_affiliate, destination_url: "https://example.com/one")
       create_duplicate_of(url_pair, destination_url: "https://example.com/two")


### PR DESCRIPTION
# Add mixed url+commission divergence spec to affiliate dedup task

Spec-only follow-up to #7195 (merged), carrying over the one piece of #7193 flagged in its closing comment: an explicit example documenting that `process_commission_divergent` resolves a pair that mixes URL and commission divergence.

## What

Adds one example to `spec/services/onetime/deduplicate_product_affiliates_spec.rb`: a pair diverging on both `destination_url` and `affiliate_basis_points` is collapsed to the row `ProductAffiliate.where(...).take` resolves. No app code changes.

## Why

The predicate shipped in #7195 already handles mixed pairs (it checks `COMMISSION_COLUMNS` regardless of URL divergence), but nothing pinned that; the URL pass (`process_url_divergent`) explicitly skips mixed pairs, so this pass is the only one that resolves them. gianfrancopiana asked for this carry-over when closing #7193.

## Before / after

- Before: mixed url+commission pairs are resolved by the pass, but only flags-only, basis-points-only, and url-only cases have dedicated examples.
- After: a regression on the mixed case (e.g. narrowing the predicate to same-URL pairs) is caught by a red spec.

## Checklist

- [x] Scope — one spec example pinning mixed url+commission divergence resolution; nothing else.
- [x] Design — mirrors the sibling examples in the same describe block (resolved-id assertion via the app's own `.take` lookup).
- [x] Build — `gumclaw/gp2067-mixed-divergence-spec`, one commit cherry-picked onto main after #7195 merged mid-build.
- [x] QA — full spec file green locally (35/0) plus the mutation proof below; spec-only, no rendered surface.
- [ ] Shipped — draft; needs CI green before ready.
- [x] Market — n/a, internal test coverage.
- [x] Sell — n/a, no customer-facing change.

## Tests

```text
DISABLE_SPRING=1 RAILS_ENV=test bundle exec rspec spec/services/onetime/deduplicate_product_affiliates_spec.rb
35 examples, 0 failures
```

Mutation proof: narrowing `commission_divergent_content?` to require identical URLs (`rows.map(&:destination_url).uniq.size == 1`) reddened exactly this new example; reverted after confirming the kill.

## QA steps

Backend-only spec addition, no rendered surface. Ran the full spec file locally (green) and the mutation check above.

---

AI disclosure: claude-fable-5. Prompt/instructions: autonomous-product-dev workflow, responding to gianfrancopiana's carry-over request on #7193.


Premerge review: clean @ f31e5b433664d59ef1d8fad2fcd4d15a71090a7b
