### PR TITLE
Follow SSRF-validated redirects in ping webhook delivery

### DIFF
--- a/app/sidekiq/post_to_individual_ping_endpoint_worker.rb
+++ b/app/sidekiq/post_to_individual_ping_endpoint_worker.rb
@@ -7,6 +7,7 @@ class PostToIndividualPingEndpointWorker
   ERROR_CODES_TO_RETRY = [499, 500, 502, 503, 504].freeze
   BACKOFF_STRATEGY = [60, 180, 600, 3600].freeze
   REQUEST_TIMEOUT_SECONDS = 5
+  MAX_REDIRECTS = 3
 
   def perform(post_url, params, content_type = Mime[:url_encoded_form].to_s, user_id = nil)
     retry_count = params["retry_count"] || 0
@@ -24,8 +25,11 @@ class PostToIndividualPingEndpointWorker
     options = {
       body:,
       headers: { "Content-Type" => content_type },
-      # Refuse redirects, but get the 3xx back (instead of a raise) so it can be logged.
-      max_redirects: 0,
+      # Endpoints commonly answer with trailing-slash/https normalization redirects (gp#2058:
+      # refusing them silently dropped sale pings), so follow a few — SsrfFilter re-validates
+      # every hop's resolved IPs, and the same POST body is re-sent on each hop. Past the limit
+      # we want the 3xx back (instead of a raise) so it can be logged.
+      max_redirects: MAX_REDIRECTS,
       allow_unfollowed_redirects: true,
       http_options: { open_timeout: REQUEST_TIMEOUT_SECONDS, read_timeout: REQUEST_TIMEOUT_SECONDS }
     }
@@ -41,7 +45,7 @@ class PostToIndividualPingEndpointWorker
     response = SsrfFilter.post(post_url, options)
 
     if response.is_a?(Net::HTTPRedirection)
-      Rails.logger.info("PostToIndividualPingEndpointWorker refused redirect response=#{response.code} content_type=#{content_type} user_id=#{user_id}")
+      Rails.logger.info("PostToIndividualPingEndpointWorker exhausted redirect limit response=#{response.code} content_type=#{content_type} user_id=#{user_id}")
       return
     end
 

--- a/spec/sidekiq/post_to_individual_ping_endpoint_worker_spec.rb
+++ b/spec/sidekiq/post_to_individual_ping_endpoint_worker_spec.rb
@@ -11,7 +11,7 @@ describe PostToIndividualPingEndpointWorker do
     {
       body:,
       headers: { "Content-Type" => content_type },
-      max_redirects: 0,
+      max_redirects: PostToIndividualPingEndpointWorker::MAX_REDIRECTS,
       allow_unfollowed_redirects: true,
       http_options: { open_timeout: 5, read_timeout: 5 }
     }
@@ -78,13 +78,44 @@ describe PostToIndividualPingEndpointWorker do
     end.to raise_error(StandardError)
   end
 
-  it "does not follow redirects" do
-    expect(SsrfFilter).to receive(:post).with("http://notification.com", hash_including(max_redirects: 0, allow_unfollowed_redirects: true)).and_return(@ok_response)
+  it "follows a bounded number of redirects, validated by SsrfFilter" do
+    expect(SsrfFilter).to receive(:post).with("http://notification.com", hash_including(max_redirects: 3, allow_unfollowed_redirects: true)).and_return(@ok_response)
 
     PostToIndividualPingEndpointWorker.new.perform("http://notification.com", { "q" => 47 })
   end
 
-  it "logs and drops the delivery without raising or retrying when the endpoint responds with a redirect" do
+  it "follows a trailing-slash redirect and re-sends the payload to the redirect target", :skip_ssrf_stub do
+    allow(Resolv).to receive(:getaddresses).with("example.com").and_return(["93.184.216.34"])
+    stub_request(:post, "http://example.com/hook/")
+      .to_return(status: 308, headers: { "Location" => "http://example.com/hook" })
+    delivered = stub_request(:post, "http://example.com/hook")
+      .with(body: "a=1", headers: { "Content-Type" => Mime[:url_encoded_form].to_s })
+      .to_return(status: 200)
+
+    expect do
+      PostToIndividualPingEndpointWorker.new.perform("http://example.com/hook/", { "a" => 1 })
+    end.to_not raise_error
+
+    expect(delivered).to have_been_requested
+  end
+
+  it "logs and drops the delivery when a redirect points at a private address", :skip_ssrf_stub do
+    allow(Resolv).to receive(:getaddresses).with("example.com").and_return(["93.184.216.34"])
+    allow(Resolv).to receive(:getaddresses).with("internal.example.net").and_return(["10.0.0.5"])
+    stub_request(:post, "http://example.com/hook")
+      .to_return(status: 302, headers: { "Location" => "http://internal.example.net/" })
+    messages = []
+    allow(Rails.logger).to receive(:info) { |message| messages << message }
+
+    expect do
+      PostToIndividualPingEndpointWorker.new.perform("http://example.com/hook", { "a" => 1 })
+    end.to_not raise_error
+
+    expect(messages).to include("[SsrfFilter::PrivateIPAddress] PostToIndividualPingEndpointWorker error content_type=#{Mime[:url_encoded_form]} user_id=")
+    expect(a_request(:post, "http://internal.example.net/")).not_to have_been_made
+  end
+
+  it "logs and drops the delivery without raising or retrying when the endpoint still redirects past the limit" do
     redirect_response = Net::HTTPFound.new("1.1", "302", "Found")
     allow(SsrfFilter).to receive(:post).and_return(redirect_response)
     messages = []
