### PR TITLE
Keep the newly selected variant's pages on a Content tab switch

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
@@ -527,9 +527,9 @@ it("skips recording a deleted page's id while another page still carries it", as
   expect(paidVariant.rich_content).toEqual([]);
 });
 
-// Sortable's layout-time setList runs before useRefToLatest's effect flushes
-// pagesRef. Without a current-pages write, that report is the previous
-// variant's membership and overwrites the newly selected tier (gp#2023).
+// Sortable writes `list` back during layout. A stale pagesRef would then
+// treat that report as the previous variant's membership and overwrite
+// the newly selected tier (gp#2023).
 it("keeps the newly selected variant's pages when Sortable reports during the switch", async () => {
   const freePage = makePage("page-free", "FREE DOC", "Freepass");
   const paidMag = makePage("page-paid-mag", "ISSUE 40", "TischLog Mag");
@@ -565,4 +565,43 @@ it("keeps the newly selected variant's pages when Sortable reports during the sw
     { id: "page-paid-extras", title: "Extras" },
   ]);
   expect(freeVariant.rich_content.map(({ id }) => id)).toEqual(["page-free"]);
+});
+
+// Shared raw ids overlap, so the disjoint-id guard does not fire. Only a
+// current pagesRef keeps extra-b and drops extra-a (gp#2023).
+it("keeps the newly selected variant's pages when a raw id is shared across tiers", async () => {
+  const tierA: VariantFixture = {
+    id: "variant-a",
+    name: "A",
+    rich_content: [makePage("shared-id", "TIER A DOC", "Alpha"), makePage("extra-a", "A EXTRA", "A extra")],
+  };
+  const tierB: VariantFixture = {
+    id: "variant-b",
+    name: "B",
+    rich_content: [makePage("shared-id", "TIER B DOC", "Beta"), makePage("extra-b", "B EXTRA", "B extra")],
+  };
+  const product = buildProduct([tierA, tierB]);
+
+  sortable.echoList = true;
+  context.product = product;
+  context.updateProduct = (update: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the update union for the fixture
+    if (typeof update === "function") (update as (p: Product) => void)(product);
+    else Object.assign(product, update);
+  };
+
+  const { rerender } = render(<ContentTabContent selectedVariantId="variant-a" />);
+  await act(async () => {});
+
+  rerender(<ContentTabContent selectedVariantId="variant-b" />);
+  await act(async () => {});
+
+  expect(tierB.rich_content.map(({ id, title }) => ({ id, title }))).toEqual([
+    { id: "shared-id", title: "Beta" },
+    { id: "extra-b", title: "B extra" },
+  ]);
+  expect(tierA.rich_content.map(({ id, title }) => ({ id, title }))).toEqual([
+    { id: "shared-id", title: "Alpha" },
+    { id: "extra-a", title: "A extra" },
+  ]);
 });

--- a/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
@@ -73,9 +73,26 @@ vi.mock("$app/components/ReviewForm", () => ({ ReviewForm: () => null }));
 vi.mock("$app/components/UpsellSelectModal", () => ({ UpsellSelectModal: () => null }));
 vi.mock("$app/components/TestimonialSelectModal", () => ({ TestimonialSelectModal: () => null }));
 vi.mock("$app/components/ProductEdit/ContentTab/EpubNudge", () => ({ EpubNudge: () => null }));
