### PR TITLE
Fix ping redirect sibling spec expectations

### DIFF
--- a/spec/sidekiq/post_to_ping_endpoints_worker_spec.rb
+++ b/spec/sidekiq/post_to_ping_endpoints_worker_spec.rb
@@ -51,7 +51,7 @@ describe PostToPingEndpointsWorker, :vcr do
     {
       body: HTTParty::HashConversions.to_params(params.deep_stringify_keys),
       headers: { "Content-Type" => content_type },
-      max_redirects: 0,
+      max_redirects: PostToIndividualPingEndpointWorker::MAX_REDIRECTS,
       allow_unfollowed_redirects: true,
       http_options: { open_timeout: 5, read_timeout: 5 }
     }


### PR DESCRIPTION
## What

Updates the `PostToPingEndpointsWorker` spec helper to use `PostToIndividualPingEndpointWorker::MAX_REDIRECTS`, matching the redirect budget introduced by #7215.

## Why

After #7215 merged, main's full suite failed seven inline resource-subscription examples in `post_to_ping_endpoints_worker_spec.rb`. Their shared helper still expected `max_redirects: 0`, so the actual `SsrfFilter.post` call with `max_redirects: 3` fell through the mock and returned `nil`; the worker then raised on `response.code`.

## Before/After

| | Before | After |
|---|---|---|
| Inline resource-subscription specs | 7 failures on main | 33 examples pass |
| Redirect expectation | Duplicated stale `0` | Reads the production constant |

## Test Results

- Before: `DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/post_to_ping_endpoints_worker_spec.rb:560` — 1 example, 1 failure (`undefined method 'code' for nil`).
- After: `DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/post_to_ping_endpoints_worker_spec.rb` — 33 examples, 0 failures.
- `git diff --check` — clean.
- Autoreview at `ae5350da0cc96be9e13a6ba9a3fdb15759a1465e` — clean; no P0/P1 findings.
- Pre-merge QA audit at `ae5350da0cc96be9e13a6ba9a3fdb15759a1465e` — clean across code, specs, comments, and evidence; stale-value mutation restored the expected failure.
- GitHub Actions and Buildkite at `ae5350da0cc96be9e13a6ba9a3fdb15759a1465e` — all checks passed; relevant specs green and Buildkite #21025 passed.

## QA steps

1. Confirmed main run 31674266240 failed only Test Fast 12, with seven examples in `post_to_ping_endpoints_worker_spec.rb` sharing the stale helper.
2. Reproduced one failed example locally before the change.
3. Ran the full spec file after the change and confirmed all 33 examples pass.
4. No rendered surface: this changes one test expectation only.

## Status

- [x] Scope — repair the stale sibling spec expectation exposed by #7215
- [x] Design — use the worker's redirect constant rather than duplicate its value
- [x] Build — one-line test-only change pushed
- [x] QA — red/green reproduced; full spec file and exact-head audit green
- [ ] Shipped — ready to merge; production deploy follows
- [ ] Market — not applicable
- [ ] Sell — not applicable

Premerge review: clean @ ae5350da0cc96be9e13a6ba9a3fdb15759a1465e

---

AI disclosure: written with Grok 4.6.
