### PR TITLE
Auto-resume DEAD/UNACCOUNTED stalled post email blasts within 24h

### DIFF
--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -7,8 +7,10 @@
 # their own audience size writing in. 11 blasts / ~1.6M undelivered emails accrued that way over
 # ten days before anyone noticed.
 #
-# Reports; resuming a blast is a per-seller human call, because several stalled blasts are
-# time-boxed sale announcements that may be worse delivered late than not at all.
+# DEAD and UNACCOUNTED blasts still inside RESUME_WINDOW are resumed here (behind
+# :auto_resume_stalled_post_email_blasts; dry-run reporting when off — gumroad-private#2106).
+# Anything past the window is held for a human, because several stalled blasts are time-boxed
+# sale announcements that may be worse delivered late than not at all.
 class AlertOnStalledPostEmailBlastsJob
   include Sidekiq::Job
   sidekiq_options retry: 2, queue: :low
@@ -21,6 +23,10 @@ class AlertOnStalledPostEmailBlastsJob
   # historical rows every run buries the new ones the alert exists to catch.
   LOOKBACK = 14.days
 
+  # A blast this recent is safe to deliver late even when it announces a sale; past this the
+  # send window may have closed, and only the seller knows.
+  RESUME_WINDOW = 24.hours
+
   # Report at most this many. The alert exists to be read.
   MAX_REPORTED = 25
 
@@ -32,6 +38,7 @@ class AlertOnStalledPostEmailBlastsJob
     scan = scan_for_stalled_blasts
     return if scan[:stalled].empty? && !scan[:truncated]
 
+    resume_stalled_blasts(scan[:stalled])
     InternalNotificationWorker.perform_async("payments", "Stalled post email blasts", message_for(scan))
   end
 
@@ -51,7 +58,7 @@ class AlertOnStalledPostEmailBlastsJob
       candidates = candidates.first(MAX_CANDIDATES_SCANNED)
       return { stalled: [], truncated: } if candidates.empty?
 
-      dead = dead_blast_ids
+      @dead_jobs = dead_blast_jobs
       busy = busy_blast_ids
       retrying = retrying_blast_ids
       queued = queued_blast_ids
@@ -61,7 +68,7 @@ class AlertOnStalledPostEmailBlastsJob
           if busy.include?(blast.id) then :running
           elsif queued.include?(blast.id) then :queued
           elsif retrying.include?(blast.id) then :retrying
-          elsif dead.include?(blast.id) then :dead
+          elsif @dead_jobs.key?(blast.id) then :dead
           else :unaccounted
           end
 
@@ -71,8 +78,44 @@ class AlertOnStalledPostEmailBlastsJob
       { stalled:, truncated: }
     end
 
-    def dead_blast_ids
-      collect_set_blast_ids(Sidekiq::DeadSet.new)
+    def resume_stalled_blasts(stalled)
+      live = Feature.active?(:auto_resume_stalled_post_email_blasts)
+
+      stalled.each do |entry|
+        next unless entry[:disposition].in?([:dead, :unaccounted])
+
+        if entry[:blast].requested_at < RESUME_WINDOW.ago
+          entry[:resume] = :held_past_window
+          next
+        end
+
+        unless live
+          entry[:resume] = :would_resume
+          next
+        end
+
+        begin
+          if entry[:disposition] == :dead
+            # Re-runs the dead payload through the normal retry path; the job's own guards
+            # (completed_at, alive/published post) re-check at perform time.
+            @dead_jobs.fetch(entry[:blast].id).retry
+          else
+            SendPostBlastEmailsJob.perform_async(entry[:blast].id)
+          end
+          entry[:resume] = :resumed
+        rescue => e
+          entry[:resume] = :resume_failed
+          Rails.logger.error("[#{self.class.name}] resume failed blast_id=#{entry[:blast].id}: #{e.class}: #{e.message}")
+        end
+      end
+    end
+
+    def dead_blast_jobs
+      jobs = {}
+      Sidekiq::DeadSet.new.scan("SendPostBlastEmailsJob") do |job|
+        jobs[job.args[0]] = job if job.klass == "SendPostBlastEmailsJob"
+      end
+      jobs
     end
 
     def retrying_blast_ids
