### PR TITLE
Trim RecoverStrandedBuyersJob comments to the rotation traps

### DIFF
--- a/app/sidekiq/recover_stranded_buyers_job.rb
+++ b/app/sidekiq/recover_stranded_buyers_job.rb
@@ -1,47 +1,36 @@
 # frozen_string_literal: true
 
-# Runs Risk::StrandedBuyerRecoveryService over the scan's candidates on a schedule instead of
-# waiting on a human to read AlertOnBlockedEstablishedBuyersJob's report. A Sidekiq job rather than
-# the admin recover endpoint because one recovery's history scans can exceed the HTTP edge budget.
+# Scheduled recovery over Risk::StrandedBuyerRecoveryService so a human does not have to drain
+# AlertOnBlockedEstablishedBuyersJob. A job, not the admin endpoint: one recovery's history scan
+# can exceed the HTTP edge budget.
 #
-# Clears live only behind :auto_recover_stranded_buyers; with the flag off every candidate is
-# dry-run and the report says what WOULD have cleared, so the rollout can be judged from real
-# candidates before any enforcement is removed.
+# Live clears only behind :auto_recover_stranded_buyers. Flag off = dry-run every candidate and
+# report what would have cleared.
 class RecoverStrandedBuyersJob
   include Sidekiq::Job
   sidekiq_options retry: 1, queue: :low, lock: :until_executed
   include RecurringLockTtl
-  # RUN_BUDGET stops new recoveries, so the worst case is the budget plus the recovery already
-  # in flight when it elapses (a single recovery has run past 2 minutes; give it ten).
+  # Worst case is RUN_BUDGET plus the recovery already in flight (one has run past 2 minutes).
   recurring_lock_ttl max_attempt: 25.minutes
 
-  # Bounds one run's blast radius; the bucketing below guarantees the rest are reached on later runs.
   MAX_RECOVERIES_PER_RUN = 25
 
-  # One recovery's history scans can run past two minutes (see the class comment), so a full
-  # window of 25 could hold a :low worker for most of an hour and a mid-run deploy restart
-  # would re-run the whole window under retry: 1. Stop starting new recoveries past this and
-  # report the remainder as unprocessed instead.
+  # Stop starting new recoveries past this. A full window of 25 can hold a :low worker for most
+  # of an hour, and a mid-run deploy restart would re-run the window under retry: 1.
   RUN_BUDGET = 15.minutes
 
-  # Coverage cycle length in days. Each buyer's bucket is a hash of their OWN email, so unlike an
-  # index into the scan array, it survives other buyers joining/leaving or the scan's rank order
-  # shifting day to day — the property Greptile's array-rotation review kept catching. Sized so a
-  # ~240-candidate population hashes to ~24 per bucket — inside MAX_RECOVERIES_PER_RUN — and the
-  # full cycle clears in ~10 days.
+  # Hash of the buyer's own email, so assignment survives others joining/leaving and the scan's
+  # rank shifting. Sized for ~240 candidates → ~24/bucket, inside MAX_RECOVERIES_PER_RUN.
   ROTATION_BUCKETS = 10
 
-  # Escalations are the run's point — each names a buyer a human decision is holding. Cleared and
-  # skipped buyers are counted, not listed.
   MAX_REPORTED_ESCALATIONS = 15
 
-  # Anchor for the sub-rotation cycle counter below. Must be a fixed date, not `Date.current.yday`
-  # (which resets every January and starves any oversized-bucket page past index 12 — Greptile P1).
+  # Fixed date, not Date.current.yday — yday resets in January and starves any oversized-bucket
+  # page past index 12.
   ROTATION_EPOCH = Date.new(2020, 1, 1)
 
-  # Oversized-bucket sub-paging, sized so a ~24-candidate bucket's subpages stay comfortably under
-  # MAX_RECOVERIES_PER_RUN even as the population grows (see `subpage` below for why this must be
-  # fixed rather than derived from the bucket's current size).
+  # Fixed modulus for oversized-bucket sub-paging. Must not be derived from the bucket's current
+  # size (see `subpage`).
   SUBPAGES_PER_BUCKET = 4
 
   def perform
@@ -66,25 +55,15 @@ class RecoverStrandedBuyersJob
   end
 
   private
-    # A dry run clears nothing and a stuck candidate's rank never decays (settled_purchases cannot
-    # grow for someone who cannot check out), so a fixed head-of-scan window would re-evaluate the
-    # same buyers forever. An array-index rotation doesn't fix that either: it walks positions in
-    # THIS run's array, so a buyer's day assignment moves whenever the scan's order or membership
-    # shifts, and a persistently non-clearing buyer can be rotated back into the unselected tail
-    # every day it runs (Greptile P1, rounds 1-3). Bucketing by a hash of the buyer's own identity
-    # against a FIXED modulus is immune to both: a buyer's day assignment depends only on who they
-    # are, never on the scan's order, size, or who else is in it this run.
+    # Dry-run clears nothing and a stuck candidate's rank never decays, so a fixed head-of-scan
+    # would re-evaluate the same buyers forever. Array-index rotation also fails: a buyer's day
+    # moves whenever the scan's order or membership shifts. Hash the buyer's identity against a
+    # FIXED modulus instead.
     #
