### PR TITLE
Block saves that would present lost content as deletions (gp#2023)

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
@@ -458,3 +458,53 @@ it("resets the rename editor across a variant switch between same-id pages", asy
   await act(async () => {});
   expect(document.querySelector('[role="tab"] .tiptap')?.textContent).toBe("Beta");
 });
+
+// Deleting a page whose STORED id another page still carries must not record
+// deletion intent: the shared id names the surviving page's row, and sending
+// it would let the save delete content the seller kept (gumroad-private#2023).
+// A unique id records as before.
+it("skips recording a deleted page's id while another page still carries it", async () => {
+  const impostor = makePage("shared-stored-id", "IMPOSTOR", "Impostor");
+  const uniquePage = makePage("unique-id", "UNIQUE", "Unique");
+  const realPage = makePage("shared-stored-id", "REAL", "Real");
+  const paidVariant: VariantFixture = { id: "variant-paid", name: "Paid", rich_content: [impostor, uniquePage] };
+  const freeVariant: VariantFixture = { id: "variant-free", name: "Free", rich_content: [realPage] };
+  const product = buildProduct([paidVariant, freeVariant]);
+
+  context.product = product;
+  context.updateProduct = (update: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the update union for the fixture
+    if (typeof update === "function") (update as (p: Product) => void)(product);
+    else Object.assign(product, update);
+  };
+
+  const { getByText } = render(<ContentTabContent selectedVariantId="variant-paid" />);
+  await act(async () => {});
+
+  const deletePageAt = async (rowIndex: number) => {
+    const triggers = document.querySelectorAll('[role="tab"] button');
+    act(() => {
+      (triggers[rowIndex] instanceof HTMLElement ? triggers[rowIndex] : undefined)?.click();
+    });
+    await act(async () => {});
+    act(() => {
+      getByText("Delete").click();
+    });
+    await act(async () => {});
+    act(() => {
+      getByText("Yes, delete").click();
+    });
+    await act(async () => {});
+  };
+
+  // The impostor shares its stored id with the real page in the other
+  // variant: deleting it must record nothing.
+  await deletePageAt(0);
+  expect(product.confirmed_removed_rich_content_ids ?? []).toEqual([]);
+  expect(paidVariant.rich_content.map(({ id }) => id)).toEqual(["unique-id"]);
+
+  // The unique page records normally.
+  await deletePageAt(0);
+  expect(product.confirmed_removed_rich_content_ids).toEqual(["unique-id"]);
+  expect(paidVariant.rich_content).toEqual([]);
+});

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -235,12 +235,26 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
     setPages(reorderRowsPreservingMembership(reportedPages, pagesRef.current));
   // Records that the seller explicitly deleted these pages, so the server-side
   // wipe guard allows removing them even though they may still have content.
+  // A STORED id another surviving page still carries is skipped: raw ids can
+  // repeat across scopes, and sending a shared stored id names the surviving
+  // page's row for deletion. Newly added pages' client ids record regardless
+  // (inert until reconciliation resolves them, which drops ambiguous cases).
   const confirmPageRemovals = (removedPages: Page[]) => {
     if (removedPages.length === 0) return;
     updateProduct((product) => {
+      const removed = new Set<Page>(removedPages);
+      const survivingPageIds = new Set(
+        [...product.rich_content, ...product.variants.flatMap((variant) => variant.rich_content)]
+          .filter((page) => !removed.has(page))
+          .map(({ id }) => id),
+      );
+      const removableIds = removedPages
+        .filter((page) => page.newlyAdded || !survivingPageIds.has(page.id))
+        .map(({ id }) => id);
+      if (removableIds.length === 0) return;
       product.confirmed_removed_rich_content_ids = [
         ...(product.confirmed_removed_rich_content_ids ?? []),
-        ...removedPages.map(({ id }) => id),
+        ...removableIds,
       ];
     });
   };

--- a/app/javascript/components/ProductEdit/ProductTab/DurationsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/DurationsEditor.tsx
@@ -40,11 +40,18 @@ export const DurationsEditor = ({
   // server-side wipe guard allows deleting it even if it still has content.
   const confirmRemoval = (duration: Duration) => {
     updateProduct((product) => {
-      // Recorded even for a newly added duration: an in-flight save may be
-      // creating it right now, and reconciliation remaps the recorded id to
-      // the canonical one. An id the server never learns is inert.
+      // Recorded even when newly added: an in-flight save may be creating it,
+      // and reconciliation remaps the id; unknown ids are inert server-side.
       product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), duration.id];
-      confirmRemovedVariantPageDeletions(product, duration.rich_content);
+      const survivingPageIds = new Set(
+        [
+          ...product.rich_content,
+          ...product.variants
+            .filter((existing) => existing.id !== duration.id)
+            .flatMap((existing) => existing.rich_content),
+        ].map(({ id }) => id),
+      );
+      confirmRemovedVariantPageDeletions(product, duration.rich_content, survivingPageIds);
     });
     onChange(durations.filter(({ id }) => id !== duration.id));
   };

--- a/app/javascript/components/ProductEdit/ProductTab/DurationsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/DurationsEditor.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown, ChevronUp, Clock, Plus, Trash } from "@boxicons/react";
 import * as React from "react";
 
-import { confirmRichContentMoveSourceDeletions, reorderPreservingMembership } from "$app/data/product_save_contract";
+import { confirmRemovedVariantPageDeletions, reorderPreservingMembership } from "$app/data/product_save_contract";
 
 import { Button } from "$app/components/Button";
 import { Modal } from "$app/components/Modal";
@@ -40,10 +40,11 @@ export const DurationsEditor = ({
   // server-side wipe guard allows deleting it even if it still has content.
   const confirmRemoval = (duration: Duration) => {
     updateProduct((product) => {
-      if (!duration.newlyAdded) {
-        product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), duration.id];
-      }
-      confirmRichContentMoveSourceDeletions(product, duration.rich_content);
+      // Recorded even for a newly added duration: an in-flight save may be
+      // creating it right now, and reconciliation remaps the recorded id to
+      // the canonical one. An id the server never learns is inert.
+      product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), duration.id];
+      confirmRemovedVariantPageDeletions(product, duration.rich_content);
     });
     onChange(durations.filter(({ id }) => id !== duration.id));
   };

--- a/app/javascript/components/ProductEdit/ProductTab/SuggestedAmountsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/SuggestedAmountsEditor.tsx
@@ -1,7 +1,7 @@
 import { Plus, Trash } from "@boxicons/react";
 import * as React from "react";
 
-import { confirmRichContentMoveSourceDeletions } from "$app/data/product_save_contract";
+import { confirmRemovedVariantPageDeletions } from "$app/data/product_save_contract";
 
 import { Button } from "$app/components/Button";
 import { PriceInput } from "$app/components/PriceInput";
@@ -28,10 +28,11 @@ export const SuggestedAmountsEditor = ({
   // custom price, which the guard treats as configuration worth protecting.
   const removeVersion = (version: Version) => {
     updateProduct((product) => {
-      if (!version.newlyAdded) {
-        product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), version.id];
-      }
-      confirmRichContentMoveSourceDeletions(product, version.rich_content);
+      // Recorded even for a newly added version: an in-flight save may be
+      // creating it right now, and reconciliation remaps the recorded id to
+      // the canonical one. An id the server never learns is inert.
+      product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), version.id];
+      confirmRemovedVariantPageDeletions(product, version.rich_content);
     });
     onChange(versions.filter(({ id }) => id !== version.id));
   };

--- a/app/javascript/components/ProductEdit/ProductTab/SuggestedAmountsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/SuggestedAmountsEditor.tsx
@@ -28,11 +28,18 @@ export const SuggestedAmountsEditor = ({
   // custom price, which the guard treats as configuration worth protecting.
   const removeVersion = (version: Version) => {
     updateProduct((product) => {
-      // Recorded even for a newly added version: an in-flight save may be
-      // creating it right now, and reconciliation remaps the recorded id to
-      // the canonical one. An id the server never learns is inert.
+      // Recorded even when newly added: an in-flight save may be creating it,
+      // and reconciliation remaps the id; unknown ids are inert server-side.
       product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), version.id];
-      confirmRemovedVariantPageDeletions(product, version.rich_content);
+      const survivingPageIds = new Set(
+        [
+          ...product.rich_content,
+          ...product.variants
+            .filter((existing) => existing.id !== version.id)
+            .flatMap((existing) => existing.rich_content),
+        ].map(({ id }) => id),
+      );
+      confirmRemovedVariantPageDeletions(product, version.rich_content, survivingPageIds);
     });
     onChange(versions.filter(({ id }) => id !== version.id));
   };

