### PR TITLE
Forward the runtime's beta features through the Gumhead gateway

### DIFF
--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -74,15 +74,10 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # equal to them would let the outer layers cut the client before the
   # rescue can render its error envelope.
   BUFFERED_TIMEOUT = 90
-  # Beta features forward except the ones that can move spend outside the
-  # ledger. An allowlist was tried first and broke the client on contact:
-  # the runtime sends eight betas today and gains more with every upgrade,
-  # and dropping one turns its body into "context_management: Extra inputs
-  # are not permitted". Enforcement belongs in the body validators above
-  # anyway — a beta header grants nothing on its own, and the fields it
-  # would unlock (fallbacks, speed, inference_geo, server-side tools) are
-  # each rejected there. Extend the denials via
-  # GUMHEAD_DENIED_ANTHROPIC_BETAS without a deploy.
+  # Client feature flags forward as sent: the spend boundary is the body
+  # validators above, not this header, and dropping a flag the body relies
+  # on fails the request. `fallback` is denied because it runs extra models
+  # server-side, outside the ledger. Tune with GUMHEAD_DENIED_ANTHROPIC_BETAS.
   DEFAULT_DENIED_ANTHROPIC_BETAS = "fallback"
 
   # One Gumhead turn is a whole tool loop of model calls, so the request
@@ -554,9 +549,8 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       headers
     end
 
-    # Denied betas are dropped rather than rejected: the matching body field
-    # is refused with a named error by the validators above, which reads
-    # better than a bare header complaint.
+    # Dropped, not rejected: the body field a denied beta would unlock gets
+    # a named error from the validators above.
     def filtered_beta_features
       requested = request.headers["anthropic-beta"].to_s.split(",").map(&:strip).reject(&:blank?)
       return if requested.empty?

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -74,10 +74,16 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # equal to them would let the outer layers cut the client before the
   # rescue can render its error envelope.
   BUFFERED_TIMEOUT = 90
-  # Beta features can change what a request may do and what usage reports
-  # (fallbacks being the sharpest example), so only vetted ones forward.
-  # Extend via GUMHEAD_ALLOWED_ANTHROPIC_BETAS without a deploy.
-  DEFAULT_ALLOWED_ANTHROPIC_BETAS = "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
+  # Beta features forward except the ones that can move spend outside the
+  # ledger. An allowlist was tried first and broke the client on contact:
+  # the runtime sends eight betas today and gains more with every upgrade,
+  # and dropping one turns its body into "context_management: Extra inputs
+  # are not permitted". Enforcement belongs in the body validators above
+  # anyway — a beta header grants nothing on its own, and the fields it
+  # would unlock (fallbacks, speed, inference_geo, server-side tools) are
+  # each rejected there. Extend the denials via
+  # GUMHEAD_DENIED_ANTHROPIC_BETAS without a deploy.
+  DEFAULT_DENIED_ANTHROPIC_BETAS = "fallback"
 
   # One Gumhead turn is a whole tool loop of model calls, so the request
   # throttle is deliberately loose; the real spend control is the daily
@@ -548,16 +554,15 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       headers
     end
 
-    # Unvetted betas are dropped rather than rejected: a request whose body
-    # depends on a dropped beta gets Anthropic's own error naming the field,
-    # and harmless unknown betas from a runtime upgrade degrade instead of
-    # hard-failing every call.
+    # Denied betas are dropped rather than rejected: the matching body field
+    # is refused with a named error by the validators above, which reads
+    # better than a bare header complaint.
     def filtered_beta_features
       requested = request.headers["anthropic-beta"].to_s.split(",").map(&:strip).reject(&:blank?)
       return if requested.empty?
 
