### PR TITLE
Serialize post blast senders with a per-blast run lock

### DIFF
--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -40,6 +40,7 @@ class RedisKey
     def blast_sent_emails(blast_id) = "blast:#{blast_id}:sent_emails"
     def blast_audience_snapshot(blast_id) = "blast:#{blast_id}:audience_snapshot"
     def blast_non_opener_emails(blast_id) = "blast:#{blast_id}:non_opener_emails"
+    def blast_sender_lock(blast_id) = "blast:#{blast_id}:sender_lock"
     def workflow_installment_rule_version(installment_id) = "workflow_installment_rule:#{installment_id}:version"
     def workflow_installment_rule_pending_token(installment_id) = "workflow_installment_rule:#{installment_id}:pending_token"
     def audience_member_load_max_execution_time_seconds = "audience_member_load:max_execution_time_seconds"

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -3,13 +3,38 @@
 class SendPostBlastEmailsJob
   include Sidekiq::Job
   include ActionView::Helpers::SanitizeHelper
-  # Deliberately no `lock: :until_executed`. The digest keys on the blast id, and every caller
-  # creates a fresh blast row before enqueuing, so it never deduplicated anything — but a hard-killed
-  # worker skips its release, and the held digest then drops every later `perform_async` for that
-  # blast silently, which is what made the documented recovery a no-op (gumroad-private#1816).
+  # Deliberately no `lock: :until_executed`: a hard-killed worker skips the digest release, and the
+  # stranded digest then silently drops every later `perform_async` for the blast, which is what
+  # made the documented recovery a no-op (gumroad-private#1816). Mutual exclusion comes from the
+  # TTL'd run lock in #perform instead — staleness is bounded, and contention reschedules the
+  # attempt rather than dropping it.
   sidekiq_options retry: 10, queue: :default
 
+  # Must outlive the longest phase with no refresh point (the audience load, capped at
+  # audience_load_timeout_seconds — default 1h). After a hard kill the lock lingers at most this
+  # long before a resume can proceed, immaterial against the 4h stall threshold of
+  # AlertOnStalledPostEmailBlastsJob.
+  SENDER_LOCK_TTL = 2.hours
+
+  SENDER_LOCK_RETRY_DELAY = 15.minutes
+
+  LOCK_RELEASE_SCRIPT = <<~LUA.squish
+    if redis.call('get', KEYS[1]) == ARGV[1] then
+      return redis.call('del', KEYS[1])
+    end
+  LUA
+
   def perform(blast_id)
+    @lock_key = RedisKey.blast_sender_lock(blast_id)
+    # CAS token, not a bare flag: a run that outlived its TTL must not delete a successor's lock.
+    @lock_token = SecureRandom.uuid
+    unless $redis.set(@lock_key, @lock_token, nx: true, ex: SENDER_LOCK_TTL.to_i)
+      # Another sender owns this blast. Re-check later rather than drop the enqueue — a silently
+      # dropped enqueue is exactly what stranded blasts before (gumroad-private#1816).
+      self.class.perform_in(SENDER_LOCK_RETRY_DELAY, blast_id)
+      return
+    end
+
     @blast = PostEmailBlast.find(blast_id)
     @post = @blast.post
     Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} post_id=#{@post.id}")
@@ -45,6 +70,8 @@ class SendPostBlastEmailsJob
     end
 
     mark_blast_as_completed
+  ensure
+    $redis.eval(LOCK_RELEASE_SCRIPT, keys: [@lock_key], argv: [@lock_token]) if @lock_token
   end
 
   private
@@ -76,6 +103,7 @@ class SendPostBlastEmailsJob
     # already accepted its recipients must not be handed them again because a later
     # provider failed, so the cleanup below only rolls back the slice that raised.
     def send_provider_slice(provider:, members:, cache:)
+      $redis.expire(@lock_key, SENDER_LOCK_TTL.to_i)
       members = store_recipients_as_sent(members)
       recipients = prepare_recipients(members)
 

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -717,6 +717,47 @@ describe SendPostBlastEmailsJob, :freeze_time do
     end
   end
 