--- a/app/javascript/components/ProductEdit/ProductTab/TiersEditor.test.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/TiersEditor.test.tsx
@@ -21,6 +21,8 @@ const productEditContext = vi.hoisted(() => ({
     vi.fn<
       (
         update: (product: {
+          rich_content: { id: string }[];
+          variants: { id: string; rich_content: { id: string }[] }[];
           confirmed_removed_variant_ids?: string[];
           confirmed_removed_rich_content_ids?: string[];
         }) => void,
@@ -99,7 +101,12 @@ it("records a newly added tier's id and its page ids when the seller removes it"
 
   const record = productEditContext.updateProduct.mock.lastCall?.[0];
   expect(record).toBeTypeOf("function");
-  const recorded: { confirmed_removed_variant_ids?: string[]; confirmed_removed_rich_content_ids?: string[] } = {};
+  const recorded: {
+    rich_content: { id: string }[];
+    variants: { id: string; rich_content: { id: string }[] }[];
+    confirmed_removed_variant_ids?: string[];
+    confirmed_removed_rich_content_ids?: string[];
+  } = { rich_content: [], variants: [] };
   record?.(recorded);
   expect(recorded.confirmed_removed_variant_ids).toEqual(["local-new-tier"]);
   expect(recorded.confirmed_removed_rich_content_ids).toEqual(["new-tier-page"]);

--- a/app/javascript/components/ProductEdit/ProductTab/TiersEditor.test.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/TiersEditor.test.tsx
@@ -17,7 +17,15 @@ const productEditContext = vi.hoisted(() => ({
   currencyType: "usd",
   setCurrencyType: vi.fn(),
   uniquePermalink: "membership",
-  updateProduct: vi.fn(),
+  updateProduct:
+    vi.fn<
+      (
+        update: (product: {
+          confirmed_removed_variant_ids?: string[];
+          confirmed_removed_rich_content_ids?: string[];
+        }) => void,
+      ) => void
+    >(),
   earliestMembershipPriceChangeDate: new Date("2026-08-12T00:00:00.000Z"),
 }));
 
@@ -65,6 +73,38 @@ const tier: Tier = {
     every_two_years: { enabled: false },
   },
 };
+
+// A newly added tier can be mid-creation by an in-flight save when the seller
+// removes it, so its client id must be recorded like any other: the response
+// remaps it to the canonical id, and an id the server never learns is inert.
+// Skipping it would leave the created tier (and its pages) with no recorded
+// deletion intent, and the save-time missing-content guard would block the
+// seller's own deletion behind a reload.
+it("records a newly added tier's id and its page ids when the seller removes it", () => {
+  const onChange = vi.fn<(tiers: Tier[]) => void>();
+  const newTier: Tier = {
+    ...tier,
+    id: "local-new-tier",
+    newlyAdded: true,
+    rich_content: [{ id: "new-tier-page", title: "Lesson", description: {}, updated_at: "2026-01-01T00:00:00Z" }],
+  };
+  const view = render(
+    <CurrentSellerProvider value={null}>
+      <TiersEditor tiers={[newTier]} onChange={onChange} />
+    </CurrentSellerProvider>,
+  );
+
+  fireEvent.click(view.getByLabelText("Remove"));
+  fireEvent.click(view.getByText("Yes, remove"));
+
+  const record = productEditContext.updateProduct.mock.lastCall?.[0];
+  expect(record).toBeTypeOf("function");
+  const recorded: { confirmed_removed_variant_ids?: string[]; confirmed_removed_rich_content_ids?: string[] } = {};
+  record?.(recorded);
+  expect(recorded.confirmed_removed_variant_ids).toEqual(["local-new-tier"]);
+  expect(recorded.confirmed_removed_rich_content_ids).toEqual(["new-tier-page"]);
+  expect(onChange).toHaveBeenCalledWith([]);
+});
 
 it("keeps the membership price-change date stable across rerenders", () => {
   const onChange = vi.fn<(tiers: Tier[]) => void>();

--- a/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
@@ -60,11 +60,18 @@ export const TiersEditor = ({ tiers, onChange }: { tiers: Tier[]; onChange: (tie
   // server-side wipe guard allows deleting it even if it still has content.
   const confirmRemoval = (tier: Tier) => {
     updateProduct((product) => {
-      // Recorded even for a newly added tier: an in-flight save may be
-      // creating it right now, and reconciliation remaps the recorded id to
-      // the canonical one. An id the server never learns is inert.
+      // Recorded even when newly added: an in-flight save may be creating it,
+      // and reconciliation remaps the id; unknown ids are inert server-side.
       product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), tier.id];
-      confirmRemovedVariantPageDeletions(product, tier.rich_content);
+      const survivingPageIds = new Set(
+        [
+          ...product.rich_content,
+          ...product.variants
+            .filter((existing) => existing.id !== tier.id)
+            .flatMap((existing) => existing.rich_content),
+        ].map(({ id }) => id),
+      );
+      confirmRemovedVariantPageDeletions(product, tier.rich_content, survivingPageIds);
     });
     onChange(tiers.filter(({ id }) => id !== tier.id));
   };

--- a/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/TiersEditor.tsx
@@ -4,7 +4,7 @@ import { format } from "date-fns";
 import * as React from "react";
 
 import { sendSamplePriceChangeEmail } from "$app/data/membership_tiers";
-import { confirmRichContentMoveSourceDeletions, reorderPreservingMembership } from "$app/data/product_save_contract";
+import { confirmRemovedVariantPageDeletions, reorderPreservingMembership } from "$app/data/product_save_contract";
 import { CurrencyCode, currencyCodeList, getIsSingleUnitCurrency } from "$app/utils/currency";
 import { priceCentsToUnit } from "$app/utils/price";
 import {
@@ -60,10 +60,11 @@ export const TiersEditor = ({ tiers, onChange }: { tiers: Tier[]; onChange: (tie
   // server-side wipe guard allows deleting it even if it still has content.
   const confirmRemoval = (tier: Tier) => {
     updateProduct((product) => {
-      if (!tier.newlyAdded) {
-        product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), tier.id];
-      }
-      confirmRichContentMoveSourceDeletions(product, tier.rich_content);
+      // Recorded even for a newly added tier: an in-flight save may be
+      // creating it right now, and reconciliation remaps the recorded id to
+      // the canonical one. An id the server never learns is inert.
+      product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), tier.id];
+      confirmRemovedVariantPageDeletions(product, tier.rich_content);
     });
     onChange(tiers.filter(({ id }) => id !== tier.id));
   };

--- a/app/javascript/components/ProductEdit/ProductTab/VersionsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/VersionsEditor.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown, ChevronUp, LayersAlt, Plus, Trash } from "@boxicons/react";
 import * as React from "react";
 
-import { confirmRichContentMoveSourceDeletions, reorderPreservingMembership } from "$app/data/product_save_contract";
+import { confirmRemovedVariantPageDeletions, reorderPreservingMembership } from "$app/data/product_save_contract";
 
 import { Button } from "$app/components/Button";
 import { Modal } from "$app/components/Modal";
@@ -41,10 +41,11 @@ export const VersionsEditor = ({
   // server-side wipe guard allows deleting it even if it still has content.
   const confirmRemoval = (version: Version) => {
     updateProduct((product) => {
-      if (!version.newlyAdded) {
-        product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), version.id];
-      }
-      confirmRichContentMoveSourceDeletions(product, version.rich_content);
+      // Recorded even for a newly added version: an in-flight save may be
+      // creating it right now, and reconciliation remaps the recorded id to
+      // the canonical one. An id the server never learns is inert.
+      product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), version.id];
+      confirmRemovedVariantPageDeletions(product, version.rich_content);
     });
     onChange(versions.filter(({ id }) => id !== version.id));
   };

--- a/app/javascript/components/ProductEdit/ProductTab/VersionsEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/VersionsEditor.tsx
@@ -41,11 +41,18 @@ export const VersionsEditor = ({
   // server-side wipe guard allows deleting it even if it still has content.
   const confirmRemoval = (version: Version) => {
     updateProduct((product) => {
-      // Recorded even for a newly added version: an in-flight save may be
-      // creating it right now, and reconciliation remaps the recorded id to
-      // the canonical one. An id the server never learns is inert.
+      // Recorded even when newly added: an in-flight save may be creating it,
+      // and reconciliation remaps the id; unknown ids are inert server-side.
       product.confirmed_removed_variant_ids = [...(product.confirmed_removed_variant_ids ?? []), version.id];
-      confirmRemovedVariantPageDeletions(product, version.rich_content);
+      const survivingPageIds = new Set(
+        [
+          ...product.rich_content,
+          ...product.variants
+            .filter((existing) => existing.id !== version.id)
+            .flatMap((existing) => existing.rich_content),
+        ].map(({ id }) => id),
+      );
+      confirmRemovedVariantPageDeletions(product, version.rich_content, survivingPageIds);
     });
     onChange(versions.filter(({ id }) => id !== version.id));
   };

--- a/app/javascript/components/server-components/ProductEditPage.test.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment happy-dom
 
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
 import { type SaveProductResponse } from "$app/data/product_edit";
+import { confirmRemovedVariantPageDeletions } from "$app/data/product_save_contract";
 
 import { ProductEditContext, type Product, type Version } from "$app/components/ProductEdit/state";
 import { showAlert } from "$app/components/server-components/Alert";
@@ -1131,4 +1132,361 @@ it("does not report a content update when only the send-time stamp differs", asy
   });
 
   expect(showAlert).toHaveBeenCalledWith("Changes saved!", "success");
+});
+
+// Pins the missing-content reload guard (gp#2023 follow-up): every UI
+// deletion path records the removed id into confirmed_removed_*_ids, so a
+// page that is missing from browser state WITHOUT a confirmed id was lost by
+// the session (blank editor mount, cross-visit state leak) — the seller never
+// deleted it. The old save-time summary presented that loss as a deletion to
+// confirm; the save must instead stop and offer a reload.
+it("blocks the save and offers a reload when saved content is missing without a recorded deletion", async () => {
+  const product = buildTieredProduct([
+    buildTier("tier-a", "Tier A", [
+      {
+        id: "vanished-page",
+        title: "Lesson 1",
+        description: {},
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ]),
+  ]);
+  const props = buildTieredProps(product);
+
+  saveProductMock.mockResolvedValue({} satisfies SaveProductResponse);
+
+  render(<ProductEditPage {...props} />);
+  await waitFor(() => expect(contextCapture.current).not.toBeNull());
+
+  // The page vanishes from browser state with NO confirmed removal recorded —
+  // the signature of a lost session record, never of a seller action.
+  act(() =>
+    contextCapture.current?.updateProduct((current) => {
+      const tierA = current.variants.find((variant) => variant.id === "tier-a");
+      if (!tierA) throw new Error("expected tier A");
+      tierA.rich_content = [];
+    }),
+  );
+
+  let saved: boolean | undefined;
+  await act(async () => {
+    saved = await contextCapture.current?.save();
+  });
+
+  expect(saved).toBe(false);
+  expect(saveProductMock).not.toHaveBeenCalled();
+  expect(screen.getByText("Some content couldn't be loaded")).toBeTruthy();
+  expect(screen.getByText("Lesson 1")).toBeTruthy();
+  expect(screen.getByText("Reload page")).toBeTruthy();
+});
+
+// The reload guard must not swallow real deletions: a page whose id IS in
+// confirmed_removed_rich_content_ids was removed by the seller, so the
+// existing save-time summary still runs and confirming it still saves.
+it("keeps the deletion summary for content the seller explicitly removed", async () => {
+  const product = buildTieredProduct([
+    buildTier("tier-a", "Tier A", [
+      {
+        id: "removed-page",
+        title: "Old lesson",
+        description: {},
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ]),
+  ]);
+  const props = buildTieredProps(product);
+
+  saveProductMock.mockResolvedValue({} satisfies SaveProductResponse);
+
+  render(<ProductEditPage {...props} />);
+  await waitFor(() => expect(contextCapture.current).not.toBeNull());
+
+  // The seller deletes the page: the UI path removes it from state AND
+  // records the confirmed id, exactly like the per-row delete modal does.
+  act(() =>
+    contextCapture.current?.updateProduct((current) => {
+      const tierA = current.variants.find((variant) => variant.id === "tier-a");
+      if (!tierA) throw new Error("expected tier A");
+      tierA.rich_content = [];
+      current.confirmed_removed_rich_content_ids = ["removed-page"];
+    }),
+  );
+
+  let save: Promise<boolean> | undefined;
+  act(() => {
+    save = contextCapture.current?.save();
+  });
+
+  await waitFor(() => expect(screen.getByText("Save and delete content?")).toBeTruthy());
+  expect(screen.queryByText("Some content couldn't be loaded")).toBeNull();
+  expect(saveProductMock).not.toHaveBeenCalled();
+
+  await act(async () => {
+    fireEvent.click(screen.getByText("Yes, save and delete"));
+    await save;
+  });
+  expect(saveProductMock).toHaveBeenCalledOnce();
+  await expect(save).resolves.toBe(true);
+});
+
+// Deleting a whole tier must not trip the reload guard: the variant editors'
+// removal path (confirmRemovedVariantPageDeletions) records the ids of the
+// pages the tier held at that moment, so the guard sees seller intent for
+// every page that went down with the tier.
+it("keeps the deletion summary when a confirmed variant removal takes its pages with it", async () => {
+  const product = buildTieredProduct([
+    buildTier("tier-a", "Tier A", [
+      {
+        id: "tier-a-page",
+        title: "Tier A lesson",
+        description: {},
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ]),
+    buildTier("tier-b", "Tier B", []),
+  ]);
+  const props = buildTieredProps(product);
+
+  saveProductMock.mockResolvedValue({} satisfies SaveProductResponse);
+
+  render(<ProductEditPage {...props} />);
+  await waitFor(() => expect(contextCapture.current).not.toBeNull());
+
+  // The seller removes the whole tier — the same mutation the variant
+  // editors' confirmRemoval performs.
+  act(() =>
+    contextCapture.current?.updateProduct((current) => {
+      const index = current.variants.findIndex((variant) => variant.id === "tier-a");
+      const tierA = current.variants[index];
+      if (index === -1 || !tierA) throw new Error("expected tier A");
+      current.confirmed_removed_variant_ids = ["tier-a"];
+      confirmRemovedVariantPageDeletions(current, tierA.rich_content);
+      current.variants.splice(index, 1);
+    }),
+  );
+
+  let save: Promise<boolean> | undefined;
+  act(() => {
+    save = contextCapture.current?.save();
+  });
+
+  await waitFor(() => expect(screen.getByText("Save and delete content?")).toBeTruthy());
+  expect(screen.queryByText("Some content couldn't be loaded")).toBeNull();
+
+  await act(async () => {
+    fireEvent.click(screen.getByText("Yes, save and delete"));
+    await save;
+  });
+  expect(saveProductMock).toHaveBeenCalledOnce();
+  await expect(save).resolves.toBe(true);
+});
+
+// A page that moved OUT of a tier before the tier was deleted must not
+// inherit the tier's confirmation: the tier no longer held it, so if the
+// session later loses the page from its destination, that is lost content —
+// the reload guard must block the save, or confirming would delete the
+// page's stored row with no destination copy saved anywhere.
+it("blocks the save when a page that left a deleted tier goes missing", async () => {
+  const product = buildTieredProduct([
+    buildTier("tier-a", "Tier A", [
+      {
+        id: "moved-page",
+        title: "Moved lesson",
+        description: {},
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ]),
+    buildTier("tier-b", "Tier B", []),
+  ]);
+  const props = buildTieredProps(product);
+
+  saveProductMock.mockResolvedValue({} satisfies SaveProductResponse);
+
+  render(<ProductEditPage {...props} />);
+  await waitFor(() => expect(contextCapture.current).not.toBeNull());
+
+  act(() =>
+    contextCapture.current?.updateProduct((current) => {
+      const index = current.variants.findIndex((variant) => variant.id === "tier-a");
+      const tierA = current.variants[index];
+      const tierB = current.variants.find((variant) => variant.id === "tier-b");
+      const page = tierA?.rich_content[0];
+      if (index === -1 || !tierA || !tierB || !page) throw new Error("expected the tiers and the page");
+      // The page moves to tier B first, so tier A holds nothing when the
+      // seller deletes it — its confirmation covers no pages.
+      tierA.rich_content = [];
+      tierB.rich_content = [{ ...page, move_source_scope: "tier-a", move_source_id: page.id, source_id: page.id }];
+      current.confirmed_removed_variant_ids = ["tier-a"];
+      confirmRemovedVariantPageDeletions(current, tierA.rich_content);
+      current.variants.splice(index, 1);
+      // The session then loses the page from tier B — the gp#2023 bug class.
+      tierB.rich_content = [];
+    }),
+  );
+
+  let saved: boolean | undefined;
+  await act(async () => {
+    saved = await contextCapture.current?.save();
+  });
+
+  expect(saved).toBe(false);
+  expect(saveProductMock).not.toHaveBeenCalled();
+  expect(screen.getByText("Some content couldn't be loaded")).toBeTruthy();
+  expect(screen.getByText("Moved lesson")).toBeTruthy();
+});
+
+// A tier deleted while a save is in flight can hold a page that same save is
+// creating. The removal records the page's CLIENT id; the response then maps
+// it to the canonical row id (reconcileConfirmedRemovalIds), so the next
+// save's diff still reads the page as a confirmed deletion. Without the
+// remapped record, the reload guard would block the seller's confirmed tier
+// deletion after the response lands.
+it("keeps the deletion summary when a tier deleted mid-save held a page that save created", async () => {
+  const product = buildTieredProduct([
+    buildTier("tier-a", "Tier A", [
+      {
+        id: "new-page",
+        newlyAdded: true,
+        title: "Brand new lesson",
+        description: {},
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ]),
+    buildTier("tier-b", "Tier B", []),
+  ]);
+  const props = buildTieredProps(product);
+
+  const requests: { resolve: (response: SaveProductResponse) => void }[] = [];
+  saveProductMock.mockImplementation(() => new Promise<SaveProductResponse>((resolve) => requests.push({ resolve })));
+
+  render(<ProductEditPage {...props} />);
+  await waitFor(() => expect(contextCapture.current).not.toBeNull());
+
+  let firstSave: Promise<boolean> | undefined;
+  act(() => {
+    firstSave = contextCapture.current?.save();
+  });
+  await waitFor(() => expect(saveProductMock).toHaveBeenCalledOnce());
+
+  // The seller deletes the tier while the save that creates its page runs.
+  act(() =>
+    contextCapture.current?.updateProduct((current) => {
+      const index = current.variants.findIndex((variant) => variant.id === "tier-a");
+      const tierA = current.variants[index];
+      if (index === -1 || !tierA) throw new Error("expected tier A");
+      current.confirmed_removed_variant_ids = ["tier-a"];
+      confirmRemovedVariantPageDeletions(current, tierA.rich_content);
+      current.variants.splice(index, 1);
+    }),
+  );
+
+  await act(async () => {
+    requests[0]?.resolve({
+      rich_content_id_mappings: { "new-page": "server-new-page" },
+      rich_content_id_mappings_by_scope: { "tier-a": { "new-page": "server-new-page" } },
+    } satisfies SaveProductResponse);
+    await firstSave;
+  });
+
+  saveProductMock.mockResolvedValue({} satisfies SaveProductResponse);
+  let secondSave: Promise<boolean> | undefined;
+  act(() => {
+    secondSave = contextCapture.current?.save();
+  });
+
+  await waitFor(() => expect(screen.getByText("Save and delete content?")).toBeTruthy());
+  expect(screen.queryByText("Some content couldn't be loaded")).toBeNull();
+
+  await act(async () => {
+    fireEvent.click(screen.getByText("Yes, save and delete"));
+    await secondSave;
+  });
+  await expect(secondSave).resolves.toBe(true);
+  // The second save carries the canonical row id as the confirmed deletion.
+  const secondPayload: unknown = saveProductMock.mock.calls[1]?.[2];
+  expect(secondPayload).toMatchObject({ confirmed_removed_rich_content_ids: ["server-new-page"] });
+});
+
+// The flat rich_content_id_mappings is last-write-wins across scopes, so when
+// the same raw client id was sent in two tiers and one tier is deleted
+// mid-save, remapping the recorded deletion through the flat map can point it
+// at the OTHER tier's row — deletion intent against a row the seller kept.
+// The remap must resolve through the deleted tier's scoped mapping instead.
+it("remaps a mid-save tier deletion's page through its own scope, never the duplicate's", async () => {
+  const product = buildTieredProduct([
+    buildTier("tier-a", "Tier A", [
+      {
+        id: "dup-page",
+        newlyAdded: true,
+        title: "A lesson",
+        description: {},
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ]),
+    buildTier("tier-b", "Tier B", [
+      {
+        id: "dup-page",
+        newlyAdded: true,
+        title: "B lesson",
+        description: {},
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ]),
+  ]);
+  const props = buildTieredProps(product);
+
+  const requests: { resolve: (response: SaveProductResponse) => void }[] = [];
+  saveProductMock.mockImplementation(() => new Promise<SaveProductResponse>((resolve) => requests.push({ resolve })));
+
+  render(<ProductEditPage {...props} />);
+  await waitFor(() => expect(contextCapture.current).not.toBeNull());
+
+  let firstSave: Promise<boolean> | undefined;
+  act(() => {
+    firstSave = contextCapture.current?.save();
+  });
+  await waitFor(() => expect(saveProductMock).toHaveBeenCalledOnce());
+
+  act(() =>
+    contextCapture.current?.updateProduct((current) => {
+      const index = current.variants.findIndex((variant) => variant.id === "tier-a");
+      const tierA = current.variants[index];
+      if (index === -1 || !tierA) throw new Error("expected tier A");
+      current.confirmed_removed_variant_ids = ["tier-a"];
+      confirmRemovedVariantPageDeletions(current, tierA.rich_content);
+      current.variants.splice(index, 1);
+    }),
+  );
+
+  await act(async () => {
+    requests[0]?.resolve({
+      // The flat map's last write points at tier B's row.
+      rich_content_id_mappings: { "dup-page": "server-row-b" },
+      rich_content_id_mappings_by_scope: {
+        "tier-a": { "dup-page": "server-row-a" },
+        "tier-b": { "dup-page": "server-row-b" },
+      },
+    } satisfies SaveProductResponse);
+    await firstSave;
+  });
+
+  saveProductMock.mockResolvedValue({} satisfies SaveProductResponse);
+  let secondSave: Promise<boolean> | undefined;
+  act(() => {
+    secondSave = contextCapture.current?.save();
+  });
+
+  // The deleted tier's page resolves through tier A's scope, so the guard
+  // sees it as confirmed and the summary (not the reload guard) runs.
+  await waitFor(() => expect(screen.getByText("Save and delete content?")).toBeTruthy());
+  expect(screen.queryByText("Some content couldn't be loaded")).toBeNull();
+
+  await act(async () => {
+    fireEvent.click(screen.getByText("Yes, save and delete"));
+    await secondSave;
+  });
+  await expect(secondSave).resolves.toBe(true);
+  // Tier A's row is the confirmed deletion; tier B's row must never be.
+  const secondPayload: unknown = saveProductMock.mock.calls[1]?.[2];
+  expect(secondPayload).toMatchObject({ confirmed_removed_rich_content_ids: ["server-row-a"] });
 });

--- a/app/javascript/components/server-components/ProductEditPage.test.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.test.tsx
@@ -1260,7 +1260,15 @@ it("keeps the deletion summary when a confirmed variant removal takes its pages 
       const tierA = current.variants[index];
       if (index === -1 || !tierA) throw new Error("expected tier A");
       current.confirmed_removed_variant_ids = ["tier-a"];
-      confirmRemovedVariantPageDeletions(current, tierA.rich_content);
+      confirmRemovedVariantPageDeletions(
+        current,
+        tierA.rich_content,
+        new Set(
+          current.variants
+            .filter((variant) => variant.id !== "tier-a")
+            .flatMap((variant) => variant.rich_content.map(({ id }) => id)),
+        ),
+      );
       current.variants.splice(index, 1);
     }),
   );
@@ -1317,7 +1325,15 @@ it("blocks the save when a page that left a deleted tier goes missing", async ()
       tierA.rich_content = [];
       tierB.rich_content = [{ ...page, move_source_scope: "tier-a", move_source_id: page.id, source_id: page.id }];
       current.confirmed_removed_variant_ids = ["tier-a"];
-      confirmRemovedVariantPageDeletions(current, tierA.rich_content);
+      confirmRemovedVariantPageDeletions(
+        current,
+        tierA.rich_content,
+        new Set(
+          current.variants
+            .filter((variant) => variant.id !== "tier-a")
+            .flatMap((variant) => variant.rich_content.map(({ id }) => id)),
+        ),
+      );
       current.variants.splice(index, 1);
       // The session then loses the page from tier B — the gp#2023 bug class.
       tierB.rich_content = [];
@@ -1375,7 +1391,15 @@ it("keeps the deletion summary when a tier deleted mid-save held a page that sav
       const tierA = current.variants[index];
       if (index === -1 || !tierA) throw new Error("expected tier A");
       current.confirmed_removed_variant_ids = ["tier-a"];
-      confirmRemovedVariantPageDeletions(current, tierA.rich_content);
+      confirmRemovedVariantPageDeletions(
+        current,
+        tierA.rich_content,
+        new Set(
+          current.variants
+            .filter((variant) => variant.id !== "tier-a")
+            .flatMap((variant) => variant.rich_content.map(({ id }) => id)),
+        ),
+      );
       current.variants.splice(index, 1);
     }),
   );
@@ -1453,7 +1477,15 @@ it("remaps a mid-save tier deletion's page through its own scope, never the dupl
       const tierA = current.variants[index];
       if (index === -1 || !tierA) throw new Error("expected tier A");
       current.confirmed_removed_variant_ids = ["tier-a"];
-      confirmRemovedVariantPageDeletions(current, tierA.rich_content);
+      confirmRemovedVariantPageDeletions(
+        current,
+        tierA.rich_content,
+        new Set(
+          current.variants
+            .filter((variant) => variant.id !== "tier-a")
+            .flatMap((variant) => variant.rich_content.map(({ id }) => id)),
+        ),
+      );
       current.variants.splice(index, 1);
     }),
   );
@@ -1489,4 +1521,60 @@ it("remaps a mid-save tier deletion's page through its own scope, never the dupl
   // Tier A's row is the confirmed deletion; tier B's row must never be.
   const secondPayload: unknown = saveProductMock.mock.calls[1]?.[2];
   expect(secondPayload).toMatchObject({ confirmed_removed_rich_content_ids: ["server-row-a"] });
+});
+
+// Presence must be judged per page, not per raw id: a same-id page in
+// ANOTHER scope proves nothing about this one. Here tier A's saved page is
+// lost while an unrelated page carrying the same raw id sits in tier B — an
+// id-only check reads that as a move and lets the save through, and the
+// legacy omission path could then delete the lost page's stored row. The
+// send-time stamp identifies the page, so the guard must block.
+it("blocks the save when a lost page's raw id survives only on a different page in another tier", async () => {
+  const product = buildTieredProduct([
+    buildTier("tier-a", "Tier A", [
+      {
+        id: "server-page",
+        title: "Real lesson",
+        description: {},
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ]),
+    buildTier("tier-b", "Tier B", []),
+  ]);
+  const props = buildTieredProps(product);
+
+  saveProductMock.mockResolvedValue({} satisfies SaveProductResponse);
+
+  render(<ProductEditPage {...props} />);
+  await waitFor(() => expect(contextCapture.current).not.toBeNull());
+
+  // First save stamps the pages and moves the baseline to the stamped state.
+  await act(async () => {
+    await contextCapture.current?.save();
+  });
+
+  // The session loses tier A's page while an unrelated page reusing the same
+  // raw id appears in tier B (a state leak, not a move: it lacks the lost
+  // page's send-time stamp).
+  act(() =>
+    contextCapture.current?.updateProduct((current) => {
+      const tierA = current.variants.find((variant) => variant.id === "tier-a");
+      const tierB = current.variants.find((variant) => variant.id === "tier-b");
+      if (!tierA || !tierB) throw new Error("expected both tiers");
+      tierA.rich_content = [];
+      tierB.rich_content = [
+        { id: "server-page", title: "Impostor", description: {}, updated_at: "2026-01-01T00:00:00Z" },
+      ];
+    }),
+  );
+
+  let saved: boolean | undefined;
+  await act(async () => {
+    saved = await contextCapture.current?.save();
+  });
+
+  expect(saved).toBe(false);
+  expect(saveProductMock).toHaveBeenCalledOnce();
+  expect(screen.getByText("Some content couldn't be loaded")).toBeTruthy();
+  expect(screen.getByText("Real lesson")).toBeTruthy();
 });

--- a/app/javascript/components/server-components/ProductEditPage.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.tsx
@@ -203,52 +203,45 @@ type PendingDeletions = {
   pages: { id: string; title: string | null }[];
 };
 
-// Every UI deletion path records the removed id into confirmed_removed_*_ids
-// (the per-row "Yes, remove" / delete-page modals), so that list is the record
-// of what the seller actually asked to delete. Splitting on it separates the
-// two situations a missing-from-state diff can mean:
-// - `confirmed`: the seller deleted it this session. Shown in the save-time
-//   summary modal — deliberately a second gate on top of the per-row modals,
-//   the last chance to notice an accumulated (possibly large) wipe as one
-//   list before it becomes permanent.
-// - `unexpected`: nothing recorded intent, so the browser state lost the
-//   record (gumroad-private#2023: blank editor mounts, cross-visit state
-//   leaks). Saving would present the loss as a deletion the seller never
-//   asked for, so the save must stop and offer a reload instead.
+// Splits the missing-from-state diff on recorded intent: every UI deletion
+// path writes the removed id into confirmed_removed_*_ids, so a missing id
+// on that list is a seller deletion (summary modal) and one off it is lost
+// browser state (gumroad-private#2023) — the save must stop and offer a
+// reload rather than present the loss as a deletion.
 const findPendingDeletions = (
   product: Product,
   lastSavedProduct: Product,
 ): { confirmed: PendingDeletions; unexpected: PendingDeletions } => {
   const currentVariantIds = new Set(product.variants.map(({ id }) => id));
-  // Only content-bearing variants warrant the scary confirmation — mirroring
-  // the server-side guard, which protects variants with visible rich-content
-  // pages OR directly-attached files (legacy products predating embedded
-  // rich-content files). Contentless variants (e.g. a coffee product's
-  // "suggested amounts", an empty just-added version) delete without fuss.
+  // Only content-bearing variants warrant the scary confirmation, mirroring
+  // the server-side guard; contentless ones delete without fuss.
   const removedVariants = lastSavedProduct.variants.filter(
     ({ id, rich_content, has_files }) =>
       !currentVariantIds.has(id) && (rich_content.some(pageHasVisibleContent) || has_files === true),
   );
 
-  // A page id that still appears anywhere in the current state (product-level
-  // or under any variant) is a MOVE (e.g. toggling "use the same content for
-  // all versions"), not a deletion.
-  const currentPageIds = new Set([
-    ...product.rich_content.map(({ id }) => id),
-    ...product.variants.flatMap((variant) => variant.rich_content.map(({ id }) => id)),
-  ]);
+  const currentPages = [...product.rich_content, ...product.variants.flatMap((variant) => variant.rich_content)];
+  const currentPageIds = new Set(currentPages.map(({ id }) => id));
+  const currentPageStamps = new Set(
+    currentPages.flatMap((page) => (page.reconciliation_id ? [page.reconciliation_id] : [])),
+  );
+  // A page still present somewhere in current state was moved, not deleted.
+  // Presence is judged by the send-time stamp when the baseline has one: raw
+  // ids can repeat across scopes, so a same-id page in another scope proves
+  // nothing about THIS page. Unstamped baselines (no save this session yet)
+  // hold server-loaded pages with unique ids, so the raw id suffices there.
+  const pageStillPresent = (page: Page) =>
+    page.reconciliation_id ? currentPageStamps.has(page.reconciliation_id) : currentPageIds.has(page.id);
   const removedPagesById = new Map<string, Page>();
   for (const page of [
     ...lastSavedProduct.rich_content,
     ...lastSavedProduct.variants.flatMap((variant) => variant.rich_content),
   ]) {
-    if (!currentPageIds.has(page.id) && pageHasVisibleContent(page)) removedPagesById.set(page.id, page);
+    if (!pageStillPresent(page) && pageHasVisibleContent(page)) removedPagesById.set(page.id, page);
   }
 
-  // Deleting a whole variant confirms its pages individually too
-  // (confirmRemovedVariantPageDeletions records the ids of the pages the
-  // variant held at that moment), so a page-level confirmed id is the single
-  // test for intent here.
+  // Removing a variant records its pages' ids too, so a page-level confirmed
+  // id is the single test for intent.
   const confirmedVariantIds = new Set(product.confirmed_removed_variant_ids ?? []);
   const confirmedPageIds = new Set(product.confirmed_removed_rich_content_ids ?? []);
   const variants = removedVariants.map(({ id, name }) => ({ id, name }));
@@ -436,15 +429,11 @@ const applyCanonicalIds = (
   }
 };
 
-// Confirmed page removals recorded while a request ran can hold client ids
-// the response has now mapped. The flat rich_content_id_mappings is ambiguous
-// when the same raw id was sent in two scopes (each scope got its own row):
-// remapping through it can turn the seller's deletion into intent against a
-// row they kept. Resolve each raw id through the sent snapshot's scoped
-// mappings instead. When two scopes disagree, the scope whose variant the
-// seller also removed is the one the recording came from; with no such
-// tiebreak the remap is dropped — an unmapped client id is inert server-side,
-// so a wrong deletion cannot happen, only a blocked save (fail-safe).
+// Remaps confirmed page removals through the response's SCOPED id mappings:
+// the flat map is last-write-wins across scopes, and a raw id sent in two
+// scopes could remap a deletion onto a row the seller kept. Disagreeing
+// scopes tiebreak on the confirmed-removed variant; failing that the remap
+// is dropped, which can only block a save (unmapped ids are inert).
 const scopedConfirmedPageIdMappings = (
   response: SaveProductResponse,
   sentPagesById: ReadonlyMap<string, ScopedPage>,
@@ -735,11 +724,8 @@ const ProductEditPage = (props: Props) => {
   };
   const runSave = (): Promise<boolean> => {
     const { confirmed, unexpected } = findPendingDeletions(product, lastSavedProductRef.current);
-    // Content that vanished from browser state without the seller deleting it
-    // means this session's record of the product is no longer trustworthy.
-    // Fail closed: block the save and offer a reload — presenting the loss as
-    // a deletion to confirm would ask the seller to authorize destroying
-    // content they never touched (gumroad-private#2023).
+    // Content missing without recorded intent means the session lost state:
+    // fail closed and ask for a reload instead of offering it as a deletion.
     if (unexpected.variants.length + unexpected.pages.length > 0) {
       setMissingContentConflict(unexpected);
       return Promise.resolve(false);

--- a/app/javascript/components/server-components/ProductEditPage.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.tsx
@@ -203,14 +203,22 @@ type PendingDeletions = {
   pages: { id: string; title: string | null }[];
 };
 
-const findPendingDeletions = (product: Product, lastSavedProduct: Product): PendingDeletions => {
-  // Note: deletions the seller confirmed per-row (the "Yes, remove" /
-  // delete-page modals record ids into confirmed_removed_*_ids) are NOT
-  // excluded here. Those ids exist to satisfy the server-side deletion guard;
-  // this summary modal is deliberately a second, save-time gate — the last
-  // chance to notice an accumulated (possibly large) wipe as one list before
-  // it becomes permanent. Every UI deletion path records a confirmed id, so
-  // excluding them would mean the summary never appears at all.
+// Every UI deletion path records the removed id into confirmed_removed_*_ids
+// (the per-row "Yes, remove" / delete-page modals), so that list is the record
+// of what the seller actually asked to delete. Splitting on it separates the
+// two situations a missing-from-state diff can mean:
+// - `confirmed`: the seller deleted it this session. Shown in the save-time
+//   summary modal — deliberately a second gate on top of the per-row modals,
+//   the last chance to notice an accumulated (possibly large) wipe as one
+//   list before it becomes permanent.
+// - `unexpected`: nothing recorded intent, so the browser state lost the
+//   record (gumroad-private#2023: blank editor mounts, cross-visit state
+//   leaks). Saving would present the loss as a deletion the seller never
+//   asked for, so the save must stop and offer a reload instead.
+const findPendingDeletions = (
+  product: Product,
+  lastSavedProduct: Product,
+): { confirmed: PendingDeletions; unexpected: PendingDeletions } => {
   const currentVariantIds = new Set(product.variants.map(({ id }) => id));
   // Only content-bearing variants warrant the scary confirmation — mirroring
   // the server-side guard, which protects variants with visible rich-content
@@ -237,9 +245,23 @@ const findPendingDeletions = (product: Product, lastSavedProduct: Product): Pend
     if (!currentPageIds.has(page.id) && pageHasVisibleContent(page)) removedPagesById.set(page.id, page);
   }
 
+  // Deleting a whole variant confirms its pages individually too
+  // (confirmRemovedVariantPageDeletions records the ids of the pages the
+  // variant held at that moment), so a page-level confirmed id is the single
+  // test for intent here.
+  const confirmedVariantIds = new Set(product.confirmed_removed_variant_ids ?? []);
+  const confirmedPageIds = new Set(product.confirmed_removed_rich_content_ids ?? []);
+  const variants = removedVariants.map(({ id, name }) => ({ id, name }));
+  const pages = [...removedPagesById.values()].map(({ id, title }) => ({ id, title }));
   return {
-    variants: removedVariants.map(({ id, name }) => ({ id, name })),
-    pages: [...removedPagesById.values()].map(({ id, title }) => ({ id, title })),
+    confirmed: {
+      variants: variants.filter(({ id }) => confirmedVariantIds.has(id)),
+      pages: pages.filter(({ id }) => confirmedPageIds.has(id)),
+    },
+    unexpected: {
+      variants: variants.filter(({ id }) => !confirmedVariantIds.has(id)),
+      pages: pages.filter(({ id }) => !confirmedPageIds.has(id)),
+    },
   };
 };
 
@@ -414,6 +436,59 @@ const applyCanonicalIds = (
   }
 };
 
+// Confirmed page removals recorded while a request ran can hold client ids
+// the response has now mapped. The flat rich_content_id_mappings is ambiguous
+// when the same raw id was sent in two scopes (each scope got its own row):
+// remapping through it can turn the seller's deletion into intent against a
+// row they kept. Resolve each raw id through the sent snapshot's scoped
+// mappings instead. When two scopes disagree, the scope whose variant the
+// seller also removed is the one the recording came from; with no such
+// tiebreak the remap is dropped — an unmapped client id is inert server-side,
+// so a wrong deletion cannot happen, only a blocked save (fail-safe).
+const scopedConfirmedPageIdMappings = (
+  response: SaveProductResponse,
+  sentPagesById: ReadonlyMap<string, ScopedPage>,
+  confirmedRemovedVariantIds: string[],
+): Record<string, string> => {
+  const byScope = response.rich_content_id_mappings_by_scope;
+  const mappings = { ...response.rich_content_id_mappings };
+  if (!byScope) return mappings;
+
+  const canonicalsByRawId = new Map<string, Map<string, string>>();
+  for (const scopedPage of sentPagesById.values()) {
+    const scopeKey = scopedPage.scope ?? "";
+    const canonical = byScope[scopeKey]?.[scopedPage.page.id];
+    if (!canonical) continue;
+    const perScope = canonicalsByRawId.get(scopedPage.page.id) ?? new Map<string, string>();
+    perScope.set(scopeKey, canonical);
+    canonicalsByRawId.set(scopedPage.page.id, perScope);
+  }
+
+  const confirmedVariantIds = new Set(confirmedRemovedVariantIds);
+  const ambiguousRawIds = new Set<string>();
+  for (const [rawId, perScope] of canonicalsByRawId) {
+    const [onlyCanonical, ...others] = new Set(perScope.values());
+    if (onlyCanonical && others.length === 0) {
+      mappings[rawId] = onlyCanonical;
+      continue;
+    }
+    const removedScopeCanonicals = [...perScope.entries()].filter(([scopeKey]) => confirmedVariantIds.has(scopeKey));
+    const tiebreak = removedScopeCanonicals.length === 1 ? removedScopeCanonicals[0] : undefined;
+    if (tiebreak) {
+      mappings[rawId] = tiebreak[1];
+    } else {
+      ambiguousRawIds.add(rawId);
+    }
+  }
+  if (ambiguousRawIds.size === 0) return mappings;
+  const unambiguousMappings: Record<string, string> = {};
+  for (const rawId in mappings) {
+    const canonical = mappings[rawId];
+    if (canonical && !ambiguousRawIds.has(rawId)) unambiguousMappings[rawId] = canonical;
+  }
+  return unambiguousMappings;
+};
+
 const findUpdatedContent = (product: Product, lastSavedProduct: Product) => {
   const contentUpdatedVariantIds = product.variants
     .filter((variant) => {
@@ -453,6 +528,10 @@ const ProductEditPage = (props: Props) => {
   // in-flight save() promise so callers awaiting save() (e.g. "Save and
   // continue") settle once the seller decides.
   const [pendingDeletions, setPendingDeletions] = React.useState<PendingDeletions | null>(null);
+  // Content present at the last save but gone from browser state without any
+  // recorded deletion intent. Non-null while the reload modal is open; every
+  // save attempt is blocked until the seller reloads (see runSave).
+  const [missingContentConflict, setMissingContentConflict] = React.useState<PendingDeletions | null>(null);
   const pendingSaveRef = React.useRef<((saved: boolean) => void) | null>(null);
   // Hidden version-level pages the server refused to delete without an
   // explicit choice (see HiddenVariantContentConflictError). Non-null while
@@ -596,6 +675,14 @@ const ProductEditPage = (props: Props) => {
       setRichContentRemovedFileEmbedIds(response.rich_content_removed_file_embed_ids ?? {});
       updateProduct((current) => {
         applyCanonicalIds(current, response, sentPagesById);
+        // Read before the variant reconcile below remaps the list: the
+        // confirmed ids and the sent snapshot's scope keys share the
+        // sent-era id namespace.
+        const confirmedPageIdMappings = scopedConfirmedPageIdMappings(
+          response,
+          sentPagesById,
+          current.confirmed_removed_variant_ids ?? [],
+        );
         current.confirmed_removed_variant_ids = reconcileConfirmedRemovalIds(
           current.confirmed_removed_variant_ids ?? [],
           sentConfirmedVariantIds,
@@ -604,7 +691,7 @@ const ProductEditPage = (props: Props) => {
         current.confirmed_removed_rich_content_ids = reconcileConfirmedRemovalIds(
           current.confirmed_removed_rich_content_ids ?? [],
           sentConfirmedPageIds,
-          response.rich_content_id_mappings,
+          confirmedPageIdMappings,
         );
       });
 
@@ -647,14 +734,23 @@ const ProductEditPage = (props: Props) => {
     return saved;
   };
   const runSave = (): Promise<boolean> => {
+    const { confirmed, unexpected } = findPendingDeletions(product, lastSavedProductRef.current);
+    // Content that vanished from browser state without the seller deleting it
+    // means this session's record of the product is no longer trustworthy.
+    // Fail closed: block the save and offer a reload — presenting the loss as
+    // a deletion to confirm would ask the seller to authorize destroying
+    // content they never touched (gumroad-private#2023).
+    if (unexpected.variants.length + unexpected.pages.length > 0) {
+      setMissingContentConflict(unexpected);
+      return Promise.resolve(false);
+    }
     // A save that deletes existing versions/tiers or content pages gets one
     // final summary confirmation before the request goes out. Each deletion
     // already had its own modal when the seller clicked delete, but this is
     // the last chance to notice an accumulated (possibly large) wipe before
     // it becomes permanent.
-    const deletions = findPendingDeletions(product, lastSavedProductRef.current);
-    if (deletions.variants.length + deletions.pages.length > 0) {
-      setPendingDeletions(deletions);
+    if (confirmed.variants.length + confirmed.pages.length > 0) {
+      setPendingDeletions(confirmed);
       return new Promise<boolean>((resolve) => {
         pendingSaveRef.current = resolve;
       });
@@ -797,6 +893,40 @@ const ProductEditPage = (props: Props) => {
                 </div>
               ) : null}
               <p>Customers who purchased this content will lose access to it.</p>
+            </div>
+          </Modal>
+        ) : null}
+        {missingContentConflict ? (
+          <Modal
+            open
+            onClose={() => setMissingContentConflict(null)}
+            title="Some content couldn't be loaded"
+            footer={
+              <>
+                <Button onClick={() => setMissingContentConflict(null)}>Keep editing</Button>
+                <Button color="accent" onClick={() => window.location.reload()}>
+                  Reload page
+                </Button>
+              </>
+            }
+          >
+            <div className="flex flex-col gap-4">
+              <p>This editor session lost track of the following content, so saving could permanently delete it:</p>
+              {missingContentConflict.variants.length > 0 ? (
+                <ul className="list-disc pl-6">
+                  {missingContentConflict.variants.map(({ id, name }) => (
+                    <li key={id}>{name || "Untitled"}</li>
+                  ))}
+                </ul>
+              ) : null}
+              {missingContentConflict.pages.length > 0 ? (
+                <ul className="list-disc pl-6">
+                  {missingContentConflict.pages.map(({ id, title }) => (
+                    <li key={id}>{titleWithFallback(title)}</li>
+                  ))}
+                </ul>
+              ) : null}
+              <p>Nothing was saved or deleted. Reload the page to keep editing with the full content.</p>
             </div>
           </Modal>
         ) : null}

--- a/app/javascript/data/product_save_contract.test.ts
+++ b/app/javascript/data/product_save_contract.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   DeletionSources,
   buildDeletionOperations,
-  confirmRichContentMoveSourceDeletions,
+  confirmRemovedVariantPageDeletions,
   hasDeletions,
   reorderPreservingMembership,
   reorderRowsPreservingMembership,
@@ -72,17 +72,31 @@ describe("buildDeletionOperations", () => {
     expect(operations.deleted_ids.variants).toEqual(["variant-a", "variant-b"]);
   });
 
-  it("preserves a moved page's source deletion when its destination variant is removed", () => {
+  it("records a removed variant's pages and their move sources", () => {
     const product = productWith({ confirmed_removed_rich_content_ids: ["already-confirmed"] });
 
-    confirmRichContentMoveSourceDeletions(product, [
-      { move_source_id: "shared-source" },
-      { move_source_id: "shared-source" },
-      {},
+    confirmRemovedVariantPageDeletions(product, [
+      { id: "stored-page", move_source_id: "shared-source" },
+      { id: "stored-page-2", move_source_id: "shared-source" },
+      // An unsaved page's client id is recorded too: inert server-side, and
+      // remapped to the canonical id if an in-flight save creates the row.
+      { id: "unsaved-page" },
     ]);
 
-    expect(product.confirmed_removed_rich_content_ids).toEqual(["already-confirmed", "shared-source"]);
-    expect(buildDeletionOperations(product).deleted_ids.rich_content).toEqual(["already-confirmed", "shared-source"]);
+    expect(product.confirmed_removed_rich_content_ids).toEqual([
+      "already-confirmed",
+      "stored-page",
+      "shared-source",
+      "stored-page-2",
+      "unsaved-page",
+    ]);
+    expect(buildDeletionOperations(product).deleted_ids.rich_content).toEqual([
+      "already-confirmed",
+      "stored-page",
+      "shared-source",
+      "stored-page-2",
+      "unsaved-page",
+    ]);
   });
 
   // Clearing a whole collection is never inferred: the caller has to pass it,

--- a/app/javascript/data/product_save_contract.test.ts
+++ b/app/javascript/data/product_save_contract.test.ts
@@ -75,13 +75,17 @@ describe("buildDeletionOperations", () => {
   it("records a removed variant's pages and their move sources", () => {
     const product = productWith({ confirmed_removed_rich_content_ids: ["already-confirmed"] });
 
-    confirmRemovedVariantPageDeletions(product, [
-      { id: "stored-page", move_source_id: "shared-source" },
-      { id: "stored-page-2", move_source_id: "shared-source" },
-      // An unsaved page's client id is recorded too: inert server-side, and
-      // remapped to the canonical id if an in-flight save creates the row.
-      { id: "unsaved-page" },
-    ]);
+    confirmRemovedVariantPageDeletions(
+      product,
+      [
+        { id: "stored-page", move_source_id: "shared-source" },
+        { id: "stored-page-2", move_source_id: "shared-source" },
+        // An unsaved page's client id is recorded too: inert server-side, and
+        // remapped to the canonical id if an in-flight save creates the row.
+        { id: "unsaved-page" },
+      ],
+      new Set(),
+    );
 
     expect(product.confirmed_removed_rich_content_ids).toEqual([
       "already-confirmed",
@@ -97,6 +101,26 @@ describe("buildDeletionOperations", () => {
       "stored-page-2",
       "unsaved-page",
     ]);
+  });
+
+  // Raw ids can repeat across scopes; a stored id a surviving page still
+  // carries must not become deletion intent against the survivor's row. A
+  // newly added page's client id records regardless: it is inert until
+  // reconciliation resolves it, and ambiguous resolutions are dropped.
+  it("skips a removed stored page's id when a surviving page still carries it", () => {
+    const product = productWith({});
+
+    confirmRemovedVariantPageDeletions(
+      product,
+      [
+        { id: "shared-stored-id" },
+        { id: "only-here", move_source_id: "kept-source" },
+        { id: "shared-new-id", newlyAdded: true },
+      ],
+      new Set(["shared-stored-id", "kept-source", "shared-new-id"]),
+    );
+
+    expect(product.confirmed_removed_rich_content_ids).toEqual(["only-here", "shared-new-id"]);
   });
 
   // Clearing a whole collection is never inferred: the caller has to pass it,

--- a/app/javascript/data/product_save_contract.ts
+++ b/app/javascript/data/product_save_contract.ts
@@ -70,26 +70,25 @@ export type DeletionSources = {
   }[];
 };
 
-// Called at the moment a variant removal is confirmed, with the pages the
-// variant holds at that moment. Records into the durable confirmed-removal
-// list:
-// - each page's id: a page still inside the variant goes down with it, and
-//   the id doubles as the session's record that the SELLER removed it — the
-//   save-time missing-content guard reads the list as intent, so a page that
-//   left the variant before this confirmation must not inherit it. A newly
-//   added page's client id is recorded too: it is inert server-side (intent
-//   ids that match no stored row authorize nothing), and if an in-flight
-//   save creates the row, reconcileConfirmedRemovalIds remaps the recorded
-//   id to the canonical one so the deletion still lands.
-// - each page's move_source_id: a page moved INTO this variant is a new
-//   destination row plus an explicit deletion of its stored source, and the
-//   page carrying that marker disappears from state with the variant. Without
-//   the promotion the save loses the source-row deletion intent.
+// Records a confirmed variant removal's page deletions: the ids of the pages
+// the variant holds at that moment (client ids included — inert server-side,
+// and remapped to canonical if an in-flight save creates the row) plus their
+// move_source_ids, whose deletion intent would otherwise vanish with the
+// variant. A page that left the variant earlier is deliberately not covered.
+// A STORED id a surviving page still carries is skipped: raw ids can repeat
+// across scopes, and sending a shared stored id names the survivor's row for
+// deletion. A newly added page's client id records even when shared — it is
+// inert until reconciliation resolves it through the removed scope's mapping,
+// which drops ambiguous cases instead of guessing.
 export const confirmRemovedVariantPageDeletions = (
   product: Pick<DeletionSources, "confirmed_removed_rich_content_ids">,
-  pages: { id: string; move_source_id?: string }[],
+  removedPages: { id: string; newlyAdded?: boolean; move_source_id?: string }[],
+  survivingPageIds: ReadonlySet<string>,
 ): void => {
-  const removedIds = pages.flatMap((page) => [page.id, ...(page.move_source_id ? [page.move_source_id] : [])]);
+  const removedIds = removedPages.flatMap((page) => [
+    ...(page.newlyAdded || !survivingPageIds.has(page.id) ? [page.id] : []),
+    ...(page.move_source_id && !survivingPageIds.has(page.move_source_id) ? [page.move_source_id] : []),
+  ]);
   if (removedIds.length === 0) return;
 
   product.confirmed_removed_rich_content_ids = [

--- a/app/javascript/data/product_save_contract.ts
+++ b/app/javascript/data/product_save_contract.ts
@@ -70,21 +70,30 @@ export type DeletionSources = {
   }[];
 };
 
-// A page moved between shared and per-version scopes is represented by a new
-// destination row plus an explicit deletion of its stored source. If the
-// seller removes the destination variant before saving, the page carrying that
-// move marker disappears from product state. Promote the marker into the
-// durable confirmed-removal list at the same moment as the variant removal so
-// the save cannot lose the source-row deletion intent.
-export const confirmRichContentMoveSourceDeletions = (
+// Called at the moment a variant removal is confirmed, with the pages the
+// variant holds at that moment. Records into the durable confirmed-removal
+// list:
+// - each page's id: a page still inside the variant goes down with it, and
+//   the id doubles as the session's record that the SELLER removed it — the
+//   save-time missing-content guard reads the list as intent, so a page that
+//   left the variant before this confirmation must not inherit it. A newly
+//   added page's client id is recorded too: it is inert server-side (intent
+//   ids that match no stored row authorize nothing), and if an in-flight
+//   save creates the row, reconcileConfirmedRemovalIds remaps the recorded
+//   id to the canonical one so the deletion still lands.
+// - each page's move_source_id: a page moved INTO this variant is a new
+//   destination row plus an explicit deletion of its stored source, and the
+//   page carrying that marker disappears from state with the variant. Without
+//   the promotion the save loses the source-row deletion intent.
+export const confirmRemovedVariantPageDeletions = (
   product: Pick<DeletionSources, "confirmed_removed_rich_content_ids">,
-  pages: { move_source_id?: string }[],
+  pages: { id: string; move_source_id?: string }[],
 ): void => {
-  const moveSourceIds = pages.flatMap((page) => (page.move_source_id ? [page.move_source_id] : []));
-  if (moveSourceIds.length === 0) return;
+  const removedIds = pages.flatMap((page) => [page.id, ...(page.move_source_id ? [page.move_source_id] : [])]);
+  if (removedIds.length === 0) return;
 
   product.confirmed_removed_rich_content_ids = [
-    ...new Set([...(product.confirmed_removed_rich_content_ids ?? []), ...moveSourceIds]),
+    ...new Set([...(product.confirmed_removed_rich_content_ids ?? []), ...removedIds]),
   ];
 };
 


### PR DESCRIPTION
## What
The product editor's save-time deletion summary derived "pages that will be deleted" from whatever was missing in browser state since the last save. Content can go missing without any seller action — a blank editor mount or leaked cross-visit state loses the record (gp#2023) — and the summary then asked the seller to confirm deleting pages they never touched.

Every UI deletion path records the removed id into `confirmed_removed_*_ids`, so that list is the record of real intent. This PR splits the missing-content diff on it:
- Content missing **with** a confirmed id keeps the existing "Save and delete content?" summary.
- Content missing **without** a confirmed id blocks the save before any request goes out. A modal lists the lost content and offers a reload. Nothing is saved or deleted.

Supporting changes keep the guard from ever blocking a real deletion:
- Removing a variant now records the ids of the pages it holds at that moment (`confirmRemovedVariantPageDeletions`, renamed from `confirmRichContentMoveSourceDeletions`), and the variant's own id even when it is newly added. An id the server never learns is inert, and reconciliation remaps ids that an in-flight save creates.
- The confirmed-page remap resolves through the response's scoped id mappings. When the same raw id was sent in two scopes, the deleted variant's scope wins; with no tiebreak the remap is dropped, so the failure mode is a blocked save and never deletion intent against a row the seller kept.
- The guard judges page presence by the send-time reconciliation stamp, so a lost page cannot hide behind a same-id page in another scope.
- Deletion records skip a persisted page's id when a surviving page still carries it, so deleting one of two same-id pages can never name the survivor's row.

## Why
Follow-up to antiwork/gumroad-private#2023, closing the mismatch found there: the warning treated state loss as seller intent, while the save contract only deletes explicitly confirmed pages. A session that lost content is untrustworthy, so its save must fail closed and ask for a reload. Eight review rounds shaped the guard around the deletion races (tier deleted mid-save, page moved out before its tier's deletion, duplicate raw ids across scopes); each case has a regression test.

## Before/After
- Before: a page missing from browser state appears in the deletion summary; confirming authorizes deleting content the seller never removed.
- After: the save stops with "Some content couldn't be loaded", lists the content, and offers a reload. Explicit deletions behave exactly as before.

## Test results
- `ProductEditPage.test.tsx` (15), `product_save_contract.test.ts`, `TiersEditor.test.tsx` — all pass; each new guard test fails against the pre-fix code.
- Focused Vitest across the touched surfaces: 97 tests pass, including a ContentTab test that drives the real page-deletion UI.
- `npx tsc --noEmit`, Prettier, and eslint are clean.

---
**AI disclosure:** Authored by Claude Fable 5 via Claude Code.