@@ -117,11 +160,12 @@ class AlertOnStalledPostEmailBlastsJob
         (omitted.positive? ? "…and #{omitted} more." : nil),
         "",
         "RUNNING/QUEUED may just be a very large blast mid-pass; DEAD and UNACCOUNTED are stranded — " \
-          "every audience member past the delivered count silently got nothing. Resume a DEAD blast by " \
-          "retrying its dead-set entry (`job.retry`). Resume an UNACCOUNTED blast (hard-killed worker, " \
-          "no dead entry) with `SendPostBlastEmailsJob.perform_async(blast_id)` — it picks up from the " \
-          "Redis audience snapshot. Confirm with the " \
-          "seller before resuming a time-boxed blast. See gumroad-private#1750 for a worked run.",
+          "every audience member past the delivered count silently got nothing. Those inside " \
+          "#{RESUME_WINDOW.inspect} of request are resumed automatically (RESUMED; behind " \
+          "auto_resume_stalled_post_email_blasts, WOULD RESUME while off). HELD PAST WINDOW needs a " \
+          "human: confirm with the seller before resuming a time-boxed blast — `job.retry` on the " \
+          "dead-set entry, or `SendPostBlastEmailsJob.perform_async(blast_id)` when unaccounted. " \
+          "See gumroad-private#1750 for a worked run.",
       ].compact.join("\n")
     end
 
@@ -129,8 +173,9 @@ class AlertOnStalledPostEmailBlastsJob
       blast = entry[:blast]
       hours = ((Time.current - blast.requested_at) / 1.hour).round(1)
       started = blast.started_at ? "" : " [never started]"
+      resume = entry[:resume] ? " → #{entry[:resume].to_s.tr("_", " ").upcase}" : ""
       "• blast #{blast.id} (post #{blast.post_id}, seller #{blast.seller_id}) — " \
-        "requested #{hours}h ago#{started}, #{blast.delivery_count} delivered, #{entry[:disposition].to_s.upcase}"
+        "requested #{hours}h ago#{started}, #{blast.delivery_count} delivered, #{entry[:disposition].to_s.upcase}#{resume}"
     end
 
     def headline(count, truncated)

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -3,11 +3,10 @@
 class SendPostBlastEmailsJob
   include Sidekiq::Job
   include ActionView::Helpers::SanitizeHelper
-  # Deliberately no `lock: :until_executed`. The digest keys on the blast id, and every caller
-  # creates a fresh blast row before enqueuing, so it never deduplicated anything — but a hard-killed
-  # worker skips its release, and the held digest then drops every later `perform_async` for that
-  # blast silently, which is what made the documented recovery a no-op (gumroad-private#1816).
-  sidekiq_options retry: 10, queue: :default
+  # Lock only while executing: recovery must be enqueueable after a hard kill, while two live
+  # attempts for the same blast must never send concurrently. The TTL releases an orphaned lock.
+  sidekiq_options retry: 10, queue: :default, lock: :while_executing, lock_ttl: 6.hours.to_i,
+                  lock_timeout: 2, on_conflict: { server: :raise }
 
   def perform(blast_id)
     @blast = PostEmailBlast.find(blast_id)

--- a/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
+++ b/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
@@ -12,10 +12,11 @@ describe AlertOnStalledPostEmailBlastsJob do
   end
 
   def stub_sidekiq(dead: [], retrying: [], busy: [], queued: [])
+    @dead_jobs = dead.index_with { |id| fake_sidekiq_job(id) }
     dead_set = instance_double(Sidekiq::DeadSet)
     allow(Sidekiq::DeadSet).to receive(:new).and_return(dead_set)
     allow(dead_set).to receive(:scan) do |_match, &block|
-      dead.each { |id| block.call(fake_sidekiq_job(id)) }
+      @dead_jobs.each_value { |job| block.call(job) }
     end
 
     retry_set = instance_double(Sidekiq::RetrySet)
@@ -38,11 +39,12 @@ describe AlertOnStalledPostEmailBlastsJob do
   end
 
   def fake_sidekiq_job(blast_id)
-    instance_double(Sidekiq::SortedEntry, klass: "SendPostBlastEmailsJob", args: [blast_id])
+    instance_double(Sidekiq::SortedEntry, klass: "SendPostBlastEmailsJob", args: [blast_id], retry: nil)
   end
 
   before do
     allow(InternalNotificationWorker).to receive(:perform_async)
