### PR TITLE
Make the Call date/time picker screen-reader operable

### DIFF
--- a/app/javascript/components/Product/ConfigurationSelector.call.test.tsx
+++ b/app/javascript/components/Product/ConfigurationSelector.call.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getRemainingCallAvailabilities } from "$app/data/call_availabilities";
+
+import {
+  ConfigurationSelector,
+  type PriceSelection,
+  type Product,
+} from "$app/components/Product/ConfigurationSelector";
+
+vi.mock("$app/data/call_availabilities", () => ({
+  getRemainingCallAvailabilities: vi.fn(),
+}));
+
+afterEach(cleanup);
+
+const durationOption = {
+  id: "duration-30",
+  name: "30 minutes",
+  quantity_left: null,
+  description: "",
+  price_difference_cents: 0,
+  recurrence_price_values: null,
+  is_pwyw: false,
+  duration_in_minutes: 30,
+};
+
+const callProduct: Product = {
+  permalink: "songwriting-consultation",
+  rental: null,
+  options: [durationOption],
+  currency_code: "usd",
+  price_cents: 7499,
+  installment_plan: null,
+  is_tiered_membership: false,
+  is_legacy_subscription: false,
+  is_quantity_enabled: false,
+  is_multiseat_license: false,
+  quantity_remaining: null,
+  recurrences: null,
+  pwyw: null,
+  ppp_details: null,
+  native_type: "call",
+};
+
+const initialSelection: PriceSelection = {
+  rent: false,
+  optionId: durationOption.id,
+  price: { error: false, value: null },
+  quantity: 1,
+  recurrence: null,
+  callStartTime: null,
+  payInInstallments: false,
+};
+
+const octoberFirstAfternoon = {
+  start_time: new Date(2024, 9, 1, 13, 0, 0),
+  end_time: new Date(2024, 9, 1, 15, 0, 0),
+};
+const octoberSecondAfternoon = {
+  start_time: new Date(2024, 9, 2, 13, 0, 0),
+  end_time: new Date(2024, 9, 2, 15, 0, 0),
+};
+
+const renderCallSelector = () => {
+  const selections: PriceSelection[] = [];
+  const Harness = () => {
+    const [selection, setSelection] = React.useState(initialSelection);
+    return (
+      <ConfigurationSelector
+        product={callProduct}
+        selection={selection}
+        setSelection={(update) => {
+          setSelection((prev) => {
+            const next = typeof update === "function" ? update(prev) : update;
+            selections.push(next);
+            return next;
+          });
+        }}
+        discount={null}
+      />
+    );
+  };
+  render(<Harness />);
+  return { selections };
+};
+
+describe("CallDateAndTimeSelector", () => {
+  it("exposes a labeled date select and native time radios a screen reader can operate", async () => {
+    vi.mocked(getRemainingCallAvailabilities).mockResolvedValue([octoberFirstAfternoon, octoberSecondAfternoon]);
+
+    const { selections } = renderCallSelector();
+
+    const dateSelect = await screen.findByLabelText("Date");
+    if (!(dateSelect instanceof HTMLSelectElement)) throw new Error("expected a native date <select>");
+    expect(dateSelect.disabled).toBe(false);
+    expect(Array.from(dateSelect.options).map((option) => option.text)).toEqual([
+      "Tuesday, October 1, 2024",
+      "Wednesday, October 2, 2024",
+    ]);
+
+    await waitFor(() => expect(selections.at(-1)?.callStartTime).toBe(octoberFirstAfternoon.start_time.toISOString()));
+
+    const firstTime = screen.getByRole("radio", { name: "01:00 PM" });
+    if (!(firstTime instanceof HTMLInputElement)) throw new Error("expected a native time radio");
+    expect(firstTime.type).toBe("radio");
+    expect(firstTime.checked).toBe(true);
+
+    fireEvent.change(dateSelect, { target: { value: "2024-10-02" } });
+    await waitFor(() => expect(selections.at(-1)?.callStartTime).toBe(octoberSecondAfternoon.start_time.toISOString()));
+
+    fireEvent.click(screen.getByRole("radio", { name: "01:30 PM" }));
+    await waitFor(() => expect(selections.at(-1)?.callStartTime).toBe(new Date(2024, 9, 2, 13, 30, 0).toISOString()));
+
+    const confirmation = screen.getByText("Wednesday, October 2 at 01:30 PM");
+    expect(confirmation.closest("[aria-live]")?.getAttribute("aria-live")).toBe("polite");
+  });
+});

