### PR TITLE
Make AssetPreview cover URLs stable when retina processing is deferred

### DIFF
--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -411,10 +411,18 @@ class AssetPreview < ApplicationRecord
     if style == :retina
       variant = retina_variant
       if variant && variant_processed?(variant)
+        return Rails.cache.fetch("attachment_#{file.id}_retina_url") { variant.url }
+      end
+
+      enqueue_retina_variant_process
+
+      # Inline workers finish during enqueue. Re-read so this call and the
+      # next one return the same URL.
+      variant = retina_variant
+      if variant && variant_processed?(variant)
         Rails.cache.fetch("attachment_#{file.id}_retina_url") { variant.url }
       else
-        enqueue_retina_variant_process
-        file.url
+        Rails.cache.fetch("attachment_#{file.id}_original_url") { file.url }
       end
     else
       Rails.cache.fetch("attachment_#{file.id}_#{style}_url") { file.url }

--- a/spec/requests/user/gallery_spec.rb
+++ b/spec/requests/user/gallery_spec.rb
@@ -44,9 +44,10 @@ describe "User Gallery Page Scenario", :elasticsearch_wait_for_refresh, type: :s
     end
 
     it "uses the first image cover as the preview" do
+      cover_url = @product_with_previews.asset_previews.last.url
       visit("/creatorgal")
       within find_product_card(@product_with_previews) do
-        expect(find("figure")).to have_image(src: @product_with_previews.asset_previews.last.url)
+        expect(find("figure")).to have_image(src: cover_url)
       end
     end
 

--- a/test/models/asset_preview_test.rb
+++ b/test/models/asset_preview_test.rb
@@ -344,12 +344,28 @@ class AssetPreviewTest < ActiveSupport::TestCase
     assert_equal 210, asset_preview.display_height
   end
 
-  test "url_from_file serves the original and enqueues processing when the retina variant is not ready" do
+  test "url_from_file serves a stable original and enqueues processing when the retina variant is not ready" do
     asset_preview = create_asset_preview
     ProcessAssetPreviewRetinaWorker.jobs.clear
 
-    assert_equal asset_preview.file.url, asset_preview.url_from_file(style: :retina)
+    first = asset_preview.url_from_file(style: :retina)
+    second = asset_preview.url_from_file(style: :retina)
+
+    assert_equal first, second
+    assert_equal Rails.cache.read("attachment_#{asset_preview.file.id}_original_url"), first
     assert_includes ProcessAssetPreviewRetinaWorker.jobs.map { _1["args"] }, [asset_preview.id]
+  end
+
+  test "url_from_file returns the same retina URL when processing finishes during enqueue" do
+    asset_preview = create_asset_preview
+
+    Sidekiq::Testing.inline! do
+      first = asset_preview.url_from_file(style: :retina)
+      second = asset_preview.url_from_file(style: :retina)
+
+      assert_equal asset_preview.retina_variant.url, first
+      assert_equal first, second
+    end
   end
 
   test "generate_retina_variant! re-raises processing failures so the worker can retry" do


### PR DESCRIPTION
## What

`AssetPreview#url_from_file` now returns the same URL on consecutive calls after #7232 deferred retina processing off the request path.

- If an inline worker finishes during enqueue, this call re-reads and returns the retina URL instead of a one-shot `file.url`.
- If the variant is still pending, the original URL is cached so the next caller does not get a new signed URL.
- `gallery_spec` captures the cover URL before `visit`.

## Why

#7232 (Don't process retina covers on the product-page request) is the right production change — it stops ImageMagick on `LinksController#show` (Sentry GUMROAD-JF). It also made the first `url()` call return `file.url` while a later call, after `ProcessAssetPreviewRetinaWorker` ran inline, returned the retina variant.

`spec/requests/user/gallery_spec.rb:46` asserts `have_image(src: cover.url)` against the URL the page already serialized. Those two calls no longer matched, so every knapsack shard that drew that example went red:

- main Slow 23 on `3e91502c` (#7251)
- main Slow 13 on `e7485ade` (#7232 itself)
- #7252 Slow 46, #7250 Slow 16, #7249 Slow 15, #7245 Slow 47

Not a flake. Not caused by #7251. Reverting #7232 would bring the product-page 500s back.

## Before / After

No rendered-surface change — profile cards still show the same cover. The URL the page emits now matches the URL the next caller reads.

Before: first `url()` → original; next `url()` after an inline worker → retina; Capybara finds no `img` with the later src.
After: both calls return the retina URL when the worker finished during enqueue; otherwise both return the cached original.

## Test Results

Full suite on `05778f1947` (Actions run 31922088612 after the run-all-specs race was retriggered): `ci/green`, Fast 0–17, Slow 0–49, Minitest, lint, typecheck. `gallery_spec.rb:46` is green here and still red on main Slow 23.

Local, this worktree:

- `bundle exec ruby -Itest test/models/asset_preview_test.rb -n "/url_from_file serves a stable original|url_from_file returns the same retina/"` — 2 runs, 6 assertions, 0 failures
- `bundle exec ruby -Itest test/models/asset_preview_test.rb -n "/url_from_file serves the processed|url returns the retina/"` — 2 runs, 2 assertions, 0 failures

## QA steps

1. Confirm main's red example is `gallery_spec.rb:46` (`have_image` src mismatch), not a BlockedObject / #7251 failure.
2. After this is green, re-check #7252 / #7245 / #7249 / #7250 — they should clear once they pick up this commit or once main is green and they merge it.

## Status

- [x] Scope — unblock main `ci/green` without reverting #7232
- [x] Design — re-read after enqueue; cache the original fallback
- [x] Build — 05778f1947
- [x] QA — minitest above
- [ ] Shipped
- [ ] Market — n/a
- [ ] Sell — n/a

---

AI disclosure: built by Gumclaw (grok-4.6) via the pr-and-issue-advancer cron.
Premerge review: clean @ 05778f1947ab528c1c10e889a29a75675fcf91ac

