### PR TITLE
Trim AssetPreview comments to the concurrency and cache traps

### DIFF
--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -146,20 +146,12 @@ class AssetPreview < ApplicationRecord
     width.to_i > MAX_IMAGE_DIMENSION || height.to_i > MAX_IMAGE_DIMENSION
   end
 
-  # Replaces an oversized image cover with a copy resized down to
-  # MAX_IMAGE_DIMENSION on its longest side. Runs from
-  # ResizeOversizedAssetPreviewWorker, never on a web request: with very
-  # large originals (the motivating case was a 254 MB, 18000px-wide PNG) the
-  # download + resize takes long enough to blow the request timeout, which is
-  # exactly the failure this exists to prevent.
+  # Worker-only: download + resize of a huge original blows the request timeout.
   def resize_oversized_image!
     return unless oversized_image?
 
-    # Remember which blob we are resizing. Resizing a huge original can take
-    # a while (that slowness is the whole reason this runs in a background
-    # job), and the cover can be replaced or deleted in the meantime. Without
-    # this check the job would attach its resized copy of the OLD image,
-    # silently clobbering the seller's newer cover.
+    # Resize can take a while; the cover may be replaced or deleted. Without
+    # this id check we'd attach a resized copy of the OLD image.
     source_blob_id = file.blob.id
 
     resized = file.variant(resize_to_limit: [MAX_IMAGE_DIMENSION, MAX_IMAGE_DIMENSION]).processed
@@ -176,18 +168,11 @@ class AssetPreview < ApplicationRecord
 
     attached_resized_copy = false
     begin
-      # with_lock reloads the record, so the deleted flag below reflects what
-      # is in the database right now. Locking the asset_previews row alone is
-      # not quite enough, though: a write to the cover's attachment lands in
-      # the active_storage_attachments table without touching this record's
-      # lock. So we also take a row lock on the attachment itself — any
-      # concurrent update or delete of that attachment blocks until this
-      # transaction commits. That closes the window where a change could land
-      # between the blob check and the attach. (Today, "replacing" a cover
-      # actually creates a NEW asset_previews row and soft-deletes the old one
-      # via mark_deleted! — an update on this row, serialized by with_lock —
-      # so the attachment lock is defense in depth for any future path that
-      # re-attaches on an existing row.)
+      # with_lock reloads, so deleted? is current. Also lock the attachment:
+      # a write there does not touch this row's lock, so a replace can land
+      # between the blob check and attach. Today's replace path creates a new
+      # row + mark_deleted! (serialized by with_lock); the attachment lock is
+      # defense in depth for a future re-attach-in-place.
       with_lock do
         attachment = ActiveStorage::Attachment.lock.find_by(record: self, name: "file")
         if !deleted? && attachment&.blob_id == source_blob_id
@@ -196,12 +181,9 @@ class AssetPreview < ApplicationRecord
         end
       end
     ensure
-      # Two ways we can end up here without having attached the resized copy:
-      # the cover changed (or was deleted) while we were resizing, or
-      # something raised after the upload. Either way, clean up the resized
-      # blob instead of leaving it orphaned in storage — purge_later so a
-      # storage hiccup here can't mask an in-flight exception, and so Sidekiq
-      # retries of this job don't pile up one orphan per attempt.
+      # Cover changed during resize, or we raised after upload. purge_later so
+      # a storage hiccup here cannot mask the exception, and retries don't
+      # orphan one blob per attempt.
       resized_blob.purge_later unless attached_resized_copy
     end
 
@@ -244,42 +226,18 @@ class AssetPreview < ApplicationRecord
     url
   end
 
-  # A still image to show for this cover before playback starts.
-  # For embedded players (YouTube/Vimeo) this is the thumbnail the platform
-  # provides via oEmbed. For video files uploaded directly to Gumroad we ask
-  # ActiveStorage for a preview — a frame ffmpeg extracts from the video — so
-  # the product page can show that frame instead of a black rectangle while
-  # the player is idle. Returns nil for images (they don't need a poster) and
-  # when no preview can be generated (e.g. ffmpeg missing or a corrupt file);
-  # the player then falls back to the old black idle state.
+  # nil (images, missing ffmpeg, corrupt file) → player stays black.
   def thumbnail_url
     return oembed_thumbnail_url if oembed
 
     video_poster_url
   end
 
