### PR TITLE
Harden the content editor's display path against unparseable docs (gp#2023)

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
@@ -93,9 +93,9 @@ const getMountedEditor = () => {
   return mountedEditor;
 };
 
-const makePage = (id: string, text: string) => ({
+const makePage = (id: string, text: string, title: string | null = null) => ({
   id,
-  title: null,
+  title,
   description: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text }] }] } as const,
   updated_at: "2026-01-01T00:00:00.000Z",
 });
@@ -153,11 +153,8 @@ it("rejects a stale variant write, resets the real editor, and persists the next
   expect(paidVariant.rich_content[0]?.description).toEqual(paidPage.description);
 });
 
-// gumroad-private#2023's display symptom: a page whose stored doc the schema
-// refuses used to fail its deferred reset silently, leaving the PREVIOUS
-// variant's doc mounted while the page list claimed the new selection — and
-// the gp#1943 guard then flipped its ref anyway, reopening the misfiled-write
-// window. The reset failure now blocks the flip and surfaces an error.
+// A failed reset leaves the previous doc mounted; writes must stay blocked
+// and the seller alerted (gumroad-private#2023).
 it("blocks writes and alerts when the newly selected page's doc cannot be parsed", async () => {
   const paidPage = makePage("page-paid-1", "PAID PAGE");
   // A known node type with an invalid shape: dropUnknownNodes keeps it, and
@@ -186,8 +183,7 @@ it("blocks writes and alerts when the newly selected page's doc cannot be parsed
 
   rerender(<ContentTabContent selectedVariantId="variant-free" />);
   await act(async () => {});
-  // The poison doc failed to mount, so the paid doc is still live. Any write
-  // event in this state must not land under the free page.
+  // The poison doc failed to mount; writes must not land under the free page.
   expect(getMountedEditor().getText()).toBe("PAID PAGE");
   expect(alerts).toContainEqual({
     message: "This page's content could not be displayed. Reload the page before editing it.",
@@ -207,10 +203,8 @@ it("blocks writes and alerts when the newly selected page's doc cannot be parsed
   expect(paidVariant.rich_content[0]?.description).toEqual(getMountedEditor().getJSON());
 });
 
-// The malformed page can also be the FIRST one the tab mounts with. useEditor
-// then mounts an empty doc without any reset having run — writes must stay
-// blocked from the start or a blur would overwrite the stored content with
-// that emptiness.
+// useEditor mounts an EMPTY doc for a malformed first page; writes must stay
+// blocked from the start or a blur overwrites the stored content.
 it("blocks writes and alerts when the initially selected page's doc cannot be parsed", async () => {
   const poisonPage = {
     id: "page-free-1",
@@ -262,10 +256,8 @@ it("finds a node in a raw doc that also contains invalid nodes", () => {
   ).toBe(true);
 });
 
-// Page identity is scope + id: two variants' pages can share a raw id before
-// save reconciliation. Keying the editor reset and the write guard on the raw
-// id alone made a switch between same-id pages a no-op — the first variant's
-// doc stayed mounted and writable under the second variant's page.
+// Two variants' pages can share a raw id before save reconciliation, so the
+// reset and the write guard must key on scope + id.
 it("re-mounts the doc and scopes writes when two variants' pages share a raw id", async () => {
   const tierAPage = makePage("shared-id", "TIER A DOC");
   const tierBPage = makePage("shared-id", "TIER B DOC");
@@ -285,8 +277,7 @@ it("re-mounts the doc and scopes writes when two variants' pages share a raw id"
   expect(getMountedEditor().getText()).toBe("TIER A DOC");
 
   rerender(<ContentTabContent selectedVariantId="variant-b" />);
-  // Still inside the switch window: the mounted doc is tier A's, and a write
-  // event must not land under tier B's same-id page.
+  // Switch window: a write must not land under tier B's same-id page.
   expect(getMountedEditor().getText()).toBe("TIER A DOC");
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the update handler ignores its args
   getMountedEditor().emit("update", { editor: getMountedEditor(), transaction: null } as never);
@@ -337,10 +328,8 @@ it("blocks writes and alerts when a same-id page in another variant cannot be pa
   expect(tierB.rich_content[0]?.description).toEqual(poisonPage.description);
 });
 
-// Returning to the page whose key the guard ref still holds (after a failed
-// reset for another page) must not reopen writes before the recovery reset
-// lands: the mounted doc may carry edits typed while the failed page was
-// selected, and an async editor transaction in that window would store them.
+// Switch-back after a failed reset must not reopen writes before the recovery
+// reset lands: the mounted doc may carry edits typed over the stale page.
 it("keeps writes blocked on switch-back until the recovery reset lands", async () => {
   const pageA = makePage("page-a", "PAGE A");
   const poisonPage = {
@@ -364,8 +353,6 @@ it("keeps writes blocked on switch-back until the recovery reset lands", async (
   await act(async () => {});
   expect(getMountedEditor().getText()).toBe("PAGE A");
 
-  // Select the poison page via the page list, type over the stale doc, then
-  // select page A again.
   const pageTabs = document.querySelectorAll('[role="tab"]');
   act(() => {
     (pageTabs[1] instanceof HTMLElement ? pageTabs[1] : undefined)?.click();
@@ -382,8 +369,7 @@ it("keeps writes blocked on switch-back until the recovery reset lands", async (
       : undefined
     )?.click();
   });
-  // Inside the pre-reset window: the mounted doc still carries the stray
-  // edits, and an async update event must not store them into page A.
+  // Pre-reset window: the stray edits must not be stored into page A.
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the update handler ignores its args
   getMountedEditor().emit("update", { editor: getMountedEditor(), transaction: null } as never);
   expect(variant.rich_content[0]?.description).toEqual(pageA.description);
@@ -391,9 +377,8 @@ it("keeps writes blocked on switch-back until the recovery reset lands", async (
   await act(async () => {});
   expect(getMountedEditor().getText()).toBe("PAGE A");
 });
-// Switching to a variant with NO pages must not let a write event in the
-// switch window copy the previous variant's doc into it via addPage:
-// "no page selected" and "reset pending" are distinct guard states.
+// "No page selected" and "reset pending" are distinct guard states: conflating
+// them lets addPage copy the stale doc into an empty variant.
 it("does not copy the stale doc into an empty variant during the switch window", async () => {
   const tierAPage = makePage("page-a", "TIER A DOC");
   const tierA: VariantFixture = { id: "variant-a", name: "A", rich_content: [tierAPage] };
@@ -412,8 +397,7 @@ it("does not copy the stale doc into an empty variant during the switch window",
   expect(getMountedEditor().getText()).toBe("TIER A DOC");
 
   rerender(<ContentTabContent selectedVariantId="variant-b" />);
-  // Inside the switch window the mounted doc is still tier A's; an update
-  // event here used to create a page holding it inside the empty variant.
+  // Switch window: the mounted doc is still tier A's.
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the update handler ignores its args
   getMountedEditor().emit("update", { editor: getMountedEditor(), transaction: null } as never);
   expect(emptyTier.rich_content).toHaveLength(0);
@@ -421,13 +405,11 @@ it("does not copy the stale doc into an empty variant during the switch window",
   await act(async () => {});
   expect(getMountedEditor().getText()).toBe("");
 });
-// PageTab's internal title editor never resets on prop changes, so the page
-// list must remount it when the variant changes — two variants' pages can
-// share a raw id, and a reused instance shows (and would write) the other
-// variant's title. An in-progress rename likewise must not carry over.
+// PageTab's title editor never resets on prop changes: same-id pages across
+// variants need a remount, and an in-progress rename must not carry over.
 it("resets the rename editor across a variant switch between same-id pages", async () => {
-  const tierAPage = { ...makePage("shared-id", "TIER A DOC"), title: "Alpha" };
-  const tierBPage = { ...makePage("shared-id", "TIER B DOC"), title: "Beta" };
+  const tierAPage = makePage("shared-id", "TIER A DOC", "Alpha");
+  const tierBPage = makePage("shared-id", "TIER B DOC", "Beta");
   // Two pages per variant so the page list renders.
   const tierA: VariantFixture = { id: "variant-a", name: "A", rich_content: [tierAPage, makePage("extra-a", "X")] };
   const tierB: VariantFixture = { id: "variant-b", name: "B", rich_content: [tierBPage, makePage("extra-b", "Y")] };
@@ -444,7 +426,6 @@ it("resets the rename editor across a variant switch between same-id pages", asy
   await act(async () => {});
   expect(getByText("Alpha")).toBeTruthy();
 
-  // Open the rename editor for tier A's page through the page-tab menu.
   const menuTriggers = document.querySelectorAll('[role="tab"] button');
   act(() => {
     (menuTriggers[0] instanceof HTMLElement ? menuTriggers[0] : undefined)?.click();
@@ -455,18 +436,17 @@ it("resets the rename editor across a variant switch between same-id pages", asy
     renameItem.click();
   });
   await act(async () => {});
-  // The title editor holds tier A's title.
+
   const titleEditor = document.querySelector('[role="tab"] .tiptap');
   expect(titleEditor?.textContent).toBe("Alpha");
 
   rerender(<ContentTabContent selectedVariantId="variant-b" />);
   await act(async () => {});
-  // The rename closed on the switch, and the tab shows tier B's own title.
+
   expect(document.querySelector('[role="tab"] .tiptap')).toBeNull();
   expect(getByText("Beta")).toBeTruthy();
   expect(queryByText("Alpha")).toBeNull();
 
-  // Re-opening the rename edits tier B's title, never tier A's.
   const newTriggers = document.querySelectorAll('[role="tab"] button');
   act(() => {
     (newTriggers[0] instanceof HTMLElement ? newTriggers[0] : undefined)?.click();

--- a/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
@@ -4,7 +4,7 @@ import type { Editor } from "@tiptap/core";
 import * as React from "react";
 import { afterEach, expect, it, vi } from "vitest";
 
-import { ContentTabContent } from "$app/components/ProductEdit/ContentTab";
+import { ContentTabContent, rawDocContainsNode } from "$app/components/ProductEdit/ContentTab";
 import { Product } from "$app/components/ProductEdit/state";
 
 // Capture the real mounted TipTap editor so the test can fire an update inside
@@ -77,10 +77,15 @@ vi.mock("react-sortablejs", () => ({
   default: ({ children }: { children: React.ReactNode }) => children,
   ReactSortable: ({ children }: { children: React.ReactNode }) => children,
 }));
+const alerts = vi.hoisted((): { message: string; level: string }[] => []);
+vi.mock("$app/components/server-components/Alert", () => ({
+  showAlert: (message: string, level: string) => alerts.push({ message, level }),
+}));
 
 afterEach(() => {
   cleanup();
   mountedEditor = null;
+  alerts.length = 0;
 });
 
 const getMountedEditor = () => {
@@ -146,4 +151,330 @@ it("rejects a stale variant write, resets the real editor, and persists the next
   expect(getMountedEditor().getText()).toBe("FREE PAGE EDITED");
   expect(freeVariant.rich_content[0]?.description).toEqual(getMountedEditor().getJSON());
   expect(paidVariant.rich_content[0]?.description).toEqual(paidPage.description);
+});
+
+// gumroad-private#2023's display symptom: a page whose stored doc the schema
+// refuses used to fail its deferred reset silently, leaving the PREVIOUS
+// variant's doc mounted while the page list claimed the new selection — and
+// the gp#1943 guard then flipped its ref anyway, reopening the misfiled-write
+// window. The reset failure now blocks the flip and surfaces an error.
+it("blocks writes and alerts when the newly selected page's doc cannot be parsed", async () => {
+  const paidPage = makePage("page-paid-1", "PAID PAGE");
+  // A known node type with an invalid shape: dropUnknownNodes keeps it, and
+  // ProseMirror's nodeFromJSON throws on a text node without text.
+  const poisonPage = {
+    id: "page-free-1",
+    title: null,
+    description: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text" }] }] },
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+  const paidVariant: VariantFixture = { id: "variant-paid", name: "Paid", rich_content: [paidPage] };
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the poison doc is deliberately malformed
+  const freeVariant = { id: "variant-free", name: "Free", rich_content: [poisonPage] } as unknown as VariantFixture;
+  const product = buildProduct([paidVariant, freeVariant]);
+
+  context.product = product;
+  context.updateProduct = (update: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the update union for the fixture
+    if (typeof update === "function") (update as (p: Product) => void)(product);
+    else Object.assign(product, update);
+  };
+
+  const { rerender } = render(<ContentTabContent selectedVariantId="variant-paid" />);
+  await act(async () => {});
+  expect(getMountedEditor().getText()).toBe("PAID PAGE");
+
+  rerender(<ContentTabContent selectedVariantId="variant-free" />);
+  await act(async () => {});
+  // The poison doc failed to mount, so the paid doc is still live. Any write
+  // event in this state must not land under the free page.
+  expect(getMountedEditor().getText()).toBe("PAID PAGE");
+  expect(alerts).toContainEqual({
+    message: "This page's content could not be displayed. Reload the page before editing it.",
+    level: "error",
+  });
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the update handler ignores its args
+  getMountedEditor().emit("update", { editor: getMountedEditor(), transaction: null } as never);
+  expect(freeVariant.rich_content[0]?.description).toEqual(poisonPage.description);
+
+  // Switching back to a parseable page recovers, and edits land on it.
+  rerender(<ContentTabContent selectedVariantId="variant-paid" />);
+  await act(async () => {});
+  expect(getMountedEditor().getText()).toBe("PAID PAGE");
+  act(() => {
+    getMountedEditor().chain().focus("end").insertContent(" EDITED").run();
+  });
+  expect(paidVariant.rich_content[0]?.description).toEqual(getMountedEditor().getJSON());
+});
+
+// The malformed page can also be the FIRST one the tab mounts with. useEditor
+// then mounts an empty doc without any reset having run — writes must stay
+// blocked from the start or a blur would overwrite the stored content with
+// that emptiness.
+it("blocks writes and alerts when the initially selected page's doc cannot be parsed", async () => {
+  const poisonPage = {
+    id: "page-free-1",
+    title: null,
+    description: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text" }] }] },
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the poison doc is deliberately malformed
+  const freeVariant = { id: "variant-free", name: "Free", rich_content: [poisonPage] } as unknown as VariantFixture;
+  const product = buildProduct([freeVariant]);
+
+  context.product = product;
+  context.updateProduct = (update: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the update union for the fixture
+    if (typeof update === "function") (update as (p: Product) => void)(product);
+    else Object.assign(product, update);
+  };
+
+  render(<ContentTabContent selectedVariantId="variant-free" />);
+  await act(async () => {});
+
+  expect(alerts).toContainEqual({
+    message: "This page's content could not be displayed. Reload the page before editing it.",
+    level: "error",
+  });
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the update handler ignores its args
+  getMountedEditor().emit("update", { editor: getMountedEditor(), transaction: null } as never);
+  expect(freeVariant.rich_content[0]?.description).toEqual(poisonPage.description);
+});
+
+// The fallback for unparseable docs must stay fail-closed for single-instance
+// node checks (license key): a malformed doc can still carry the node.
+it("finds a node in a raw doc that also contains invalid nodes", () => {
+  const doc = {
+    type: "doc",
+    content: [
+      { type: "paragraph", content: [{ type: "text" }] },
+      { type: "licenseKey", attrs: {} },
+    ],
+  };
+  expect(rawDocContainsNode(doc, "licenseKey")).toBe(true);
+  expect(rawDocContainsNode(doc, "posts")).toBe(false);
+  expect(rawDocContainsNode(null, "licenseKey")).toBe(false);
+  expect(
+    rawDocContainsNode(
+      { type: "doc", content: [{ type: "blockquote", content: [{ type: "licenseKey" }] }] },
+      "licenseKey",
+    ),
+  ).toBe(true);
+});
+
+// Page identity is scope + id: two variants' pages can share a raw id before
+// save reconciliation. Keying the editor reset and the write guard on the raw
+// id alone made a switch between same-id pages a no-op — the first variant's
+// doc stayed mounted and writable under the second variant's page.
+it("re-mounts the doc and scopes writes when two variants' pages share a raw id", async () => {
+  const tierAPage = makePage("shared-id", "TIER A DOC");
+  const tierBPage = makePage("shared-id", "TIER B DOC");
+  const tierA: VariantFixture = { id: "variant-a", name: "A", rich_content: [tierAPage] };
+  const tierB: VariantFixture = { id: "variant-b", name: "B", rich_content: [tierBPage] };
+  const product = buildProduct([tierA, tierB]);
+
+  context.product = product;
+  context.updateProduct = (update: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the update union for the fixture
+    if (typeof update === "function") (update as (p: Product) => void)(product);
+    else Object.assign(product, update);
+  };
+
+  const { rerender } = render(<ContentTabContent selectedVariantId="variant-a" />);
+  await act(async () => {});
+  expect(getMountedEditor().getText()).toBe("TIER A DOC");
+
+  rerender(<ContentTabContent selectedVariantId="variant-b" />);
+  // Still inside the switch window: the mounted doc is tier A's, and a write
+  // event must not land under tier B's same-id page.
+  expect(getMountedEditor().getText()).toBe("TIER A DOC");
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the update handler ignores its args
+  getMountedEditor().emit("update", { editor: getMountedEditor(), transaction: null } as never);
+  expect(tierB.rich_content[0]?.description).toEqual(tierBPage.description);
+
+  await act(async () => {});
+  expect(getMountedEditor().getText()).toBe("TIER B DOC");
+  act(() => {
+    getMountedEditor().chain().focus("end").insertContent(" EDITED").run();
+  });
+  expect(tierB.rich_content[0]?.description).toEqual(getMountedEditor().getJSON());
+  expect(tierA.rich_content[0]?.description).toEqual(tierAPage.description);
+});
+
+it("blocks writes and alerts when a same-id page in another variant cannot be parsed", async () => {
+  const tierAPage = makePage("shared-id", "TIER A DOC");
+  const poisonPage = {
+    id: "shared-id",
+    title: null,
+    description: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text" }] }] },
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+  const tierA: VariantFixture = { id: "variant-a", name: "A", rich_content: [tierAPage] };
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the poison doc is deliberately malformed
+  const tierB = { id: "variant-b", name: "B", rich_content: [poisonPage] } as unknown as VariantFixture;
+  const product = buildProduct([tierA, tierB]);
+
+  context.product = product;
+  context.updateProduct = (update: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the update union for the fixture
+    if (typeof update === "function") (update as (p: Product) => void)(product);
+    else Object.assign(product, update);
+  };
+
+  const { rerender } = render(<ContentTabContent selectedVariantId="variant-a" />);
+  await act(async () => {});
+  expect(getMountedEditor().getText()).toBe("TIER A DOC");
+
+  rerender(<ContentTabContent selectedVariantId="variant-b" />);
+  await act(async () => {});
+  expect(getMountedEditor().getText()).toBe("TIER A DOC");
+  expect(alerts).toContainEqual({
+    message: "This page's content could not be displayed. Reload the page before editing it.",
+    level: "error",
+  });
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the update handler ignores its args
+  getMountedEditor().emit("update", { editor: getMountedEditor(), transaction: null } as never);
+  expect(tierB.rich_content[0]?.description).toEqual(poisonPage.description);
+});
+
+// Returning to the page whose key the guard ref still holds (after a failed
+// reset for another page) must not reopen writes before the recovery reset
+// lands: the mounted doc may carry edits typed while the failed page was
+// selected, and an async editor transaction in that window would store them.
+it("keeps writes blocked on switch-back until the recovery reset lands", async () => {
+  const pageA = makePage("page-a", "PAGE A");
+  const poisonPage = {
+    id: "page-b",
+    title: null,
+    description: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text" }] }] },
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the poison doc is deliberately malformed
+  const variant = { id: "variant-a", name: "A", rich_content: [pageA, poisonPage] } as unknown as VariantFixture;
+  const product = buildProduct([variant]);
+
+  context.product = product;
+  context.updateProduct = (update: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the update union for the fixture
+    if (typeof update === "function") (update as (p: Product) => void)(product);
+    else Object.assign(product, update);
+  };
+
+  render(<ContentTabContent selectedVariantId="variant-a" />);
+  await act(async () => {});
+  expect(getMountedEditor().getText()).toBe("PAGE A");
+
+  // Select the poison page via the page list, type over the stale doc, then
+  // select page A again.
+  const pageTabs = document.querySelectorAll('[role="tab"]');
+  act(() => {
+    (pageTabs[1] instanceof HTMLElement ? pageTabs[1] : undefined)?.click();
+  });
+  await act(async () => {});
+  expect(getMountedEditor().getText()).toBe("PAGE A");
+  act(() => {
+    getMountedEditor().chain().focus("end").insertContent(" STRAY").run();
+  });
+  act(() => {
+    (document.querySelectorAll('[role="tab"]')[0] instanceof HTMLElement
+      ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowed by the check above
+        (document.querySelectorAll('[role="tab"]')[0] as HTMLElement)
+      : undefined
+    )?.click();
+  });
+  // Inside the pre-reset window: the mounted doc still carries the stray
+  // edits, and an async update event must not store them into page A.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the update handler ignores its args
+  getMountedEditor().emit("update", { editor: getMountedEditor(), transaction: null } as never);
+  expect(variant.rich_content[0]?.description).toEqual(pageA.description);
+
+  await act(async () => {});
+  expect(getMountedEditor().getText()).toBe("PAGE A");
+});
+// Switching to a variant with NO pages must not let a write event in the
+// switch window copy the previous variant's doc into it via addPage:
+// "no page selected" and "reset pending" are distinct guard states.
+it("does not copy the stale doc into an empty variant during the switch window", async () => {
+  const tierAPage = makePage("page-a", "TIER A DOC");
+  const tierA: VariantFixture = { id: "variant-a", name: "A", rich_content: [tierAPage] };
+  const emptyTier: VariantFixture = { id: "variant-b", name: "B", rich_content: [] };
+  const product = buildProduct([tierA, emptyTier]);
+
+  context.product = product;
+  context.updateProduct = (update: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the update union for the fixture
+    if (typeof update === "function") (update as (p: Product) => void)(product);
+    else Object.assign(product, update);
+  };
+
+  const { rerender } = render(<ContentTabContent selectedVariantId="variant-a" />);
+  await act(async () => {});
+  expect(getMountedEditor().getText()).toBe("TIER A DOC");
+
+  rerender(<ContentTabContent selectedVariantId="variant-b" />);
+  // Inside the switch window the mounted doc is still tier A's; an update
+  // event here used to create a page holding it inside the empty variant.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the update handler ignores its args
+  getMountedEditor().emit("update", { editor: getMountedEditor(), transaction: null } as never);
+  expect(emptyTier.rich_content).toHaveLength(0);
+
+  await act(async () => {});
+  expect(getMountedEditor().getText()).toBe("");
+});
+// PageTab's internal title editor never resets on prop changes, so the page
+// list must remount it when the variant changes — two variants' pages can
+// share a raw id, and a reused instance shows (and would write) the other
+// variant's title. An in-progress rename likewise must not carry over.
+it("resets the rename editor across a variant switch between same-id pages", async () => {
+  const tierAPage = { ...makePage("shared-id", "TIER A DOC"), title: "Alpha" };
+  const tierBPage = { ...makePage("shared-id", "TIER B DOC"), title: "Beta" };
+  // Two pages per variant so the page list renders.
+  const tierA: VariantFixture = { id: "variant-a", name: "A", rich_content: [tierAPage, makePage("extra-a", "X")] };
+  const tierB: VariantFixture = { id: "variant-b", name: "B", rich_content: [tierBPage, makePage("extra-b", "Y")] };
+  const product = buildProduct([tierA, tierB]);
+
+  context.product = product;
+  context.updateProduct = (update: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the update union for the fixture
+    if (typeof update === "function") (update as (p: Product) => void)(product);
+    else Object.assign(product, update);
+  };
+
+  const { rerender, getByText, queryByText } = render(<ContentTabContent selectedVariantId="variant-a" />);
+  await act(async () => {});
+  expect(getByText("Alpha")).toBeTruthy();
+
+  // Open the rename editor for tier A's page through the page-tab menu.
+  const menuTriggers = document.querySelectorAll('[role="tab"] button');
+  act(() => {
+    (menuTriggers[0] instanceof HTMLElement ? menuTriggers[0] : undefined)?.click();
+  });
+  await act(async () => {});
+  const renameItem = getByText("Rename");
+  act(() => {
+    renameItem.click();
+  });
+  await act(async () => {});
+  // The title editor holds tier A's title.
+  const titleEditor = document.querySelector('[role="tab"] .tiptap');
+  expect(titleEditor?.textContent).toBe("Alpha");
+
+  rerender(<ContentTabContent selectedVariantId="variant-b" />);
+  await act(async () => {});
+  // The rename closed on the switch, and the tab shows tier B's own title.
+  expect(document.querySelector('[role="tab"] .tiptap')).toBeNull();
+  expect(getByText("Beta")).toBeTruthy();
+  expect(queryByText("Alpha")).toBeNull();
+
+  // Re-opening the rename edits tier B's title, never tier A's.
+  const newTriggers = document.querySelectorAll('[role="tab"] button');
+  act(() => {
+    (newTriggers[0] instanceof HTMLElement ? newTriggers[0] : undefined)?.click();
+  });
+  await act(async () => {});
+  act(() => {
+    getByText("Rename").click();
+  });
+  await act(async () => {});
+  expect(document.querySelector('[role="tab"] .tiptap')?.textContent).toBe("Beta");
 });

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -22,7 +22,7 @@ import {
   Star,
   TwitterX,
 } from "@boxicons/react";
-import { findChildren, generateJSON, Node as TiptapNode } from "@tiptap/core";
+import { type Editor, findChildren, generateJSON, Node as TiptapNode } from "@tiptap/core";
 import { DOMSerializer } from "@tiptap/pm/model";
 import { EditorContent } from "@tiptap/react";
 import { parseISO } from "date-fns";
@@ -70,6 +70,7 @@ import { ReviewForm } from "$app/components/ReviewForm";
 import {
   baseEditorOptions,
   getInsertAtFromSelection,
+  lastContentResetFailed,
   PopoverMenuItem,
   RichTextEditorToolbar,
   useImageUploadSettings,
@@ -115,6 +116,22 @@ declare global {
     ___dropbox_files_picked: DropboxFile[] | null;
   }
 }
+
+// "Reset requested, not yet confirmed" marker for the mounted-doc identity
+// guard. Distinct from undefined on purpose: undefined is the VALID no-page
+// selection, and conflating the two lets a write fire in the switch window to
+// an empty variant — addPage would copy the stale doc into it.
+const EDITOR_CONTENT_PENDING = Symbol("editor-content-pending");
+
+// Fallback node search for a stored doc the schema cannot parse: walks the
+// raw JSON so single-instance checks (license key) stay fail-closed even when
+// the doc also contains invalid nodes.
+export const rawDocContainsNode = (value: unknown, type: string): boolean => {
+  if (Array.isArray(value)) return value.some((child) => rawDocContainsNode(child, type));
+  if (typeof value !== "object" || value === null) return false;
+  if ("type" in value && value.type === type) return true;
+  return "content" in value && rawDocContainsNode(value.content, type);
+};
 
 export const extensions = (productId: string, extraExtensions: TiptapNode[] = []) => [
   ...extraExtensions,
@@ -252,12 +269,22 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
   const selectedPage = pages.find((page) => page.id === selectedPageId);
   if ((selectedPageId || pages.length) && !selectedPage) setSelectedPageId(pages[0]?.id);
   const [renamingPageId, setRenamingPageId] = React.useState<string | null>(null);
+  // A rename in progress names a page by raw id; after a variant switch that
+  // id can address a DIFFERENT page in the new variant. Close the rename
+  // instead of letting it carry over.
+  React.useEffect(() => setRenamingPageId(null), [selectedVariantId]);
   const [confirmingDeletePage, setConfirmingDeletePage] = React.useState<Page | null>(null);
   const [pagesExpanded, setPagesExpanded] = React.useState(false);
   const showPageList =
     pages.length > 1 || selectedPage?.title || renamingPageId != null || product.native_type === "commission";
   const [insertMenuState, setInsertMenuState] = React.useState<"open" | "inputs" | null>(null);
-  const initialValue = React.useMemo(() => selectedPage?.description ?? "", [selectedPageId]);
+  // Page identity is scope + id, never the raw id alone: two variants' pages
+  // can share a raw id before save reconciliation, and a variant switch
+  // between them changes which doc must be mounted while selectedPageId stays
+  // the same. Everything keyed on the selection below uses this composite.
+  const selectedScopedPageKey =
+    selectedPageId == null ? undefined : scopedRichContentPageKey(selectedVariant?.id ?? null, selectedPageId);
+  const initialValue = React.useMemo(() => selectedPage?.description ?? "", [selectedScopedPageKey]);
 
   const onSelectFiles = (ids: string[]) => {
     if (!editor) return;
@@ -359,14 +386,32 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
   });
   const removedFileEmbedIds = removedFileEmbedIdsForPage(selectedPage, richContentRemovedFileEmbedIds);
   // Tracks which page the mounted doc actually belongs to. Queued after
-  // useRichTextEditor's own reset microtask (hook order), so it only flips
-  // once the editor really holds the new page's doc — see updateContentRef.
-  const editorContentPageIdRef = React.useRef<string | undefined>(selectedPageId);
+  // useRichTextEditor's own reset microtask (hook order + same deps), so it
+  // only flips once the editor really holds that page's doc — see
+  // updateContentRef. Starts undefined and flips only after a SUCCESSFUL
+  // reset: a failed reset leaves the wrong doc mounted (the previous page's,
+  // or the empty doc useEditor mounts for a malformed first page), so writes
+  // stay blocked and the seller gets an explicit error instead of a silent
+  // wrong render.
+  const editorContentPageKeyRef = React.useRef<string | undefined | typeof EDITOR_CONTENT_PENDING>(
+    EDITOR_CONTENT_PENDING,
+  );
   React.useEffect(() => {
+    // Invalidate synchronously: the mounted doc no longer matches the
+    // selection until the paired reset lands. In particular, returning to the
+    // page whose key the ref still holds (after a failed reset for another
+    // page) must not inherit the old match — the mounted doc may carry stray
+    // edits the recovery reset is about to discard.
+    editorContentPageKeyRef.current = EDITOR_CONTENT_PENDING;
     queueMicrotask(() => {
-      editorContentPageIdRef.current = selectedPageId;
+      if (!editor) return;
+      if (lastContentResetFailed(editor)) {
+        showAlert("This page's content could not be displayed. Reload the page before editing it.", "error");
+        return;
+      }
+      editorContentPageKeyRef.current = selectedScopedPageKey;
     });
-  }, [selectedPageId]);
+  }, [selectedScopedPageKey, editor]);
   React.useEffect(() => {
     if (editor) reconcileMountedEditorFileEmbedIds(editor, fileIdMappings);
   }, [editor, fileIdMappings]);
@@ -383,7 +428,7 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
     if (!editor) return;
     // Mounted doc still belongs to the previous page during the switch window
     // (gp#1943); skip rather than misfile it under the newly selected page.
-    if (editorContentPageIdRef.current !== selectedPageId) return;
+    if (editorContentPageKeyRef.current !== selectedScopedPageKey) return;
 
     // Correctly set the IDs of the file embeds copied from another product
     const fragment = DOMSerializer.fromSchema(editor.schema).serializeFragment(editor.state.doc.content);
@@ -415,19 +460,45 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
     };
   }, [editor]);
 
+  // A page whose stored doc the schema refuses must degrade to a plain page
+  // entry, not crash the whole tab at render — the guarded editor reset is
+  // what surfaces the failure when the page is selected.
+  const parsedPageDescription = (mountedEditor: Editor, page: Page) => {
+    try {
+      return mountedEditor.schema.nodeFromJSON(page.description);
+    } catch {
+      return null;
+    }
+  };
+
+  const findPageWithNode = (type: string) =>
+    editor &&
+    pages.find((page) => {
+      const description = parsedPageDescription(editor, page);
+      // Unparseable page: scan the raw JSON instead. Answering "not present"
+      // here would let single-instance nodes (the license key) be inserted a
+      // second time on a healthy page.
+      if (!description) return rawDocContainsNode(page.description, type);
+      return findChildren(description, (node) => node.type.name === type).length > 0;
+    });
+
   const pageIcons = React.useMemo(
     () =>
       new Map(
         editor
           ? pages.map((page) => {
-              const description = editor.schema.nodeFromJSON(page.description);
+              const description = parsedPageDescription(editor, page);
               return [
                 page.id,
                 generatePageIcon({
-                  hasLicense: findChildren(description, (node) => node.type.name === LicenseKey.name).length > 0,
-                  fileIds: findChildren(description, (node) => node.type.name === FileEmbed.name).map(({ node }) =>
-                    String(node.attrs.id),
-                  ),
+                  hasLicense: description
+                    ? findChildren(description, (node) => node.type.name === LicenseKey.name).length > 0
+                    : false,
+                  fileIds: description
+                    ? findChildren(description, (node) => node.type.name === FileEmbed.name).map(({ node }) =>
+                        String(node.attrs.id),
+                      )
+                    : [],
                   allFiles: product.files,
                 }),
               ] as const;
@@ -436,13 +507,6 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
       ),
     [pages],
   );
-
-  const findPageWithNode = (type: string) =>
-    editor &&
-    pages.find(
-      (page) =>
-        findChildren(editor.schema.nodeFromJSON(page.description), (node) => node.type.name === type).length > 0,
-    );
 
   const onInsertPosts = () => {
     if (!editor) return;
@@ -942,7 +1006,12 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
                         <>
                           {pages.map((page) => (
                             <PageTab
-                              key={page.id}
+                              // Scoped key: two variants' pages can share a raw
+                              // id, and PageTab's internal title editor never
+                              // resets on prop changes — reusing the instance
+                              // across a variant switch would show (and write)
+                              // the other variant's title.
+                              key={scopedRichContentPageKey(selectedVariant?.id ?? null, page.id)}
                               page={page}
                               selected={page === selectedPage}
                               icon={pageIcons.get(page.id) ?? "text-only"}

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -278,10 +278,8 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
   const showPageList =
     pages.length > 1 || selectedPage?.title || renamingPageId != null || product.native_type === "commission";
   const [insertMenuState, setInsertMenuState] = React.useState<"open" | "inputs" | null>(null);
-  // Page identity is scope + id, never the raw id alone: two variants' pages
-  // can share a raw id before save reconciliation, and a variant switch
-  // between them changes which doc must be mounted while selectedPageId stays
-  // the same. Everything keyed on the selection below uses this composite.
+  // Page identity is scope + id: two variants' pages can share a raw id
+  // before save reconciliation, so raw-id keys miss same-id variant switches.
   const selectedScopedPageKey =
     selectedPageId == null ? undefined : scopedRichContentPageKey(selectedVariant?.id ?? null, selectedPageId);
   const initialValue = React.useMemo(() => selectedPage?.description ?? "", [selectedScopedPageKey]);
@@ -385,23 +383,17 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
     onInputNonImageFiles: (files) => uploadFilesRef.current(files),
   });
   const removedFileEmbedIds = removedFileEmbedIdsForPage(selectedPage, richContentRemovedFileEmbedIds);
-  // Tracks which page the mounted doc actually belongs to. Queued after
-  // useRichTextEditor's own reset microtask (hook order + same deps), so it
-  // only flips once the editor really holds that page's doc — see
-  // updateContentRef. Starts undefined and flips only after a SUCCESSFUL
-  // reset: a failed reset leaves the wrong doc mounted (the previous page's,
-  // or the empty doc useEditor mounts for a malformed first page), so writes
-  // stay blocked and the seller gets an explicit error instead of a silent
-  // wrong render.
+  // Which page the mounted doc actually belongs to (see updateContentRef).
+  // Queued after useRichTextEditor's reset microtask (hook order), and set
+  // only after a SUCCESSFUL reset: a failed reset leaves the wrong doc
+  // mounted, so writes stay blocked and the seller gets an explicit error.
   const editorContentPageKeyRef = React.useRef<string | undefined | typeof EDITOR_CONTENT_PENDING>(
     EDITOR_CONTENT_PENDING,
   );
   React.useEffect(() => {
     // Invalidate synchronously: the mounted doc no longer matches the
-    // selection until the paired reset lands. In particular, returning to the
-    // page whose key the ref still holds (after a failed reset for another
-    // page) must not inherit the old match — the mounted doc may carry stray
-    // edits the recovery reset is about to discard.
+    // selection until the paired reset lands — a switch-back to the key the
+    // ref still holds must not inherit the old match.
     editorContentPageKeyRef.current = EDITOR_CONTENT_PENDING;
     queueMicrotask(() => {
       if (!editor) return;
@@ -1006,11 +998,9 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
                         <>
                           {pages.map((page) => (
                             <PageTab
-                              // Scoped key: two variants' pages can share a raw
-                              // id, and PageTab's internal title editor never
-                              // resets on prop changes — reusing the instance
-                              // across a variant switch would show (and write)
-                              // the other variant's title.
+                              // Scoped key: PageTab's title editor never resets
+                              // on prop changes, so same-id pages across
+                              // variants need a remount.
                               key={scopedRichContentPageKey(selectedVariant?.id ?? null, page.id)}
                               page={page}
                               selected={page === selectedPage}

--- a/app/javascript/components/RichTextEditor.test.ts
+++ b/app/javascript/components/RichTextEditor.test.ts
@@ -4,9 +4,14 @@ import { Editor, getSchema, Node } from "@tiptap/core";
 import { undoDepth } from "@tiptap/pm/history";
 import StarterKit from "@tiptap/starter-kit";
 import * as React from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { dropUnknownNodes, useRichTextEditor, validateUrl } from "$app/components/RichTextEditor";
+import {
+  dropUnknownNodes,
+  lastContentResetFailed,
+  useRichTextEditor,
+  validateUrl,
+} from "$app/components/RichTextEditor";
 
 // vite.config.ts's `define` replaces the bare `SSR` identifier at build time; vitest doesn't run
 // through that build step, so stub the global here for the hook test below.
@@ -211,5 +216,144 @@ describe("useRichTextEditor", () => {
       await Promise.resolve();
     });
     expect(getEditor().getText()).toBe("PAGE B");
+  });
+
+  // The deferred reset runs inside queueMicrotask, which swallows exceptions.
+  // A doc the schema refuses used to die there silently: the PREVIOUS content
+  // stayed mounted while the UI claimed the new selection, and callers had no
+  // signal to block writes (gumroad-private#2023's display symptom).
+  it("keeps the previous doc, records the failure, and recovers when a reset throws", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    let editor: Editor | null = null;
+    const Harness = ({ initialValue }: { initialValue: object }) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- exercising the hook's public Content type
+      editor = useRichTextEditor({ initialValue: initialValue as never });
+      return null;
+    };
+    const getEditor = (): Editor => {
+      if (!editor) throw new Error("editor did not mount");
+      return editor;
+    };
+
+    const valid = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "first" }] }] };
+    // A known node type with an invalid shape: dropUnknownNodes keeps it, and
+    // ProseMirror's nodeFromJSON throws on a text node without text.
+    const poison = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text" }] }] };
+    const { rerender } = render(React.createElement(Harness, { initialValue: valid }));
+    expect(getEditor().getText()).toBe("first");
+
+    rerender(React.createElement(Harness, { initialValue: poison }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getEditor().getText()).toBe("first");
+    expect(lastContentResetFailed(getEditor())).toBe(true);
+    expect(consoleError).toHaveBeenCalledWith("RichTextEditor: content reset failed", expect.anything());
+
+    const next = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "second" }] }] };
+    rerender(React.createElement(Harness, { initialValue: next }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getEditor().getText()).toBe("second");
+    expect(lastContentResetFailed(getEditor())).toBe(false);
+    consoleError.mockRestore();
+  });
+
+  // The strict content check must not regress HTML consumers: stored product
+  // HTML legitimately contains tags with no schema rule (e.g. span), and the
+  // lenient DOM parse keeps their supported children.
+  it("keeps parsing HTML strings leniently when they contain unsupported tags", async () => {
+    let editor: Editor | null = null;
+    const Harness = ({ initialValue }: { initialValue: string }) => {
+      editor = useRichTextEditor({ initialValue });
+      return null;
+    };
+    const getEditor = (): Editor => {
+      if (!editor) throw new Error("editor did not mount");
+      return editor;
+    };
+
+    const { rerender } = render(React.createElement(Harness, { initialValue: "<p>first</p>" }));
+    expect(getEditor().getText()).toBe("first");
+
+    rerender(React.createElement(Harness, { initialValue: "<p><span>kept</span></p>" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getEditor().getText()).toBe("kept");
+    expect(lastContentResetFailed(getEditor())).toBe(false);
+  });
+
+  // useEditor's own creation path mounts an EMPTY doc for malformed initial
+  // content without any signal. The reset effect re-runs when the editor
+  // materializes, so the very first content also goes through the strict
+  // check and records the failure.
+  it("records the failure when the INITIAL content is malformed", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    let editor: Editor | null = null;
+    const Harness = ({ initialValue }: { initialValue: object }) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- exercising the hook's public Content type
+      editor = useRichTextEditor({ initialValue: initialValue as never });
+      return null;
+    };
+
+    const poison = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text" }] }] };
+    render(React.createElement(Harness, { initialValue: poison }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    if (!editor) throw new Error("editor did not mount");
+    expect(lastContentResetFailed(editor)).toBe(true);
+    expect(consoleError).toHaveBeenCalledWith("RichTextEditor: content reset failed", expect.anything());
+    consoleError.mockRestore();
+  });
+
+  // Edits typed while a failed selection was displayed land on the STALE
+  // mounted doc. Returning to the previous content must reset the editor from
+  // state even though that content's identity never changed — otherwise the
+  // stray edits would be attributed to it on the next update or blur.
+  it("discards edits made over a stale doc when returning to the last valid content", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    let editor: Editor | null = null;
+    const Harness = ({ initialValue }: { initialValue: object }) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- exercising the hook's public Content type
+      editor = useRichTextEditor({ initialValue: initialValue as never });
+      return null;
+    };
+    const getEditor = (): Editor => {
+      if (!editor) throw new Error("editor did not mount");
+      return editor;
+    };
+
+    // A STRING content: the processed value compares equal across recomputes,
+    // which is the one path where the identity check alone would skip the
+    // recovery reset (object contents get a fresh identity from the memo).
+    const pageA = "<p>PAGE A</p>";
+    const poison = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text" }] }] };
+    const { rerender } = render(React.createElement(Harness, { initialValue: pageA }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getEditor().getText()).toBe("PAGE A");
+
+    rerender(React.createElement(Harness, { initialValue: poison }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(lastContentResetFailed(getEditor())).toBe(true);
+    // The seller types into what LOOKS like the new page but is the stale doc.
+    act(() => {
+      getEditor().chain().focus("end").insertContent(" STRAY").run();
+    });
+    expect(getEditor().getText()).toBe("PAGE A STRAY");
+
+    rerender(React.createElement(Harness, { initialValue: pageA }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getEditor().getText()).toBe("PAGE A");
+    expect(lastContentResetFailed(getEditor())).toBe(false);
+    consoleError.mockRestore();
   });
 });

--- a/app/javascript/components/RichTextEditor.test.ts
+++ b/app/javascript/components/RichTextEditor.test.ts
@@ -218,10 +218,8 @@ describe("useRichTextEditor", () => {
     expect(getEditor().getText()).toBe("PAGE B");
   });
 
-  // The deferred reset runs inside queueMicrotask, which swallows exceptions.
-  // A doc the schema refuses used to die there silently: the PREVIOUS content
-  // stayed mounted while the UI claimed the new selection, and callers had no
-  // signal to block writes (gumroad-private#2023's display symptom).
+  // queueMicrotask swallows exceptions, so a refused doc used to leave the
+  // previous content mounted with no signal to block writes.
   it("keeps the previous doc, records the failure, and recovers when a reset throws", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     let editor: Editor | null = null;
@@ -260,8 +258,7 @@ describe("useRichTextEditor", () => {
     consoleError.mockRestore();
   });
 
-  // The strict content check must not regress HTML consumers: stored product
-  // HTML legitimately contains tags with no schema rule (e.g. span), and the
+  // Stored product HTML legitimately contains tags with no schema rule; the
   // lenient DOM parse keeps their supported children.
   it("keeps parsing HTML strings leniently when they contain unsupported tags", async () => {
     let editor: Editor | null = null;
@@ -285,10 +282,8 @@ describe("useRichTextEditor", () => {
     expect(lastContentResetFailed(getEditor())).toBe(false);
   });
 
-  // useEditor's own creation path mounts an EMPTY doc for malformed initial
-  // content without any signal. The reset effect re-runs when the editor
-  // materializes, so the very first content also goes through the strict
-  // check and records the failure.
+  // useEditor mounts an EMPTY doc for malformed initial content; the strict
+  // check must also cover the first content once the editor materializes.
   it("records the failure when the INITIAL content is malformed", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     let editor: Editor | null = null;
@@ -309,14 +304,12 @@ describe("useRichTextEditor", () => {
     consoleError.mockRestore();
   });
 
-  // Edits typed while a failed selection was displayed land on the STALE
-  // mounted doc. Returning to the previous content must reset the editor from
-  // state even though that content's identity never changed — otherwise the
-  // stray edits would be attributed to it on the next update or blur.
+  // Returning to the previous content must reset even when its identity never
+  // changed, or stray edits typed over the stale doc get attributed to it.
   it("discards edits made over a stale doc when returning to the last valid content", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     let editor: Editor | null = null;
-    const Harness = ({ initialValue }: { initialValue: object }) => {
+    const Harness = ({ initialValue }: { initialValue: object | string }) => {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- exercising the hook's public Content type
       editor = useRichTextEditor({ initialValue: initialValue as never });
       return null;
@@ -326,9 +319,8 @@ describe("useRichTextEditor", () => {
       return editor;
     };
 
-    // A STRING content: the processed value compares equal across recomputes,
-    // which is the one path where the identity check alone would skip the
-    // recovery reset (object contents get a fresh identity from the memo).
+    // String content compares by value across recomputes — the one path where
+    // the identity check alone would skip the recovery reset.
     const pageA = "<p>PAGE A</p>";
     const poison = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text" }] }] };
     const { rerender } = render(React.createElement(Harness, { initialValue: pageA }));
@@ -342,7 +334,6 @@ describe("useRichTextEditor", () => {
       await Promise.resolve();
     });
     expect(lastContentResetFailed(getEditor())).toBe(true);
-    // The seller types into what LOOKS like the new page but is the stale doc.
     act(() => {
       getEditor().chain().focus("end").insertContent(" STRAY").run();
     });

--- a/app/javascript/components/RichTextEditor.tsx
+++ b/app/javascript/components/RichTextEditor.tsx
@@ -402,33 +402,24 @@ export const useRichTextEditor = ({
 
   React.useEffect(() => editor?.setOptions({ editable }), [editable]);
 
-  // What useEditor itself applied at creation. The effect below also fires
-  // when the editor materializes (`editor` dep); replaying the same content
-  // there would discard anything typed since creation, so that run validates
-  // without replacing the state.
+  // What useEditor itself applied at creation: when the effect fires because
+  // the editor materialized (not because content changed), it validates
+  // without replacing the state — a replay would discard edits typed since.
   const appliedContentRef = React.useRef(content);
-  // `editor` is a dependency on purpose: with immediatelyRender: false it is
-  // null on the first render, and useEditor's own creation path silently
-  // mounts an EMPTY doc for malformed initial content — the strict check must
-  // also cover the very first content once the editor exists.
   React.useEffect(
     () =>
       queueMicrotask(() => {
         if (!editor) return;
         try {
-          // Strict only for JSON docs: without errorOnInvalidContent an
-          // unparseable doc silently mounts EMPTY, and the next update/blur
-          // serializes that emptiness over the real stored content. HTML
-          // strings keep the lenient parse — stored product HTML legitimately
-          // contains tags with no schema rule, and the DOM parser degrades by
-          // keeping their supported children.
+          // Strict for JSON docs only: an unparseable doc otherwise mounts
+          // EMPTY and the next update/blur persists that emptiness. HTML
+          // strings keep the lenient parse (stored HTML legitimately contains
+          // tags with no schema rule).
           const doc = createDocument(content, editor.state.schema, undefined, {
             errorOnInvalidContent: typeof content !== "string",
           });
-          // Also reset when RECOVERING from a failure with unchanged content:
-          // the mounted doc may carry edits typed while the failed selection
-          // was displayed, and skipping the reset would let a later update
-          // attribute them to this content.
+          // Also reset when recovering from a failure with unchanged content:
+          // the mounted doc may carry edits typed over the stale selection.
           if (appliedContentRef.current !== content || contentResetFailures.has(editor)) {
             // discard any history from before content was reset
             editor.view.updateState(EditorState.create({ doc, schema: editor.schema, plugins: editor.state.plugins }));
@@ -436,10 +427,8 @@ export const useRichTextEditor = ({
           appliedContentRef.current = content;
           contentResetFailures.delete(editor);
         } catch (error) {
-          // The previous (or empty initial) doc stays mounted while the UI
-          // claims the new selection. Record the failure so callers that gate
-          // writes on the mounted doc (ContentTab's editorContentPageIdRef)
-          // keep them blocked.
+          // The wrong doc stays mounted; record the failure so callers that
+          // gate writes on the mounted doc keep them blocked.
           contentResetFailures.set(editor, error);
           // eslint-disable-next-line no-console
           console.error("RichTextEditor: content reset failed", error);

--- a/app/javascript/components/RichTextEditor.tsx
+++ b/app/javascript/components/RichTextEditor.tsx
@@ -402,23 +402,60 @@ export const useRichTextEditor = ({
 
   React.useEffect(() => editor?.setOptions({ editable }), [editable]);
 
+  // What useEditor itself applied at creation. The effect below also fires
+  // when the editor materializes (`editor` dep); replaying the same content
+  // there would discard anything typed since creation, so that run validates
+  // without replacing the state.
+  const appliedContentRef = React.useRef(content);
+  // `editor` is a dependency on purpose: with immediatelyRender: false it is
+  // null on the first render, and useEditor's own creation path silently
+  // mounts an EMPTY doc for malformed initial content — the strict check must
+  // also cover the very first content once the editor exists.
   React.useEffect(
     () =>
       queueMicrotask(() => {
-        // discard any history from before content was reset
-        editor?.view.updateState(
-          EditorState.create({
-            doc: createDocument(content, editor.state.schema),
-            schema: editor.schema,
-            plugins: editor.state.plugins,
-          }),
-        );
+        if (!editor) return;
+        try {
+          // Strict only for JSON docs: without errorOnInvalidContent an
+          // unparseable doc silently mounts EMPTY, and the next update/blur
+          // serializes that emptiness over the real stored content. HTML
+          // strings keep the lenient parse — stored product HTML legitimately
+          // contains tags with no schema rule, and the DOM parser degrades by
+          // keeping their supported children.
+          const doc = createDocument(content, editor.state.schema, undefined, {
+            errorOnInvalidContent: typeof content !== "string",
+          });
+          // Also reset when RECOVERING from a failure with unchanged content:
+          // the mounted doc may carry edits typed while the failed selection
+          // was displayed, and skipping the reset would let a later update
+          // attribute them to this content.
+          if (appliedContentRef.current !== content || contentResetFailures.has(editor)) {
+            // discard any history from before content was reset
+            editor.view.updateState(EditorState.create({ doc, schema: editor.schema, plugins: editor.state.plugins }));
+          }
+          appliedContentRef.current = content;
+          contentResetFailures.delete(editor);
+        } catch (error) {
+          // The previous (or empty initial) doc stays mounted while the UI
+          // claims the new selection. Record the failure so callers that gate
+          // writes on the mounted doc (ContentTab's editorContentPageIdRef)
+          // keep them blocked.
+          contentResetFailures.set(editor, error);
+          // eslint-disable-next-line no-console
+          console.error("RichTextEditor: content reset failed", error);
+        }
       }),
-    [content],
+    [content, editor],
   );
 
   return editor ?? null;
 };
+
+// Editors whose most recent content reset threw. queueMicrotask swallows
+// exceptions, so this is the only signal that the mounted doc does not match
+// the content the caller last passed in.
+const contentResetFailures = new WeakMap<Editor, unknown>();
+export const lastContentResetFailed = (editor: Editor) => contentResetFailures.has(editor);
 
 export const RichTextEditorToolbar = ({
   editor,

--- a/app/javascript/pages/Products/Edit.test.tsx
+++ b/app/javascript/pages/Products/Edit.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import ProductEditInertiaPage from "$app/pages/Products/Edit";
+
+Object.assign(globalThis, { SSR: false });
+
+// One entry per LazyProductEditPage INSTANCE lifetime. The editor seeds its
+// state from props once (useState(props.product)), so navigating between
+// products must remount it — the key by product id is what guarantees that.
+const mounts = vi.hoisted((): string[] => []);
+vi.mock("$app/components/ProductEdit/load", () => ({
+  LazyProductEditPage: ({ id }: { id: string }) => {
+    React.useEffect(() => {
+      mounts.push(id);
+    }, []);
+    return null;
+  },
+}));
+
+const pageProps = vi.hoisted((): { current: Record<string, unknown> } => ({ current: {} }));
+vi.mock("@inertiajs/react", () => ({
+  usePage: () => ({ props: pageProps.current }),
+}));
+
+vi.mock("$app/hooks/useDropbox", () => ({ useDropbox: () => {} }));
+
+const makePageProps = (id: string): Record<string, unknown> => ({
+  dropbox_api_key: null,
+  id,
+  unique_permalink: `permalink-${id}`,
+  thumbnail: null,
+  refund_policies: [],
+  currency_type: "usd",
+  is_tiered_membership: false,
+  is_listed_on_discover: false,
+  is_physical: false,
+  profile_sections: [],
+  taxonomies: [],
+  taxonomy_attributes: [],
+  earliest_membership_price_change_date: "2026-08-10T00:00:00.000Z",
+  custom_domain_verification_status: null,
+  sales_count_for_inventory: 0,
+  successful_sales_count: 0,
+  ratings: { count: 0, average: 0, percentages: [0, 0, 0, 0, 0] },
+  seller: { id: "seller-id", name: "Seller", avatar_url: "", profile_url: "", is_verified: false },
+  existing_files: [],
+  aws_key: "",
+  s3_url: "",
+  available_countries: [],
+  google_client_id: "",
+  seller_refund_policy_enabled: false,
+  seller_refund_policy: { title: "", fine_print: null },
+  cancellation_discounts_enabled: false,
+  receipt_email_from: "seller@example.com",
+  price_checker_enabled: false,
+  custom_html_pages_enabled: false,
+  custom_html_store_hostnames: [],
+  custom_html_global_nav_hosts: [],
+  custom_html_global_nav_paths: [],
+  ai_generated: false,
+  product: {
+    name: `Product ${id}`,
+    description: "",
+    custom_permalink: null,
+    price_cents: 100,
+    suggested_price_cents: null,
+    customizable_price: false,
+    eligible_for_installment_plans: false,
+    allow_installment_plan: false,
+    installment_plan: null,
+    custom_button_text_option: null,
+    custom_summary: null,
+    custom_html: null,
+    custom_view_content_button_text: null,
+    custom_view_content_button_text_max_length: 20,
+    custom_receipt_text: null,
+    custom_receipt_text_max_length: 1_000,
+    custom_attributes: [],
+    taxonomy_attribute_values: {},
+    inferred_taxonomy_attribute_values: {},
+    file_attributes: [],
+    max_purchase_count: null,
+    quantity_enabled: false,
+    can_enable_quantity: true,
+    should_show_sales_count: false,
+    hide_sold_out_variants: false,
+    is_epublication: false,
+    product_refund_policy_enabled: false,
+    refund_policy: {
+      allowed_refund_periods_in_days: [],
+      max_refund_period_in_days: 30,
+      fine_print_enabled: false,
+      fine_print: null,
+      title: "",
+    },
+    is_published: false,
+    free_trial_enabled: false,
+    free_trial_duration_amount: null,
+    free_trial_duration_unit: null,
+    should_include_last_post: false,
+    should_show_all_posts: false,
+    block_access_after_membership_cancellation: false,
+    duration_in_months: null,
+    subscription_duration: null,
+    integrations: { discord: null, circle: null, google_calendar: null },
+    covers: [],
+    availabilities: [],
+    section_ids: [],
+    taxonomy_id: null,
+    tags: [],
+    display_product_reviews: false,
+    is_adult: false,
+    discover_fee_per_thousand: 0,
+    shipping_destinations: [],
+    custom_domain: "",
+    collaborating_user: null,
+    native_type: "digital",
+    files: [],
+    rich_content: [],
+    variants: [],
+    has_same_rich_content_for_all_variants: false,
+    is_multiseat_license: false,
+    call_limitation_info: null,
+    require_shipping: false,
+    cancellation_discount: null,
+    default_offer_code: null,
+    public_files: [],
+    community_chat_enabled: false,
+    confirmed_removed_variant_ids: [],
+    confirmed_removed_rich_content_ids: [],
+  },
+});
+
+beforeEach(() => {
+  mounts.length = 0;
+});
+
+afterEach(cleanup);
+
+it("remounts the editor when the Inertia visit switches products, and only then", async () => {
+  pageProps.current = makePageProps("product-a");
+  const { rerender } = render(<ProductEditInertiaPage />);
+  await act(async () => {});
+  expect(mounts).toEqual(["product-a"]);
+
+  // Same product, refreshed props: the editor instance (and its state) stays.
+  pageProps.current = makePageProps("product-a");
+  rerender(<ProductEditInertiaPage />);
+  await act(async () => {});
+  expect(mounts).toEqual(["product-a"]);
+
+  // Different product: the editor must remount so its state reseeds from the
+  // new product's props.
+  pageProps.current = makePageProps("product-b");
+  rerender(<ProductEditInertiaPage />);
+  await act(async () => {});
+  expect(mounts).toEqual(["product-a", "product-b"]);
+});

--- a/app/javascript/pages/Products/Edit.tsx
+++ b/app/javascript/pages/Products/Edit.tsx
@@ -29,7 +29,11 @@ export default function ProductEditInertiaPage() {
   return (
     <ProductEditBoundary>
       <React.Suspense fallback={<ProductEditLoadingSkeleton title={editProps.product.name} />}>
-        <LazyProductEditPage {...editProps} />
+        {/* Keyed by product: Inertia keeps this page component mounted across
+            client-side visits, and the editor seeds its state from props once
+            (useState(props.product)) — without the key, product A's editor
+            state survives into product B's URL. */}
+        <LazyProductEditPage key={editProps.id} {...editProps} />
       </React.Suspense>
     </ProductEditBoundary>
   );

--- a/spec/requests/products/edit/malformed_rich_content_spec.rb
+++ b/spec/requests/products/edit/malformed_rich_content_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authorize_called"
+
+# End-to-end leg of gumroad-private#2023's display hardening: a stored page
+# whose doc the editor schema refuses must degrade to a blocked page with an
+# explicit error, never crash the tab or let edits land on the wrong doc. The
+# sub-microtask guard windows themselves are pinned by component tests
+# (ContentTab/index.test.tsx); this covers the presenter-to-editor seam those
+# tests stub.
+describe("Product Edit content tab with a malformed stored page", type: :system, js: true) do
+  include ProductEditPageHelpers
+
+  let(:seller) { create(:named_seller) }
+
+  include_context "with switching account to user as admin for seller"
+
+  it "renders the tab, blocks the malformed page, and keeps the valid page editable" do
+    product = create(:product, user: seller)
+    create(
+      :rich_content,
+      entity: product,
+      title: "Good page",
+      description: [{ "type" => "paragraph", "content" => [{ "type" => "text", "text" => "Readable content" }] }]
+    )
+    create(
+      :rich_content,
+      entity: product,
+      title: "Broken page",
+      # A text node without text: ProseMirror's nodeFromJSON refuses it.
+      description: [{ "type" => "paragraph", "content" => [{ "type" => "text" }] }]
+    )
+
+    visit "#{edit_link_path(product.unique_permalink)}/content"
+
+    # The tab renders both entries; the malformed page does not take it down.
+    expect(page).to have_selector("[role='tab']", text: "Good page")
+    expect(page).to have_selector("[role='tab']", text: "Broken page")
+    expect(page).to have_text("Readable content")
+
+    find("[role='tab']", text: "Broken page").click
+    expect(page).to have_alert(text: "This page's content could not be displayed. Reload the page before editing it.")
+
+    find("[role='tab']", text: "Good page").click
+    expect(page).to have_text("Readable content")
+  end
+end


### PR DESCRIPTION
## What

Hardens the product editor's display path against content documents the schema cannot parse, and stops editor state from leaking across Inertia visits. Four changes:

- `useRichTextEditor`'s deferred content reset now passes `errorOnInvalidContent`, catches the failure, records it (exposed as `lastContentResetFailed`), and logs it. Without this, TipTap silently mounts an EMPTY document for unparseable content — and the next blur serializes that emptiness over the real stored page.
- `ContentTab` flips its `editorContentPageIdRef` write guard only when the paired reset succeeded. On failure the previous page's doc stays mounted, writes stay blocked, and the seller gets an explicit "reload before editing" error instead of a silent wrong render.
- `ContentTab`'s two render-time parses of stored page docs (`pageIcons`, `findPageWithNode`) degrade to fallbacks instead of crashing the whole tab for one bad page.
- `ContentTab` keys the mounted-doc identity (the reset memo, the write-guard ref, and its flip) on scope + page id instead of the raw page id: two variants' pages can share a raw id before save reconciliation, and the raw-id key made a switch between them a no-op — the first variant's doc stayed mounted and writable under the second variant's page.
- `pages/Products/Edit.tsx` keys `LazyProductEditPage` by product id. Inertia keeps the page component mounted across client-side visits and the editor seeds its state from props once, so without the key one product's editor state can survive into another product's URL.

## Why

gumroad-private#2023's investigation traced the seller-facing display symptom ("the dropdown loads the wrong tier's content", pages rendering empty) to this chain: a page doc that fails to mount leaves the editor showing the previous tier's content or an empty pane; the #7147 write guard's ref then flips anyway because its ordering assumption does not survive a swallowed exception; from there, an ordinary blur can misfile or wipe content. Every failure in this chain was silent. These changes make each step either survive or fail loudly, and they close the state-carryover class the keyless Inertia page allowed.

## Before / After

Before: selecting a page whose stored doc the schema refuses either crashes the whole Content tab (render-time parse) or silently shows the previous page's content — or an empty editor whose first blur overwrites the real content.

After: the tab renders, the affected page keeps its previous doc on screen with writes blocked, an error alert tells the seller to reload, and the failure is logged.

No pixel changes on the healthy path. 

## Test Results

- `npx vitest run app/javascript/components/RichTextEditor.test.ts app/javascript/components/ProductEdit/ContentTab/index.test.tsx` — 27 passed. Twelve new tests: the hook keeps the previous doc, records the failure, and recovers on the next valid reset; HTML strings keep the lenient parse; a malformed INITIAL doc records the failure once the editor materializes; ContentTab blocks writes and alerts for an unparseable page both when switching to it and when it is the first page mounted; returning to the last valid content discards edits typed over a stale doc; same-raw-id pages across variants re-mount correctly and scope their writes, including the malformed case; the raw-JSON fallback keeps single-instance node checks fail-closed; switch-back after a failed reset keeps writes blocked until the recovery reset lands; the switch window to an empty variant cannot copy the stale doc into it; the page-title rename editor resets across a variant switch between same-id pages.
- `npx vitest run app/javascript/pages/Products/Edit.test.tsx` — pins the product-keyed remount: an Inertia visit to the same product keeps the editor instance; a visit to a different product remounts it so state reseeds from the new props.
- `bundle exec rspec spec/requests/products/edit/malformed_rich_content_spec.rb` — real-browser system spec for the presenter-to-editor seam the component tests stub: a malformed stored page renders as a blocked entry with the explicit error, the tab survives, and the valid page stays editable. Fails against main by construction (pre-fix, the tab render crashes on that data).
- Mutation checks: disabling `errorOnInvalidContent` fails the hook test; making the ref flip unconditional fails the ContentTab test; dropping the failure-aware recovery reset fails the stale-edit test; reverting the scoped identity key fails both same-id tests; removing the synchronous guard invalidation fails the switch-back test; collapsing the pending sentinel into undefined fails the empty-variant test; reverting the scoped PageTab key plus the rename reset fails the rename test; removing the key in Edit.tsx fails the remount test.
- Structured review ran seven rounds. Round 1 found two P1s (strict validation regressed HTML-string consumers; the initial mount bypassed the failure tracking). Round 2 found a P1 (recovery to identity-equal content skipped the reset, letting stale edits persist) and a P2 (the parse fallback answered fail-open for single-instance node checks). Round 3 found a P1 (identity keyed on the raw page id misses same-id pages across variants). Round 4 found a P1 (switch-back after a failed reset reopened writes before the recovery reset). Round 5 found a P1 (the invalidated guard state collided with the valid no-page selection, a hole that predates this PR). Round 6 found a P1 (the page-title editor kept raw-id identity, the same class as round 3). All are fixed and pinned by tests.
- `npx eslint` on all five touched files — clean. `npm run typecheck` — no errors in touched files; the 3 remaining errors are pre-existing on main (missing route helpers).
- Structured review: autoreview (codex engine), seven rounds total — final round clean, no accepted or actionable findings; "patch is correct (0.91)".
- `bin/test-confidence`: 99% reached, "Safe to commit" (run after every round).

---

AI disclosure: authored by Claude Fable 5 (Claude Code). Prompts: investigate gumroad-private#2023 and its fix history to root cause; then "create a draft pr with the second change about display hardening. run /autoreview before pushing. assign draft pr to me". This is part 2 of the investigation's fix plan (part 1 was #7206).

