### PR TITLE
Charge 5% after $20k trailing-30-day sales

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1296,7 +1296,7 @@ class Link < ApplicationRecord
   end
 
   def gumroad_amount_for_paypal_order(amount_cents:, affiliate_id: nil, vat_cents: 0, was_recommended: false)
-    fee_per_thousand = Purchase::GUMROAD_FLAT_FEE_PER_THOUSAND
+    fee_per_thousand = user.gumroad_fee_per_thousand
 
     if was_recommended
       gumroad_fee_cents = (amount_cents * (fee_per_thousand + discover_fee_per_thousand - Purchase::GUMROAD_DISCOVER_EXTRA_FEE_PER_THOUSAND)) / 1000

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -412,6 +412,10 @@ class Purchase < ApplicationRecord
     purchase.purchase_state_previously_changed? && purchase.purchase_state == "successful"
   }
 
+  after_commit :enqueue_high_volume_fee_eligibility_refresh, if: -> (purchase) {
+    purchase.purchase_state_previously_changed? && purchase.purchase_state == "successful"
+  }
+
   after_commit :enqueue_record_order_charge_outcome, if: -> (purchase) {
     purchase.purchase_state_previously_changed? &&
       ORDER_OUTCOME_STATES.include?(purchase.purchase_state)
@@ -3643,6 +3647,10 @@ class Purchase < ApplicationRecord
     UpdateSalesRelatedProductsInfosJob.perform_async(id, increment)
   end
 
+  def enqueue_high_volume_fee_eligibility_refresh
+    RefreshHighVolumeSellerFeeEligibilityJob.perform_async(seller_id)
+  end
+
   def free_purchase?
     price_cents == 0 && shipping_cents == 0
   end
@@ -4949,7 +4957,10 @@ class Purchase < ApplicationRecord
     end
 
     def gumroad_flat_fee_per_thousand
-      seller.waive_gumroad_fee_on_new_sales? && subscription.blank? && !is_preorder_charge? ? 0 : GUMROAD_FLAT_FEE_PER_THOUSAND
+      return 0 if seller.waive_gumroad_fee_on_new_sales? && subscription.blank? && !is_preorder_charge?
+      return User::HIGH_VOLUME_FEE_PER_THOUSAND if seller.high_volume_seller_fee?
+
+      GUMROAD_FLAT_FEE_PER_THOUSAND
     end
 
     def calculate_taxes

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -412,8 +412,11 @@ class Purchase < ApplicationRecord
     purchase.purchase_state_previously_changed? && purchase.purchase_state == "successful"
   }
 
