### PR TITLE
Map a fixed mandate interval for subscription restart purchases (gp#1410)

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3838,7 +3838,7 @@ class Purchase < ApplicationRecord
     # Restart purchases re-establish a mandate on the same fixed interval as the rest of
     # the recurrence (they pass the guard above via `setup_future_charges`, not an original
     # or upgrade flag), so they must be mapped like any other recurring membership charge.
-    if is_original_subscription_purchase? || is_upgrade_purchase? || is_recurring_subscription_charge?
+    if is_original_subscription_purchase? || is_upgrade_purchase? || is_recurring_subscription_charge
       case subscription_duration
       when "every_two_years"
         interval = "year"

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3835,7 +3835,10 @@ class Purchase < ApplicationRecord
     interval = "sporadic"
     interval_count = 1
 
-    if is_original_subscription_purchase? || is_upgrade_purchase?
+    # Restart purchases re-establish a mandate on the same fixed interval as the rest of
+    # the recurrence (they pass the guard above via `setup_future_charges`, not an original
+    # or upgrade flag), so they must be mapped like any other recurring membership charge.
+    if is_original_subscription_purchase? || is_upgrade_purchase? || is_recurring_subscription_charge?
       case subscription_duration
       when "every_two_years"
         interval = "year"

--- a/test/models/purchase_test.rb
+++ b/test/models/purchase_test.rb
@@ -6105,6 +6105,9 @@ class PurchaseTest < ActiveSupport::TestCase
   test "#mandate_options_for_stripe maps the fixed recurrence interval for a restart purchase (not sporadic)" do
     product = create_membership_product  # monthly recurrence
     subscription = create_subscription(link: product)
+    create_purchase(charge_processor_id: StripeChargeProcessor.charge_processor_id, link: product, purchase_state: "successful",
+                    card_country: "IN", subscription:, is_original_subscription_purchase: true,
+                    price_cents: 100, total_transaction_cents: 105, displayed_price_cents: 100)
     # A restart purchase re-establishes the mandate on the existing subscription: it is not
     # the original purchase and not an upgrade, but it does set up future off-session
     # charges, so it must carry the same fixed interval as the rest of the recurrence.

--- a/test/models/purchase_test.rb
+++ b/test/models/purchase_test.rb
@@ -6102,6 +6102,27 @@ class PurchaseTest < ActiveSupport::TestCase
     assert_equal 525, mandate_options[:payment_method_options][:card][:mandate_options][:amount]
   end
 
+  test "#mandate_options_for_stripe maps the fixed recurrence interval for a restart purchase (not sporadic)" do
+    product = create_membership_product  # monthly recurrence
+    subscription = create_subscription(link: product)
+    # A restart purchase re-establishes the mandate on the existing subscription: it is not
+    # the original purchase and not an upgrade, but it does set up future off-session
+    # charges, so it must carry the same fixed interval as the rest of the recurrence.
+    restart_purchase = create_purchase(charge_processor_id: StripeChargeProcessor.charge_processor_id, link: product, purchase_state: "in_progress",
+                                       card_country: "IN", subscription:, is_original_subscription_purchase: false,
+                                       price_cents: 100, total_transaction_cents: 105, displayed_price_cents: 100,
+                                       setup_future_charges: true)
+    chargeable = mock("chargeable")
+    chargeable.stubs(:requires_mandate?).returns(true)
+    restart_purchase.stubs(:chargeable).returns(chargeable)
+    restart_purchase.stubs(:subscription_duration).returns("monthly")
+
+    mandate_options = restart_purchase.mandate_options_for_stripe
+
+    assert_equal "month", mandate_options[:payment_method_options][:card][:mandate_options][:interval]
+    assert_equal 1, mandate_options[:payment_method_options][:card][:mandate_options][:interval_count]
+  end
+
   # ---- #is_an_async_off_session_charge_in_india? ----------------------------
 
   test "#is_an_async_off_session_charge_in_india? when card country is not India returns false if it is a regular purchase" do


### PR DESCRIPTION
# Map a fixed mandate interval for subscription restart purchases (gp#1410)

## What

`Purchase#mandate_options_for_stripe` now derives the e-mandate `interval`/`interval_count` from the subscription's recurrence for **restart purchases** too — not just original and upgrade purchases.

A restart re-establishes the recurring payment on an existing (deactivated) membership. It reaches `mandate_options_for_stripe` via the `setup_future_charges` guard (not an original/upgrade flag), so it was falling through the interval map and registering a **`sporadic`** mandate. For a membership that renews monthly/yearly, a sporadic mandate doesn't authorize the fixed-interval renewals, planting the next renewal's `transaction_not_allowed` decline.

## Why

antiwork/gumroad-private#1410: seller 9460701 (top creator, 51k lifetime) — a restart purchase on a recurring membership registers a sporadic e-mandate, then the re-authorization path never completes. The core defect is live at `app/models/purchase.rb:3838`: the interval map only ran for `is_original_subscription_purchase? || is_upgrade_purchase?`.

## Before / After

- **Before:** restart purchase on a monthly membership → mandate `interval: "sporadic"` → next renewal declined.
- **After:** restart purchase on a monthly membership → mandate `interval: "month", interval_count: 1` (yearly → `"year"`, etc.) — the same fixed interval as the rest of the recurrence.

No rendered surface — backend mandate-shape fix only; the observable effect is the `mandate_options` hash asserted in Test Results.

## Test Results

From captured output on the branch (lane env, `DISABLE_SPRING=1`, rbenv Ruby 3.4.3):

- `bin/rails test test/models/purchase_test.rb -n "/mandate_options_for_stripe/"` — **10 runs, 13 assertions, 0 failures**.
- Broader group incl. `is_an_async_off_session_charge_in_india?` + `check_indian_card_mandate_was_registered` — **24 runs, 27 assertions, 0 failures**.
- **Red proof:** with the fix reverted to origin/main, the new restart spec fails — `Expected: "month", Actual: "sporadic"` — so it pins the fix, not the fixture.
- `ruby -c` clean on both changed files.

## QA steps

Backend-only; no preview surface. Read the diff of `app/models/purchase.rb:3838` and `test/models/purchase_test.rb` (new restart test), then optionally run the spec group above. After deploy, the specific repro (seller 9460701 restart with an Indian-card mandate) should produce a fixed-interval mandate on the next restart, and the re-authorization path completes.

## AI disclosure

Built autonomously by Hermes (grok-4.6) per the dispatcher standing order for antiwork/gumroad-private#1410.

Premerge review: clean @ 73d6efcfef4983094ae8b81e5c7a327cc0e8b67d
