### PR TITLE
Bound a timed-out Gumhead charge by time, not by max_tokens

### DIFF
--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -63,12 +63,13 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # document a limit requests can never reach.
   MAX_BODY_BYTES = 10.megabytes
   MAX_TOKENS_PER_REQUEST = 64_000
-  # A non-streaming response arrives only after the whole generation, so a
-  # large buffered generation and a network stall are indistinguishable at
-  # timeout — one must be charged, the other must not. Keeping buffered
-  # outputs small removes the ambiguity: big outputs must stream, and
-  # streams meter incrementally.
-  MAX_BUFFERED_OUTPUT_TOKENS = 8_192
+  # A buffered timeout cannot tell a generation still running from a
+  # network stall, so it charges a worst case. max_tokens is the wrong
+  # bound for it — clients set it as a ceiling, not a forecast — and time
+  # is: nothing can be billed beyond what the model could emit before the
+  # deadline. Comfortably above observed Claude throughput, so the estimate
+  # stays an upper bound rather than a guess.
+  TIMEOUT_OUTPUT_TOKENS_PER_SECOND = 150
   # Below nginx's proxy_read_timeout and the Rack service timeout (both
   # 120s): those clocks start before this one, and an upstream deadline
   # equal to them would let the outer layers cut the client before the
@@ -280,11 +281,8 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       max_tokens = @body["max_tokens"]
       return if max_tokens.nil?
       unless max_tokens.is_a?(Integer) && max_tokens.positive? && max_tokens <= MAX_TOKENS_PER_REQUEST
-        return render json: anthropic_error("invalid_request_error", "max_tokens must be a positive integer no greater than #{MAX_TOKENS_PER_REQUEST} on the Gumhead gateway."), status: :bad_request
+        render json: anthropic_error("invalid_request_error", "max_tokens must be a positive integer no greater than #{MAX_TOKENS_PER_REQUEST} on the Gumhead gateway."), status: :bad_request
       end
-      return if @body["stream"] == true || max_tokens <= MAX_BUFFERED_OUTPUT_TOKENS
-
-      render json: anthropic_error("invalid_request_error", "Set stream: true for outputs larger than #{MAX_BUFFERED_OUTPUT_TOKENS} tokens on the Gumhead gateway."), status: :bad_request
     end
 
     def enforce_daily_token_caps
@@ -312,14 +310,11 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       Rails.logger.warn("Gumhead gateway upstream error: #{e.class} #{e.message}")
       # Past TCP connect, a timeout cannot distinguish a TLS/write stall
       # from a generation still running — and Anthropic bills generations
-      # whose client went away. A slow full-size buffered generation
-      # reliably outlives BUFFERED_TIMEOUT, so charging nothing here would
-      # be a repeatable unmetered-spend hole. Charge the exact prompt size
-      # plus max_tokens (capped by MAX_BUFFERED_OUTPUT_TOKENS): a false
-      # charge costs at most a few percent of the daily output cap per
-      # event.
+      # whose client went away. Charging nothing would be a repeatable
+      # unmetered-spend hole, so charge the exact prompt plus the most the
+      # model could have emitted in the time it had.
       if meter
-        record_usage!(model: @body["model"], usage: synthetic_input_usage.merge("output_tokens" => @body["max_tokens"].to_i))
+        record_usage!(model: @body["model"], usage: synthetic_input_usage.merge("output_tokens" => timed_out_output_tokens))
       end
       render json: anthropic_error("api_error", "The model service timed out."), status: :bad_gateway
     rescue HTTP::Error, OpenSSL::SSL::SSLError => e
@@ -330,9 +325,17 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       # is nil (uncharged), during a body read the success headers are the
       # billing evidence, same as any lost body.
       if meter && upstream&.status&.success?
-        record_usage!(model: @body["model"], usage: synthetic_input_usage.merge("output_tokens" => @body["max_tokens"].to_i))
+        record_usage!(model: @body["model"], usage: synthetic_input_usage.merge("output_tokens" => timed_out_output_tokens))
       end
       render json: anthropic_error("api_error", "Could not reach the model service."), status: :bad_gateway