-    # Returns [page_key, selected]. Every branch below runs through a persisted rotation cursor
-    # keyed on page_key — not just the oversized-bucket sub-paging case — because ANY window whose
-    # composition/order is deterministic per occurrence will restart at the same buyer on every
-    # future occurrence once RUN_BUDGET truncates it mid-run, starving that buyer's neighbors
-    # regardless of whether the window came from bucketing at all (nyomanjyotisa review). page_key
-    # identifies THIS PAGE specifically (bucket_id + which page within it, or :total when the whole
-    # population fits in one run), not just the bucket: a bucket's pages are all reached in turn
-    # (see the cycle index below), and a cursor shared across pages would accumulate identically on
-    # every occurrence regardless of which page ran — so on same-sized pages `cursor % page.size` is
-    # always 0 and every page replays its own first prefix forever (Greptile P1).
+    # Returns [page_key, selected]. Every branch uses a persisted cursor keyed on THIS page
+    # (bucket+subpage, or :total), not the bucket: a budget-truncated deterministic window
+    # restarts at the same buyer, and a cursor shared across same-sized pages makes
+    # `cursor % page.size` stay 0.
     def window(candidates)
       if candidates.size <= MAX_RECOVERIES_PER_RUN
         page_key = [:total]
@@ -97,37 +76,21 @@ class RecoverStrandedBuyersJob
       return [nil, due_today] if due_today.empty?
       return [[bucket_id], rotate_page([bucket_id], due_today)] if due_today.size <= MAX_RECOVERIES_PER_RUN
 
-      # An oversized bucket needs its own sub-rotation, or the same ordered prefix would run every
-      # cycle forever and the tail would never be reached (Greptile P1). Slicing by POSITION
-      # (each_slice) doesn't survive membership churn: if the bucket gains or loses a member
-      # between occurrences, everyone's slice index shifts and a persistently-stranded buyer can
-      # drift out of every page that ever gets selected (Greptile P1, round 9). `subpage` hashes
-      # each buyer's OWN identity against a FIXED modulus instead — the same technique as `bucket`
-      # above — so a buyer's subpage assignment depends only on who they are, never on who else is
-      # in the bucket or how many. `cycle` rotates through that fixed set (not `pages.size`, which
-      # is exactly the churn-sensitive quantity being replaced) so every subpage gets a turn.
+      # Hash-split the oversized bucket against a second fixed modulus. Position slices
+      # (each_slice) shift when membership churns. Cycle uses SUBPAGES_PER_BUCKET, not pages.size.
       subpage_id = (elapsed_days / ROTATION_BUCKETS) % SUBPAGES_PER_BUCKET
       page = due_today.select { |c| subpage(c[:email]) == subpage_id }
       return [nil, []] if page.empty?
 
       page_key = [bucket_id, subpage_id]
-      # SUBPAGES_PER_BUCKET is sized for the CURRENT population (see its comment); a hash split
-      # gives no guarantee on subpage size, so a big enough or skewed-enough bucket can still put
-      # more than MAX_RECOVERIES_PER_RUN buyers in one subpage (Greptile P1). Cap it explicitly —
-      # `rotate_page`'s cursor still advances by the modulo of the FULL page, so capping here only
-      # slows eventual coverage of an oversized subpage, it doesn't skip anyone.
+      # A hash split does not cap subpage size. rotate_page still advances by the full page, so
+      # this cap only slows coverage — it does not skip anyone.
       [page_key, rotate_page(page_key, page).first(MAX_RECOVERIES_PER_RUN)]
     end
 
-    # A page's own composition and order are deterministic, so a run that hits RUN_BUDGET partway
-    # through always stops at the same buyer, on every future occurrence of this exact page — the
-    # suffix after them never gets a turn (Greptile P1). Rotating to start just after the last
-    # buyer's own EMAIL (not a numeric offset into the current array) moves a different
-    # buyer to the front each occurrence and survives peers joining/leaving on either side of the
-    # cursor between occurrences (Greptile round 11 P1): an offset drifts with the array, an
-    # identity boundary does not. Compared and stored via `identity` (matching `bucket`/`subpage`'s
-    # downcasing) so a scan returning a different casing of the same email across occurrences can't
-    # desync the cursor from bucket/subpage membership (Greptile P1).
+    # A budget-truncated page always stops at the same buyer. Resume just after the last processed
+    # email (via `identity`), not a numeric offset — offsets drift when peers join/leave, and a
+    # casing mismatch would desync the cursor from bucket/subpage membership.
     def rotate_page(page_key, page)
       cursor = page_cursor(page_key)
       return page if cursor.nil?
@@ -143,19 +106,14 @@ class RecoverStrandedBuyersJob
       nil
     end
 