-      allowed = GlobalConfig.get("GUMHEAD_ALLOWED_ANTHROPIC_BETAS", DEFAULT_ALLOWED_ANTHROPIC_BETAS).to_s.split(",").map(&:strip).reject(&:blank?)
-      (requested & allowed).join(",")
+      denied = GlobalConfig.get("GUMHEAD_DENIED_ANTHROPIC_BETAS", DEFAULT_DENIED_ANTHROPIC_BETAS).to_s.split(",").map(&:strip).reject(&:blank?)
+      requested.reject { |feature| denied.any? { |pattern| feature.include?(pattern) } }.join(",")
     end
 
     def anthropic_api_key

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -266,16 +266,33 @@ describe Api::V2::Gumhead::MessagesController do
       expect(response.status).to eq(400)
     end
 
-    it "forwards only allowlisted anthropic-beta features" do
+    # The runtime's real header, verbatim: every one of these must survive,
+    # or its body fields come back as "Extra inputs are not permitted".
+    it "forwards the runtime's beta features untouched" do
       stub_request(:post, messages_url)
         .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
-      request.headers["anthropic-beta"] = "interleaved-thinking-2025-05-14, server-side-fallback-2026-07-01"
+      runtime_betas = "claude-code-20250219,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13," \
+                      "context-management-2025-06-27,prompt-caching-scope-2026-01-05," \
+                      "mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24"
+      request.headers["anthropic-beta"] = runtime_betas
 
       post_messages
 
       expect(response.status).to eq(200)
       expect(WebMock).to have_requested(:post, messages_url).with { |req|
-        req.headers["Anthropic-Beta"] == "interleaved-thinking-2025-05-14"
+        req.headers["Anthropic-Beta"] == runtime_betas
+      }
+    end
+
+    it "drops beta features that could move spend outside the ledger" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
+      request.headers["anthropic-beta"] = "context-management-2025-06-27, server-side-fallback-2026-07-01"
+
+      post_messages
+
+      expect(WebMock).to have_requested(:post, messages_url).with { |req|
+        req.headers["Anthropic-Beta"] == "context-management-2025-06-27"
       }
     end
   end


### PR DESCRIPTION
## What

The gateway now forwards the client's `anthropic-beta` features and denies only the family that can move spend outside the ledger (`fallback`), instead of forwarding an allowlist of two.

## Why

Found by running Gumhead against the deployed gateway. The first real turn failed:

```
API Error: 400 context_management: Extra inputs are not permitted
```

The runtime sends eight beta features today:

```
claude-code-20250219, interleaved-thinking-2025-05-14, thinking-token-count-2026-05-13,
context-management-2025-06-27, prompt-caching-scope-2026-01-05,
mid-conversation-system-2026-04-07, advisor-tool-2026-03-01, effort-2025-11-24
```

The allowlist forwarded one of them, so its body — which carries `context_management`, `output_config`, and `thinking` — reached Anthropic without the headers that authorize those fields. Confirmed against production: the same body succeeds without `context_management` and fails with it, whether or not the caller sends the beta headers, because the gateway strips them either way.

An allowlist of client feature flags cannot hold: the list grows with every runtime upgrade, and each addition breaks the pet with an error naming a field nobody set by hand.

## Why this is still safe

Enforcement was never the header — it is the body validators, and they are unchanged:

- `fallbacks`, `speed`, and `inference_geo` are rejected outright (unweighted pricing paths).
- Server-side tools are rejected (they bill per use outside the token ledger).
- `max_tokens` is bounded, and buffered outputs are capped.

A beta header grants nothing unless the request also carries the corresponding field, and every field that matters for spend is refused with a named error. The `fallback` denial stays because that one runs extra models server-side.

`GUMHEAD_DENIED_ANTHROPIC_BETAS` tunes the denials without a deploy.

## Tests

- The runtime's real eight-beta header must survive verbatim.
- A denied beta is dropped while the rest pass through.
- 51 examples, 0 failures; rubocop clean.

## Verification

Verified end to end against production before and after: the token comes from the seller's Gumroad login, the runtime is pointed at `/v2/gumhead`, and no `ANTHROPIC_API_KEY` exists on the machine. Buffered calls already returned 200 with real usage; this fixes the full agent turn.
