### PR TITLE
Log which conflict refused a product-editor save (gp#2023)

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -624,6 +624,7 @@ class LinksController < ApplicationController
       # are older than the stored rows, meaning another session saved after
       # this session loaded. Return the conflicting records so the editor can
       # show the seller what changed and offer a reload.
+      log_editor_save_conflict("stale_content_conflict", stale_record_ids: e.stale_records.map { { type: _1[:type], id: _1[:id] } })
       return render json: {
         error_message: e.message,
         error_code: "stale_content_conflict",
@@ -633,6 +634,7 @@ class LinksController < ApplicationController
       # Raised under the product lock before any mutation. The current response
       # mapping has no scope dimension, so the client must reload rather than
       # guess which stored row a repeated submitted page id should address.
+      log_editor_save_conflict("ambiguous_rich_content_id_conflict", @_rich_content_ambiguity_details || {})
       return render json: {
         error_message: e.message,
         error_code: "ambiguous_rich_content_id_conflict",
@@ -655,6 +657,7 @@ class LinksController < ApplicationController
       # candidate retries in gumroad-private#1532 — a deletion-only write, or
       # re-fetch-then-reconcile — get a current token from the reload they
       # already have to do, so neither needs one on the refusal.
+      log_editor_save_conflict("stale_deletion_conflict")
       return render json: {
         error_message: e.message,
         error_code: "stale_deletion_conflict",
@@ -668,6 +671,7 @@ class LinksController < ApplicationController
       # it inspects, so list every hidden version page here (fresh from the
       # rolled-back state) — one choice must cover all of them, not one dialog
       # per version.
+      log_editor_save_conflict("hidden_variant_content_conflict")
       return render json: {
         error_message: e.message,
         error_code: "hidden_variant_content_conflict",
@@ -1035,16 +1039,16 @@ class LinksController < ApplicationController
       # Older editor tabs only understand the global response map, so keep
       # enforcing global uniqueness until the scoped-mapping protocol is sent.
       if product_permitted_params[:rich_content_provenance_version].to_i < 2
-        duplicate_id = references.filter_map { _1[:page][:id].presence }.tally.find { |_id, count| count > 1 }
-        raise Product::SaveContract::AmbiguousRichContentIdConflict if duplicate_id
+        duplicate_ids = references.filter_map { _1[:page][:id].presence }.tally.select { |_id, count| count > 1 }.keys
+        raise_ambiguous_rich_content_conflict!(check: "global", conflicts: duplicate_ids) if duplicate_ids.any?
         return
       end
 
-      per_scope_duplicate = references
+      per_scope_duplicate_ids = references
         .group_by { _1[:destination_scope_key] }
-        .values
-        .any? { |refs| refs.filter_map { _1[:page][:id].presence }.tally.any? { |_id, count| count > 1 } }
-      raise Product::SaveContract::AmbiguousRichContentIdConflict if per_scope_duplicate
+        .transform_values { |refs| refs.filter_map { _1[:page][:id].presence }.tally.select { |_id, count| count > 1 }.keys }
+        .select { |_scope, ids| ids.any? }
+      raise_ambiguous_rich_content_conflict!(check: "per_scope", conflicts: per_scope_duplicate_ids) if per_scope_duplicate_ids.any?
 
       # Only new client ids may repeat across scopes. A persisted page belongs
       # to one scope, so addressing it from multiple destinations is ambiguous.
@@ -1057,8 +1061,31 @@ class LinksController < ApplicationController
         end
         .group_by(&:first)
         .transform_values { |pairs| pairs.map(&:last).uniq }
+        .select { |_id, scopes| scopes.size > 1 }
+      raise_ambiguous_rich_content_conflict!(check: "existing_id_multiple_scopes", conflicts: existing_id_scopes) if existing_id_scopes.any?
+    end
 
-      raise Product::SaveContract::AmbiguousRichContentIdConflict if existing_id_scopes.values.any? { |scopes| scopes.size > 1 }
+    # Which of the three ambiguity checks fired, and on what. gp#2023 burned
+    # two fix attempts against 409s nobody could classify after the fact, so
+    # the offending ids/scopes are captured here for the rescue in #update to
+    # log. Page ids are client ids or external ids and scope keys are variant
+    # ids — no seller content.
+    def raise_ambiguous_rich_content_conflict!(check:, conflicts:)
+      @_rich_content_ambiguity_details = { check:, conflicts: }
+      raise Product::SaveContract::AmbiguousRichContentIdConflict
+    end
+
+    # One greppable line per refused editor save. The conflict responses are
+    # deliberate refusals the seller sees, and until now nothing recorded which
+    # one fired: lograge strips params and the guards raise without logging, so
+    # every support report of a failed save starts from zero.
+    def log_editor_save_conflict(error_code, details = {})
+      detail_suffix = details.map { |key, value| " #{key}=#{value.inspect}" }.join
+      Rails.logger.info(
+        "[product_editor_save_conflict] error_code=#{error_code} product_id=#{@product.id} " \
+        "seller_id=#{@product.user_id} provenance_version=#{product_permitted_params[:rich_content_provenance_version].to_i} " \
+        "request_id=#{request.request_id}#{detail_suffix}"
+      )
     end
 
     def check_banned

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1065,20 +1065,17 @@ class LinksController < ApplicationController
       raise_ambiguous_rich_content_conflict!(check: "existing_id_multiple_scopes", conflicts: existing_id_scopes) if existing_id_scopes.any?
     end
 
-    # Which of the three ambiguity checks fired, and on what. gp#2023 burned
-    # two fix attempts against 409s nobody could classify after the fact, so
-    # the offending ids/scopes are captured here for the rescue in #update to
-    # log. Page ids are client ids or external ids and scope keys are variant
-    # ids — no seller content.
+    # Captures which check fired and the offending ids/scopes for the rescue
+    # in #update to log. Ids and scope keys are opaque identifiers, never
+    # seller content.
     def raise_ambiguous_rich_content_conflict!(check:, conflicts:)
       @_rich_content_ambiguity_details = { check:, conflicts: }
       raise Product::SaveContract::AmbiguousRichContentIdConflict
     end
 
-    # One greppable line per refused editor save. The conflict responses are
-    # deliberate refusals the seller sees, and until now nothing recorded which
-    # one fired: lograge strips params and the guards raise without logging, so
-    # every support report of a failed save starts from zero.
+    # One greppable line per refused editor save. Lograge strips params, so
+    # without this the conflict responses are indistinguishable in production
+    # logs (gumroad-private#2023).
     def log_editor_save_conflict(error_code, details = {})
       detail_suffix = details.map { |key, value| " #{key}=#{value.inspect}" }.join
       Rails.logger.info(

--- a/spec/controllers/links_controller_scoped_rich_content_ambiguity_spec.rb
+++ b/spec/controllers/links_controller_scoped_rich_content_ambiguity_spec.rb
@@ -118,4 +118,156 @@ describe LinksController, type: :controller do
 
     expect(response).to have_http_status(:conflict).or have_http_status(:unprocessable_entity)
   end
+
+  it "rejects an existing page id submitted under two different variant scopes" do
+    category = create(:variant_category, link: product, title: "Tier")
+    tier_a = create(:variant, variant_category: category, name: "Tier A")
+    tier_b = create(:variant, variant_category: category, name: "Tier B")
+    page = create(:rich_content, entity: tier_a, title: "One", description: paragraph("Original"))
+
+    params = editor_save_params(
+      [
+        {
+          id: tier_a.external_id,
+          name: tier_a.name,
+          price_difference_cents: 0,
+          rich_content: [
+            { id: page.external_id, title: "One", description: { type: "doc", content: paragraph("Kept") } }
+          ],
+        },
+        {
+          id: tier_b.external_id,
+          name: tier_b.name,
+          price_difference_cents: 0,
+          rich_content: [
+            { id: page.external_id, title: "One", description: { type: "doc", content: paragraph("Also here") } }
+          ],
+        }
+      ]
+    )
+
+    post :update, params: params, as: :json
+
+    expect(response).to have_http_status(:conflict)
+    expect(page.reload.entity).to eq(tier_a)
+  end
+
+  # gumroad-private#2023 stayed open through two fix attempts because the 409s
+  # left no record of which check fired or on what payload. These pin the
+  # classification line each refusal now writes.
+  describe "conflict logging" do
+    before { allow(Rails.logger).to receive(:info).and_call_original }
+
+    it "logs the per-scope duplicate check with the offending id" do
+      category = create(:variant_category, link: product, title: "Tier")
+      tier_a = create(:variant, variant_category: category, name: "Tier A")
+
+      params = editor_save_params(
+        [
+          {
+            id: tier_a.external_id,
+            name: tier_a.name,
+            price_difference_cents: 0,
+            rich_content: [
+              { id: "dup-id", title: "One", description: { type: "doc", content: paragraph("1") } },
+              { id: "dup-id", title: "Two", description: { type: "doc", content: paragraph("2") } }
+            ],
+          }
+        ]
+      )
+
+      post :update, params: params, as: :json
+
+      expect(response).to have_http_status(:conflict)
+      expect(Rails.logger).to have_received(:info).with(
+        a_string_including(
+          "[product_editor_save_conflict]",
+          "error_code=ambiguous_rich_content_id_conflict",
+          "product_id=#{product.id}",
+          "provenance_version=2",
+          'check="per_scope"',
+          "dup-id"
+        )
+      )
+    end
+
+    it "logs the global check for a payload without scoped-mapping support" do
+      category = create(:variant_category, link: product, title: "Tier")
+      tier_a = create(:variant, variant_category: category, name: "Tier A")
+      tier_b = create(:variant, variant_category: category, name: "Tier B")
+
+      params = editor_save_params(
+        [
+          {
+            id: tier_a.external_id,
+            name: tier_a.name,
+            price_difference_cents: 0,
+            rich_content: [
+              { id: "shared-client-id", title: "A", description: { type: "doc", content: paragraph("A") } }
+            ],
+          },
+          {
+            id: tier_b.external_id,
+            name: tier_b.name,
+            price_difference_cents: 0,
+            rich_content: [
+              { id: "shared-client-id", title: "B", description: { type: "doc", content: paragraph("B") } }
+            ],
+          }
+        ]
+      )
+      params[:rich_content_provenance_version] = 1
+
+      post :update, params: params, as: :json
+
+      expect(response).to have_http_status(:conflict)
+      expect(Rails.logger).to have_received(:info).with(
+        a_string_including(
+          "error_code=ambiguous_rich_content_id_conflict",
+          "provenance_version=1",
+          'check="global"',
+          "shared-client-id"
+        )
+      )
+    end
+
+    it "logs the existing-id check with the id and both scopes" do
+      category = create(:variant_category, link: product, title: "Tier")
+      tier_a = create(:variant, variant_category: category, name: "Tier A")
+      tier_b = create(:variant, variant_category: category, name: "Tier B")
+      page = create(:rich_content, entity: tier_a, title: "One", description: paragraph("Original"))
+
+      params = editor_save_params(
+        [
+          {
+            id: tier_a.external_id,
+            name: tier_a.name,
+            price_difference_cents: 0,
+            rich_content: [
+              { id: page.external_id, title: "One", description: { type: "doc", content: paragraph("Kept") } }
+            ],
+          },
+          {
+            id: tier_b.external_id,
+            name: tier_b.name,
+            price_difference_cents: 0,
+            rich_content: [
+              { id: page.external_id, title: "One", description: { type: "doc", content: paragraph("Also here") } }
+            ],
+          }
+        ]
+      )
+
+      post :update, params: params, as: :json
+
+      expect(response).to have_http_status(:conflict)
+      expect(Rails.logger).to have_received(:info).with(
+        a_string_including(
+          "error_code=ambiguous_rich_content_id_conflict",
+          'check="existing_id_multiple_scopes"',
+          page.external_id
+        )
+      )
+    end
+  end
 end

--- a/spec/controllers/links_controller_scoped_rich_content_ambiguity_spec.rb
+++ b/spec/controllers/links_controller_scoped_rich_content_ambiguity_spec.rb
@@ -152,9 +152,7 @@ describe LinksController, type: :controller do
     expect(page.reload.entity).to eq(tier_a)
   end
 
-  # gumroad-private#2023 stayed open through two fix attempts because the 409s
-  # left no record of which check fired or on what payload. These pin the
-  # classification line each refusal now writes.
+  # Pins the classification line each refusal writes (gumroad-private#2023).
   describe "conflict logging" do
     before { allow(Rails.logger).to receive(:info).and_call_original }
 


### PR DESCRIPTION
## What

Adds one structured log line for every refused product-editor save in `LinksController#update`. The four conflict responses (`stale_content_conflict`, `ambiguous_rich_content_id_conflict`, `stale_deletion_conflict`, `hidden_variant_content_conflict`) now log the error code, product id, seller id, the payload's `rich_content_provenance_version`, and the request id. The rich-content ambiguity guard also records which of its three checks fired and the offending page ids and scopes.

## Why

gumroad-private#2023 went through two fix attempts against 409s that left no server-side record of which conflict fired. Lograge strips request params and the guard raised without logging, so each investigation started from zero — the only save attempt on the affected product on Aug 12 returned a 409 that remains unclassifiable today. The sibling guards already report (the deletion guard notifies, the stale-write guard reports in detect mode); this brings the conflict responses to parity. The line fires only on refused saves, so the healthy path is unchanged.

## Before / After

Before: a refused editor save appears in production logs as a bare 409/422 status line.

After: the same request also emits one greppable line, for example:

```
[product_editor_save_conflict] error_code=ambiguous_rich_content_id_conflict product_id=123 seller_id=456 provenance_version=2 request_id=... check="per_scope" conflicts={9=>["dup-id"]}
```

Log values are external ids, client-generated ids, and variant scope keys. No seller content is logged. No UI or behavior change.

Walkthrough video: pending; will be added before this PR leaves draft.

## Test Results

- `bundle exec rspec spec/controllers/links_controller_scoped_rich_content_ambiguity_spec.rb` — 6 examples, 0 failures. Three new examples pin the classification line for each guard check; one new example adds the previously missing rejection coverage for an existing page id submitted under two variant scopes.
- Mutation check: with the controller change stashed, the per-scope logging example fails; restored, all pass.
- `bundle exec rubocop -a` on both touched files — no offenses.
- Structured review: autoreview (codex engine) — clean, no accepted or actionable findings; "patch is correct (0.95)".
- `bin/test-confidence`: 99% reached, "Safe to commit"; 3 failures confirmed pre-existing and skipped (links_controller_custom_html_spec, products/edit/edit_spec, products/edit/rich_text_editor_spec).

---

AI disclosure: authored by Claude Fable 5 (Claude Code). Prompts: investigate gumroad-private#2023 and its fix history to root cause; then "start with part 1 now. do the changes in a new branch up to date with main, run /autoreview before pushing and publish a draft pr assigned to me". Part 1 is the observability step from the investigation's fix plan.
