### PR TITLE
Route blocked-established buyer/subscriber reports to the agent inbox

### DIFF
--- a/app/sidekiq/alert_on_blocked_established_buyers_job.rb
+++ b/app/sidekiq/alert_on_blocked_established_buyers_job.rb
@@ -24,7 +24,9 @@ class AlertOnBlockedEstablishedBuyersJob
     # platform, decided the report was empty.
     return if scan[:stranded].empty? && !scan[:truncated]
 
-    InternalNotificationWorker.perform_async("risk", "Blocked established buyers", message_for(scan))
+    # agent_reports, not risk: RecoverStrandedBuyersJob works this same population autonomously
+    # and escalates the ambiguous cases itself, so humans only need its report (gumroad-private#2106).
+    InternalNotificationWorker.perform_async("agent_reports", "Blocked established buyers", message_for(scan))
   end
 
   private

--- a/app/sidekiq/alert_on_blocked_established_subscribers_job.rb
+++ b/app/sidekiq/alert_on_blocked_established_subscribers_job.rb
@@ -57,7 +57,9 @@ class AlertOnBlockedEstablishedSubscribersJob
     # platform, decided the report was empty.
     return if scan[:stranded].empty? && !scan[:truncated]
 
-    InternalNotificationWorker.perform_async("risk", "Blocked established subscribers", message_for(scan))
+    # agent_reports, not risk: the stranded-buyer recovery lane works these candidates
+    # autonomously, so humans only see its escalations (gumroad-private#2106).
+    InternalNotificationWorker.perform_async("agent_reports", "Blocked established subscribers", message_for(scan))
   end
 
   private

--- a/app/sidekiq/recover_stranded_buyers_job.rb
+++ b/app/sidekiq/recover_stranded_buyers_job.rb
@@ -179,18 +179,23 @@ class RecoverStrandedBuyersJob
         dry_run: !live,
       )
       { email: candidate[:email], verdict: result.verdict, reason: result.reason,
-        cleared: result.cleared.size, withheld: result.skipped.size }
+        cleared: result.cleared.size, withheld: result.skipped.size,
+        withheld_for_human: result.skipped.count { |_block, why| why == :shared_identifier_needs_human_review } }
     rescue => e
       # One buyer's failure must not strand the rest of the run or the report — anything the
       # service raises (its own guard errors, a deadlock on unblock!, RecordInvalid from the admin
       # comment) becomes a named ERROR line. A live clear that failed mid-transaction already
       # rolled its rows back inside the service.
-      { email: candidate[:email], verdict: :error, reason: "#{e.class}: #{e.message}", cleared: 0, withheld: 0 }
+      { email: candidate[:email], verdict: :error, reason: "#{e.class}: #{e.message}", cleared: 0, withheld: 0, withheld_for_human: 0 }
     end
 
     def message_for(outcomes, live:, total:, out_of_budget: 0)
       counts = outcomes.group_by { _1[:verdict] }.transform_values(&:size)
       escalations = outcomes.select { _1[:verdict] == :escalate }
+      # Named, not just counted: a shared-radius (domain/IP) block only ever clears when a human
+      # reads this line and decides — with the detail reports now agent-only (#7230), this is the
+      # sole human-facing surface that identifies who is waiting.
+      human_holds = outcomes.select { _1[:withheld_for_human].to_i.positive? }
       errors = outcomes.select { _1[:verdict] == :error }
       blocks_cleared = outcomes.sum { _1[:cleared] }
       withheld = outcomes.sum { _1[:withheld] }
@@ -204,6 +209,9 @@ class RecoverStrandedBuyersJob
         ("" if escalations.any?),
         *escalations.first(MAX_REPORTED_ESCALATIONS).map { |o| "• ESCALATE #{o[:email]} — authored block, needs a human decision" },
         (escalations.size > MAX_REPORTED_ESCALATIONS ? "…and #{escalations.size - MAX_REPORTED_ESCALATIONS} more escalations." : nil),
+        ("" if human_holds.any?),
+        *human_holds.first(MAX_REPORTED_ESCALATIONS).map { |o| "• WITHHELD #{o[:email]} — #{o[:withheld_for_human]} shared-radius block(s) (domain/IP), needs a human decision" },
+        (human_holds.size > MAX_REPORTED_ESCALATIONS ? "…and #{human_holds.size - MAX_REPORTED_ESCALATIONS} more withheld buyers." : nil),
         ("" if errors.any?),
         *errors.map { |o| "• ERROR #{o[:email]} — #{o[:reason]}" },
       ].compact.join("\n")