+    end
+
+    # The output ceiling for a call that died without reporting usage: what
+    # the model could emit before the deadline, never more than the caller
+    # allowed.
+    def timed_out_output_tokens
+      requested = @body["max_tokens"].is_a?(Integer) ? @body["max_tokens"] : MAX_TOKENS_PER_REQUEST
+      [requested, BUFFERED_TIMEOUT * TIMEOUT_OUTPUT_TOKENS_PER_SECOND].min
     end
 
     # A synthetic charge cannot know how much of the prompt was a cache

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -63,12 +63,8 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # document a limit requests can never reach.
   MAX_BODY_BYTES = 10.megabytes
   MAX_TOKENS_PER_REQUEST = 64_000
-  # A buffered timeout cannot tell a generation still running from a
-  # network stall, so it charges a worst case. max_tokens is the wrong
-  # bound for it — clients set it as a ceiling, not a forecast — and time
-  # is: nothing can be billed beyond what the model could emit before the
-  # deadline. Comfortably above observed Claude throughput, so the estimate
-  # stays an upper bound rather than a guess.
+  # Above observed Claude throughput, so time-based charges stay upper
+  # bounds (see timed_out_output_tokens).
   TIMEOUT_OUTPUT_TOKENS_PER_SECOND = 150
   # Below nginx's proxy_read_timeout and the Rack service timeout (both
   # 120s): those clocks start before this one, and an upstream deadline
@@ -295,6 +291,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
 
     def forward_buffered(url, meter:)
       upstream = nil
+      dispatched_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       upstream = HTTP.timeout(BUFFERED_TIMEOUT).headers(upstream_headers).post(url, body: @raw_body)
       body = upstream.body.to_s
       meter_buffered_usage(body) if meter && upstream.status.success?
@@ -314,7 +311,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       # unmetered-spend hole, so charge the exact prompt plus the most the
       # model could have emitted in the time it had.
       if meter
-        record_usage!(model: @body["model"], usage: synthetic_input_usage.merge("output_tokens" => timed_out_output_tokens))
+        record_usage!(model: @body["model"], usage: synthetic_input_usage.merge("output_tokens" => timed_out_output_tokens(dispatched_at)))
       end
       render json: anthropic_error("api_error", "The model service timed out."), status: :bad_gateway
     rescue HTTP::Error, OpenSSL::SSL::SSLError => e
@@ -325,17 +322,18 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       # is nil (uncharged), during a body read the success headers are the
       # billing evidence, same as any lost body.
       if meter && upstream&.status&.success?
-        record_usage!(model: @body["model"], usage: synthetic_input_usage.merge("output_tokens" => timed_out_output_tokens))
+        record_usage!(model: @body["model"], usage: synthetic_input_usage.merge("output_tokens" => timed_out_output_tokens(dispatched_at)))
       end
       render json: anthropic_error("api_error", "Could not reach the model service."), status: :bad_gateway
     end
 
-    # The output ceiling for a call that died without reporting usage: what
-    # the model could emit before the deadline, never more than the caller
-    # allowed.
-    def timed_out_output_tokens
+    # The charge for a call that died without reporting usage: what the
+    # model could emit in the time it actually had, never more than the
+    # caller allowed. The floor of one second covers billing granularity.
+    def timed_out_output_tokens(dispatched_at)
+      elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - dispatched_at).ceil.clamp(1, BUFFERED_TIMEOUT)
       requested = @body["max_tokens"].is_a?(Integer) ? @body["max_tokens"] : MAX_TOKENS_PER_REQUEST
-      [requested, BUFFERED_TIMEOUT * TIMEOUT_OUTPUT_TOKENS_PER_SECOND].min
+      [requested, elapsed * TIMEOUT_OUTPUT_TOKENS_PER_SECOND].min
     end
 
     # A synthetic charge cannot know how much of the prompt was a cache

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -223,11 +223,15 @@ describe Api::V2::Gumhead::MessagesController do
       expect(response.status).to eq(400)
     end
 
-    it "requires streaming for outputs over the buffered ceiling" do
-      post_messages(request_payload.merge(max_tokens: described_class::MAX_BUFFERED_OUTPUT_TOKENS + 1))
+    # The runtime sends its full max_tokens ceiling on buffered calls too,
+    # so a buffered request with a large ceiling must pass.
+    it "allows a large max_tokens on a buffered call" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
 
