### PR TITLE
Heal combined-charge PayPal purchases stuck in_progress after a succeeded capture

### DIFF
--- a/app/services/purchase/sync_status_with_charge_processor_service.rb
+++ b/app/services/purchase/sync_status_with_charge_processor_service.rb
@@ -59,6 +59,15 @@ class Purchase::SyncStatusWithChargeProcessorService
                          !charge.try(:refunded) && !charge.try(:refunded?) && !charge.try(:disputed)
       charge_succeeded &&= @charge_outcome == :succeeded if @require_final_charge_status
 
+      if charge_succeeded && @charge_outcome == :succeeded && charge.flow_of_funds.nil? &&
+         !purchase.stripe_charge_processor? && purchase.is_part_of_combined_charge?
+        # Non-Stripe processors never produce a flow of funds (PaypalCharge deliberately skips
+        # building one), so "nil, wait for settlement" would wait forever. Synthesize the same
+        # simple flow of funds the normal success path does in Purchase#load_flow_of_funds,
+        # sized to the whole combined charge because the split below divides by it.
+        charge.flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, purchase.charge.amount_cents)
+      end
+
       if charge_succeeded && charge.flow_of_funds.nil? && (purchase.is_part_of_combined_charge? || purchase.buyer_presentment?)
         # The charge succeeded but the processor has not produced the balance transaction the flow
         # of funds is read from, so retry later rather than failing a purchase whose money moved.

--- a/spec/services/purchase/sync_status_with_charge_processor_service_spec.rb
+++ b/spec/services/purchase/sync_status_with_charge_processor_service_spec.rb
@@ -448,8 +448,6 @@ describe Purchase::SyncStatusWithChargeProcessorService, :vcr do
     end
 
     it "synthesizes a flow of funds and heals a combined-charge PayPal purchase whose success callback was missed" do