--- a/config/initializers/chat_rooms.rb
+++ b/config/initializers/chat_rooms.rb
@@ -9,6 +9,9 @@ PAYMENTS_NOTIFICATION_EMAIL = GlobalConfig.get("PAYMENTS_NOTIFICATION_EMAIL", "h
 INTERNAL_NOTIFICATION_ALWAYS_CC = GlobalConfig.get("INTERNAL_NOTIFICATION_ALWAYS_CC", "gumclaw@gumroad.com")
 
 CHAT_ROOMS = {
+  # Reports the agent already works autonomously (gumroad-private#2106): delivered to the
+  # agent inbox only, so the finding stays recorded without pushing mail at a human.
+  agent_reports: { email: INTERNAL_NOTIFICATION_ALWAYS_CC },
   announcements: { email: INTERNAL_NOTIFICATION_EMAIL },
   awards: { email: INTERNAL_NOTIFICATION_EMAIL },
   internals_log: { email: INTERNAL_NOTIFICATION_EMAIL },

--- a/spec/mailers/internal_notification_mailer_spec.rb
+++ b/spec/mailers/internal_notification_mailer_spec.rb
@@ -53,6 +53,24 @@ describe InternalNotificationMailer do
       end
     end
 
+    context "for the agent_reports room" do
+      subject(:mail) do
+        described_class.notify(
+          room_name: "agent_reports",
+          sender: "Blocked established buyers",
+          message_text: "report"
+        )
+      end
+
+      # The room exists to keep autonomously-worked reports out of human inboxes
+      # (gumroad-private#2106); pointing it at a human recipient regresses that silently.
+      it "delivers to the agent inbox only" do
+        expect(mail.to).to eq([INTERNAL_NOTIFICATION_ALWAYS_CC])
+        expect(mail.to).not_to include(INTERNAL_NOTIFICATION_EMAIL)
+        expect(mail.cc).to be_nil
+      end
+    end
+
     context "when room has no email configured" do
       subject(:mail) do
         described_class.notify(

--- a/spec/sidekiq/alert_on_blocked_established_buyers_job_spec.rb
+++ b/spec/sidekiq/alert_on_blocked_established_buyers_job_spec.rb
@@ -41,7 +41,7 @@ describe AlertOnBlockedEstablishedBuyersJob do
     described_class.new.perform
 
     expect(InternalNotificationWorker).to have_received(:perform_async) do |room, sender, message|
-      expect(room).to eq("risk")
+      expect(room).to eq("agent_reports")
       expect(sender).to eq("Blocked established buyers")
       expect(message).to include(email)
       expect(message).to include("#{established_count} settled purchases")
@@ -677,7 +677,7 @@ describe AlertOnBlockedEstablishedBuyersJob do
   # InternalNotificationMailer#notify returns silently when the room has no recipient, which would
   # leave the job permanently dark with all specs green.
   it "sends to a room that resolves to a real recipient" do
-    mail = InternalNotificationMailer.notify(room_name: "risk", sender: "spec", message_text: "hello")
+    mail = InternalNotificationMailer.notify(room_name: "agent_reports", sender: "spec", message_text: "hello")
 
     expect(mail.to).to be_present
   end

--- a/spec/sidekiq/alert_on_blocked_established_subscribers_job_spec.rb
+++ b/spec/sidekiq/alert_on_blocked_established_subscribers_job_spec.rb
@@ -48,7 +48,7 @@ describe AlertOnBlockedEstablishedSubscribersJob do
     described_class.new.perform
 
     expect(InternalNotificationWorker).to have_received(:perform_async) do |room, _sender, message|
-      expect(room).to eq("risk")
+      expect(room).to eq("agent_reports")
       expect(message).to include("subscription #{subscription.id}")
       expect(message).to include("#{described_class::MIN_SUCCESSFUL_CHARGES} successful charges")
       expect(message).to include("blocked since #{block.blocked_at.to_date}")
@@ -62,7 +62,7 @@ describe AlertOnBlockedEstablishedSubscribersJob do
 
     described_class.new.perform
 
-    expect(InternalNotificationWorker).to have_received(:perform_async).with("risk", "Blocked established subscribers", anything)
+    expect(InternalNotificationWorker).to have_received(:perform_async).with("agent_reports", "Blocked established subscribers", anything)
   end
 
   # The gap the pre-merge review found: a renewal can fail on a domain block too, and those rows
@@ -909,7 +909,7 @@ describe AlertOnBlockedEstablishedSubscribersJob do
   # and InternalNotificationMailer#notify returns silently when the room has no recipient, which
   # would leave the job permanently dark with all specs green.
   it "sends to a room that resolves to a real recipient" do
-    mail = InternalNotificationMailer.notify(room_name: "risk", sender: "spec", message_text: "hello")
+    mail = InternalNotificationMailer.notify(room_name: "agent_reports", sender: "spec", message_text: "hello")
 
     expect(mail.to).to be_present
   end

--- a/spec/sidekiq/recover_stranded_buyers_job_spec.rb
+++ b/spec/sidekiq/recover_stranded_buyers_job_spec.rb
@@ -145,6 +145,38 @@ describe RecoverStrandedBuyersJob do
     end
   end
 
+  it "names withheld buyers so a human can act on shared-radius blocks the detail report no longer reaches them for" do
+    allow(Risk::StrandedBuyerScanService).to receive(:call)
+      .and_return(stranded: [candidate.merge(email: "held@example.com")], truncated: false)
+    withheld_blocks = [
+      [PlatformBlock.new(object_type: PlatformBlock::TYPES[:email_domain]), :shared_identifier_needs_human_review],
+      [PlatformBlock.new(object_type: PlatformBlock::TYPES[:charge_processor_fingerprint]), :card_still_declining_at_issuer],
+    ]
+    allow(Risk::StrandedBuyerRecoveryService).to receive(:call)
+      .and_return(recovery_result(:cleared, :single_decline_auto_block, cleared: [PlatformBlock.new], skipped: withheld_blocks))
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _sender, message|
+      # Only the shared-radius hold is a human decision; a still-declining card is the issuer's, so
+      # the line must count 1, not 2.
+      expect(message).to include("WITHHELD held@example.com — 1 shared-radius block(s)")
+    end
+  end
+
+  it "prints no WITHHELD line when nothing was held for a human" do
+    allow(Risk::StrandedBuyerScanService).to receive(:call)
+      .and_return(stranded: [candidate], truncated: false)
+    allow(Risk::StrandedBuyerRecoveryService).to receive(:call)
+      .and_return(recovery_result(:cleared, :single_decline_auto_block, cleared: [PlatformBlock.new]))
+
+    described_class.new.perform
+
+    expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _sender, message|
+      expect(message).not_to include("WITHHELD")
+    end
+  end
+
   it "stops starting recoveries once the run budget elapses and reports the remainder as unprocessed" do
     candidates = 3.times.map { |i| candidate.merge(email: "slow#{i}@example.com") }
     allow(Risk::StrandedBuyerScanService).to receive(:call).and_return(stranded: candidates, truncated: false)


### PR DESCRIPTION
Premerge review: clean @ 91c9fa889041661a657a7d7b74dbeb403e26c721

## Status

- [x] Scope — Sahil's directive on gumroad-private#2106 ("Suppress the mail"): stop pushing the two blocked-established reports at a human inbox
- [x] Design — route to a new `agent_reports` room (agent inbox only) rather than deleting the send, so findings stay recorded and agent-ingestible
- [x] Build — both jobs rerouted, room added, specs updated + new recipient pin
- [x] QA — mailer rendered in test env; full spec runs below; mutation proof (room reverted to `risk` → spec red); QA audit Round 1 at `a3f21193` clean; Round 2 at `91c9fa88` clean (delta = Greptile-P1 fix naming withheld shared-radius buyers in the recovery job's human report)
- [ ] Shipped — awaiting merge + deploy
- [ ] Market — n/a (internal ops change)
- [ ] Sell — n/a

## What

Routes the `Blocked established buyers` and `Blocked established subscribers` reports to a new `agent_reports` room (delivered to the agent inbox only) instead of the `risk` room's human inbox.

## Why

With `:auto_recover_stranded_buyers` now live, `RecoverStrandedBuyersJob` works this exact population autonomously and escalates the genuinely ambiguous cases itself, so these two reports are redundant push-mail for a human. Routing to `agent_reports` rather than deleting the send keeps the findings recorded and agent-ingestible (the agent inbox was already CC'd on every notification) while removing them from the human `risk` inbox.

## Before / After

| Report | Before (`to` / `cc`) | After (`to` / `cc`) |
| --- | --- | --- |
| Blocked established buyers | hi@gumroad.com / gumclaw@gumroad.com | gumclaw@gumroad.com / — |
| Blocked established subscribers | hi@gumroad.com / gumclaw@gumroad.com | gumclaw@gumroad.com / — |

No other room or report changes. The mailer already dedups CC when the room recipient IS the always-CC address, so `agent_reports` mail carries no duplicate CC (covered by an existing spec plus a new one pinning the room's recipient).

## Test Results

- `bundle exec rspec spec/mailers/internal_notification_mailer_spec.rb` — 9 examples, 0 failures (includes the new `agent_reports` recipient pin)
- `bundle exec rspec spec/sidekiq/alert_on_blocked_established_buyers_job_spec.rb spec/sidekiq/alert_on_blocked_established_subscribers_job_spec.rb` — 103 examples, 0 failures
- `bundle exec rspec spec/sidekiq/recover_stranded_buyers_job_spec.rb` — 23 examples, 0 failures (covers the 91c9fa88 WITHHELD-line delta)
- Full suite (`run-all-specs`) green on CI at `91c9fa88`; one flaky shard (`js_error_reporter_spec`, unrelated, green locally and on rerun)
- Mutation proof: reverting the buyers job's room to `"risk"` turns the room-pinning example red (`spec/sidekiq/alert_on_blocked_established_buyers_job_spec.rb:34`); mutant removed, worktree byte-identical to HEAD afterwards
- `ruby -c` on all changed .rb files — Syntax OK

## QA steps

Rendered `InternalNotificationMailer.notify(room_name: "agent_reports", ...)` in the test env and verified `to == ["gumclaw@gumroad.com"]`, `cc == nil`, subject carries `[agent_reports]`. Backend-only change with no user-facing rendered surface — confirming that explicitly rather than skipping the evidence step silently.

---

AI disclosure: authored by gumclaw (Hermes agent, model grok-4.6).
