### PR TITLE
Skip redundant npm setup on web container boot

### DIFF
--- a/docker/web/server.sh
+++ b/docker/web/server.sh
@@ -23,7 +23,13 @@ if [[ $BRANCH_DEPLOYMENT == "true" ]]; then
   fi
 fi
 
-echo "npm run setup"
-npm run setup
+# Production/staging images already ran this in compile_assets.sh (docker commit).
+# Re-running on every boot holds :3000 closed while nginx is already in ALB rotation.
+if [[ ! -f app/javascript/utils/routes.js || ! -f public/pages-tailwind.css ]]; then
+  echo "npm run setup"
+  npm run setup
+else
+  echo "npm run setup skipped (outputs already in image)"
+fi
 
 exec bundle exec rails server -p $PORT


### PR DESCRIPTION
Skip redundant npm setup on web container boot

> Draft status: skip is in; CI/QA still owed before ready.

## What

`docker/web/server.sh` no longer re-runs `npm run setup` when `app/javascript/utils/routes.js` and `public/pages-tailwind.css` are already in the image. Local and preview boots that lack those files still generate them.

## Why

Production and staging images already run `npm run setup` inside `compile_assets.sh` and `docker commit` the result. Re-running it on every Puma start holds port 3000 closed for about a minute after nginx is already answering the ALB liveness check, so scale-out traffic gets nginx 502s.

The ALB check stays a static nginx `/healthcheck.txt` on purpose (liveness, not readiness). This change only removes the wasted boot work.

## Before / after

- Before: every web container ran `npm run setup` (js:export + pages-tailwind) before `rails server`, even when the compile-assets commit already wrote both outputs.
- After: both outputs present → skip and exec rails immediately. Either output missing → same `npm run setup` as before.

## Checklist

- [x] Scope — server.sh only. compile_assets.sh still generates the files at image build. ALB health check unchanged.
- [x] Design — skip when both baked outputs exist, rather than a RAILS_ENV special case, so local/preview keep working.
- [x] Build — `gp2175-skip-boot-npm-setup`
- [ ] QA — local skip-predicate proof below; hosted preview not applicable
- [ ] Shipped
- [x] Market — n/a (boot path)
- [x] Sell — n/a

## Test Results

```text
bash -n docker/web/server.sh
# ok

predicate proof (same if as server.sh):
  neither file  -> runs setup
  only routes.js -> runs setup
  both files     -> skips
```

## QA steps

1. Confirmed `compile_assets.sh` still calls `npm run setup` before the image is committed.
2. Ran the skip predicate against missing / half / both output files (results in Test Results).
3. `bash -n docker/web/server.sh`.
4. After deploy: a scale-out instance's puma task should log `npm run setup skipped (outputs already in image)` and bind :3000 without a ~60s tailwind step.

No rendered surface. Preview app does not exercise production image boot.

---

AI disclosure: grok-4.6. Prompt/instructions: autonomous-product-dev; skip boot-time asset generation when the deploy image already baked it.
Premerge review: clean @ c0049cffdd49f797c51946f1cc6786f2732f8d8d
