### PR TITLE
Let bin/branch-specs run on a shell with no UTF-8 locale

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,6 +120,12 @@ jobs:
           bundler-cache: true
       - run: bundle exec rubocop --format github
 
+      # Lives here because this job always runs and already has the project's
+      # Ruby. relevant_specs is the wrong home: it is skipped exactly when the
+      # run-all-specs label is set, which is whenever the selector itself changes.
+      - name: Self-test the spec selector
+        run: ruby spec/bin/branch_specs_test.rb
+
   migration_versions:
     name: Migration versions
     runs-on: ubicloud-standard-2

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -126,9 +126,20 @@ MAX_SELECTED_FILES = 120
 
 ESCALATE_EXIT = 3
 
+def escalate!(reason)
+  warn "bin/branch-specs: ESCALATE — #{reason}"
+  warn "Run the full suite instead: add the run-all-specs label to the PR."
+  exit ESCALATE_EXIT
+end
+
+# Reads name UTF-8 so an ASCII-only locale cannot make them raise. Bytes that
+# are no valid encoding we refuse rather than scrub: U+FFFD can name a different
+# real file, which would quietly run the wrong spec.
 def git(*args)
-  out = IO.popen(["git", *args], err: File::NULL, &:read)
-  $?.success? ? out.split("\n") : []
+  out = IO.popen(["git", *args], err: File::NULL, external_encoding: "UTF-8", &:read)
+  return [] unless $?.success?
+  escalate!("git reported a path that is not valid UTF-8") unless out.valid_encoding?
+  out.split("\n")
 end
 
 base = "origin/main"
@@ -144,7 +155,8 @@ until argv.empty?
   when "--smoke" then smoke = true
   when "--no-smoke" then smoke = false # kept for compatibility
   when "-h", "--help"
