### PR TITLE
Trim PostSendgridApi comments to the caller contract

### DIFF
--- a/app/services/post_sendgrid_api.rb
+++ b/app/services/post_sendgrid_api.rb
@@ -9,16 +9,8 @@ class PostSendgridApi
 
   def self.process(**args) = new(**args).send_emails
 
-  # Sends post emails via SendGrid API.
-  # How it works:
-  # - renders and locally caches the email template
-  # - sends the emails via SendGrid API, with substitutions for each recipient
-  # - records the emails as sent in EmailInfo
-  # - updates delivery statistics
-  # - sends push notifications
-  # It does not:
-  # - check whether the post has already been sent to the email addresses (it's the caller's responsibility)
-  # - create any UrlRedirect records (same)
+  # Does not check whether the post was already sent, or create UrlRedirects —
+  # both are the caller's job.
   #
   # `recipients` keys:
   # required => :email (string)

--- a/app/services/post_sendgrid_api.rb
+++ b/app/services/post_sendgrid_api.rb
@@ -9,8 +9,8 @@ class PostSendgridApi
 
   def self.process(**args) = new(**args).send_emails
 
-  # Does not check whether the post was already sent, or create UrlRedirects —
-  # both are the caller's job.
+  # Does not check whether the post was already sent to each recipient email, or
+  # create UrlRedirects — both are the caller's job.
   #
   # `recipients` keys:
   # required => :email (string)


### PR DESCRIPTION
Premerge review: clean @ 0322820471b8a08ed39feda982b58dbd355c0e73

## What

Comment-only trim of `app/services/post_sendgrid_api.rb`. **Comments only, no behaviour change** — the diff touches nothing but comment text.

```
293 → 285 lines   (−8)
git diff --numstat: 2 insertions, 10 deletions
```

## Why

The initializer comment restated `send_emails` as a "How it works" tutorial. That is noise for a maintainer who already knows this file.

## What I deliberately KEPT

- **Already-sent checks and UrlRedirect creation are the caller's job** — not obvious from `send_emails` itself.
- **`recipients` keys** (required `:email`, optional record associations) — the initialize kwargs don't document the hash shape.

## What went

The "Sends post emails via SendGrid API" / how-it-works bullet list (render, send, EmailInfo, stats, push).

## What I rejected as NOT slop

- `app/models/asset_preview.rb` — already compressed in #7247.
- `spec/models/purchase/purchase_refunds_spec.rb` multi-item presentment block — load-bearing: what the examples pin (amount clamp to the line, sibling untouched) and the fixture caveat (mocked `ChargeProcessor.refund!`, not routing to a shared PaymentIntent).

## Test Results

```
$ ruby -c app/services/post_sendgrid_api.rb
Syntax OK

$ bundle exec rubocop app/services/post_sendgrid_api.rb
1 file inspected, no offenses detected

$ VITE_RUBY_AUTO_BUILD=false bundle exec rspec spec/services/post_sendgrid_api_spec.rb
37 examples, 0 failures
```

Branch CI (`Tests` 31957761978) completed success — 0 pending, 0 failures.

Needs only a skim.

---

docs-only — diff is the reviewable artifact. Comments only, no behaviour change; no preview URL or QA click-path.

Model: grok-4.6 via Hermes cron `ai-slop-reducer`. Prompt: cut AI slop comments, change no behaviour, one small PR.