-  # Generating a poster means downloading the video and running ffmpeg, which
-  # can take a while for large files. That work never happens on a web
-  # request thread: GenerateVideoPosterWorker is enqueued when the cover is
-  # created and does the generation in the background. Renders only ever read
-  # an already-generated result.
-  #
-  # Where that result lives matters. In production the cache store is namespaced
-  # by the deploy revision (config/environments/production.rb:
-  # `namespace: ENV.fetch("REVISION")`), so every deploy is a full cache clear —
-  # a poster kept only in Rails.cache disappears on every deploy. Hence the read
-  # order:
-  #
-  #   1. Rails.cache, a memo for the URL string of a poster we have already
-  #      confirmed, so the common render costs no queries;
-  #   2. otherwise the blob's persisted preview_image, which is a real database
-  #      record and survives deploys — a cache miss must never hide a poster we
-  #      demonstrably have;
-  #   3. otherwise nil, and enqueue a generation so the poster appears on later
-  #      views (the player shows its plain idle state this time).
-  #
-  # Failures cache an empty-string sentinel for an hour so the worker's retries
-  # don't re-download and re-run ffmpeg on a video ffmpeg cannot preview.
+  # Generation (download + ffmpeg) is off the request path.
+  # Production cache is namespaced by deploy REVISION, so a cache-only poster
+  # vanishes every deploy. Read: Rails.cache → persisted preview_image
+  # (survives deploys) → nil and enqueue. Empty-string sentinel for 1 hour
+  # so retries don't re-run ffmpeg on a video it cannot preview.
   FAILED_POSTER_SENTINEL = ""
   FAILED_POSTER_RETRY_INTERVAL = 1.hour
 
@@ -289,41 +247,25 @@ class AssetPreview < ApplicationRecord
     cached = Rails.cache.read(video_poster_cache_key)
     return cached if cached.present?
 
-    # Cache miss, or the failure sentinel: read through to the persisted preview.
-    # This is what makes a poster survive a deploy — unlike the cache, the
-    # preview_image attachment is a real database record pointing at a real
-    # object in storage. We're on a web request, so this only reports a poster
-    # whose resized copy already exists; it never stops to make one (see
-    # persisted_video_poster_url).
+    # Cache miss or sentinel: persisted preview only — never generate here.
     persisted = persisted_video_poster_url
     if persisted.present?
       Rails.cache.write(video_poster_cache_key, persisted)
       return persisted
     end
 
-    # The sentinel means generation already tried and ffmpeg couldn't preview
-    # this blob, so don't queue another attempt until it expires.
+    # Sentinel: ffmpeg already failed; wait for expiry before requeue.
     return nil unless cached.nil?
 
-    # Nothing generated yet — covers created before poster support existed land
-    # here. Kick off a background generation so the poster shows up on
-    # subsequent views; this view renders without one.
     GenerateVideoPosterWorker.perform_async(id)
     nil
   end
 
-  # The URL of the poster frame ActiveStorage has already persisted for this
-  # video, or nil if it hasn't persisted one. Returns nil rather than raising if
-  # the attachment record exists but its URL can't be built (a half-written
-  # preview shouldn't 500 a product page — a missing poster only costs us the
-  # nicety of a preview frame).
+  # Already-persisted poster URL, or nil. Rescues URL-build failures so a
+  # half-written preview cannot 500 a product page.
   #
-  # Pass process: true only from background work. The poster is stored at full
-  # size and we serve a resized copy of it, and asking ActiveStorage for that
-  # resized copy's URL when it doesn't exist yet makes it right there and then:
-  # download the poster, run the image processor, upload the result. That is
-  # fine in a worker and unacceptable on a web request, where a page full of
-  # covers would do it once per cover while the request waits.
+  # process: true only from a worker. variant.processed generates the resized
+  # copy inline; a page of covers would do that once per cover.
   def persisted_video_poster_url(process: false)
     blob = file.blob
     return nil unless blob&.preview_image&.attached?
