### PR TITLE
Run the branch-specs self-test in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,6 +143,13 @@ jobs:
       - name: Self-test the checker
         run: ruby spec/bin/check_migration_versions_test.rb
 
+      # Hosted here, not in relevant_specs: run-all-specs skips that job, and
+      # every PR that edits the selector must carry the label, so a self-test
+      # there would never run on the PRs that change what it tests. This job
+      # runs on every PR and needs no bundle, same as the self-test.
+      - name: Self-test the branch-specs selector
+        run: ruby spec/bin/branch_specs_test.rb
+
   build:
     name: Build images${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
     runs-on: blacksmith-8vcpu-ubuntu-2204


### PR DESCRIPTION
## What

CI now runs `spec/bin/branch_specs_test.rb`. The step is one line in the `migration_versions` job, after the existing migration self-test.

Before this change, no CI job ran the file. Only `check_migration_versions_test.rb` was wired in. Follow-up to #7263, which extends the file from 8 to 19 checks.

## Why

`bin/branch-specs` selects the spec list for trimmed PR runs. A crash in the selector fails the `relevant_specs` job, so CI catches it. A wrong spec list does not crash, so nothing catches it. The self-test is the only guard against that failure mode, and a guard that no job runs protects nothing.

Placement: `migration_versions`, not `relevant_specs`.

- The `run-all-specs` label skips `relevant_specs`. Every PR that edits `bin/branch-specs` escalates and must carry that label. A self-test in `relevant_specs` would never run on the PRs that change what it tests.
- `migration_versions` needs only `ci_gate`, so it runs on every PR and on `main`. It uses no bundle, and the self-test is plain Ruby by design.
- A new standalone job would allocate a runner per PR and add a status check to branch protection. One step in an existing job costs neither.

The job name does not mention the selector. A comment above the step explains the placement. A rename would break the required-check name in branch protection, so the mismatch stays.

## Before/After

Before: no CI job runs the file.

After, the step runs it on every PR:

```
$ ruby spec/bin/branch_specs_test.rb
8 checks passed
```

No video: the change is one CI step with no user-facing surface. The diff and the check run are the reviewable artifacts.

## Test Results

- `ruby spec/bin/branch_specs_test.rb` — 8 checks pass on this branch. The count becomes 19 when #7263 merges.
- The workflow file parses as YAML.
- `ruby bin/branch-specs` escalates on this diff, as expected for a `tests.yml` edit, so the PR carries the `run-all-specs` label.

---

AI disclosure: written with Claude Fable 5.