+  describe "sender run lock" do
+    it "reschedules and sends nothing when another sender holds the blast's lock" do
+      blast = create(:blast, :just_requested, post: basic_post_with_audience)
+      lock_key = RedisKey.blast_sender_lock(blast.id)
+      $redis.set(lock_key, "other-run")
+
+      expect do
+        described_class.new.perform(blast.id)
+      end.to change { described_class.jobs.size }.by(1)
+
+      expect(described_class.jobs.last["args"]).to eq([blast.id])
+      expect_sent_count 0
+      expect(blast.reload.started_at).to be_blank
+      # The bounced run's own release must not delete the owner's lock.
+      expect($redis.get(lock_key)).to eq("other-run")
+    ensure
+      $redis.del(lock_key) if lock_key
+    end
+
+    it "releases the lock after a completed send" do
+      blast = create(:blast, :just_requested, post: basic_post_with_audience)
+
+      described_class.new.perform(blast.id)
+
+      expect(blast.reload.completed_at).to be_present
+      expect($redis.exists?(RedisKey.blast_sender_lock(blast.id))).to eq(false)
+    end
+
+    it "releases the lock when a provider send raises so a retry can reacquire it" do
+      blast = create(:blast, :just_requested, post: basic_post_with_audience)
+      allow(PostEmailApi).to receive(:provider_for).and_return(MailerInfo::EMAIL_PROVIDER_SENDGRID)
+      expect(PostSendgridApi).to receive(:process).and_raise(StandardError.new("API failure"))
+
+      expect do
+        described_class.new.perform(blast.id)
+      end.to raise_error(StandardError, "API failure")
+
+      expect($redis.exists?(RedisKey.blast_sender_lock(blast.id))).to eq(false)
+    end
+  end
+
   def expect_sent_count(count)
     expect(PostSendgridApi.mails.size).to eq(count)
   end


### PR DESCRIPTION
## What

`SendPostBlastEmailsJob` now takes a per-blast Redis run lock before sending: `SET NX` with a 2-hour TTL, refreshed on every provider slice, released via a CAS-token Lua script so a run that outlived its TTL can never delete a successor's lock. A second sender enqueued for the same blast — a watchdog auto-resume, a console `perform_async` during incident recovery, a dead-set retry — reschedules itself 15 minutes out instead of running concurrently.

## Why

Resuming a stalled blast is only safe if no other sender for it is secretly alive, and today nothing enforces that. Regular blasts survive a concurrent duplicate because `SentPostEmail.insert_all_emails` claims recipients pre-send on a unique index — but non-opener resends dedupe against a Redis set that is read once at job start and only written after delivery, so two concurrent senders both see the unsent audience and double-deliver it.

Two alternatives exist for the same problem:

- #7222 (closed) put `lock: :while_executing, lock_ttl: 6h` on this job via sidekiq-unique-jobs. Same semantics, but it reintroduces the machinery whose stranded-digest failure mode made blast recovery a silent no-op (gumroad-private#1816). This lock differs on both axes that mattered there: staleness is bounded by the TTL, and contention reschedules rather than silently drops.
- #7223 guards its auto-resume with a once-per-blast `SET NX` marker. That serializes the watchdog against itself but protects no other caller, and its DEAD/UNACCOUNTED classification is inferred from point-in-time Sidekiq snapshots, which can misread a live sender as vanished. With the lock at the sender, that classification becomes advisory instead of load-bearing, and #7223 can ship unchanged on top of this.

This is the same hand-rolled lock pattern already in production in `AutoTopUpNegativeDestinationBalancesJob` (CAS token + guarded Lua release).

## Before / After

Backend-only; there is genuinely no UI surface to record. The behavioral before/after, pinned by the new specs: before, a second `SendPostBlastEmailsJob.perform_async(blast_id)` issued while a sender was mid-run executed immediately (double-delivering a non-opener blast's remaining audience); after, it reschedules 15 minutes out, the owner's lock is untouched, and the audience receives one copy.

## Test Results

- `bundle exec rspec spec/sidekiq/send_post_blast_emails_job_spec.rb` — 43 examples: the 3 new "sender run lock" examples pass; the 18 failures are pre-existing local-environment failures (purchase factories need a Gumroad merchant account that doesn't exist locally) and occur identically on unmodified `main` (40 examples, same 18 failures).
- Mutation proof: reverting only `app/sidekiq/send_post_blast_emails_job.rb` to `main` while keeping the new specs turns the contention example red (the two release examples pass vacuously without a lock; the contention one is the load-bearing pin). File restored byte-identical after.
- `bundle exec rubocop -a` on the three changed files — no offenses.
- `bin/check-migration-versions` — OK (no migrations in this PR).
- `bin/test-confidence` could not run in this shell (no `ANTHROPIC_API_KEY`); the affected spec file was run directly instead.

## QA steps

1. Start a large blast, then enqueue a duplicate `SendPostBlastEmailsJob.perform_async(blast.id)` from a console: the duplicate lands in the scheduled set ~15 minutes out, and `$redis.get(RedisKey.blast_sender_lock(blast.id))` shows the running attempt's token.
2. Let the blast complete: the lock key is deleted, and the rescheduled duplicate exits through the existing `completed_at` guard without sending.
3. Normal operation is unchanged — the lock is uncontended on every ordinary send — so this can soak in production before `:auto_resume_stalled_post_blasts` (#7223) ramps.

---

AI disclosure: Claude Fable 5.