@@ -472,16 +414,8 @@ class AssetPreview < ApplicationRecord
       "attachment_#{file.id}_poster_url"
     end
 
-    # Whether the resized copy of the persisted poster already exists, so that
-    # asking for its URL is a lookup instead of an image-processing run. Rails
-    # records every resized copy it has made in active_storage_variant_records
-    # (config.active_storage.track_variants, on by default), so this is one
-    # indexed row read.
-    #
-    # Returning false when we can't tell is deliberate: the caller then reports
-    # "no poster yet", which enqueues GenerateVideoPosterWorker unless the
-    # failure sentinel is still live, and the worker makes the resized copy off
-    # the request path.
+    # Lookup, not an image-processing run. false when we can't tell: the caller
+    # reports "no poster" and the worker makes the resized copy off-request.
     def variant_processed?(variant)
       return false unless ActiveStorage.track_variants
 


### PR DESCRIPTION
Premerge review: exempt (comments only, no behaviour change)

## What

Comment-only trim of `app/models/asset_preview.rb`. **Comments only, no behaviour change** — the diff touches nothing but comment text.

```
587 → 521 lines   (−66)
git diff --numstat: 25 insertions, 91 deletions
```

Proof the code is untouched:

```
CODE IDENTICAL (comment/blank lines only)
```

## Why

The poster and resize paths had grown essays that restated the next line, narrated a 254 MB motivating case, and re-explained ActiveStorage's variant table. That noise is what teaches people to skip the comments that matter.

## What I deliberately KEPT

Every load-bearing trap stays — this is compression, not deletion:

- **Worker-only resize** — download + resize of a huge original blows the request timeout.
- **source_blob_id check** — resize can take a while; without the id we'd attach a resized copy of the OLD image.
- **Upload before lock** — lock is never held across network I/O.
- **with_lock reloads `deleted?`** and we also lock the attachment row (a write there does not touch this row's lock). Today's replace path is new-row + `mark_deleted!`; the attachment lock is defense in depth for a future re-attach-in-place.
- **`purge_later` on unused resized blobs** — a storage hiccup must not mask the exception, and retries must not orphan one blob per attempt.
- **nil poster → player stays black**
- **Production cache is namespaced by deploy REVISION** — a cache-only poster vanishes every deploy. Read order: Rails.cache → persisted `preview_image` → nil and enqueue. Empty-string sentinel for 1 hour so retries don't re-run ffmpeg on a video it cannot preview.
- **Never generate a poster on the request path** (cache miss/sentinel reads persisted preview only).
- **`process: true` only from a worker** — `variant.processed` generates the resized copy inline; a page of covers would do that once per cover.
- **Rescue URL-build failures** so a half-written preview cannot 500 a product page.
- **`variant_processed?` returns false when we can't tell** — the worker makes the resized copy off-request.

## What went

The 254 MB motivating-case history, the thumbnail_url restatement of the two-line method, the numbered cache-read essay (the order is still stated), the duplicated "survive a deploy" paragraph on the cache-miss path, the "covers that predate posters" narration, and the ActiveStorage `track_variants` tutorial.

## Test Results

```
$ ruby -c app/models/asset_preview.rb
Syntax OK

$ bundle exec rubocop app/models/asset_preview.rb
1 file inspected, no offenses detected

$ bundle exec rspec spec/models/asset_preview_poster_spec.rb
15 examples, 0 failures

$ bundle exec rails test test/models/asset_preview_test.rb
82 runs, 178 assertions, 0 failures, 0 errors
```

Branch CI (`Tests` 31894634614) completed success — 0 pending, 0 failures.

Needs only a skim.

---

docs-only — diff is the reviewable artifact. Comments only, no behaviour change; no preview URL or QA click-path.

Model: grok-4.6 via Hermes cron `ai-slop-reducer`. Prompt: cut AI slop comments, change no behaviour, one small PR.