+const sortable = vi.hoisted(() => ({ echoList: false }));
 vi.mock("react-sortablejs", () => ({
   default: ({ children }: { children: React.ReactNode }) => children,
-  ReactSortable: ({ children }: { children: React.ReactNode }) => children,
+  // Production Sortable writes `list` back through setList during layout.
+  // Off by default so other tests keep a silent stub; the switch-overwrite
+  // case turns it on to reproduce that write.
+  ReactSortable: ({
+    children,
+    list,
+    setList,
+  }: {
+    children: React.ReactNode;
+    list: unknown[];
+    setList: (next: unknown[]) => void;
+  }) => {
+    React.useLayoutEffect(() => {
+      if (sortable.echoList) setList(list);
+    }, [list, setList]);
+    return children;
+  },
 }));
 const alerts = vi.hoisted((): { message: string; level: string }[] => []);
 vi.mock("$app/components/server-components/Alert", () => ({
@@ -86,6 +103,7 @@ afterEach(() => {
   cleanup();
   mountedEditor = null;
   alerts.length = 0;
+  sortable.echoList = false;
 });
 
 const getMountedEditor = () => {
@@ -507,4 +525,44 @@ it("skips recording a deleted page's id while another page still carries it", as
   await deletePageAt(0);
   expect(product.confirmed_removed_rich_content_ids).toEqual(["unique-id"]);
   expect(paidVariant.rich_content).toEqual([]);
+});
+
+// Sortable's layout-time setList runs before useRefToLatest's effect flushes
+// pagesRef. Without a current-pages write, that report is the previous
+// variant's membership and overwrites the newly selected tier (gp#2023).
+it("keeps the newly selected variant's pages when Sortable reports during the switch", async () => {
+  const freePage = makePage("page-free", "FREE DOC", "Freepass");
+  const paidMag = makePage("page-paid-mag", "ISSUE 40", "TischLog Mag");
+  const paidExtras = makePage("page-paid-extras", "BONUS", "Extras");
+  const freeVariant: VariantFixture = { id: "variant-free", name: "Creator Freepass", rich_content: [freePage] };
+  const paidVariant: VariantFixture = {
+    id: "variant-paid",
+    name: "Insight Collector",
+    rich_content: [paidMag, paidExtras],
+  };
+  const product = buildProduct([freeVariant, paidVariant]);
+
+  sortable.echoList = true;
+  context.product = product;
+  context.updateProduct = (update: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the update union for the fixture
+    if (typeof update === "function") (update as (p: Product) => void)(product);
+    else Object.assign(product, update);
+  };
+
+  const { rerender } = render(<ContentTabContent selectedVariantId="variant-free" />);
+  await act(async () => {});
+  expect(paidVariant.rich_content.map(({ id, title }) => ({ id, title }))).toEqual([
+    { id: "page-paid-mag", title: "TischLog Mag" },
+    { id: "page-paid-extras", title: "Extras" },
+  ]);
+
+  rerender(<ContentTabContent selectedVariantId="variant-paid" />);
+  await act(async () => {});
+
+  expect(paidVariant.rich_content.map(({ id, title }) => ({ id, title }))).toEqual([
+    { id: "page-paid-mag", title: "TischLog Mag" },
+    { id: "page-paid-extras", title: "Extras" },
+  ]);
+  expect(freeVariant.rich_content.map(({ id }) => id)).toEqual(["page-free"]);
 });

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -218,11 +218,14 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
   const pages: (Page & { chosen?: boolean })[] = selectedVariant ? selectedVariant.rich_content : product.rich_content;
   const pagesRef = useRefToLatest(pages);
   const setPages = (nextPages: Page[]) =>
-    updateProduct((product) => {
-      if (selectedVariant) selectedVariant.rich_content = nextPages;
+    updateProduct((current) => {
+      const variant = current.has_same_rich_content_for_all_variants
+        ? undefined
+        : current.variants.find((item) => item.id === selectedVariantId);
+      if (variant) variant.rich_content = nextPages;
       else {
-        product.has_same_rich_content_for_all_variants = true;
-        product.rich_content = nextPages;
+        current.has_same_rich_content_for_all_variants = true;
+        current.rich_content = nextPages;
       }
     });
   // Only the sortable goes through this. Its report is a DOM-derived list, so a
@@ -231,8 +234,20 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
   // row (gumroad-private#1508). Intentional removals (the confirm modal, the
   // copy-from-version replacement) call setPages directly, so reconciliation
   // cannot resurrect what the seller actually deleted.
-  const reorderPages = (reportedPages: Page[]) =>
-    setPages(reorderRowsPreservingMembership(reportedPages, pagesRef.current));
+  const reorderPages = (reportedPages: Page[]) => {
+    const currentPages = pagesRef.current;
+    // A report whose ids are disjoint from this variant is the previous
+    // variant's list arriving late (Sortable layout vs a stale pagesRef).
+    // Adopting it would replace this tier's pages with another tier's.
+    if (
+      reportedPages.length > 0 &&
+      currentPages.length > 0 &&
+      reportedPages.every((row) => !currentPages.some((page) => page.id === row.id))
+    ) {
+      return;
+    }
+    setPages(reorderRowsPreservingMembership(reportedPages, currentPages));
+  };
   // Records that the seller explicitly deleted these pages, so the server-side
   // wipe guard allows removing them even though they may still have content.
   // A STORED id another surviving page still carries is skipped: raw ids can

--- a/app/javascript/components/useRefToLatest.ts
+++ b/app/javascript/components/useRefToLatest.ts
@@ -1,11 +1,10 @@
 import * as React from "react";
 
-// Use to stash the latest `value` into a ref.
-// Useful to update hook consumer-supplied event handler without tearing down and setting up a new event listener.
+// Assign during render so layout-time children (Sortable setList) see this
+// paint's value. An effect-timed write left ContentTab holding the previous
+// variant for one frame and overwrote the newly selected tier's pages.
 export const useRefToLatest = <T>(value: T): React.MutableRefObject<T> => {
   const ref = React.useRef(value);
-  React.useEffect(() => {
-    ref.current = value;
-  }, [value]);
+  ref.current = value;
   return ref;
 };

--- a/spec/services/product/variant_deleted_ids_kind_invariant_spec.rb
+++ b/spec/services/product/variant_deleted_ids_kind_invariant_spec.rb
@@ -250,7 +250,10 @@ describe "deleted_ids[:variants] kind invariant" do
     it "reorders the content page list without letting a page leave the list" do
       source = File.read(javascript_root.join("components", "ProductEdit", "ContentTab", "index.tsx"))
 
-      expect(source).to match(/reorderRowsPreservingMembership\(reportedPages, pagesRef\.current\)/),
+      expect(source).to match(/const currentPages = pagesRef\.current/),
+                        "The content page list must snapshot pagesRef before reordering. A stale or " \
+                        "inline-only read can drop a page the sortable omitted — see gumroad-private#1508."
+      expect(source).to match(/reorderRowsPreservingMembership\(reportedPages, currentPages\)/),
                         "The content page list must reorder through reorderRowsPreservingMembership. Assigning " \
                         "the sortable's list straight to rich_content drops any page it omits — see " \
                         "gumroad-private#1508."


### PR DESCRIPTION
## What

Stops the Content editor from replacing a newly selected membership tier's pages with the previously selected tier's pages.

Selecting a paid tier remounts the page-list Sortable, which writes its `list` back through `setList` during layout. `pagesRef` was updated in a `useEffect`, so that write still saw the previous variant. `reorderRowsPreservingMembership` then adopted the previous tier's pages (no id overlap) and `setPages` stored them on the newly selected variant. The original paid-tier pages vanished from live state while still sitting in `lastSavedProductRef`, so [#7213](https://github.com/antiwork/gumroad/pull/7213)'s "Some content couldn't be loaded" modal fired after a clean refresh.

This:

- Assigns `useRefToLatest` during render so layout-time children see this paint's value
- Ignores a Sortable report whose ids are disjoint from the current variant
- Writes `setPages` through the updater's matching variant by id, not a closed-over object

## Why

[#7213](https://github.com/antiwork/gumroad/pull/7213) is a fail-closed save guard, not a load-path fix. The seller still hit that modal yesterday after a hard refresh: the paid-tier issues painted behind the modal while those same page titles were listed as missing. That is this overwrite — the mounted doc still had the original page, live state did not.

Part of [Fix recurring content editor tier-switching/save-conflict bug on membership products](https://github.com/antiwork/gumroad-private/issues/2023). Does not close that issue: seller retest of a paid-tier add/save is still required after this deploys.

## Before / After

Before: select any paid tier after Freepass → Sortable writes Freepass pages onto that tier → save blocked with "Some content couldn't be loaded" listing TischLog Mag + Extras.

After: the newly selected tier keeps its own pages. Save is not blocked by a false missing-content conflict.

Visual QA on the preview app after it deploys: open a membership with per-tier pages, switch from the first tier to another, confirm the page list and titles stay with that tier, then save.

## Test Results

- `npx vitest run app/javascript/components/ProductEdit/ContentTab/index.test.tsx app/javascript/components/server-components/ProductEditPage.test.tsx` — 27 passed
- Mutation check: reverting both production changes turns the new switch spec red (paid tier receives the Freepass page). Restoring them turns it green.

## QA steps

1. Open the preview app product editor for a membership with per-tier content (not "same content for all versions").
2. Note the first tier's page titles, then select a different tier from Editing.
3. Confirm that tier's original pages/titles remain (not the first tier's).
4. Save. Expect "Changes saved!", not "Some content couldn't be loaded".

---

AI disclosure: Written by Hermes Agent (Grok 4.6 / xAI) for Gianfranco. Prompts: what remains to close gumroad-private#2023; then "you do the PR and assign to me (Gianfranco)".
Premerge review: clean @ d4e6302b18f889906e2d0848d236413c7b71b95b