+  # Full refunds flip stripe_refunded without touching purchase_state, so they need
+  # their own trigger or the cached 5%-fee eligibility stays true after GMV drops.
   after_commit :enqueue_high_volume_fee_eligibility_refresh, if: -> (purchase) {
-    purchase.purchase_state_previously_changed? && purchase.purchase_state == "successful"
+    (purchase.purchase_state_previously_changed? && purchase.purchase_state == "successful") ||
+      (purchase.stripe_refunded_previously_changed? && purchase.stripe_refunded?)
   }
 
   after_commit :enqueue_record_order_charge_outcome, if: -> (purchase) {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,12 @@ class User < ApplicationRecord
 
   MIN_SALES_CENTS_VALUE_FOR_STORE_AGENT = 10_000
 
+  # 5% once trailing-30-day GMV is at least $20k. Eligibility is cached so purchase
+  # fee calc does not SUM the seller's sales (closed #4283).
+  HIGH_VOLUME_FEE_PER_THOUSAND = 50
+  HIGH_VOLUME_FEE_THRESHOLD_CENTS = 2_000_000
+  HIGH_VOLUME_FEE_WINDOW = 30.days
+
   # Ceiling on how long a cached avatar URL can keep being served after the file
   # behind it goes away (avatar URLs are otherwise stable for the seller's picture).
   AVATAR_VARIANT_URL_CACHE_TTL = 1.day
@@ -242,6 +248,40 @@ class User < ApplicationRecord
 
   def disable_buyer_currency_rounding=(value)
     set_json_data_for_attr("disable_buyer_currency_rounding", ActiveModel::Type::Boolean.new.cast(value))
+  end
+
+  def high_volume_fee_eligible
+    ActiveModel::Type::Boolean.new.cast(json_data_for_attr("high_volume_fee_eligible", default: false))
+  end
+  alias_method :high_volume_fee_eligible?, :high_volume_fee_eligible
+
+  def high_volume_fee_eligible=(value)
+    set_json_data_for_attr("high_volume_fee_eligible", ActiveModel::Type::Boolean.new.cast(value))
+    json_data_will_change!
+  end
+
+  def high_volume_seller_fee?
+    Feature.active?(:high_volume_seller_fee, self) && high_volume_fee_eligible?
+  end
+
+  def gumroad_fee_per_thousand
+    return custom_fee_per_thousand if custom_fee_per_thousand.present?
+    return HIGH_VOLUME_FEE_PER_THOUSAND if high_volume_seller_fee?
+
+    Purchase::GUMROAD_FLAT_FEE_PER_THOUSAND
+  end
+
+  def trailing_month_gross_sales_cents
+    sales.paid.where("purchases.created_at >= ?", HIGH_VOLUME_FEE_WINDOW.ago).sum(:price_cents)
+  end
+
+  def refresh_high_volume_fee_eligibility!
+    eligible = trailing_month_gross_sales_cents >= HIGH_VOLUME_FEE_THRESHOLD_CENTS
+    return eligible if high_volume_fee_eligible? == eligible
+
+    self.high_volume_fee_eligible = eligible
+    save!(validate: false)
+    eligible
   end
 
   attr_blockable :email

--- a/app/presenters/checkout/form_presenter.rb
+++ b/app/presenters/checkout/form_presenter.rb
@@ -78,7 +78,7 @@ class Checkout::FormPresenter
       else
         discover_fee_percent = (Purchase::GUMROAD_DISCOVER_FEE_PER_THOUSAND / 10.0).round(1)
         discover_fee_percent = discover_fee_percent.to_i == discover_fee_percent ? discover_fee_percent.to_i : discover_fee_percent
-        direct_fee_percent = ((seller.custom_fee_per_thousand.presence || Purchase::GUMROAD_FLAT_FEE_PER_THOUSAND) / 10.0).round(1)
+        direct_fee_percent = (seller.gumroad_fee_per_thousand / 10.0).round(1)
         direct_fee_percent = direct_fee_percent.to_i == direct_fee_percent ? direct_fee_percent.to_i : direct_fee_percent
         fixed_fee_cents = Purchase::GUMROAD_FIXED_FEE_CENTS
 

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -816,7 +816,7 @@ class SettingsPresenter
 
       discover_fee_percent = (Purchase::GUMROAD_DISCOVER_FEE_PER_THOUSAND / 10.0).round(1)
       discover_fee_percent = discover_fee_percent.to_i == discover_fee_percent ? discover_fee_percent.to_i : discover_fee_percent
-      direct_fee_percent = ((seller.custom_fee_per_thousand.presence || Purchase::GUMROAD_FLAT_FEE_PER_THOUSAND) / 10.0).round(1)
+      direct_fee_percent = (seller.gumroad_fee_per_thousand / 10.0).round(1)
       direct_fee_percent = direct_fee_percent.to_i == direct_fee_percent ? direct_fee_percent.to_i : direct_fee_percent
       fixed_fee_cents = Purchase::GUMROAD_FIXED_FEE_CENTS
 

--- a/app/services/checkout/presentment_rounding.rb
+++ b/app/services/checkout/presentment_rounding.rb
@@ -124,7 +124,7 @@ class Checkout::PresentmentRounding
   def self.absorbable_gumroad_cents(seller:, canonical_price_and_tip_cents:, merchant_account: nil)
     return 0 if merchant_account&.is_a_brazilian_stripe_connect_account?
 
-    fee_per_thousand = (seller.custom_fee_per_thousand.presence || Purchase::GUMROAD_FLAT_FEE_PER_THOUSAND).to_i
+    fee_per_thousand = seller.gumroad_fee_per_thousand.to_i
     return 0 unless fee_per_thousand.positive?
 
     canonical_price_and_tip_cents.to_i * fee_per_thousand / 1000

--- a/app/sidekiq/refresh_high_volume_seller_fee_eligibility_job.rb
+++ b/app/sidekiq/refresh_high_volume_seller_fee_eligibility_job.rb
@@ -16,9 +16,16 @@ class RefreshHighVolumeSellerFeeEligibilityJob
   end
 
   private
+    # Threshold-crossers can only appear via new paid sales, but the per-sale hook can
+    # be missed (dead job, flag ramped after the sales landed), so recompute the full
+    # qualifying set from purchases each night instead of only yesterday's sellers.
     def seller_ids_to_refresh
-      recent = Purchase.successful.where("created_at >= ?", 1.day.ago).distinct.pluck(:seller_id)
+      qualifying = Purchase.paid
+        .where("purchases.created_at >= ?", User::HIGH_VOLUME_FEE_WINDOW.ago)
+        .group(:seller_id)
+        .having("SUM(purchases.price_cents) >= ?", User::HIGH_VOLUME_FEE_THRESHOLD_CENTS)
+        .pluck(:seller_id)
       flagged = User.where("json_data LIKE ?", "%high_volume_fee_eligible%true%").pluck(:id)
-      (recent + flagged).uniq
+      (qualifying + flagged).uniq
     end
 end

--- a/app/sidekiq/refresh_high_volume_seller_fee_eligibility_job.rb
+++ b/app/sidekiq/refresh_high_volume_seller_fee_eligibility_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Recomputes the cached 30-day GMV flag used by the 5%-after-$20k fee.
+# Per-seller on each successful sale; nightly with no args to drop sellers who fell below.
+class RefreshHighVolumeSellerFeeEligibilityJob
+  include Sidekiq::Job
+  sidekiq_options retry: 3, queue: :low
+
+  def perform(seller_id = nil)
+    if seller_id.present?
+      User.find_by(id: seller_id)&.refresh_high_volume_fee_eligibility!
+      return
+    end
+
+    seller_ids_to_refresh.each { |id| self.class.perform_async(id) }
+  end
+
+  private
+    def seller_ids_to_refresh
+      recent = Purchase.successful.where("created_at >= ?", 1.day.ago).distinct.pluck(:seller_id)
+      flagged = User.where("json_data LIKE ?", "%high_volume_fee_eligible%true%").pluck(:id)
+      (recent + flagged).uniq
+    end
+end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -152,6 +152,11 @@ stale_transient_suppression_sweep:
   class: StaleTransientSuppressionSweepJob
   queue: low
   description: Clears stale TRANSIENT SendGrid bounce/block suppressions for users active since the failure (bounded, logged; never touches spam reports or unsubscribes)
+refresh_high_volume_seller_fee_eligibility:
+  cron: "45 4 * * *" # UTC 04:45 — after the suppression sweep, off payout/report hours
+  class: RefreshHighVolumeSellerFeeEligibilityJob
+  queue: low
+  description: Recomputes the cached 30-day GMV flag for the 5%-after-$20k seller fee
 purge_old_deleted_asset_previews: # Duration: 1min
   cron: "30 10 * * *" # UTC 10:30
   class: PurgeOldDeletedAssetPreviewsWorker

--- a/test/models/purchase/high_volume_seller_fee_test.rb
+++ b/test/models/purchase/high_volume_seller_fee_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Purchase::HighVolumeSellerFeeTest < ActiveSupport::TestCase
+  setup do
+    @seller = create_user
+    @product = create_product(user: @seller)
+    Feature.activate(:high_volume_seller_fee)
+  end
+
+  teardown do
+    Feature.deactivate(:high_volume_seller_fee)
+  end
+
+  test "gumroad_flat_fee_per_thousand is 5% for an eligible seller when the flag is on" do
+    mark_volume_eligible!(@seller)
+    purchase = create_purchase(link: @product, seller: @seller, purchase_state: "in_progress", price_cents: 1000)
+
+    assert_equal User::HIGH_VOLUME_FEE_PER_THOUSAND, purchase.send(:gumroad_flat_fee_per_thousand)
+  end
+
+  test "gumroad_flat_fee_per_thousand stays 10% when the flag is off" do
+    Feature.deactivate(:high_volume_seller_fee)
+    mark_volume_eligible!(@seller)
+    purchase = create_purchase(link: @product, seller: @seller, purchase_state: "in_progress", price_cents: 1000)
+
+    assert_equal Purchase::GUMROAD_FLAT_FEE_PER_THOUSAND, purchase.send(:gumroad_flat_fee_per_thousand)
+  end
+
+  test "a negotiated custom fee still wins over the volume rate" do
+    mark_volume_eligible!(@seller)
+    @seller.update!(custom_fee_per_thousand: 40)
+    purchase = create_purchase(link: @product, seller: @seller, purchase_state: "in_progress", price_cents: 10_000)
+    purchase.send(:calculate_custom_fee_per_thousand)
+
+    assert_equal 40, purchase.custom_fee_per_thousand
+  end
+
+  test "discover fee is unchanged for an eligible seller" do
+    mark_volume_eligible!(@seller)
+    purchase = create_purchase(link: @product, seller: @seller, purchase_state: "in_progress", price_cents: 10_000)
+    purchase.stubs(:charge_discover_fee?).returns(true)
+    purchase.send(:calculate_custom_fee_per_thousand)
+
+    assert_nil purchase.custom_fee_per_thousand
+  end
+
+  test "a successful purchase enqueues an eligibility refresh for the seller" do
+    create_purchase(link: @product, seller: @seller, price_cents: 1000)
+
+    assert RefreshHighVolumeSellerFeeEligibilityJob.jobs.any? { |job| job["args"] == [@seller.id] }
+  end
+
+  private
+    def mark_volume_eligible!(seller)
+      seller.high_volume_fee_eligible = true
+      seller.save!(validate: false)
+    end
+end

--- a/test/models/purchase/high_volume_seller_fee_test.rb
+++ b/test/models/purchase/high_volume_seller_fee_test.rb
@@ -52,6 +52,15 @@ class Purchase::HighVolumeSellerFeeTest < ActiveSupport::TestCase
     assert RefreshHighVolumeSellerFeeEligibilityJob.jobs.any? { |job| job["args"] == [@seller.id] }
   end
 
+  test "a full refund enqueues an eligibility refresh for the seller" do
+    purchase = create_purchase(link: @product, seller: @seller, price_cents: 1000)
+    RefreshHighVolumeSellerFeeEligibilityJob.clear
+
+    purchase.update!(stripe_refunded: true)
+
+    assert RefreshHighVolumeSellerFeeEligibilityJob.jobs.any? { |job| job["args"] == [@seller.id] }
+  end
+
   private
     def mark_volume_eligible!(seller)
       seller.high_volume_fee_eligible = true

--- a/test/models/user/high_volume_seller_fee_test.rb
+++ b/test/models/user/high_volume_seller_fee_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class User::HighVolumeSellerFeeTest < ActiveSupport::TestCase
+  setup do
+    @seller = create_user
+    Feature.activate(:high_volume_seller_fee)
+  end
+
+  teardown do
+    Feature.deactivate(:high_volume_seller_fee)
+  end
+
+  test "gumroad_fee_per_thousand is 10% when the seller is not volume-eligible" do
+    assert_equal Purchase::GUMROAD_FLAT_FEE_PER_THOUSAND, @seller.gumroad_fee_per_thousand
+    assert_not @seller.high_volume_seller_fee?
+  end
+
+  test "gumroad_fee_per_thousand is 5% when the flag is on and the seller is volume-eligible" do
+    mark_volume_eligible!(@seller)
+
+    assert @seller.high_volume_seller_fee?
+    assert_equal User::HIGH_VOLUME_FEE_PER_THOUSAND, @seller.gumroad_fee_per_thousand
+  end
+
+  test "gumroad_fee_per_thousand stays 10% when the seller is eligible but the flag is off" do
+    Feature.deactivate(:high_volume_seller_fee)
+    mark_volume_eligible!(@seller)
+
+    assert_not @seller.high_volume_seller_fee?
+    assert_equal Purchase::GUMROAD_FLAT_FEE_PER_THOUSAND, @seller.gumroad_fee_per_thousand
+  end
+
+  test "a negotiated custom fee wins over the volume rate" do
+    mark_volume_eligible!(@seller)
+    @seller.update!(custom_fee_per_thousand: 40)
+
+    assert_equal 40, @seller.gumroad_fee_per_thousand
+  end
+
+  test "trailing_month_gross_sales_cents sums paid sales inside the window and ignores older or refunded ones" do
+    product = create_product(user: @seller)
+    create_purchase(link: product, seller: @seller, price_cents: 1_500_000, created_at: 2.days.ago)
+    create_purchase(link: product, seller: @seller, price_cents: 800_000, created_at: 31.days.ago)
+    create_purchase(link: product, seller: @seller, price_cents: 400_000, stripe_refunded: true, created_at: 1.day.ago)
+    create_failed_purchase(link: product, seller: @seller, price_cents: 900_000, created_at: 1.day.ago)
+
+    assert_equal 1_500_000, @seller.trailing_month_gross_sales_cents
+  end
+
+  test "refresh_high_volume_fee_eligibility! flips the cache on and off at the $20k threshold" do
+    product = create_product(user: @seller)
+    create_purchase(link: product, seller: @seller, price_cents: User::HIGH_VOLUME_FEE_THRESHOLD_CENTS, created_at: 1.day.ago)
+
+    assert @seller.refresh_high_volume_fee_eligibility!
+    assert @seller.reload.high_volume_fee_eligible?
+
+    Purchase.where(seller_id: @seller.id).update_all(stripe_refunded: true)
+
+    assert_not @seller.refresh_high_volume_fee_eligibility!
+    assert_not @seller.reload.high_volume_fee_eligible?
+  end
+
+  private
+    def mark_volume_eligible!(seller)
+      seller.high_volume_fee_eligible = true
+      seller.save!(validate: false)
+    end
+end

--- a/test/sidekiq/refresh_high_volume_seller_fee_eligibility_job_test.rb
+++ b/test/sidekiq/refresh_high_volume_seller_fee_eligibility_job_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RefreshHighVolumeSellerFeeEligibilityJobTest < ActiveSupport::TestCase
+  test "perform with a seller_id refreshes that seller" do
+    seller = create_user
+    product = create_product(user: seller)
+    create_purchase(link: product, seller: seller, price_cents: User::HIGH_VOLUME_FEE_THRESHOLD_CENTS, created_at: 1.day.ago)
+
+    RefreshHighVolumeSellerFeeEligibilityJob.new.perform(seller.id)
+
+    assert seller.reload.high_volume_fee_eligible?
+  end
+
+  test "seller_ids_to_refresh includes recent sellers and currently flagged sellers" do
+    recent = create_user
+    product = create_product(user: recent)
+    create_purchase(link: product, seller: recent, price_cents: 100, created_at: 2.hours.ago)
+
+    flagged = create_user
+    flagged.high_volume_fee_eligible = true
+    flagged.save!(validate: false)
+
+    stale = create_user
+
+    ids = RefreshHighVolumeSellerFeeEligibilityJob.new.send(:seller_ids_to_refresh)
+    assert_includes ids, recent.id
+    assert_includes ids, flagged.id
+    assert_not_includes ids, stale.id
+  end
+end

--- a/test/sidekiq/refresh_high_volume_seller_fee_eligibility_job_test.rb
+++ b/test/sidekiq/refresh_high_volume_seller_fee_eligibility_job_test.rb
@@ -13,20 +13,48 @@ class RefreshHighVolumeSellerFeeEligibilityJobTest < ActiveSupport::TestCase
     assert seller.reload.high_volume_fee_eligible?
   end
 
-  test "seller_ids_to_refresh includes recent sellers and currently flagged sellers" do
-    recent = create_user
-    product = create_product(user: recent)
-    create_purchase(link: product, seller: recent, price_cents: 100, created_at: 2.hours.ago)
+  test "seller_ids_to_refresh includes qualifying and flagged sellers, not below-threshold ones" do
+    # Qualifying purely on window GMV: no sale yesterday, no cache populated.
+    qualifying = create_user
+    qualifying_product = create_product(user: qualifying)
+    create_purchase(link: qualifying_product, seller: qualifying, price_cents: User::HIGH_VOLUME_FEE_THRESHOLD_CENTS, created_at: 10.days.ago)
 
     flagged = create_user
     flagged.high_volume_fee_eligible = true
     flagged.save!(validate: false)
 
+    below_threshold = create_user
+    below_product = create_product(user: below_threshold)
+    create_purchase(link: below_product, seller: below_threshold, price_cents: 100, created_at: 2.hours.ago)
+
     stale = create_user
 
     ids = RefreshHighVolumeSellerFeeEligibilityJob.new.send(:seller_ids_to_refresh)
-    assert_includes ids, recent.id
+    assert_includes ids, qualifying.id
     assert_includes ids, flagged.id
+    assert_not_includes ids, below_threshold.id
     assert_not_includes ids, stale.id
+  end
+
+  test "seller_ids_to_refresh sums across purchases and ignores refunded and out-of-window sales" do
+    seller = create_user
+    product = create_product(user: seller)
+    half = User::HIGH_VOLUME_FEE_THRESHOLD_CENTS / 2
+    create_purchase(link: product, seller: seller, price_cents: half, created_at: 5.days.ago)
+    create_purchase(link: product, seller: seller, price_cents: half, created_at: 20.days.ago)
+
+    refunded_out = create_user
+    refunded_product = create_product(user: refunded_out)
+    refunded = create_purchase(link: refunded_product, seller: refunded_out, price_cents: User::HIGH_VOLUME_FEE_THRESHOLD_CENTS, created_at: 5.days.ago)
+    refunded.update_columns(stripe_refunded: true)
+
+    aged_out = create_user
+    aged_product = create_product(user: aged_out)
+    create_purchase(link: aged_product, seller: aged_out, price_cents: User::HIGH_VOLUME_FEE_THRESHOLD_CENTS, created_at: 40.days.ago)
+
+    ids = RefreshHighVolumeSellerFeeEligibilityJob.new.send(:seller_ids_to_refresh)
+    assert_includes ids, seller.id
+    assert_not_includes ids, refunded_out.id
+    assert_not_includes ids, aged_out.id
   end
 end


### PR DESCRIPTION
Charge 5% after $20k trailing-30-day sales

> Draft status: Code and local minitest are in. Flag is off. Money-path, so this stays draft until CI, pre-merge QA audit, and a human merge.

## What

Sellers whose trailing 30-day gross sales are at least $20,000 pay a 5% Gumroad fee on new direct sales instead of 10%. Eligibility is cached on the user (`high_volume_fee_eligible`) and recomputed after each successful sale plus a nightly job. The fee change is gated behind Flipper `:high_volume_seller_fee` (off until ramped). A negotiated `custom_fee_per_thousand` still wins. Discover 30% is unchanged. The $0.50 fixed fee is unchanged.

## Why

Sahil asked for high-volume sellers to get 5% after $20k/month (antiwork/gumroad-private#2177) rather than one-off custom rates.

## Before / after

- Before: every seller without a custom fee pays 10% (`GUMROAD_FLAT_FEE_PER_THOUSAND = 100`).
- After, flag off: same as before.
- After, flag on + cached trailing-30-day GMV >= $20,000: `gumroad_flat_fee_per_thousand` is 50 (5%).
- After, flag on + below the threshold: still 10%.

Rejected: live `SUM(price_cents)` on every purchase (closed #4283 — too expensive). Cache + nightly refresh instead.

## Checklist

- [x] Scope — volume fee only. No per-seller custom rate on this PR. Discover / processing / fixed $0.50 unchanged.
- [x] Design — cached eligibility, Flipper master switch, custom fee still wins.
- [x] Build — `61cfad71b` on `gp2177-high-volume-seller-fee` (base `5d0004605` + Greptile P1 fixes: refund-triggered eligibility refresh; nightly job scans the full 30-day window instead of yesterday's sellers).
- [x] QA — local minitest 15/15 plus mutation checks: (1) delete the 5% return → eligible example Expected 50 / Actual 100; (2) revert the refund trigger → refund example red; (3) revert the nightly query to yesterday-only → 2 job examples red. No rendered surface until the flag is on.
- [ ] Shipped — money-path. Human merge + Flipper ramp. Do not automerge.
- [x] Market — n/a until the flag is on.
- [x] Sell — existing fee-negotiation tickets stay on file; they pick this up after ramp.

## Test Results

```text
At 61cfad71b (Greptile P1 fix round):

DISABLE_SPRING=1 bundle exec ruby -Itest test/models/user/high_volume_seller_fee_test.rb
6 runs, 12 assertions, 0 failures, 0 errors, 0 skips

DISABLE_SPRING=1 bundle exec ruby -Itest test/models/purchase/high_volume_seller_fee_test.rb
6 runs, 6 assertions, 0 failures, 0 errors, 0 skips

DISABLE_SPRING=1 bundle exec ruby -Itest test/sidekiq/refresh_high_volume_seller_fee_eligibility_job_test.rb
3 runs, 15 assertions, 0 failures, 0 errors, 0 skips

Mutation checks:
1. Removed `return User::HIGH_VOLUME_FEE_PER_THOUSAND if seller.high_volume_seller_fee?`
   → eligible example Expected: 50 / Actual: 100. Restored, green.
2. Reverted the refund clause of the eligibility-refresh callback to the
   successful-only condition → "a full refund enqueues an eligibility refresh"
   went red (1 failure). Restored, green.
3. Reverted seller_ids_to_refresh to the yesterday-only query → 2 of 3 job
   examples red (qualifying-without-recent-sale, refunded/aged exclusions).
   Restored, green.
```

## QA steps

1. Confirm Flipper `:high_volume_seller_fee` is off on this branch (default). A normal purchase still uses 10%.
2. After merge, ramp the flag (actor or global). Nightly job + next successful sale set `high_volume_fee_eligible` for sellers at or above $20k trailing-30-day GMV.
3. Direct sale for an eligible seller: Gumroad percent is 5%. Discover stays 30%. A seller with `custom_fee_per_thousand` keeps that rate.

---

AI disclosure: grok-4.6. Prompt/instructions: execute Sahil's gp#2177 ruling (store the request, then PR to enable 5% after $20k/month) via autonomous-product-dev.