@@ -94,7 +125,7 @@ describe PostToIndividualPingEndpointWorker do
       PostToIndividualPingEndpointWorker.new.perform("http://notification.com", { "q" => 47 })
     end.to_not raise_error
 
-    expect(messages).to include("PostToIndividualPingEndpointWorker refused redirect response=302 content_type=#{Mime[:url_encoded_form]} user_id=")
+    expect(messages).to include("PostToIndividualPingEndpointWorker exhausted redirect limit response=302 content_type=#{Mime[:url_encoded_form]} user_id=")
     expect(PostToIndividualPingEndpointWorker.jobs.size).to eq(0)
   end
 


### PR DESCRIPTION
## What

`PostToIndividualPingEndpointWorker` now follows up to 3 redirect hops when delivering Ping webhooks, instead of refusing all redirects. Redirects are followed through `SsrfFilter`, so every hop is validated the same way the first request is. An endpoint that still redirects past the limit gets its 3xx logged (`exhausted redirect limit`) and the delivery dropped, exactly like the previous refusal path.

## Why

The SSRF hardening in #7136 switched ping delivery to `SsrfFilter.post` with `max_redirects: 0`. That closed a real bypass — a `post_url` that passes validation but redirects the request to an internal target — but it also broke sellers whose endpoints answer with benign normalization redirects. Vercel, nginx, and most frameworks 308/301-redirect trailing-slash paths and http→https upgrades by default, and every ping to such an endpoint has been silently dropped since: logged, never retried, never surfaced to the seller. This is the root cause of gp#2058, where a seller's `sale` pings stopped exactly at the #7136 deploy while their other resource-subscription events (registered without the trailing slash) kept working.

Following redirects *through the gem* rather than reverting to the old client keeps the security property intact: `ssrf_filter` re-resolves DNS on each hop, rejects any hop whose IPs fall in the private/reserved blocklist, connects to the exact IP it validated, and strips `Authorization`/`Cookie` headers on cross-origin hops. The vulnerability #7136 closed was *unvalidated* redirect-following; bounded validated following does not reopen it. A redirect into a private range raises `SsrfFilter::PrivateIPAddress`, which is already in `INTERNET_EXCEPTIONS` and is logged and dropped without retries.

## Before/After

Non-user-facing worker change.

| Endpoint behavior | Before (#7136) | After |
|---|---|---|
| Responds 2xx directly | delivered | delivered (unchanged) |
| 308/301 trailing-slash or https normalization, then 2xx | dropped silently, logged `refused redirect` | delivered; same POST body re-sent to the validated target |
| Redirects to a private/internal address | never followed | hop rejected by `SsrfFilter`, delivery dropped, no request made |
| Redirects more than 3 times | dropped at the first hop | dropped, logged `exhausted redirect limit` |

## QA steps

1. On a test account, set Settings → Advanced → Ping URL to an HTTPS endpoint whose path triggers a framework redirect (e.g. a Vercel/Next.js API route with a trailing slash: `https://<app>.vercel.app/api/<route>/`).
2. Make a test purchase of one of the account's products.
3. Before this change: no request reaches the endpoint; the worker logs `refused redirect response=308`. After: the endpoint receives the sale ping payload (the request lands on the slash-less route).
4. Point the Ping URL at an endpoint that redirects to `http://169.254.169.254/` and repeat; confirm no request reaches the internal target and the worker logs `[SsrfFilter::PrivateIPAddress]`.

## Test Results

- `bundle exec rspec spec/sidekiq/post_to_individual_ping_endpoint_worker_spec.rb` — 15 examples, 0 failures. New coverage: an end-to-end WebMock example that a trailing-slash 308 is followed and the payload re-delivered, and one that a redirect pointing at a private address is rejected with no request made.
- Revert check: with the worker change stashed, the new examples fail (redirect not followed / old log message), so they pin the fix.
- `bundle exec rspec spec/models/resource_subscription_spec.rb` — passes; `post_to_ping_endpoints_worker_spec.rb` fails locally identically on unmodified `main` (known local missing-merchant-account gap; runs in CI).
- `bundle exec rubocop` on both changed files — no offenses.

---

AI disclosure: written with Claude Fable 5 (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
