### PR TITLE
Map mailer templates to their mailer specs in branch-specs

### DIFF
--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -195,6 +195,78 @@ def specs_mentioning(basename)
   $?.success? ? out.split("\n") : []
 end
 
+def grep_files(pattern, root)
+  out = IO.popen(["grep", "-rlE", pattern, root], err: File::NULL, &:read)
+  $?.success? ? out.split("\n") : []
+end
+
+def mailer_subclassed?(mailer)
+  camel = mailer.split("_").map(&:capitalize).join
+  grep_files("<\\s*#{Regexp.escape(camel)}\\b", "app/mailers/").any?
+end
+
+# Files that render a template. A qualified render spells out the whole key
+# (customer_mailer/receipt/item); a bare one names only the partial and Rails
+# resolves it against the mailer's prefix, so it can reach a top-level partial
+# only, and only from that mailer's own templates.
+def template_referrers(view)
+  owner, rest = view.delete_prefix("app/views/").split("/", 2)
+  key = "#{owner}/#{rest.sub(%r{\.[^/]*\z}, '').sub(%r{(\A|/)_}, '\1')}"
+  refs = grep_files("[\"']#{Regexp.escape(key)}[\"']", "app/")
+  bare = rest[%r{\A_([^/]+?)\.}, 1]
+  refs += grep_files("[\"']#{Regexp.escape(bare)}[\"']", "app/views/#{owner}/") if bare
+  refs.uniq - [view]
+end
+
+# A mailer template is covered by spec/mailers/<mailer>_spec.rb, keyed on the
+# first path segment: partials nest deeper (customer_mailer/receipt/sections/
+# _header.html.erb) and still belong to customer_mailer.
+#
+# Naming only that owner is not enough, because templates cross mailers:
+# customer_low_priority_mailer renders customer_mailer/receipt/sections/items,
+# and receipt/_item reaches it one level further down. So walk the render graph
+# up from the changed template and collect every mailer it can be reached from.
+# A referrer that is not a mailer view ends the walk with no answer — the
+# receipt previews controller renders customer_mailer/receipt, and no mailer
+# spec covers that — so the caller escalates, as it does today.
+def mailer_view_specs(path)
+  owner = path[%r{\Aapp/views/([^/]+)/.+\z}, 1]
+  return [] unless owner && File.exist?("app/mailers/#{owner}.rb")
+
+  mailers = [owner]
+  seen = [path]
+  queue = [path]
+  until queue.empty?
+    template_referrers(queue.shift).each do |ref|
+      next if seen.include?(ref)
+      seen << ref
+      case ref
+      when %r{\Aapp/views/([^/]+)/}
+        return [] unless File.exist?("app/mailers/#{$1}.rb")
+        mailers << $1
+        queue << ref
+      when %r{\Aapp/mailers/([^/]+)\.rb\z}
+        mailers << $1
+      else
+        return []
+      end
+    end
+  end
+
+  # A mailer other mailers inherit from lends its prefix to their bare renders,
+  # so its templates are reachable from view trees this walk never visits.
+  return [] if mailers.uniq.any? { |m| mailer_subclassed?(m) }
+
+  covered = mailers.uniq.map do |m|
+    (["spec/mailers/#{m}_spec.rb"] + Dir.glob("spec/mailers/#{m}/**/*_spec.rb")).select { |s| File.exist?(s) }
+  end
+  # One uncovered mailer in the graph is enough to escalate. Returning the rest
+  # would let the owner's own spec stand in for coverage that does not exist.
+  return [] if covered.any?(&:empty?)
+
+  covered.flatten
+end
+
 def spec_candidates(path)
   case path
   when %r{\Aspec/.*_spec\.rb\z}
@@ -210,8 +282,15 @@ def spec_candidates(path)
       Dir.glob("spec/#{$1}/#{$2}#{$3}/**/*_spec.rb")
     e2e = Dir.glob("spec/requests/**/#{$3}*_spec.rb")
     unit + e2e
-  when %r{\Aapp/views/(.*)/[^/]+\z}
-    Dir.glob("spec/requests/#{$1}*_spec.rb") + Dir.glob("spec/views/#{$1}/**/*_spec.rb")
+  when %r{\Aapp/views/(([^/]+)(?:/.*)?)/[^/]+\z}
+    # A mailer's templates are attributed by the render graph alone. Adding the
+    # request/view globs here would let an unrelated spec keep the caller from
+    # escalating on a graph the walk could not resolve.
+    if File.exist?("app/mailers/#{$2}.rb")
+      mailer_view_specs(path)
+    else
+      Dir.glob("spec/requests/#{$1}*_spec.rb") + Dir.glob("spec/views/#{$1}/**/*_spec.rb")
+    end
   when %r{\Aapp/([^/]+)/(.*)\.rb\z}
     ["spec/#{$1}/#{$2}_spec.rb"]
   when %r{\Alib/(.*)\.rb\z}

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -3,7 +3,8 @@
 
 # Tests for bin/branch-specs' mapping layers: Public/Profile component
 # fanout, a per-file config/ exception list, vitest co-location, lib/app
