### PR TITLE
Accept mobile app WebView token sign-in on the create-product pages

### DIFF
--- a/app/controllers/concerns/mobile_app_web_view.rb
+++ b/app/controllers/concerns/mobile_app_web_view.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Signs the mobile app's embedded WebView into a web session using the OAuth
+# bearer token the app appends to its first request, and shares
+# is_mobile_app_web_view so pages can hide web-only chrome like the nav.
+# Callers pick which actions accept the token via enable_mobile_app_web_view.
+module MobileAppWebView
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def enable_mobile_app_web_view(only: nil)
+      prepend_before_action :authenticate_mobile_app_web_view!, only: only
+      before_action :persist_mobile_app_web_view, only: only
+
+      inertia_share do
+        {
+          is_mobile_app_web_view: params[:display] == "mobile_app" || session[:mobile_app_web_view] == true
+        }
+      end
+    end
+  end
+
+  private
+    def persist_mobile_app_web_view
+      return unless params[:display] == "mobile_app" && user_signed_in?
+
+      session[:mobile_app_web_view] = true
+    end
+
+    def authenticate_mobile_app_web_view!
+      return if params[:access_token].blank?
+      return if user_signed_in?
+      return unless ActiveSupport::SecurityUtils.secure_compare(params[:mobile_token].to_s, Api::Mobile::BaseController::MOBILE_TOKEN)
+
+      doorkeeper_authorize! :mobile_api
+      # Without this, a doorkeeper-rejected (revoked/expired/wrong-scope) token still signs in.
+      return if performed?
+
+      sign_in current_api_user if current_api_user.present?
+    end
+end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -8,6 +8,9 @@ class LinksController < ApplicationController
   include PageMeta::Favicon, PageMeta::Product
   include RequireAccountEmail
   include RendersCustomHtmlPages
+  include MobileAppWebView
+
+  enable_mobile_app_web_view only: %i[new create edit]
 
   DEFAULT_PRICE = 500
   PRICE_INPUT_MAX_LENGTH = 64

--- a/app/controllers/settings/base_controller.rb
+++ b/app/controllers/settings/base_controller.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class Settings::BaseController < Sellers::BaseController
+  include MobileAppWebView
+
   layout "inertia"
 
-  prepend_before_action :authenticate_mobile_app_web_view!
-  before_action :persist_mobile_app_web_view
+  enable_mobile_app_web_view
 
   inertia_share do
     {
-      settings_pages: -> { settings_presenter.pages },
-      is_mobile_app_web_view: params[:display] == "mobile_app" || session[:mobile_app_web_view] == true
+      settings_pages: -> { settings_presenter.pages }
     }
   end
 
@@ -20,24 +20,5 @@ class Settings::BaseController < Sellers::BaseController
   protected
     def settings_presenter
       @settings_presenter ||= SettingsPresenter.new(pundit_user:)
-    end
-
-  private
-    def persist_mobile_app_web_view
-      return unless params[:display] == "mobile_app" && user_signed_in?
-
-      session[:mobile_app_web_view] = true
-    end
-
-    def authenticate_mobile_app_web_view!
-      return if params[:access_token].blank?
-      return if user_signed_in?
-      return unless ActiveSupport::SecurityUtils.secure_compare(params[:mobile_token].to_s, Api::Mobile::BaseController::MOBILE_TOKEN)
-
-      doorkeeper_authorize! :mobile_api
-      # Without this, a doorkeeper-rejected (revoked/expired/wrong-scope) token still signs in.
-      return if performed?
-
-      sign_in current_api_user if current_api_user.present?
     end
 end