--- a/app/javascript/components/Product/ConfigurationSelector.call.test.tsx
+++ b/app/javascript/components/Product/ConfigurationSelector.call.test.tsx
@@ -29,11 +29,11 @@ const durationOption = {
 };
 
 const callProduct: Product = {
-  permalink: "songwriting-consultation",
+  permalink: "call-product",
   rental: null,
   options: [durationOption],
   currency_code: "usd",
-  price_cents: 7499,
+  price_cents: 1000,
   installment_plan: null,
   is_tiered_membership: false,
   is_legacy_subscription: false,

--- a/app/javascript/components/Product/ConfigurationSelector.tsx
+++ b/app/javascript/components/Product/ConfigurationSelector.tsx
@@ -5,6 +5,7 @@ import {
   eachDayOfInterval,
   eachMinuteOfInterval,
   endOfDay,
+  format,
   interval,
   isEqual,
   max,
@@ -44,6 +45,7 @@ import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
 import { Input } from "$app/components/ui/Input";
 import { Label } from "$app/components/ui/Label";
 import { Pill } from "$app/components/ui/Pill";
+import { Select } from "$app/components/ui/Select";
 import { Tab, Tabs } from "$app/components/ui/Tabs";
 import { useRunOnce } from "$app/components/useRunOnce";
 
@@ -497,6 +499,18 @@ const CallDateAndTimeSelector = ({
   const setSelectedDateFromReactCalendar = (date: Date) =>
     onChange({ callStartTime: getAvailableStartTimesByDate(date)[0] ?? null });
 
+  const availableDates = React.useMemo(
+    () =>
+      Object.keys(availabilitiesByDate)
+        .map((date) => new Date(date))
+        .filter((date) => isAvailableOnDate(date))
+        .sort(compareAsc),
+    [availabilitiesByDate, callDurationInMinutes],
+  );
+  const dateSelectId = React.useId();
+  const timeGroupName = React.useId();
+  const selectedDateValue = selectedStartTime ? format(selectedStartTime, "yyyy-MM-dd") : "";
+
   if (firstAvailableStartTime === null && !isLoading) {
     return (
       <Alert role="status" variant="warning">
@@ -519,6 +533,29 @@ const CallDateAndTimeSelector = ({
           <span>Select a date</span>
           {isLoading ? <LoadingSpinner /> : null}
         </h4>
+        <Fieldset>
+          <FieldsetTitle>
+            <Label htmlFor={dateSelectId}>Date</Label>
+          </FieldsetTitle>
+          <Select
+            id={dateSelectId}
+            value={selectedDateValue}
+            disabled={isLoading || availableDates.length === 0}
+            onChange={(event) => {
+              const [year, month, day] = event.target.value.split("-").map(Number);
+              setSelectedDateFromReactCalendar(new Date(year, month - 1, day));
+            }}
+          >
+            {availableDates.map((date) => {
+              const value = format(date, "yyyy-MM-dd");
+              return (
+                <option key={value} value={value}>
+                  {formatCallDate(date, { time: { hidden: true }, timeZone: { hidden: true } })}
+                </option>
+              );
+            })}
+          </Select>
+        </Fieldset>
         <Calendar
           locale={{ code: "en-US" }}
           mode="single"
@@ -546,27 +583,35 @@ const CallDateAndTimeSelector = ({
               {clientTimeZone.shortFormattedName}
             </span>
           </h4>
-          <Tabs variant="buttons" className="grid-cols-2 md:grid-flow-row" role="radiogroup">
+          <fieldset className="grid grid-cols-2 gap-3 md:grid-flow-row">
+            <legend className="sr-only">Select a time</legend>
             {getAvailableStartTimesByDate(selectedStartTime).map((time) => {
               const isSelected = isEqual(selectedStartTime, time);
+              const label = formatCallDate(time, { date: { hidden: true }, timeZone: { hidden: true } });
               return (
-                <Tab key={time.toISOString()} isSelected={isSelected} asChild>
-                  <Button
-                    role="radio"
-                    aria-checked={isSelected}
-                    onClick={() => onChange({ callStartTime: time })}
-                    className="justify-center"
-                  >
-                    <div>{formatCallDate(time, { date: { hidden: true }, timeZone: { hidden: true } })}</div>
-                  </Button>
-                </Tab>
+                <Label
+                  key={time.toISOString()}
+                  className={`justify-center rounded-sm border px-4 py-3 ${
+                    isSelected ? "border-indicator bg-background ring-1 ring-indicator" : "border-border"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    className="sr-only"
+                    name={timeGroupName}
+                    value={time.toISOString()}
+                    checked={isSelected}
+                    onChange={() => onChange({ callStartTime: time })}
+                  />
+                  {label}
+                </Label>
               );
             })}
-          </Tabs>
+          </fieldset>
         </section>
       ) : null}
       {selectedStartTime ? (
-        <div>
+        <div role="status" aria-live="polite">
           <h4>
             You selected{" "}
             <strong>

--- a/app/javascript/components/Product/ConfigurationSelector.tsx
+++ b/app/javascript/components/Product/ConfigurationSelector.tsx
@@ -591,7 +591,7 @@ const CallDateAndTimeSelector = ({
               return (
                 <Label
                   key={time.toISOString()}
-                  className={`justify-center rounded-sm border px-4 py-3 ${
+                  className={`justify-center rounded-sm border px-4 py-3 has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-accent ${
                     isSelected ? "border-indicator bg-background ring-1 ring-indicator" : "border-border"
                   }`}
                 >


### PR DESCRIPTION
# Make the Call date/time picker screen-reader operable

> Draft status: code and unit test are on the branch. Preview-app screenshots and the pre-merge QA audit are still owed.

## What

Call checkout now has a labeled native date `<select>` of available days, and time slots are native radio inputs instead of tab-styled buttons. The calendar stays for mouse users. The confirmation line is announced with `aria-live="polite"`.

## Why

The previous picker was a `react-day-picker` grid plus `Tabs` pretending to be a radiogroup. Screen-reader users (JAWS / VoiceOver) could not select a date or a time, so they could not complete a Call purchase. Native form controls are in the tab order and work with standard screen-reader keystrokes.

## Before / after

- Before: date only via the calendar grid; times were `role="tab"` / `role="radio"` buttons inside `Tabs`. No labeled native date control.
- After: a `Date` select lists available days; times are real `<input type="radio">` labeled with the slot. Calendar still works for the existing click path.

Preview screenshots are owed on the hosted branch app.

## Checklist

- [x] Scope — Call checkout date/time only. Duration tabs and other product types unchanged.
- [x] Design — native date select + native time radios; keep the calendar. Rejected replacing the calendar entirely (existing system specs click month/day buttons).
- [x] Build — `c5d441d56` plus a follow-up to keep the spec fixture generic.
- [ ] QA — preview-app click path + screen-reader/keyboard check still owed
- [ ] Shipped — draft
- [x] Market — n/a (accessibility bugfix)
- [x] Sell — n/a

## Test Results

- `npx eslint app/javascript/components/Product/ConfigurationSelector.tsx app/javascript/components/Product/ConfigurationSelector.call.test.tsx` — clean
- `npx vitest run app/javascript/components/Product/ConfigurationSelector.call.test.tsx` — 1 passed (1 file) in 3.76s at `c5d441d56`

## QA steps

Owed on the hosted preview after this draft is up:

1. Open a Call product with availability.
2. Tab to `Date`, change the day with the keyboard, confirm times update.
3. Tab to a time radio, change it with arrow keys, confirm "You selected …" updates.
4. Confirm the calendar still picks a day with a click (existing buyer path).

---

AI disclosure: grok-4.6. Prompt/instructions: handle the opened private issue to fix the Call product date/time picker for screen-reader users.