-      # gumroad-private#1608: PaypalCharge never builds a flow of funds, so the "processor hasn't
-      # settled yet, retry later" guard fired on every pass forever for these rows.
       merchant_account = create(:merchant_account_paypal, user: @product.user,
                                                           charge_processor_merchant_id: "CJS32DZ7NDN5L", currency: "gbp")
       purchase = create(:purchase, link: @product, purchase_state: "in_progress",

--- a/spec/services/purchase/sync_status_with_charge_processor_service_spec.rb
+++ b/spec/services/purchase/sync_status_with_charge_processor_service_spec.rb
@@ -447,6 +447,37 @@ describe Purchase::SyncStatusWithChargeProcessorService, :vcr do
       expect(@seller.reload.unpaid_balance_cents).to eq(@initial_balance)
     end
 
+    it "synthesizes a flow of funds and heals a combined-charge PayPal purchase whose success callback was missed" do
+      # gumroad-private#1608: PaypalCharge never builds a flow of funds, so the "processor hasn't
+      # settled yet, retry later" guard fired on every pass forever for these rows.
+      merchant_account = create(:merchant_account_paypal, user: @product.user,
+                                                          charge_processor_merchant_id: "CJS32DZ7NDN5L", currency: "gbp")
+      purchase = create(:purchase, link: @product, purchase_state: "in_progress",
+                                   charge_processor_id: PaypalChargeProcessor.charge_processor_id,
+                                   merchant_account:, stripe_transaction_id: "8XC12345AB678901C")
+      purchase.is_part_of_combined_charge = true
+      purchase.save!
+      charge = create(:charge, order: create(:order), seller: @seller, merchant_account:,
+                               processor: PaypalChargeProcessor.charge_processor_id,
+                               processor_transaction_id: nil,
+                               amount_cents: purchase.total_transaction_cents,
+                               gumroad_amount_cents: purchase.total_transaction_amount_for_gumroad_cents)
+      charge.purchases << purchase
+
+      paypal_charge = BaseProcessorCharge.new
+      paypal_charge.id = purchase.stripe_transaction_id
+      paypal_charge.status = "completed"
+      paypal_charge.charge_processor_id = PaypalChargeProcessor.charge_processor_id
+      paypal_charge.flow_of_funds = nil
+      allow(ChargeProcessor).to receive(:get_or_search_charge).with(purchase).and_return(paypal_charge)
+
+      expect(Purchase::SyncStatusWithChargeProcessorService.new(purchase).perform).to be(true)
+
+      expect(purchase.reload.successful?).to be(true)
+      expect(purchase.flow_of_funds).to be_present
+      expect(purchase.flow_of_funds.gumroad_amount.currency).to eq(Currency::USD)
+    end
+
     it "marks the purchase as failed and returns false if purchase's charge has been refunded" do
       merchant_account = create(:merchant_account_paypal, user: @product.user,
                                                           charge_processor_merchant_id: "CJS32DZ7NDN5L", currency: "gbp")


### PR DESCRIPTION
- [x] Scope — heal combined-charge PayPal purchases stuck in_progress after a succeeded capture (gp#1608, ershad's 2026-08-13 verification pass)
- [x] Design — synthesize the same simple USD flow of funds the normal PayPal success path uses; gate on final `:succeeded` outcome only
- [x] Build — service change + regression spec; 68 examples green, red proof against pre-fix code
- [x] QA — pre-merge QA audit clean (see marker); production proof is the 3 stuck rows healing post-deploy
- [ ] Shipped — awaiting human review (money path, auto-merge not armed)
- [ ] Market — n/a (internal recovery path)
- [ ] Sell — n/a

## What

Heals combined-charge PayPal purchases left `in_progress` forever after their PayPal capture succeeded. When `SyncStatusWithChargeProcessorService` sees a succeeded, unrefunded, undisputed non-Stripe charge with a nil flow of funds on a combined-charge purchase, it now synthesizes the same simple USD flow of funds the normal PayPal success path uses (`Purchase#load_flow_of_funds`), sized to the whole combined charge so the per-purchase split reconciles, and finalizes the purchase.

## Why

gumroad-private#1608 (verification pass by @ershad, 2026-08-13): 3 PayPal purchases ($49.35, $49.00, $18.00 — the oldest waiting 37 days) are charged-buyer-no-product and permanently unhealable by the current code. `PaypalCharge#load_transaction_details_for_paypal_order_api` never builds a flow of funds (the builder call is commented out by design), so the "processor hasn't settled yet, retry later" guard fires on every `UnstickStuckInProgressPurchasesJob` pass, forever. Stripe's fix (#6746) does not cover this shape.

The synthesized flow of funds is exactly what the normal path produces: `Purchase#load_flow_of_funds` runs `FlowOfFunds.build_simple_flow_of_funds(Currency::USD, ...)` for every non-Stripe processor at charge time. These rows only missed it because the success callback never ran. The guard requires `@charge_outcome == :succeeded` (not merely a valid status), so PayPal `created`/`approved` — non-final statuses — keep waiting; only `completed` heals.

## Before / After

Before: succeeded PayPal capture + missed callback → sync returns `false` on every pass, purchase `in_progress` forever, buyer charged with no product, row reported daily under the "could not be recovered" alert until it ages out at 90 days.

After: the same row finalizes on the next sync pass (daily 04:30 UTC job or manual run) — flow of funds recorded in USD as on the normal path, `MarkSuccessfulService` runs, buyer gets the product and receipt.

No rendered surface — backend state-machine recovery only; the observable effect is the purchase state transition asserted in Test Results.

## Test Results

From captured output on this branch (lane env, `DISABLE_SPRING=1`):

- `bundle exec rspec spec/services/purchase/sync_status_with_charge_processor_service_spec.rb spec/services/purchase/unstick_stuck_in_progress_service_spec.rb` — 68 examples, 0 failures.
- Red proof: with the service change reverted (spec kept), the new example fails — `perform` returns `false` and the purchase stays `in_progress` — so the spec pins the fix, not the fixture.
- `ruby -c` clean on both files.

## QA steps

Ran the new spec end to end: combined-charge PayPal purchase `in_progress`, processor returns a succeeded `completed` capture with nil flow_of_funds → `perform` returns true, purchase `successful`, `flow_of_funds` present with USD gumroad amount. Production QA after deploy: the 3 stuck rows (`345776319`, `346775853`, `348965434`) should heal on the next `UnstickStuckInProgressPurchasesJob` run; gp#1608 tracks the cohort count.

Premerge review: clean @ a1c0518a8975b0a1bb6cd7b8cf4eeabed8a1b1e9

Pre-merge QA audit round 1 ran clean at `b81083778` (adversarial review: precedent, guard ordering, blast radius, spec red-proof re-run independently, currency convention all verified; two P3 notes, none blocking). Head `a1c0518a8` differs from the audited SHA only by a comment-only spec deletion (Greptile P2), byte-diff verified.

## Merge plan

Money path (purchase finalization → seller credit) — auto-merge NOT armed; needs human review. `run-all-specs` labeled.

---

AI disclosure: built by Hermes (claude-fable-5) as an autonomous fix for gumroad-private#1608.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: assigning **@rmarescu** as the human owner of this (PR) — derived from who owns the linked PR / filed it / reviews this surface. Labelled `awaiting-human`: it's with you now.

Automated ownership fix — while an item is being worked, assignee=gumclaw; at hand-off, assignee swaps to a human. If more visibility is needed, add another human assignee rather than replacing.
<!-- gumclaw-ownership-sweep -->