--- a/spec/requests/products/new_mobile_app_web_view_spec.rb
+++ b/spec/requests/products/new_mobile_app_web_view_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "inertia_rails/rspec"
+
+describe "Create product mobile app WebView authentication", type: :request, inertia: true do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:named_seller) }
+  let(:oauth_app) { create(:oauth_application, owner: user) }
+  let(:access_token) { create("doorkeeper/access_token", application: oauth_app, resource_owner_id: user.id, scopes: "mobile_api") }
+  let(:mobile_token) { Api::Mobile::BaseController::MOBILE_TOKEN }
+
+  before do
+    create(:user_compliance_info, country: "United States", user:)
+    host! DOMAIN
+  end
+
+  def inertia_props
+    JSON.parse(response.body)["props"]
+  end
+
+  context "with ?display=mobile_app, a valid access_token and the correct mobile_token" do
+    it "signs the token's user into a web session and flags the Inertia prop" do
+      get new_product_path, params: { display: "mobile_app", access_token: access_token.token, mobile_token: }, headers: { "X-Inertia" => "true" }
+
+      expect(response).to be_successful
+      expect(inertia_props["is_mobile_app_web_view"]).to eq(true)
+    end
+
+    it "establishes a web session so the post-create redirect to the product editor stays authenticated" do
+      get new_product_path, params: { display: "mobile_app", access_token: access_token.token, mobile_token: }, headers: { "X-Inertia" => "true" }
+      expect(response).to be_successful
+
+      product = create(:product, user:)
+      get edit_link_path(product.unique_permalink), headers: { "X-Inertia" => "true" }
+      expect(response).to be_successful
+      expect(inertia_props["is_mobile_app_web_view"]).to eq(true)
+    end
+  end
+
+  context "without an access_token" do
+    it "redirects to login instead of signing anyone in" do
+      get new_product_path
+
+      expect(response).to redirect_to(login_path(next: new_product_path))
+    end
+  end
+
+  context "with a wrong mobile_token" do
+    it "does not sign the user in" do
+      get new_product_path, params: { display: "mobile_app", access_token: access_token.token, mobile_token: "wrong_token" }
+
+      expect(response).to have_http_status(:redirect)
+      expect(response.location).to include(login_path)
+    end
+  end
+
+  context "with an access_token that lacks the mobile_api scope" do
+    let(:access_token) { create("doorkeeper/access_token", application: oauth_app, resource_owner_id: user.id, scopes: "creator_api") }
+
+    it "is forbidden by doorkeeper and leaks no session on a follow-up request" do
+      get new_product_path, params: { display: "mobile_app", access_token: access_token.token, mobile_token: }
+      expect(response).to have_http_status(:forbidden)
+
+      get new_product_path
+      expect(response.location).to include(login_path)
+    end
+  end
+end


### PR DESCRIPTION
Issue: antiwork/gumroad-mobile#350 (companion to antiwork/gumroad-mobile#351)

## What

Extracts `Settings::BaseController`'s mobile-app WebView token sign-in (`authenticate_mobile_app_web_view!` + `persist_mobile_app_web_view` + the `is_mobile_app_web_view` Inertia share) into a reusable `MobileAppWebView` concern, and enables it on `LinksController` for `new`, `create`, and `edit` — the three actions the mobile app's new in-app create-product WebView hits (`/products/new`, the form POST, and the post-create redirect to the editor).

No behavior change for the settings pages: the concern is a verbatim extraction, opt-in per controller via `enable_mobile_app_web_view(only:)`.

## Why

Sahil picked "create products from the app" as the first mobile parity item on antiwork/gumroad-mobile#350. The app authenticates WebViews by appending `access_token` + `mobile_token` query params on the first request, but only `Settings::BaseController` accepts that today — `/products/new` in the app's WebView would land on the login page.

## Before / After

Backend-only; the visible surface is the mobile PR (antiwork/gumroad-mobile#351). Value table:

| Request | Before | After |
|---|---|---|
| `GET /products/new?display=mobile_app&access_token=<valid>&mobile_token=<valid>` | 302 → /login | 200, signed in, `is_mobile_app_web_view: true` |
| Follow-up `GET /products/:id/edit` (session established) | 302 → /login | 200, `is_mobile_app_web_view: true` (nav hidden) |
| Wrong/blank `mobile_token` | 302 → /login | unchanged: 302 → /login, no session |
| Token lacking `mobile_api` scope | n/a | 403 from doorkeeper, no session leak |
| Settings pages | token sign-in works | unchanged (13/13 existing spec examples green) |

## Test Results

- New `spec/requests/products/new_mobile_app_web_view_spec.rb`: 5 examples, 0 failures.
- Existing `spec/requests/settings/mobile_app_web_view_spec.rb` (pins the extracted concern's behavior on settings): 13 examples, 0 failures.
- Mutation proof (revert leg): with the `LinksController` include removed — confirmed in-process via `LinksController.include?(MobileAppWebView) == false` — the same request returns 302 → /login with no `is_mobile_app_web_view` prop, which fails the spec's `be_successful` expectation. The new spec is load-bearing.
- `ruby -c` + rubocop clean on all touched files.

## QA steps

Ran the two request-spec suites above against a lane database; the new spec exercises the exact query-param shape `buildAuthenticatedWebViewUrl` produces in the app.

---

AI disclosure: built by Hermes Agent (claude-fable-5).

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (still a draft — I'm building it; CI still running (3 checks) — settle before handing off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