-    doc = File.read(__FILE__).lines
+    # The header block above contains em-dashes, so this read needs UTF-8 too.
+    doc = File.read(__FILE__, encoding: "UTF-8").lines
       .drop_while { |line| line.start_with?("#!") || line.include?("frozen_string_literal") || line.strip.empty? }
       .take_while { |line| line.start_with?("#") }
     puts doc.join.gsub(/^# ?/, "")
@@ -168,12 +180,6 @@ changed.merge(git("ls-files", "--others", "--exclude-standard"))
 
 changed.reject! { |path| IGNORED_PATTERNS.any? { |re| re.match?(path) } }
 
-def escalate!(reason)
-  warn "bin/branch-specs: ESCALATE — #{reason}"
-  warn "Run the full suite instead: add the run-all-specs label to the PR."
-  exit ESCALATE_EXIT
-end
-
 unmappable = changed.select do |path|
   ESCALATE_PATTERNS.any? { |re| re.match?(path) } && !CONFIG_SPEC_MAP.key?(path)
 end
@@ -191,13 +197,19 @@ escalate!("unmapped spec/support change: #{unmapped_support.first(3).join(', ')}
 def specs_mentioning(basename)
   camel = basename.split("_").map(&:capitalize).join
   pattern = "\\b(#{Regexp.escape(basename)}|#{Regexp.escape(camel)})\\b"
-  out = IO.popen(["grep", "-rlE", pattern, "spec/", "--include=*_spec.rb"], err: File::NULL, &:read)
-  $?.success? ? out.split("\n") : []
+  # grep prints path bytes unescaped, so the same rule as git() applies here.
+  out = IO.popen(["grep", "-rlE", pattern, "spec/", "--include=*_spec.rb"], err: File::NULL, external_encoding: "UTF-8", &:read)
+  return [] unless $?.success?
+  escalate!("grep reported a spec path that is not valid UTF-8") unless out.valid_encoding?
+  out.split("\n")
 end
 
 def grep_files(pattern, root)
-  out = IO.popen(["grep", "-rlE", pattern, root], err: File::NULL, &:read)
-  $?.success? ? out.split("\n") : []
+  # Same encoding rule as git(): name UTF-8, refuse bytes that are not.
+  out = IO.popen(["grep", "-rlE", pattern, root], err: File::NULL, external_encoding: "UTF-8", &:read)
+  return [] unless $?.success?
+  escalate!("grep reported a path that is not valid UTF-8") unless out.valid_encoding?
+  out.split("\n")
 end
 
 def mailer_subclassed?(mailer)

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -4,7 +4,8 @@
 # Tests for bin/branch-specs' mapping layers: Public/Profile component
 # fanout, a per-file config/ exception list, vitest co-location, lib/app
 # content-attribution fallback, help_center view mapping, and the mailer
-# template render graph.
+# template render graph. Also its behavior under an ASCII-only locale, where
+# each read must name an encoding.
 #
 # Same shape as check_migration_versions_test.rb: throwaway git repos, no
 # Rails. The selector runs from the repo root of the throwaway repo, so each
@@ -21,12 +22,13 @@ SELECTOR = File.expand_path("../../bin/branch-specs", __dir__)
 $failures = []
 $count = 0
 
-def build_repo(dir, base_files:, head_files:)
+def build_repo(dir, base_files:, head_files:, quote_path: nil)
   Dir.chdir(dir) do
     system("git init -q -b main .", exception: true)
     system("git config user.email t@t.t", exception: true)
     system("git config user.name t", exception: true)
     system("git config commit.gpgsign false", exception: true)
+    system("git config core.quotePath #{quote_path}", exception: true) unless quote_path.nil?
 
     write = lambda do |files|
       files.each do |path, content|
@@ -43,11 +45,23 @@ def build_repo(dir, base_files:, head_files:)
   end
 end
 
-def check(name, base_files:, head_files:, expect_specs: nil, expect_escalate: false)
+# Forces Encoding.default_external to US-ASCII, which the selector's reads have
+# to survive. LC_ALL=C, not an empty LANG: capture3 merges into the current
+# environment, an empty LC_ALL is ignored, and a stray LC_CTYPE restores UTF-8.
+ASCII_LOCALE = { "LC_ALL" => "C", "LANG" => "C", "LC_CTYPE" => nil, "LANGUAGE" => nil }.freeze
+
+# Captured output arrives tagged with this process's default_external, which is
+# itself US-ASCII when the suite runs without a locale. Read it as UTF-8 so the
+# non-ASCII expectations below compare as text rather than raising.
+def utf8(str) = str.dup.force_encoding(Encoding::UTF_8)
+
+def check(name, base_files:, head_files:, expect_specs: nil, expect_escalate: false, env: {}, quote_path: nil)
   $count += 1
   Dir.mktmpdir do |dir|
-    build_repo(dir, base_files:, head_files:)
-    stdout, stderr, status = Open3.capture3("ruby", SELECTOR, "--base", "base", chdir: dir)
+    build_repo(dir, base_files:, head_files:, quote_path:)
+    stdout, stderr, status = Open3.capture3(env, "ruby", SELECTOR, "--base", "base", chdir: dir)
+    stdout = utf8(stdout)
+    stderr = utf8(stderr)
 
     if expect_escalate
       unless status.exitstatus == 3
@@ -346,6 +360,98 @@ check(
   base_files: { "app/javascript/components/Novel/Thing.tsx" => "old" },
   head_files: { "app/javascript/components/Novel/Thing.tsx" => "new" },
   expect_escalate: true,
+)
+
+# --- Locale handling -------------------------------------------------------
+#
+# Three reads can carry non-ASCII bytes: the header comments via --help, git
+# paths, and grep paths. Under an ASCII-only locale an unqualified read of any
+# of them raises ArgumentError.
+
+# --help takes no base ref, so it does not fit check().
+def check_help_under_ascii_locale
+  $count += 1
+  stdout, stderr, status = Open3.capture3(ASCII_LOCALE, "ruby", SELECTOR, "--help")
+  stdout = utf8(stdout)
+  stderr = utf8(stderr)
+  name = "--help renders under an ASCII-only locale"
+  if !status.success?
+    $failures << "#{name}: exit #{status.exitstatus}\nstderr: #{stderr}"
+  elsif !stdout.include?("Usage:")
+    $failures << "#{name}: header block missing from output\nstdout: #{stdout}"
+  elsif !stdout.include?("—")
+    $failures << "#{name}: em-dash lost, so the read transcoded\nstdout: #{stdout}"
+  end
+end
+check_help_under_ascii_locale
+
+# git prints raw path bytes when core.quotePath is off.
+check(
+  "non-ASCII changed path maps under an ASCII-only locale",
+  base_files: {
+    "app/models/café.rb" => "old",
+    "spec/models/café_spec.rb" => SPEC_STUB,
+  },
+  head_files: { "app/models/café.rb" => "new" },
+  expect_specs: ["spec/models/café_spec.rb"],
+  env: ASCII_LOCALE,
+  quote_path: false,
+)
+
+# grep prints raw path bytes always, so content attribution needs the same care.
+check(
+  "non-ASCII spec filename resolves by content under an ASCII-only locale",
+  base_files: {
+    "lib/utilities/compliance/colombia_id_number.rb" => "old",
+    "spec/services/café_compliance_spec.rb" =>
+      "#{SPEC_STUB}describe \"x\" do\n  it { ColombiaIdNumber.valid?(\"1\") }\nend\n",
+  },
+  head_files: { "lib/utilities/compliance/colombia_id_number.rb" => "new" },
+  expect_specs: ["spec/services/café_compliance_spec.rb"],
+  env: ASCII_LOCALE,
+  quote_path: false,
+)
+
+# Bytes that are no valid encoding must be refused, not scrubbed: U+FFFD can
+# name a different real file. They come from a stub grep because APFS rejects
+# such filenames, so a real-file fixture would only ever run on Linux. The
+# assertion is on stderr because scrubbing also exits 3, via a mapping gap.
+def check_invalid_path_bytes_rejected(name, base_files:, head_files:)
+  $count += 1
+  Dir.mktmpdir do |dir|
+    build_repo(dir, base_files:, head_files:)
+    stub = File.join(dir, "stub-bin")
+    FileUtils.mkdir_p(stub)
+    File.write(File.join(stub, "grep"), "#!/bin/sh\nprintf 'spec/bad\\377_spec.rb\\n'\n")
+    FileUtils.chmod(0o755, File.join(stub, "grep"))
+
+    env = ASCII_LOCALE.merge("PATH" => "#{stub}:#{ENV.fetch('PATH')}")
+    _stdout, stderr, status = Open3.capture3(env, "ruby", SELECTOR, "--base", "base", chdir: dir)
+    stderr = utf8(stderr).scrub
+
+    if status.exitstatus != 3
+      $failures << "#{name}: expected escalate (exit 3), got #{status.exitstatus}\nstderr: #{stderr}"
+    elsif !stderr.include?("not valid UTF-8")
+      $failures << "#{name}: escalated for the wrong reason, so the bytes were reinterpreted\nstderr: #{stderr}"
+    end
+  end
+end
+# Both greps that read path names: content attribution, and the mailer render
+# graph. Each reaches its grep first for the diff it is given.
+check_invalid_path_bytes_rejected(
+  "invalid path bytes from the content-attribution grep are refused",
+  base_files: { "lib/utilities/compliance/colombia_id_number.rb" => "old" },
+  head_files: { "lib/utilities/compliance/colombia_id_number.rb" => "new" },
+)
+
+check_invalid_path_bytes_rejected(
+  "invalid path bytes from the mailer render-graph grep are refused",
+  base_files: {
+    "app/mailers/customer_mailer.rb" => MAILER_STUB,
+    "spec/mailers/customer_mailer_spec.rb" => SPEC_STUB,
+    "app/views/customer_mailer/_footer.html.erb" => "old",
+  },
+  head_files: { "app/views/customer_mailer/_footer.html.erb" => "new" },
 )
 
 if $failures.empty?


### PR DESCRIPTION
## What

`bin/branch-specs` crashed on a shell whose locale is not UTF-8:

```
$ LANG= ruby bin/branch-specs --help
invalid byte sequence in US-ASCII (ArgumentError)
```

The script read files and subprocess output without naming an encoding, so it
inherited `Encoding.default_external`. Where that is US-ASCII, the first
non-ASCII byte raises.

Three reads had the problem. All now ask for UTF-8:

- `--help` reads the script's own header comments, which contain an em-dash. This is the reported crash.
- `git()` reads path names from `git`. Reachable when a repo sets `core.quotePath=false`; the default escapes non-ASCII paths, which is why this stayed hidden.
- `specs_mentioning()` reads path names from `grep`. `grep` prints path bytes as they are, so this needed only a non-UTF-8 locale and a spec file with an accent in its name.

A POSIX path can also be bytes that are no encoding at all. The two subprocess
reads now check for that and escalate to the full suite, rather than guess at a
path they cannot represent.

`--help` prints the same text as before, byte for byte.

## Why

Contributors on a POSIX or empty locale could not run the tool at all. Fixing only the first read leaves the same failure in two other places, and one of those arrives the day someone adds a spec file with an accent in its name.

Two approaches were tried and dropped:

- One `Encoding.default_external = Encoding::UTF_8` at the top fixes all three at once, but `ruby -w` warns on it. Ruby discourages the global change, so each read names its own encoding instead.
- `String#scrub` also clears the crash, but it replaces bad bytes with `U+FFFD`, and that name can be a different real file. It would quietly run the wrong spec and exit 0. Refusing the path keeps the guarantee honest.

The ESCALATE message needed no change. Ruby reads the script as UTF-8 whatever the locale, and writing to stderr passes the bytes through. Checked with stderr on a terminal and redirected to a file.

## Before / After

No video: this is a command line script with no interface, so the terminal output is the whole behavior.

Before, on `main`:

```
$ LANG= ruby bin/branch-specs --help
bin/branch-specs:147:in 'String#gsub': invalid byte sequence in US-ASCII (ArgumentError)
    puts doc.join.gsub(/^# ?/, "")
                       ^^^^^^^^^^
```

After:

```
$ LANG= ruby bin/branch-specs --help
Prints the spec files a branch needs for confidence, instead of the whole
suite: specs mapped from changed files, expanded through a fanout registry
for files whose behavior many end-to-end specs depend on.
...
Usage:
  bin/branch-specs                 # print the list, one per line
  bin/branch-specs --base main     # diff against a different base ref
  bin/branch-specs --smoke         # include the legacy smoke set
  bin/rspec $(bin/branch-specs)    # run it locally
```

## Test Results

Four cases added to `spec/bin/branch_specs_test.rb`, covering each read:

- `--help` under an ASCII-only locale: exits 0, prints the header, keeps the em-dash
- a changed path with an accent, `core.quotePath=false`: maps to its spec
- a spec filename with an accent, found by content: selected
- path bytes that are no valid encoding: exit 3, and the message says why

The suite now runs in CI, in `lint_ruby`. It was in the repo but no workflow called it, so nothing enforced it.

Run against three versions of the selector, to show the cases carry weight:

| Selector | Result |
| --- | --- |
| this branch | 12 checks passed |
| `origin/main` | 4/12 failed |
| the `scrub` version, since dropped | 1/12 failed, on the aliasing case |

The locale fixture uses `LC_ALL=C`. An empty `LANG` is not enough: `capture3` merges into the current environment, an empty `LC_ALL` is ignored, and a stray `LC_CTYPE` restores UTF-8 and hides the bug. Confirmed the fixture holds by running the suite against both selectors on a bare host, with `LC_CTYPE=C.UTF-8`, and under a full `en_US.UTF-8` locale — `origin/main` fails 4/12 in all three.

Also run:

- `bundle exec rubocop bin/branch-specs spec/bin/branch_specs_test.rb` — clean
- `ruby spec/bin/check_migration_versions_test.rb` — 21 checks passed, unaffected
- `--help`, `--smoke`, no argument, and a bad argument give the same exit codes under an unset `LANG`, `POSIX`, `C`, and `en_US.UTF-8`
- the suite passes from a depth-1 clone, matching `lint_ruby`'s checkout

This PR changes the selector, so the selector escalates on its own diff. It needs the **run-all-specs** label.

---

AI disclosure: written with Claude Opus 5.