-# content-attribution fallback, and help_center view mapping.
+# content-attribution fallback, help_center view mapping, and the mailer
+# template render graph.
 #
 # Same shape as check_migration_versions_test.rb: throwaway git repos, no
 # Rails. The selector runs from the repo root of the throwaway repo, so each
@@ -159,6 +160,183 @@ check(
     "app/views/help_center/articles/contents/_260-your-payout-settings-page.html.erb" => "new",
   },
   expect_specs: %w[spec/requests/help_center_spec.rb],
+)
+
+MAILER_STUB = "# frozen_string_literal: true\n"
+
+# The plain case: a mailer template is covered by its mailer's spec.
+check(
+  "mailer template maps to its mailer spec",
+  base_files: {
+    "app/mailers/contacting_creator_mailer.rb" => MAILER_STUB,
+    "spec/mailers/contacting_creator_mailer_spec.rb" => SPEC_STUB,
+    "app/views/contacting_creator_mailer/chargeback_evidence_due_soon.html.erb" => "old",
+  },
+  head_files: {
+    "app/views/contacting_creator_mailer/chargeback_evidence_due_soon.html.erb" => "new",
+  },
+  expect_specs: %w[spec/mailers/contacting_creator_mailer_spec.rb],
+)
+
+# A partial another mailer renders must pull that mailer's spec in too.
+check(
+  "shared mailer partial pulls in the consuming mailer's spec",
+  base_files: {
+    "app/mailers/customer_mailer.rb" => MAILER_STUB,
+    "app/mailers/customer_low_priority_mailer.rb" => MAILER_STUB,
+    "spec/mailers/customer_mailer_spec.rb" => SPEC_STUB,
+    "spec/mailers/customer_low_priority_mailer_spec.rb" => SPEC_STUB,
+    "app/views/customer_mailer/_footer.html.erb" => "old",
+    "app/views/customer_low_priority_mailer/notice.html.erb" =>
+      %(<%= render("customer_mailer/footer") %>\n),
+  },
+  head_files: { "app/views/customer_mailer/_footer.html.erb" => "new" },
+  expect_specs: %w[
+    spec/mailers/customer_low_priority_mailer_spec.rb
+    spec/mailers/customer_mailer_spec.rb
+  ],
+)
+
+# The consumer is often one partial further out, so the walk is transitive:
+# _item <- _items <- the other mailer's template.
+check(
+  "transitively shared mailer partial reaches the consuming mailer",
+  base_files: {
+    "app/mailers/customer_mailer.rb" => MAILER_STUB,
+    "app/mailers/customer_low_priority_mailer.rb" => MAILER_STUB,
+    "spec/mailers/customer_mailer_spec.rb" => SPEC_STUB,
+    "spec/mailers/customer_low_priority_mailer_spec.rb" => SPEC_STUB,
+    "app/views/customer_mailer/_item.html.erb" => "old",
+    "app/views/customer_mailer/_items.html.erb" => %(<%= render("customer_mailer/item") %>\n),
+    "app/views/customer_low_priority_mailer/notice.html.erb" =>
+      %(<%= render("customer_mailer/items") %>\n),
+  },
+  head_files: { "app/views/customer_mailer/_item.html.erb" => "new" },
+  expect_specs: %w[
+    spec/mailers/customer_low_priority_mailer_spec.rb
+    spec/mailers/customer_mailer_spec.rb
+  ],
+)
+
+# A referrer outside app/views has no mailer spec to name, so the safe answer
+# is the full suite — including when it is reached through another partial.
+check(
+  "mailer template a controller renders still escalates",
+  base_files: {
+    "app/mailers/customer_mailer.rb" => MAILER_STUB,
+    "spec/mailers/customer_mailer_spec.rb" => SPEC_STUB,
+    "app/views/customer_mailer/_receipt.html.erb" => "old",
+    "app/controllers/api/internal/receipt_previews_controller.rb" =>
+      %(render(template: "customer_mailer/receipt")\n),
+  },
+  head_files: { "app/views/customer_mailer/_receipt.html.erb" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "mailer partial transitively reaching a controller still escalates",
+  base_files: {
+    "app/mailers/customer_mailer.rb" => MAILER_STUB,
+    "spec/mailers/customer_mailer_spec.rb" => SPEC_STUB,
+    "app/views/customer_mailer/receipt/_item.html.erb" => "old",
+    "app/views/customer_mailer/_receipt.html.erb" =>
+      %(<%= render("customer_mailer/receipt/item") %>\n),
+    "app/controllers/api/internal/receipt_previews_controller.rb" =>
+      %(render(template: "customer_mailer/receipt")\n),
+  },
+  head_files: { "app/views/customer_mailer/receipt/_item.html.erb" => "new" },
+  expect_escalate: true,
+)
+
+# Rails resolves a bare render against the mailer's prefix, so the walk has to
+# follow those too or it stops before reaching the external consumer.
+check(
+  "bare render keeps the walk going to the consuming mailer",
+  base_files: {
+    "app/mailers/affiliate_mailer.rb" => MAILER_STUB,
+    "app/mailers/affiliate_request_mailer.rb" => MAILER_STUB,
+    "spec/mailers/affiliate_mailer_spec.rb" => SPEC_STUB,
+    "spec/mailers/affiliate_request_mailer_spec.rb" => SPEC_STUB,
+    "app/views/affiliate_mailer/_footer.html.erb" => "old",
+    # renders the partial by bare name, and is itself rendered by the other mailer
+    "app/views/affiliate_mailer/invitation.html.erb" => %(<%= render("footer") %>\n),
+    "app/views/affiliate_request_mailer/approved.html.erb" =>
+      %(<%= render("affiliate_mailer/invitation") %>\n),
+  },
+  head_files: { "app/views/affiliate_mailer/_footer.html.erb" => "new" },
+  expect_specs: %w[
+    spec/mailers/affiliate_mailer_spec.rb
+    spec/mailers/affiliate_request_mailer_spec.rb
+  ],
+)
+
+# The owner having a spec must not paper over a consumer that has none.
+check(
+  "consuming mailer without a spec escalates even when the owner has one",
+  base_files: {
+    "app/mailers/customer_mailer.rb" => MAILER_STUB,
+    "app/mailers/support_contact_mailer.rb" => MAILER_STUB,
+    "spec/mailers/customer_mailer_spec.rb" => SPEC_STUB,
+    "app/views/customer_mailer/_footer.html.erb" => "old",
+    "app/views/support_contact_mailer/notice.html.erb" =>
+      %(<%= render("customer_mailer/footer") %>\n),
+  },
+  head_files: { "app/views/customer_mailer/_footer.html.erb" => "new" },
+  expect_escalate: true,
+)
+
+# No spec/mailers/<mailer>_spec.rb means nothing to select; do not invent one.
+check(
+  "mailer template with no mailer spec still escalates",
+  base_files: {
+    "app/mailers/support_contact_mailer.rb" => MAILER_STUB,
+    "app/views/support_contact_mailer/contact_form.html.erb" => "old",
+  },
+  head_files: { "app/views/support_contact_mailer/contact_form.html.erb" => "new" },
+  expect_escalate: true,
+)
+
+# An unrelated spec named after the mailer must not stand in for the render
+# graph and keep the selector from escalating.
+check(
+  "unsafe mailer graph escalates even when a view spec exists for the directory",
+  base_files: {
+    "app/mailers/customer_mailer.rb" => MAILER_STUB,
+    "spec/mailers/customer_mailer_spec.rb" => SPEC_STUB,
+    "spec/views/customer_mailer/receipt_spec.rb" => SPEC_STUB,
+    "app/views/customer_mailer/_receipt.html.erb" => "old",
+    "app/controllers/api/internal/receipt_previews_controller.rb" =>
+      %(render(template: "customer_mailer/receipt")\n),
+  },
+  head_files: { "app/views/customer_mailer/_receipt.html.erb" => "new" },
+  expect_escalate: true,
+)
+
+# Bare renders resolve through inherited prefixes, so a parent mailer's
+# templates are reachable from view trees the walk never visits.
+check(
+  "template of a mailer other mailers inherit from escalates",
+  base_files: {
+    "app/mailers/application_mailer.rb" => "class ApplicationMailer < ActionMailer::Base\nend\n",
+    "app/mailers/customer_mailer.rb" => "class CustomerMailer < ApplicationMailer\nend\n",
+    "spec/mailers/application_mailer_spec.rb" => SPEC_STUB,
+    "spec/mailers/customer_mailer_spec.rb" => SPEC_STUB,
+    "app/views/application_mailer/_footer.html.erb" => "old",
+    "app/views/customer_mailer/notice.html.erb" => %(<%= render("footer") %>\n),
+  },
+  head_files: { "app/views/application_mailer/_footer.html.erb" => "new" },
+  expect_escalate: true,
+)
+
+# A non-mailer view directory must not pick up a mailer spec.
+check(
+  "non-mailer view directory does not map to spec/mailers",
+  base_files: {
+    "spec/mailers/products_spec.rb" => SPEC_STUB,
+    "app/views/products/show.html.erb" => "old",
+  },
+  head_files: { "app/views/products/show.html.erb" => "new" },
+  expect_escalate: true,
 )
 
 # A genuinely unmapped app file must still escalate (the guard this whole


### PR DESCRIPTION
## What

`bin/branch-specs` had no mapping for mailer templates. A diff touching `app/views/<mailer>/*.html.erb` selected no specs, so the selector reported a mapping gap and forced the full suite via the `run-all-specs` label.

Seen on #7261 ([job](https://github.com/antiwork/gumroad/actions/runs/31972578481/job/95227239766)):

```
bin/branch-specs: ESCALATE — diff touches app/views/contacting_creator_mailer/chargeback_evidence_due_soon.html.erb but no specs were selected for it (mapping gap)
Run the full suite instead: add the run-all-specs label to the PR.
```

That PR already had the covering mailer spec in its diff. The selector could not connect the two.

Mailer templates are now attributed by walking the render graph. The walk starts at the changed template, follows qualified renders (`customer_mailer/receipt/item`) and bare ones (`render("footer")`, which Rails resolves against the mailer's prefix) up through every consumer, and collects the spec of each mailer the template can be reached from.

174 of 185 mailer view files now map to specs instead of escalating.

## Why

The obvious rule — `app/views/<mailer>/<action>.html.erb` maps to `spec/mailers/<mailer>_spec.rb` — is wrong on its own, because mailer templates cross mailer boundaries. `customer_low_priority_mailer` renders `customer_mailer/receipt/sections/items`, and `receipt/_item` reaches that consumer one level further down. Naming only the mailer that owns the directory would run `customer_mailer_spec.rb` and skip the specs that actually exercise the change, turning a mapping gap into a false green — a worse outcome than the escalation it replaces.

So the walk is transitive, and it refuses to answer whenever it cannot see the whole picture. It returns nothing, and the caller escalates exactly as it does today, when:

- a referrer is not a mailer view — `Api::Internal::ReceiptPreviewsController` renders `customer_mailer/receipt`, and no mailer spec covers that
- any mailer in the graph has no spec of its own
- the owning mailer is subclassed, lending its prefix to bare renders in view trees the walk never visits

The 11 files that still escalate are the `customer_mailer/receipt` subtree, which the previews controller reaches, and `support_contact_mailer/contact_form.html.erb`, which has no mailer spec. Both are correct answers, not remaining gaps.

The escalation behaviour from #7086 is unchanged. This only stops it firing when the mapping is knowable.

## Before/After

Same diff as #7261 — the changed template plus its mailer spec:

Before
```
$ ruby bin/branch-specs
bin/branch-specs: ESCALATE — diff touches app/views/contacting_creator_mailer/chargeback_evidence_due_soon.html.erb but no specs were selected for it (mapping gap)
Run the full suite instead: add the run-all-specs label to the PR.
exit=3
```

After
```
$ ruby bin/branch-specs
spec/mailers/contacting_creator_mailer_spec.rb
exit=0
```

A shared partial pulls in every consumer:

```
$ # diff touches app/views/customer_mailer/_product_questions_footer.html.erb
spec/mailers/customer_low_priority_mailer_spec.rb
spec/mailers/customer_mailer_spec.rb
```

A template the previews controller renders still escalates:

```
$ # diff touches app/views/customer_mailer/receipt.html.erb
bin/branch-specs: ESCALATE — diff touches app/views/customer_mailer/receipt.html.erb but no specs were selected for it (mapping gap)
exit=3
```

No video: this is CI tooling with no user-facing surface, and the selector's output is the reviewable artifact.

## Test Results

`spec/bin/branch_specs_test.rb` gains 11 cases covering the plain mapping, direct and transitive cross-mailer sharing, bare renders, and each escalation guard.

```
$ ruby spec/bin/branch_specs_test.rb
19 checks passed
```

Each new positive case fails against the selector without this change, and each new guard case fails against the intermediate versions that lacked its guard — verified by reverting the script and rerunning.

```
$ bundle exec rubocop bin/branch-specs spec/bin/branch_specs_test.rb
2 files inspected, no offenses detected
```

Swept all 392 files under `app/views/` comparing selections before and after: no selection is lost anywhere, every gained spec is a mailer spec, and no non-mailer view directory changes behaviour.

Runtime on a typical diff is 0.47s, and 4.2s for a diff touching 20 mailer templates.

Note: nothing in CI runs `spec/bin/branch_specs_test.rb` today — only `check_migration_versions_test.rb` is wired in. Worth a follow-up.

---

AI disclosure: written with Claude Opus 5.