-    # Stores the LAST PROCESSED BUYER'S EMAIL, not a count — a count is a position in whichever
-    # array `window` happens to rebuild next time, which drifts under membership churn exactly like
-    # the array-index bucket/subpage selection this replaced. An identity boundary means "resume
-    # just after this buyer" regardless of who joined or left on either side of them.
+    # Last processed email, not a count — a count is a position in the next rebuilt array.
     def save_page_cursor(page_key, last_processed_email)
       $redis.set(RedisKey.recover_stranded_buyers_page_cursor(page_key), identity(last_processed_email))
     rescue => e
       ErrorNotifier.notify(e)
     end
 
-    # Single canonical form for sorting, cursor comparison, and cursor storage — must match what
-    # `bucket`/`subpage` hash on, or a scan returning a different casing of the same email across
-    # occurrences desyncs the cursor from bucket/subpage membership (Greptile P1).
+    # Must match what `bucket`/`subpage` hash on.
     def identity(email)
       email.to_s.downcase
     end
@@ -166,8 +124,7 @@ class RecoverStrandedBuyersJob
       Digest::MD5.hexdigest(identity(email)).to_i(16) % ROTATION_BUCKETS
     end
 
-    # Same technique as `bucket`, against a second, independent hash so an email isn't pinned to
-    # the same relative rank in both — a different fixed modulus for the sub-split within a bucket.
+    # Independent hash so an email is not pinned to the same relative rank in both splits.
     def subpage(email)
       Digest::MD5.hexdigest("subpage:#{identity(email)}").to_i(16) % SUBPAGES_PER_BUCKET
     end
@@ -182,10 +139,8 @@ class RecoverStrandedBuyersJob
         cleared: result.cleared.size, withheld: result.skipped.size,
         withheld_for_human: result.skipped.count { |_block, why| why == :shared_identifier_needs_human_review } }
     rescue => e
-      # One buyer's failure must not strand the rest of the run or the report — anything the
-      # service raises (its own guard errors, a deadlock on unblock!, RecordInvalid from the admin
-      # comment) becomes a named ERROR line. A live clear that failed mid-transaction already
-      # rolled its rows back inside the service.
+      # One buyer's failure must not stop the rest. A live clear that failed mid-transaction
+      # already rolled back inside the service.
       { email: candidate[:email], verdict: :error, reason: "#{e.class}: #{e.message}", cleared: 0, withheld: 0, withheld_for_human: 0 }
     end
 


### PR DESCRIPTION
Premerge review: exempt (comments only, no behaviour change)

## What

Comment-only trim of `app/sidekiq/recover_stranded_buyers_job.rb`. **Comments only, no behaviour change** — the diff touches nothing but comment text.

```
219 → 174 lines   (−45)
git diff --numstat: 34 insertions, 79 deletions
```

Proof the code is untouched:

```
CODE IDENTICAL (comment/blank lines only)
```

## Why

The file had grown a review diary: "Greptile P1, rounds 1–3", "round 9", "round 11", "nyomanjyotisa review" next to facts a maintainer already needs. Those citations teach people to skip the comments that matter. The rotation/cursor traps stay; the narration of who found them does not.

## What I deliberately KEPT

Every load-bearing invariant stays — this is compression, not deletion:

- **Hash the buyer's own email against a fixed modulus**, not an array index — assignment must survive scan-order and membership churn.
- **Page-keyed cursor, not bucket-keyed** — a shared cursor makes same-sized pages replay `cursor % page.size == 0`.
- **Budget-truncated deterministic windows restart at the same buyer** — every branch goes through the persisted cursor.
- **`ROTATION_EPOCH` is a fixed date, not `Date.current.yday`** — yday resets in January and starves oversized-bucket pages past index 12.
- **Subpage is a second independent hash**, not `each_slice` / `pages.size` — position slices shift when membership churns.
- **Cap does not skip** — `rotate_page` still advances by the full page.
- **Cursor stores the last processed email**, not a count — a count is a position in the next rebuilt array.
- **`identity` must match what `bucket`/`subpage` hash on** (downcasing).
- **Blank email must land in a bucket** and fail as that recovery's ERROR, not raise and take down the run.
- **One buyer's failure must not stop the rest**; a mid-transaction live clear already rolled back inside the service.
- **Live clears only behind `:auto_recover_stranded_buyers`**; flag off is dry-run.
- **A job, not the admin endpoint** — one history scan can exceed the HTTP edge budget.
- **`RUN_BUDGET` worst case** is the budget plus the recovery already in flight.

## What went

Review-round citations, restatements of the next line (`MAX_RECOVERIES_PER_RUN`, `MAX_REPORTED_ESCALATIONS`), and the duplicated "why hash-by-identity / why not a count" essays once the same fact already lives on the method that needs it.

## Test Results

```
$ ruby -c app/sidekiq/recover_stranded_buyers_job.rb
Syntax OK

$ bundle exec rubocop app/sidekiq/recover_stranded_buyers_job.rb
1 file inspected, no offenses detected

$ bundle exec rspec spec/sidekiq/recover_stranded_buyers_job_spec.rb
23 examples, 0 failures
```

Branch CI (`Tests` 31817794735) completed success — 0 pending, 0 failures.

Needs only a skim.