+    allow(SendPostBlastEmailsJob).to receive(:perform_async)
   end
 
   it "reports a stalled blast with its dead-set disposition and per-blast delivered count" do
@@ -118,6 +120,91 @@ describe AlertOnStalledPostEmailBlastsJob do
     expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
       expect(message).to include("At least 1 email blast")
       expect(message).to include("The scan stopped at 1 incomplete blasts")
+    end
+  end
+
+  describe "auto-resume" do
+    context "when auto_resume_stalled_post_email_blasts is off" do
+      it "reports what it would resume without enqueuing anything" do
+        blast = stalled_blast(started: false)
+        stub_sidekiq
+
+        described_class.new.perform
+
+        expect(SendPostBlastEmailsJob).not_to have_received(:perform_async)
+        expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+          expect(message).to match(/blast #{blast.id}.*UNACCOUNTED → WOULD RESUME/)
+        end
+      end
+    end
+
+    context "when auto_resume_stalled_post_email_blasts is on" do
+      before { Feature.activate(:auto_resume_stalled_post_email_blasts) }
+
+      it "re-enqueues an unaccounted blast inside the resume window" do
+        blast = stalled_blast(started: false)
+        stub_sidekiq
+
+        described_class.new.perform
+
+        expect(SendPostBlastEmailsJob).to have_received(:perform_async).with(blast.id)
+        expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+          expect(message).to match(/blast #{blast.id}.*UNACCOUNTED → RESUMED/)
+        end
+      end
+
+      it "retries a dead blast's own dead-set entry instead of enqueuing a fresh job" do
+        blast = stalled_blast
+        stub_sidekiq(dead: [blast.id])
+
+        described_class.new.perform
+
+        expect(@dead_jobs.fetch(blast.id)).to have_received(:retry)
+        expect(SendPostBlastEmailsJob).not_to have_received(:perform_async)
+        expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+          expect(message).to match(/blast #{blast.id}.*DEAD → RESUMED/)
+        end
+      end
+
+      it "holds a blast past the resume window for a human" do
+        blast = stalled_blast(requested_hours_ago: 30, started: false)
+        stub_sidekiq
+
+        described_class.new.perform
+
+        expect(SendPostBlastEmailsJob).not_to have_received(:perform_async)
+        expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+          expect(message).to match(/blast #{blast.id}.*UNACCOUNTED → HELD PAST WINDOW/)
+        end
+      end
+
+      it "never resumes running, queued or retrying blasts" do
+        running = stalled_blast
+        queued = stalled_blast(post: create(:installment))
+        retrying = stalled_blast(post: create(:installment))
+        stub_sidekiq(busy: [running.id], queued: [queued.id], retrying: [retrying.id])
+
+        described_class.new.perform
+
+        expect(SendPostBlastEmailsJob).not_to have_received(:perform_async)
+        expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+          [running, queued, retrying].each do |blast|
+            expect(message).not_to match(/blast #{blast.id}.*→/)
+          end
+        end
+      end
+
+      it "reports a failed resume and still sends the alert" do
+        blast = stalled_blast(started: false)
+        stub_sidekiq
+        allow(SendPostBlastEmailsJob).to receive(:perform_async).and_raise(RedisClient::ConnectionError)
+
+        described_class.new.perform
+
+        expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+          expect(message).to match(/blast #{blast.id}.*UNACCOUNTED → RESUME FAILED/)
+        end
+      end
     end
   end
 end

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -21,12 +21,14 @@ describe SendPostBlastEmailsJob, :freeze_time do
     post
   end
 
-  # Asserted on the options rather than on behaviour because SidekiqUniqueJobs is disabled outright
-  # in test (`config.enabled = !Rails.env.test?`), so a re-enqueue succeeds here either way. A
-  # stranded digest silently drops every later `perform_async` for the blast, which is what made
-  # resuming a hard-killed blast a no-op (gumroad-private#1816).
-  it "declares no unique lock, so a stranded digest cannot suppress a resume" do
-    expect(described_class.get_sidekiq_options).not_to have_key("lock")
+  # SidekiqUniqueJobs is disabled in test, so pin the production middleware contract directly.
+  it "serializes live attempts without suppressing recovery enqueues" do
+    expect(described_class.get_sidekiq_options).to include(
+      "lock" => :while_executing,
+      "lock_ttl" => 6.hours.to_i,
+      "lock_timeout" => 2,
+      "on_conflict" => { "server" => :raise },
+    )
   end
 
   describe "#perform" do


### PR DESCRIPTION
## What

`AlertOnStalledPostEmailBlastsJob` now auto-resumes stalled blasts instead of only reporting them, behind a new `:auto_resume_stalled_post_email_blasts` flag (conservative default per gumroad-private#2106 decision 3, approved by Sahil 2026-08-13):

- **DEAD** blasts (dead-set entry exists): `job.retry` on the blast's own dead-set entry.
- **UNACCOUNTED** blasts (hard-killed worker, no dead entry): `SendPostBlastEmailsJob.perform_async(blast_id)` — picks up from the Redis audience snapshot.
- Only blasts requested within **24h** (`RESUME_WINDOW`) are resumed; older ones are `HELD PAST WINDOW` for a human, since time-boxed sale announcements may be worse delivered late than not at all.
- RUNNING / QUEUED / RETRYING blasts are never touched. Same-blast executions are serialized at runtime, so a queue-to-running transition cannot overlap the recovery copy; recovery enqueues remain possible after a hard kill.
- With the flag off, each eligible blast is annotated `WOULD RESUME` (dry-run, same pattern as `RecoverStrandedBuyersJob`).
- A resume failure is caught, logged, and annotated `RESUME FAILED` — the alert itself always still sends.

## Why

gumroad-private#2106: Sahil directed that the risk/payout alert jobs run fully autonomously. This was the last report-only job of the six — resuming a stalled blast previously required a human to read the alert and run the recovery command by hand.

## Before / After

Before (report line): `• blast 42 (post 7, seller 123) — requested 6.2h ago, 6800 delivered, DEAD`
After, flag on, inside window: `• blast 42 (post 7, seller 123) — requested 6.2h ago, 6800 delivered, DEAD → RESUMED`
After, flag on, past window: `… requested 30.0h ago, 0 delivered, UNACCOUNTED → HELD PAST WINDOW`
After, flag off: `… UNACCOUNTED → WOULD RESUME`

## Status

- [x] Scope — gp#2106 decision 3, conservative default approved
- [x] Design — DEAD `job.retry` / UNACCOUNTED re-enqueue / 24h `RESUME_WINDOW` / flag-gated dry-run
- [x] Build — job + flag gate + window hold
- [ ] QA — review fix checks green at the current head; clean current-head QA audit pending
- [ ] Shipped — merge + deploy, then ramp `auto_resume_stalled_post_email_blasts`
- [ ] Market — not applicable to this internal recovery job
- [ ] Sell — not applicable to this internal recovery job

## Test Results

- `bundle exec rspec spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb` — 12 examples, 0 failures (local, lane 0 env, load ~17).
- Mutation checks (run locally, mutant restored and diff-verified clean after each):
  - `live = Feature.active?(...)` → `live = true`: exactly the "reports what it would resume without enqueuing" example went red.
  - window guard → `if false`: exactly the "holds a blast past the resume window" example went red.
- `ruby -c` clean on the alert job, sender job, and changed specs.
- Review-fix runs: the alert job's full 12-example spec plus the sender's lock-contract example — 13 examples, 0 failures; the full sender spec — 40 examples, 0 failures after restoring the lane's required seeds and Vite test bundle.
- Execution-lock mutation: replacing `:while_executing` with `:until_executed` reddened only `serializes live attempts without suppressing recovery enqueues`.

## QA steps

1. Ran the full spec file locally against a lane test DB (above).
2. No rendered surface — this is a backend Sidekiq job whose only output is the internal notification message; the before/after report lines above are the observable artifact (generated by the specs' captured messages).

## Rollout

Flag ships OFF; the job's next runs annotate `WOULD RESUME` on real candidates so the ramp can be judged from live dry-run output, then `Feature.activate(:auto_resume_stalled_post_email_blasts)` (same playbook as the two flags ramped on gp#2106 today).

---

This PR was implemented with AI assistance using Grok 4.6, Claude Fable 5, and GPT-5.6 Sol.
