### PR TITLE
Run the branch-specs self-test once, not twice

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,12 +120,6 @@ jobs:
           bundler-cache: true
       - run: bundle exec rubocop --format github
 
-      # Lives here because this job always runs and already has the project's
-      # Ruby. relevant_specs is the wrong home: it is skipped exactly when the
-      # run-all-specs label is set, which is whenever the selector itself changes.
-      - name: Self-test the spec selector
-        run: ruby spec/bin/branch_specs_test.rb
-
   migration_versions:
     name: Migration versions
     runs-on: ubicloud-standard-2


### PR DESCRIPTION
## What

Removes the `spec/bin/branch_specs_test.rb` step from `lint_ruby`. The suite
still runs, once, from `migration_versions`.

## Why

Two PRs wired the same self-test into CI within minutes of each other. #7266
added it to `migration_versions`, and #7264 added it to `lint_ruby`. Both
merged, so `main` runs the file twice.

#7266's placement is the one to keep. It argued the choice in its description
and left a comment in the workflow explaining it. The `lint_ruby` copy was
incidental, and the job reads better as lint only.

The one reason I had for preferring `lint_ruby` — that it runs
`ruby/setup-ruby`, while `migration_versions` uses the runner's own Ruby, and
the test file needs Ruby 3.1 or newer — does not hold. #7266's step passes on
the runner as it is, reporting 19 checks at the time.

## Before / After

No video: this removes one CI step and has no user-facing surface.

Before, on `main`:

```
$ grep -n branch_specs_test .github/workflows/tests.yml
127:        run: ruby spec/bin/branch_specs_test.rb    # lint_ruby
157:        run: ruby spec/bin/branch_specs_test.rb    # migration_versions
```

After:

```
$ grep -n branch_specs_test .github/workflows/tests.yml
151:        run: ruby spec/bin/branch_specs_test.rb    # migration_versions
```

## Test Results

- The workflow parses as YAML, and `lint_ruby` is back to checkout, setup-ruby, and rubocop.
- `ruby spec/bin/branch_specs_test.rb` — 24 checks passed. The file is untouched here.
- `ruby bin/branch-specs` escalates on a `tests.yml` diff, so this PR carries the **run-all-specs** label.

---

AI disclosure: written with Claude Opus 5.