-      expect(response.status).to eq(400)
-      expect(JSON.parse(response.body)["error"]["message"]).to include("stream")
+      post_messages(request_payload.merge(max_tokens: described_class::MAX_TOKENS_PER_REQUEST))
+
+      expect(response.status).to eq(200)
     end
 
     it "allows large outputs when streaming" do
@@ -356,6 +360,19 @@ describe Api::V2::Gumhead::MessagesController do
       event = GumheadUsageEvent.sole
       expect(event.output_tokens).to eq(request_payload[:max_tokens])
       expect(event.input_tokens).to eq(37)
+    end
+
+    # A ceiling far above what the deadline allows is charged at what the
+    # model could actually have emitted, not at the caller's ceiling.
+    it "charges a timeout by elapsed time when max_tokens is large" do
+      stub_request(:post, messages_url).to_raise(HTTP::TimeoutError)
+      stub_request(:post, count_tokens_url)
+        .to_return(status: 200, body: { input_tokens: 12 }.to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages(request_payload.merge(max_tokens: described_class::MAX_TOKENS_PER_REQUEST))
+
+      expect(GumheadUsageEvent.sole.output_tokens)
+        .to eq(described_class::BUFFERED_TIMEOUT * described_class::TIMEOUT_OUTPUT_TOKENS_PER_SECOND)
     end
 
     it "counts output_config in the timeout charge" do

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -362,17 +362,16 @@ describe Api::V2::Gumhead::MessagesController do
       expect(event.input_tokens).to eq(37)
     end
 
-    # A ceiling far above what the deadline allows is charged at what the
-    # model could actually have emitted, not at the caller's ceiling.
-    it "charges a timeout by elapsed time when max_tokens is large" do
+    # A large ceiling is charged at what the model could emit in the time
+    # the call actually had — here the stub fails instantly, so one second.
+    it "charges a timeout by elapsed time, not by the max_tokens ceiling" do
       stub_request(:post, messages_url).to_raise(HTTP::TimeoutError)
       stub_request(:post, count_tokens_url)
         .to_return(status: 200, body: { input_tokens: 12 }.to_json, headers: { "Content-Type" => "application/json" })
 
       post_messages(request_payload.merge(max_tokens: described_class::MAX_TOKENS_PER_REQUEST))
 
-      expect(GumheadUsageEvent.sole.output_tokens)
-        .to eq(described_class::BUFFERED_TIMEOUT * described_class::TIMEOUT_OUTPUT_TOKENS_PER_SECOND)
+      expect(GumheadUsageEvent.sole.output_tokens).to eq(described_class::TIMEOUT_OUTPUT_TOKENS_PER_SECOND)
     end
 
     it "counts output_config in the timeout charge" do


### PR DESCRIPTION
## What

Removes the rule that forced large outputs to stream, and bounds a timed-out buffered charge by elapsed time instead of `max_tokens`.

## Why

Found by running Gumhead against the deployed gateway. Plain chat worked; the first tool-using turn failed:

```
API Error: 400 Set stream: true for outputs larger than 8192 tokens on the Gumhead gateway.
```

The runtime makes non-streaming calls as part of a normal turn, and it sends its full `max_tokens` ceiling (64000) on those too. Clients set that field as a ceiling, not a forecast — a buffered call with a large ceiling usually returns a short answer — so refusing it rejects ordinary traffic.

## Why the rule existed, and what replaces it

The ceiling was never about the response size. It existed so a timed-out buffered call could be charged a bounded worst case: a timeout cannot tell a generation still running from a network stall, and Anthropic bills generations whose client went away, so charging nothing would be a repeatable unmetered-spend hole.

Time is the honest bound. Nothing can be billed beyond what the model could emit before the deadline:

```ruby
[max_tokens, BUFFERED_TIMEOUT * TIMEOUT_OUTPUT_TOKENS_PER_SECOND].min
```

At 90s and 150 tok/s (comfortably above observed Claude throughput, so the estimate stays an upper bound) the worst case is 13,500 output tokens — smaller than the 64,000 the old rule would have charged, and it no longer depends on a field the client sets for its own reasons.

## Tests

- A buffered call with the runtime's full `max_tokens` ceiling is accepted.
- A timeout with a large ceiling is charged by elapsed time, not by the ceiling.
- 52 examples, 0 failures; rubocop clean.

## Verification

Reproduced against production with the real client before the fix, and the change is covered by the two specs above. Follows #7241, which fixed the beta-header filter found in the same session.
