### PR TITLE
Force INR reauth for Indian card mandates

### DIFF
--- a/app/controllers/stripe/setup_intents_controller.rb
+++ b/app/controllers/stripe/setup_intents_controller.rb
@@ -71,14 +71,17 @@ class Stripe::SetupIntentsController < ApplicationController
     def mandate_options_for_stripe(chargeable, subscription: nil)
       if chargeable.requires_mandate?
         if subscription&.india_card_mandate_reliability_enabled?
-          terms = subscription.indian_card_mandate_terms(
+          terms, mandate_rate = subscription.indian_card_mandate_terms_with_rate(
             billing_info: billing_info_params,
             authenticated_offer_code_buyer: logged_in_user
           )
           return if terms.blank?
 
           return {
-            metadata: { gumroad_subscription_id: subscription.external_id },
+            metadata: {
+              gumroad_subscription_id: subscription.external_id,
+              gumroad_mandate_rate: mandate_rate
+            }.compact,
             payment_method_options: {
               card: {
                 mandate_options: {

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -4050,7 +4050,9 @@ class Purchase < ApplicationRecord
     price_cents + shipping_cents.to_i + tax.tax_cents.to_i
   end
 
-  def mandate_maximum_amount_cents
+  # `fixed_rate` pins the displayed-to-USD conversion the free-trial branch needs, so a
+  # cached-rate refresh between sizing a mandate and validating it compares equal amounts.
+  def mandate_maximum_amount_cents(fixed_rate: nil)
     # An upgrade purchase only charges the prorated difference today, and any active
     # discount record lives on the subscription's original purchase rather than on the
     # upgrade purchase itself. Future renewals bill that original purchase (which
@@ -4071,7 +4073,8 @@ class Purchase < ApplicationRecord
       price_cents = if reference_purchase.subscription.present?
         reference_purchase.subscription.indian_card_mandate_price_cents(
           reference_purchase,
-          renewal_price_cents
+          renewal_price_cents,
+          fixed_rate:
         )
       else
         reference_purchase.indian_card_mandate_price_cents(

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -456,6 +456,7 @@ class Subscription < ApplicationRecord
   def update_renewal_for_indian_card_mandate!(status, expected_credit_card_id: nil, expected_registration_purchase_id: nil, mandate_id: nil, clear_reauthorization: false, notify_buyer: false, notify_buyer_if_already_disabled: false)
     return unless india_card_mandate_reliability_enabled?
 
+    completed_reauthorization = false
     with_lock do
       return if expected_credit_card_id.present? && credit_card_to_charge&.id != expected_credit_card_id
       return if expected_registration_purchase_id.present? && indian_card_mandate_source_purchase(expected_credit_card_id)&.id != expected_registration_purchase_id
@@ -465,7 +466,10 @@ class Subscription < ApplicationRecord
 
         self.stripe_mandate_id = mandate_id if mandate_id.present?
         self.renewal_disabled_due_to_indian_card_mandate = false
-        self.indian_card_mandate_requires_reauthorization = false if clear_reauthorization
+        if clear_reauthorization && indian_card_mandate_requires_reauthorization?
+          self.indian_card_mandate_requires_reauthorization = false
+          completed_reauthorization = true
+        end
         notify_buyer = false
       else
         return unless status.in?(%w[inactive missing pending])
@@ -476,6 +480,8 @@ class Subscription < ApplicationRecord
       end
       save! if changed?
     end
+
+    record_indian_card_mandate_presentment! if completed_reauthorization
 
     if notify_buyer
       after_commit do
@@ -589,10 +595,20 @@ class Subscription < ApplicationRecord
 
     amount = canonical_cap_cents
     currency = Currency::USD
+    price_rate = nil
     if presentment_matches
       currency = presentment.presentment_currency
+      price_rate = presentment.signup_currency_units_per_usd
+    elsif (recovery_currency = indian_card_recovery_presentment_currency).present?
+      # Stripe will not register an India recurring e-mandate in USD for many Indian issuers
+      # (gp#1410), so a listed-INR membership with no stored fixing must still collect its
+      # replacement mandate in rupees, sized at today's rate.
+      currency = recovery_currency
+      price_rate = get_rate(currency)
+    end
+    if price_rate.present?
       variable_cap_cents = [canonical_cap_cents - price_cap_cents, 0].max
-      amount = indian_card_presentment_cents(price_cap_cents, presentment.signup_currency_units_per_usd, currency) +
+      amount = indian_card_presentment_cents(price_cap_cents, price_rate, currency) +
         indian_card_presentment_cents(variable_cap_cents, get_rate(currency), currency)
     end
 
@@ -627,6 +643,59 @@ class Subscription < ApplicationRecord
     amount = BigDecimal(canonical_cents.to_s) * BigDecimal(currency_units_per_usd.to_s)
     amount /= 100 if is_currency_type_single_unit?(currency)
     amount.ceil
+  end
+
+  # The gp#1410 recovery shape: only a membership whose renewals can re-fix in rupees
+  # (product and original purchase both listed in INR) may fall back to INR mandate terms.
+  # Anything else keeps canonical USD, because a mandate in a currency the renewal lane
+  # cannot bill would strand the subscription after a successful reauthorization.
+  def indian_card_recovery_presentment_currency
+    return unless india_card_mandate_reliability_enabled?
+
+    purchase = original_purchase
+    return if purchase.nil?
+
+    currency = Currency::INR
+    return unless link.price_currency_type.to_s.downcase == currency
+    displayed_currency = purchase[:displayed_price_currency_type].presence || link.price_currency_type
+    return unless displayed_currency.to_s.downcase == currency
+    return unless indian_card_renewal_presentment_supported?(currency)
+
+    currency
+  end
+
+  # A completed INR reauthorization leaves the mandate in rupees while the subscription still
+  # has no stored fixing (its historical charges settled in canonical USD). The renewal lane
+  # refuses to invent a buyer-currency amount without a stored row, so record the listed-INR
+  # fixing here from the same purchase terms the mandate cap was sized from. Without it, the
+  # first renewal after a successful reauthorization pauses the subscription again.
+  def record_indian_card_mandate_presentment!
+    currency = indian_card_recovery_presentment_currency
+    return if currency.blank?
+
+    purchase = original_purchase
+    canonical_price_cents = LaterChargePresentment.canonical_price_cents_for(purchase)
+    presentment_price_cents = purchase.displayed_price_cents.to_i
+    rate = BigDecimal(purchase.rate_converted_to_usd.to_s, exception: false)
+    return unless canonical_price_cents.positive? && presentment_price_cents.positive? && rate&.positive?
+
+    with_lock do
+      return if current_later_charge_presentment.present?
+
+      later_charge_presentments.create!(
+        processor: StripeChargeProcessor.charge_processor_id,
+        presentment_currency: currency,
+        presentment_price_cents:,
+        canonical_price_cents:,
+        signup_currency_units_per_usd: rate,
+        effective_from: Time.current
+      )
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    # The reauthorization already succeeded; a failed fixing only delays recovery until the
+    # next renewal pauses again, so report it instead of failing the buyer's update.
+    ErrorNotifier.notify(e, subscription: external_id)
+    nil
   end
 
   def indian_card_renewal_presentment_supported?(currency)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -479,9 +479,10 @@ class Subscription < ApplicationRecord
         self.renewal_disabled_due_to_indian_card_mandate = true
       end
       save! if changed?
+      # Inside the lock: committing cleared flags without the fixing would let a concurrent
+      # scan observe a recovered subscription with no stored amount and pause it again.
+      record_indian_card_mandate_presentment! if completed_reauthorization
     end
-
-    record_indian_card_mandate_presentment! if completed_reauthorization
 
     if notify_buyer
       after_commit do
@@ -582,7 +583,8 @@ class Subscription < ApplicationRecord
     canonical_price_cents = renewal_price_cents if canonical_price_cents.zero?
     presentment_matches = presentment.present? &&
       presentment.canonical_price_cents == canonical_price_cents &&
-      indian_card_renewal_presentment_supported?(presentment.presentment_currency)
+      indian_card_renewal_presentment_supported?(presentment.presentment_currency) &&
+      indian_card_presentment_price_current?(presentment, purchase)
     recovery_currency = indian_card_recovery_presentment_currency unless presentment_matches
     price_cap_rate = if presentment_matches
       purchase.rate_converted_to_usd.presence
@@ -597,7 +599,7 @@ class Subscription < ApplicationRecord
     canonical_cap_cents = if billing_info.present?
       indian_card_mandate_amount_for_billing_info(purchase, billing_info, price_cap_cents)
     else
-      purchase.mandate_maximum_amount_cents
+      purchase.mandate_maximum_amount_cents(fixed_rate: (fixed_rate if recovery_currency.present?))
     end
     canonical_cap_cents = price_cap_cents if canonical_cap_cents.zero?
     return unless canonical_cap_cents.positive?
@@ -617,7 +619,34 @@ class Subscription < ApplicationRecord
     end
     if price_rate.present?
       variable_cap_cents = [canonical_cap_cents - price_cap_cents, 0].max
-      amount = indian_card_presentment_cents(price_cap_cents, price_rate, currency) +
+      if recovery_currency.present? && billing_info.blank?
+        # The canonical cap keeps signup-rate dollars while the recovery price cap uses the
+        # current rate; FX drift between the two bases must not consume the tax/shipping
+        # headroom. Floor the variable part at the cap's own non-price part — the same
+        # pre-discount price basis mandate_maximum_amount_cents scaled, at the same rate.
+        price_basis_cents = if purchase.is_free_trial_purchase?
+          price_cap_cents
+        else
+          indian_card_mandate_price_cents(purchase, renewal_price_cents, fixed_rate: purchase.rate_converted_to_usd.presence)
+        end
+        extras_cents = [canonical_cap_cents - price_basis_cents, 0].max
+        if extras_cents.positive? && price_basis_cents.positive? && price_cap_cents.positive?
+          # Scale the signup-basis extras to the pinned price basis so today's tax converts
+          # to today's rupees. Future FX drift stays uncovered, as on every fixed cap.
+          extras_cents = Rational(extras_cents * price_cap_cents, price_basis_cents).ceil
+        end
+        variable_cap_cents = [variable_cap_cents, extras_cents].max
+      end
+      price_part_cents = indian_card_presentment_cents(price_cap_cents, price_rate, currency)
+      if recovery_currency.present?
+        # The listed price converts to rounded USD cents and back, which can land a few
+        # paise below the exact amount the recovered fixing will bill; a cap below the
+        # fixed renewal amount guarantees a decline. Floor at the exact listed price.
+        listed_price_floor_cents = purchase.mandate_maximum_displayed_price_cents.to_i
+        listed_price_floor_cents = renewal_price_cents.to_i if listed_price_floor_cents.zero?
+        price_part_cents = [price_part_cents, listed_price_floor_cents].max
+      end
+      amount = price_part_cents +
         indian_card_presentment_cents(variable_cap_cents, fixed_rate || get_rate(currency), currency)
     end
 
@@ -633,12 +662,18 @@ class Subscription < ApplicationRecord
     billing_info: nil,
     authenticated_offer_code_buyer: AUTHENTICATED_OFFER_CODE_BUYER_NOT_PROVIDED
   )
-    terms = indian_card_mandate_terms(billing_info:, authenticated_offer_code_buyer:)
-    return [terms, nil] if terms.blank? || terms[:currency] == Currency::USD
+    2.times do
+      terms = indian_card_mandate_terms(billing_info:, authenticated_offer_code_buyer:)
+      return [terms, nil] if terms.blank? || terms[:currency] == Currency::USD
 
-    rate = get_rate(terms[:currency])
-    terms = indian_card_mandate_terms(billing_info:, authenticated_offer_code_buyer:, fixed_rate: rate)
-    [terms, rate]
+      rate = get_rate(terms[:currency])
+      pinned = indian_card_mandate_terms(billing_info:, authenticated_offer_code_buyer:, fixed_rate: rate)
+      # A concurrent re-fixing can flip the terms currency between the two reads; the rate
+      # must belong to the currency it prices, so retry, then give up on pinning.
+      return [pinned, rate] if pinned.present? && pinned[:currency] == terms[:currency]
+    end
+
+    [indian_card_mandate_terms(billing_info:, authenticated_offer_code_buyer:), nil]
   end
 
   def future_subscription_charge?(authenticated_offer_code_buyer: AUTHENTICATED_OFFER_CODE_BUYER_NOT_PROVIDED)
@@ -670,6 +705,38 @@ class Subscription < ApplicationRecord
     amount.ceil
   end
 
+  # A listed-currency fixing is only current while its fixed price equals the plan's listed
+  # price: a plan change can move the price while the canonical USD value coincidentally
+  # stays equal (price and rate moving together), and a mandate approved off that row would
+  # authorize the old amount. Cross-currency (quote-lane) fixings have no listed price to
+  # compare and keep the canonical-only match.
+  def indian_card_presentment_price_current?(presentment, purchase)
+    displayed_currency = (purchase[:displayed_price_currency_type].presence || link.price_currency_type).to_s.downcase
+    if displayed_currency == presentment.presentment_currency
+      # Every price the current plan can legitimately fix: the signup price, this cycle's
+      # discounted price, and the post-discount full price (a renewal re-fixes to it when a
+      # limited-duration discount ends). A plan change moves all of them away.
+      plan_price_candidates = [
+        purchase.displayed_price_cents.to_i,
+        current_subscription_price_cents.to_i,
+        renewal_pre_discount_total_cents.to_i,
+      ].select(&:positive?)
+      return true if plan_price_candidates.empty?
+
+      plan_price_candidates.include?(presentment.presentment_price_cents)
+    else
+      # A cross-currency (quote-lane) row carries no listed price to compare; it is current
+      # only while renewals still bill the signup price it was fixed from. After a
+      # limited-duration discount ends, a mandate approved off the row would be sized and
+      # denominated for terms the renewal no longer uses. Free signups fixed their row from
+      # renewal terms, so they have no signup price to hold against it.
+      signup_price_cents = purchase.displayed_price_cents.to_i
+      return true unless signup_price_cents.positive?
+
+      current_subscription_price_cents.to_i == signup_price_cents
+    end
+  end
+
   # The gp#1410 recovery shape: only a membership whose renewals can re-fix in rupees
   # (product and original purchase both listed in INR) may fall back to INR mandate terms —
   # a mandate the renewal lane cannot bill would strand the subscription after reauth.
@@ -695,30 +762,41 @@ class Subscription < ApplicationRecord
     currency = indian_card_recovery_presentment_currency
     return if currency.blank?
 
+    # Record the price the renewal will actually bill — the currently authorized renewal
+    # amount, not the signup price, which stays discounted after a limited-duration
+    # discount ends. The signup canonical and rate apply only while the two agree.
     purchase = original_purchase
+    presentment_price_cents = current_subscription_price_cents.to_i
+    presentment_price_cents = renewal_pre_discount_total_cents.to_i if presentment_price_cents.zero?
+    return unless presentment_price_cents.positive?
+
     canonical_price_cents = LaterChargePresentment.canonical_price_cents_for(purchase)
-    presentment_price_cents = purchase.displayed_price_cents.to_i
     rate = BigDecimal(purchase.rate_converted_to_usd.to_s, exception: false)
-    if presentment_price_cents.zero? || canonical_price_cents.zero?
-      # Free-trial and fully-discounted registrations carry zero prices; size the fixing
-      # from the renewal terms instead — the pre-discount total when a temporary discount
-      # zeroes the current one. The renewal lane re-fixes exact canonical drift.
-      presentment_price_cents = current_subscription_price_cents.to_i
-      presentment_price_cents = renewal_pre_discount_total_cents.to_i if presentment_price_cents.zero?
+    unless presentment_price_cents == purchase.displayed_price_cents.to_i &&
+           canonical_price_cents.positive? && rate&.positive?
       rate = BigDecimal(get_rate(currency).to_s, exception: false)
-      canonical_price_cents = rate&.positive? ? get_usd_cents(currency, presentment_price_cents, rate:) : 0
+      return unless rate&.positive?
+
+      canonical_price_cents = get_usd_cents(currency, presentment_price_cents, rate:)
     end
-    return unless canonical_price_cents.positive? && presentment_price_cents.positive? && rate&.positive?
+    return unless canonical_price_cents.positive?
 
     with_lock do
       current = current_later_charge_presentment
-      # Keep any fixing that indian_card_mandate_terms itself would use — the mandate was
-      # then approved in that currency, not in INR. Supersede only a row terms rejected
-      # (wrong canonical or unsupported currency), which the INR mandate cannot bill.
       if current.present?
-        return if current.presentment_currency == currency
-        return if current.canonical_price_cents == canonical_price_cents &&
-                  indian_card_renewal_presentment_supported?(current.presentment_currency)
+        # A same-currency fixing at the plan's current price stays authoritative: FX
+        # re-fixing keeps the price and only moves the canonical value, which the renewal
+        # lane re-fixes itself. At any other price the mandate was approved off recovery
+        # terms, so the row must be superseded even when its canonical value matches.
+        return if current.presentment_currency == currency &&
+                  current.presentment_price_cents == presentment_price_cents
+        # Keep a cross-currency row exactly when indian_card_mandate_terms would bill it —
+        # the mandate was then approved in that row's currency, not in the recovery
+        # currency. Same predicate set as presentment_matches.
+        return if current.presentment_currency != currency &&
+                  current.canonical_price_cents == LaterChargePresentment.canonical_price_cents_for(purchase) &&
+                  indian_card_renewal_presentment_supported?(current.presentment_currency) &&
+                  indian_card_presentment_price_current?(current, purchase)
       end
 
       later_charge_presentments.create!(

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -490,7 +490,7 @@ class Subscription < ApplicationRecord
     end
   end
 
-  def require_indian_card_mandate_reauthorization!(notify_buyer: true, clear_existing_mandate: false)
+  def require_indian_card_mandate_reauthorization!(notify_buyer: true, clear_existing_mandate: false, notify_buyer_if_already_disabled: false)
     return unless india_card_mandate_reliability_enabled?
 
     should_notify_buyer = false
@@ -499,7 +499,9 @@ class Subscription < ApplicationRecord
       return unless card&.stripe_charge_processor? && card.requires_mandate?
       return unless alive?(include_pending_cancellation: false)
 
-      should_notify_buyer = notify_buyer && !renewal_disabled_due_to_indian_card_mandate?
+      should_notify_buyer = notify_buyer &&
+        (!renewal_disabled_due_to_indian_card_mandate? ||
+          (notify_buyer_if_already_disabled && !indian_card_mandate_requires_reauthorization?))
       self.stripe_mandate_id = nil if clear_existing_mandate
       self.renewal_disabled_due_to_indian_card_mandate = true
       self.indian_card_mandate_requires_reauthorization = true
@@ -568,7 +570,8 @@ class Subscription < ApplicationRecord
 
   def indian_card_mandate_terms(
     billing_info: nil,
-    authenticated_offer_code_buyer: AUTHENTICATED_OFFER_CODE_BUYER_NOT_PROVIDED
+    authenticated_offer_code_buyer: AUTHENTICATED_OFFER_CODE_BUYER_NOT_PROVIDED,
+    fixed_rate: nil
   )
     purchase = original_purchase
     return if purchase.nil?
@@ -580,10 +583,16 @@ class Subscription < ApplicationRecord
     presentment_matches = presentment.present? &&
       presentment.canonical_price_cents == canonical_price_cents &&
       indian_card_renewal_presentment_supported?(presentment.presentment_currency)
+    recovery_currency = indian_card_recovery_presentment_currency unless presentment_matches
+    price_cap_rate = if presentment_matches
+      purchase.rate_converted_to_usd.presence
+    elsif recovery_currency.present?
+      fixed_rate
+    end
     price_cap_cents = indian_card_mandate_price_cents(
       purchase,
       renewal_price_cents,
-      fixed_rate: (purchase.rate_converted_to_usd.presence if presentment_matches)
+      fixed_rate: price_cap_rate
     )
     canonical_cap_cents = if billing_info.present?
       indian_card_mandate_amount_for_billing_info(purchase, billing_info, price_cap_cents)
@@ -599,21 +608,37 @@ class Subscription < ApplicationRecord
     if presentment_matches
       currency = presentment.presentment_currency
       price_rate = presentment.signup_currency_units_per_usd
-    elsif (recovery_currency = indian_card_recovery_presentment_currency).present?
+    elsif recovery_currency.present?
       # Stripe will not register an India recurring e-mandate in USD for many Indian issuers
       # (gp#1410), so a listed-INR membership with no stored fixing must still collect its
       # replacement mandate in rupees, sized at today's rate.
       currency = recovery_currency
-      price_rate = get_rate(currency)
+      price_rate = fixed_rate || get_rate(currency)
     end
     if price_rate.present?
       variable_cap_cents = [canonical_cap_cents - price_cap_cents, 0].max
       amount = indian_card_presentment_cents(price_cap_cents, price_rate, currency) +
-        indian_card_presentment_cents(variable_cap_cents, get_rate(currency), currency)
+        indian_card_presentment_cents(variable_cap_cents, fixed_rate || get_rate(currency), currency)
     end
 
     interval, interval_count = StripeChargeProcessor.indian_card_mandate_interval(recurrence)
     { amount:, currency:, interval:, interval_count: }
+  end
+
+  # Terms plus the conversion rate they were sized with. The caller stores the rate beside
+  # the mandate it creates (SetupIntent metadata) and validates with it later: the cached
+  # rate refreshes hourly, and a refresh between setup and validation must not reject the
+  # mandate the buyer just approved.
+  def indian_card_mandate_terms_with_rate(
+    billing_info: nil,
+    authenticated_offer_code_buyer: AUTHENTICATED_OFFER_CODE_BUYER_NOT_PROVIDED
+  )
+    terms = indian_card_mandate_terms(billing_info:, authenticated_offer_code_buyer:)
+    return [terms, nil] if terms.blank? || terms[:currency] == Currency::USD
+
+    rate = get_rate(terms[:currency])
+    terms = indian_card_mandate_terms(billing_info:, authenticated_offer_code_buyer:, fixed_rate: rate)
+    [terms, rate]
   end
 
   def future_subscription_charge?(authenticated_offer_code_buyer: AUTHENTICATED_OFFER_CODE_BUYER_NOT_PROVIDED)
@@ -646,9 +671,8 @@ class Subscription < ApplicationRecord
   end
 
   # The gp#1410 recovery shape: only a membership whose renewals can re-fix in rupees
-  # (product and original purchase both listed in INR) may fall back to INR mandate terms.
-  # Anything else keeps canonical USD, because a mandate in a currency the renewal lane
-  # cannot bill would strand the subscription after a successful reauthorization.
+  # (product and original purchase both listed in INR) may fall back to INR mandate terms —
+  # a mandate the renewal lane cannot bill would strand the subscription after reauth.
   def indian_card_recovery_presentment_currency
     return unless india_card_mandate_reliability_enabled?
 
@@ -664,11 +688,9 @@ class Subscription < ApplicationRecord
     currency
   end
 
-  # A completed INR reauthorization leaves the mandate in rupees while the subscription still
-  # has no stored fixing (its historical charges settled in canonical USD). The renewal lane
-  # refuses to invent a buyer-currency amount without a stored row, so record the listed-INR
-  # fixing here from the same purchase terms the mandate cap was sized from. Without it, the
-  # first renewal after a successful reauthorization pauses the subscription again.
+  # The renewal lane refuses to invent a buyer-currency amount without a stored row, so a
+  # completed INR reauthorization must record the listed-INR fixing — otherwise the first
+  # renewal after a successful reauthorization pauses the subscription again.
   def record_indian_card_mandate_presentment!
     currency = indian_card_recovery_presentment_currency
     return if currency.blank?
@@ -677,10 +699,27 @@ class Subscription < ApplicationRecord
     canonical_price_cents = LaterChargePresentment.canonical_price_cents_for(purchase)
     presentment_price_cents = purchase.displayed_price_cents.to_i
     rate = BigDecimal(purchase.rate_converted_to_usd.to_s, exception: false)
+    if presentment_price_cents.zero? || canonical_price_cents.zero?
+      # Free-trial and fully-discounted registrations carry zero prices; size the fixing
+      # from the renewal terms instead — the pre-discount total when a temporary discount
+      # zeroes the current one. The renewal lane re-fixes exact canonical drift.
+      presentment_price_cents = current_subscription_price_cents.to_i
+      presentment_price_cents = renewal_pre_discount_total_cents.to_i if presentment_price_cents.zero?
+      rate = BigDecimal(get_rate(currency).to_s, exception: false)
+      canonical_price_cents = rate&.positive? ? get_usd_cents(currency, presentment_price_cents, rate:) : 0
+    end
     return unless canonical_price_cents.positive? && presentment_price_cents.positive? && rate&.positive?
 
     with_lock do
-      return if current_later_charge_presentment.present?
+      current = current_later_charge_presentment
+      # Keep any fixing that indian_card_mandate_terms itself would use — the mandate was
+      # then approved in that currency, not in INR. Supersede only a row terms rejected
+      # (wrong canonical or unsupported currency), which the INR mandate cannot bill.
+      if current.present?
+        return if current.presentment_currency == currency
+        return if current.canonical_price_cents == canonical_price_cents &&
+                  indian_card_renewal_presentment_supported?(current.presentment_currency)
+      end
 
       later_charge_presentments.create!(
         processor: StripeChargeProcessor.charge_processor_id,

--- a/app/services/onetime/pause_indian_card_mandate_renewals.rb
+++ b/app/services/onetime/pause_indian_card_mandate_renewals.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# Pauses renewals for the memberships at risk of gp#1410: the saved card is India-issued and
+# the recurring e-mandate Stripe holds is unusable for India recurring payments — it is
+# absent, no longer active, or was registered in USD (any membership without a stored non-USD
+# fixing charged in canonical USD, and many Indian issuers no longer accept USD e-mandates).
+#
+# The next off-session renewal for these memberships is guaranteed to fail, so pause them up
+# front instead of waiting for each renewal date. `require_indian_card_mandate_reauthorization!`
+# keeps the buyer's access, sends the existing "update your payment method" email once, and
+# routes them through the INR reauthorization path.
+#
+#   Onetime::PauseIndianCardMandateRenewals.process(seller_id: 123, dry_run: true)
+#   Onetime::PauseIndianCardMandateRenewals.process(seller_id: 123)
+class Onetime::PauseIndianCardMandateRenewals
+  BATCH_SIZE = 100
+
+  def self.process(seller_id:, dry_run: true)
+    new(seller_id:, dry_run:).process
+  end
+
+  def initialize(seller_id:, dry_run: true)
+    @seller_id = seller_id
+    @dry_run = dry_run
+  end
+
+  def process
+    scanned = 0
+    paused = 0
+    already_paused = 0
+    mandate_check_errors = 0
+
+    scope.find_in_batches(batch_size: BATCH_SIZE) do |subscriptions|
+      ReplicaLagWatcher.watch unless dry_run
+
+      subscriptions.each do |subscription|
+        scanned += 1
+        next unless subscription.india_card_mandate_reliability_enabled?
+
+        card = subscription.credit_card_to_charge
+        next unless card&.stripe_charge_processor? && card.requires_mandate?
+
+        if subscription.renewal_disabled_due_to_indian_card_mandate? &&
+           subscription.indian_card_mandate_requires_reauthorization?
+          already_paused += 1
+          next
+        end
+
+        begin
+          next unless at_risk?(subscription, card)
+        rescue ChargeProcessorError => e
+          # A transient Stripe failure must not pause (and email) a member whose mandate may
+          # be fine; skip and re-run for the leftovers.
+          mandate_check_errors += 1
+          ErrorNotifier.notify(e, subscription: subscription.external_id)
+          next
+        end
+
+        paused += 1
+        subscription.require_indian_card_mandate_reauthorization! unless dry_run
+      end
+    end
+
+    Rails.logger.info(
+      "[#{self.class.name}] seller_id=#{seller_id} scanned=#{scanned} " \
+      "#{dry_run ? 'would_pause' : 'paused'}=#{paused} already_paused=#{already_paused} " \
+      "mandate_check_errors=#{mandate_check_errors}"
+    )
+    { scanned:, paused:, already_paused:, mandate_check_errors: }
+  end
+
+  private
+    attr_reader :seller_id, :dry_run
+
+    def scope
+      Subscription
+        .where(seller_id:)
+        .active_without_pending_cancel
+        .not_is_installment_plan
+        .joins(:link)
+        .merge(Link.membership)
+    end
+
+    # At risk means the next off-session renewal cannot reference a usable INR e-mandate:
+    # either the membership has no stored non-USD fixing (so its historical mandate, if any,
+    # was registered in USD), or it has one but the mandate itself is gone or inactive.
+    def at_risk?(subscription, card)
+      presentment = subscription.current_later_charge_presentment
+      return true if presentment.nil? || presentment.presentment_currency == Currency::USD
+
+      _mandate, status, = subscription.indian_card_mandate_for(card.id)
+      status != "active"
+    end
+end

--- a/app/services/onetime/pause_indian_card_mandate_renewals.rb
+++ b/app/services/onetime/pause_indian_card_mandate_renewals.rb
@@ -44,6 +44,7 @@ class Onetime::PauseIndianCardMandateRenewals
           next
         end
 
+        observed_state = mandate_observed_state(subscription)
         begin
           next unless at_risk?(subscription, card)
         rescue ChargeProcessorError => e
@@ -58,11 +59,25 @@ class Onetime::PauseIndianCardMandateRenewals
           next
         end
 
-        paused += 1
-        # notify_buyer_if_already_disabled: a renewal-disabled membership without the reauth
-        # flag was paused before the INR path deployed; this run's email is its signal to
-        # come back and reauthorize.
-        subscription.require_indian_card_mandate_reauthorization!(notify_buyer_if_already_disabled: true) unless dry_run
+        if dry_run
+          paused += 1
+          next
+        end
+
+        subscription.with_lock do
+          # A buyer can complete reauthorization between the classification above and this
+          # lock; pausing then would undo their recovery and block the fresh mandate. Skip
+          # when anything the classification read has changed — a re-run reclassifies.
+          if mandate_observed_state(subscription) == observed_state
+            # notify_buyer_if_already_disabled: a renewal-disabled membership without the
+            # reauth flag was paused before the INR path deployed; this run's email is its
+            # signal to come back and reauthorize.
+            subscription.require_indian_card_mandate_reauthorization!(notify_buyer_if_already_disabled: true)
+            paused += 1
+          else
+            Rails.logger.info("[#{self.class.name}] state changed mid-scan for subscription #{subscription.external_id}; skipped")
+          end
+        end
       end
     end
 
@@ -86,14 +101,57 @@ class Onetime::PauseIndianCardMandateRenewals
         .merge(Link.membership)
     end
 
-    # At risk means the next off-session renewal cannot reference a usable INR e-mandate:
-    # either the membership has no stored non-USD fixing (so its historical mandate, if any,
-    # was registered in USD), or it has one but the mandate itself is gone or inactive.
+    # At risk means the next off-session renewal cannot proceed: the membership has no
+    # stored non-USD fixing (so its historical mandate, if any, was registered in USD), its
+    # fixing cannot satisfy the non-USD currency the renewal will require, or the mandate
+    # itself is gone or inactive.
     def at_risk?(subscription, card)
       presentment = subscription.current_later_charge_presentment
       return true if presentment.nil? || presentment.presentment_currency == Currency::USD
 
+      terms_currency = subscription.indian_card_mandate_terms&.dig(:currency)
+      # A stored non-USD fixing whose terms collapsed to canonical USD is incoherent: the
+      # mandate on file was registered for the fixing's currency, and a USD renewal cannot
+      # reference it.
+      return true if terms_currency.blank? || terms_currency == Currency::USD
+      return true if terms_currency != presentment.presentment_currency
+
+      # A listed-currency fixing from a previous plan can sit beside a mandate approved
+      # for that plan; the renewal would re-fix and submit against it. Compare the fixed
+      # price, not the canonical value — FX re-fixing keeps the price and only moves the
+      # canonical USD amount, while a plan change moves the price itself. Cross-currency
+      # (quote-lane) fixings need no price check: terms only keep their currency while the
+      # canonical value matches, and otherwise fall back to USD, which pauses above.
+      purchase = subscription.original_purchase
+      displayed_currency = (purchase&.displayed_price_currency_type.presence ||
+        subscription.link.price_currency_type).to_s.downcase
+      if displayed_currency == presentment.presentment_currency
+        # Every price the current plan can legitimately fix: the signup price, this
+        # cycle's discounted price, and the post-discount full price. A plan change
+        # moves all of them away from the old fixing.
+        plan_price_candidates = [
+          purchase&.displayed_price_cents.to_i,
+          subscription.current_subscription_price_cents.to_i,
+          subscription.renewal_pre_discount_total_cents.to_i,
+        ].select(&:positive?)
+        return true if plan_price_candidates.any? &&
+                       !plan_price_candidates.include?(presentment.presentment_price_cents)
+      end
+
       _mandate, status, = subscription.indian_card_mandate_for(card.id)
-      status != "active"
+      # "pending" is a transient registration state that CheckIndianCardMandateRegistrationJob
+      # resolves on its own; pausing it here would flag a mandate that may activate moments
+      # later. The cohort is inactive/missing only.
+      !status.in?(%w[active pending])
+    end
+
+    def mandate_observed_state(subscription)
+      [
+        subscription.stripe_mandate_id,
+        subscription.credit_card_to_charge&.id,
+        subscription.renewal_disabled_due_to_indian_card_mandate?,
+        subscription.indian_card_mandate_requires_reauthorization?,
+        subscription.current_later_charge_presentment&.id,
+      ]
     end
 end

--- a/app/services/onetime/pause_indian_card_mandate_renewals.rb
+++ b/app/services/onetime/pause_indian_card_mandate_renewals.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
-# Pauses renewals for the memberships at risk of gp#1410: the saved card is India-issued and
-# the recurring e-mandate Stripe holds is unusable for India recurring payments — it is
-# absent, no longer active, or was registered in USD (any membership without a stored non-USD
-# fixing charged in canonical USD, and many Indian issuers no longer accept USD e-mandates).
-#
-# The next off-session renewal for these memberships is guaranteed to fail, so pause them up
-# front instead of waiting for each renewal date. `require_indian_card_mandate_reauthorization!`
-# keeps the buyer's access, sends the existing "update your payment method" email once, and
-# routes them through the INR reauthorization path.
+# Pauses gp#1410's at-risk memberships up front instead of waiting for each renewal to fail:
+# an India-issued card whose mandate is absent, inactive, or implied-USD (no stored non-USD
+# fixing) cannot renew, because many Indian issuers refuse USD e-mandates. Pausing keeps
+# access and sends the buyer onto the INR reauthorization path.
 #
 #   Onetime::PauseIndianCardMandateRenewals.process(seller_id: 123, dry_run: true)
 #   Onetime::PauseIndianCardMandateRenewals.process(seller_id: 123)
@@ -36,6 +31,9 @@ class Onetime::PauseIndianCardMandateRenewals
       subscriptions.each do |subscription|
         scanned += 1
         next unless subscription.india_card_mandate_reliability_enabled?
+        # A membership that will never charge again (completed, or permanently free) needs no
+        # mandate and must not be paused or emailed.
+        next unless subscription.future_subscription_charge?
 
         card = subscription.credit_card_to_charge
         next unless card&.stripe_charge_processor? && card.requires_mandate?
@@ -50,14 +48,21 @@ class Onetime::PauseIndianCardMandateRenewals
           next unless at_risk?(subscription, card)
         rescue ChargeProcessorError => e
           # A transient Stripe failure must not pause (and email) a member whose mandate may
-          # be fine; skip and re-run for the leftovers.
+          # be fine; skip and re-run for the leftovers. Only a real run reports these — dry-run
+          # lookup noise is not actionable. (Anomaly reports from inside the lookup itself,
+          # e.g. a mandate bound to another payment method, stay on for both: they flag bad
+          # data worth seeing whenever it is observed.)
           mandate_check_errors += 1
-          ErrorNotifier.notify(e, subscription: subscription.external_id)
+          Rails.logger.info("[#{self.class.name}] mandate check failed for subscription #{subscription.external_id}: #{e.class}")
+          ErrorNotifier.notify(e, subscription: subscription.external_id) unless dry_run
           next
         end
 
         paused += 1
-        subscription.require_indian_card_mandate_reauthorization! unless dry_run
+        # notify_buyer_if_already_disabled: a renewal-disabled membership without the reauth
+        # flag was paused before the INR path deployed; this run's email is its signal to
+        # come back and reauthorize.
+        subscription.require_indian_card_mandate_reauthorization!(notify_buyer_if_already_disabled: true) unless dry_run
       end
     end
 

--- a/app/services/subscription/updater_service.rb
+++ b/app/services/subscription/updater_service.rb
@@ -392,6 +392,10 @@ class Subscription::UpdaterService
         subscription.indian_card_mandate_requires_reauthorization = false
       end
       subscription.save!
+      # The validated setup intent carried the subscription's own mandate terms, so a mandate
+      # here is in the terms currency; store the matching fixing before any charge below bills
+      # the renewal amount.
+      subscription.record_indian_card_mandate_presentment! if stripe_mandate_id.present?
     end
 
     def associate_replacement_card!(credit_card, had_saved_card:, **mandate_validation)

--- a/app/services/subscription/updater_service.rb
+++ b/app/services/subscription/updater_service.rb
@@ -366,9 +366,16 @@ class Subscription::UpdaterService
       mandate_options = setup_intent.card_mandate_options
       return false if mandate_options.blank?
 
+      # Recompute the terms with the rate stamped when the setup intent was created, so a
+      # cached-rate refresh between setup and this validation cannot reject the mandate the
+      # buyer just approved. The stamp is server-authored metadata; a missing or unusable
+      # value falls back to the live rate (intents created before the stamp existed).
+      fixed_rate = BigDecimal(setup_intent.metadata[:gumroad_mandate_rate].to_s, exception: false)
+      fixed_rate = nil unless fixed_rate&.positive?
       expected_terms = subscription.indian_card_mandate_terms(
         billing_info: params[:contact_info],
-        authenticated_offer_code_buyer: logged_in_user
+        authenticated_offer_code_buyer: logged_in_user,
+        fixed_rate:
       )
       return false if expected_terms.blank?
 

--- a/app/services/subscription/updater_service.rb
+++ b/app/services/subscription/updater_service.rb
@@ -239,6 +239,7 @@ class Subscription::UpdaterService
           # Charge user if necessary
           if should_charge_user?
             result = charge_user!
+            record_mandate_presentment_after_charge! if result[:success]
             if saved_card_mandate_terms_changed && result[:success]
               subscription.require_indian_card_mandate_reauthorization!(notify_buyer: false)
             end
@@ -399,10 +400,22 @@ class Subscription::UpdaterService
         subscription.indian_card_mandate_requires_reauthorization = false
       end
       subscription.save!
+      return if stripe_mandate_id.blank?
+
       # The validated setup intent carried the subscription's own mandate terms, so a mandate
-      # here is in the terms currency; store the matching fixing before any charge below bills
-      # the renewal amount.
-      subscription.record_indian_card_mandate_presentment! if stripe_mandate_id.present?
+      # here is in the terms currency. The fixing must exist before any charge below — an
+      # overdue renewal bills it, and a prorated upgrade re-fixes its own amount from it —
+      # and it is recorded again after the charge so an upgrade's prorated re-fix does not
+      # linger as the renewal amount.
+      subscription.record_indian_card_mandate_presentment!
+      @record_mandate_presentment_after_charge = true
+    end
+
+    def record_mandate_presentment_after_charge!
+      return unless @record_mandate_presentment_after_charge
+
+      @record_mandate_presentment_after_charge = false
+      subscription.record_indian_card_mandate_presentment!
     end
 
     def associate_replacement_card!(credit_card, had_saved_card:, **mandate_validation)

--- a/spec/controllers/stripe/setup_intents_controller_spec.rb
+++ b/spec/controllers/stripe/setup_intents_controller_spec.rb
@@ -103,14 +103,19 @@ describe Stripe::SetupIntentsController, :vcr do
         allow(Rails.env).to receive(:production?).and_return(true)
         allow(controller).to receive(:params).and_return(ActionController::Parameters.new(products: [{ price: 1, subscription_id: subscription.external_id }]))
         allow(subscription).to receive(:india_card_mandate_reliability_enabled?).and_return(true)
-        expect(subscription).to receive(:indian_card_mandate_terms).twice.with(
+        expect(subscription).to receive(:indian_card_mandate_terms_with_rate).twice.with(
           billing_info: nil,
           authenticated_offer_code_buyer: nil
         ).and_return(
-          amount: 12_34,
-          currency: Currency::INR,
-          interval: "month",
-          interval_count: 3
+          [
+            {
+              amount: 12_34,
+              currency: Currency::INR,
+              interval: "month",
+              interval_count: 3
+            },
+            "80.0"
+          ]
         )
 
         mandate_options = controller.send(:mandate_options_for_stripe, chargeable, subscription:)
@@ -118,7 +123,10 @@ describe Stripe::SetupIntentsController, :vcr do
         mandate_terms = mandate_options.dig(:payment_method_options, :card, :mandate_options)
         next_mandate_terms = next_mandate_options.dig(:payment_method_options, :card, :mandate_options)
 
-        expect(mandate_options[:metadata]).to eq(gumroad_subscription_id: subscription.external_id)
+        expect(mandate_options[:metadata]).to eq(
+          gumroad_subscription_id: subscription.external_id,
+          gumroad_mandate_rate: "80.0"
+        )
         expect(mandate_terms).to include(
           amount: 12_34,
           currency: Currency::INR,
@@ -134,18 +142,24 @@ describe Stripe::SetupIntentsController, :vcr do
         chargeable = double(requires_mandate?: true)
         allow(controller).to receive(:params).and_return(ActionController::Parameters.new(products: [{ subscription_id: subscription.external_id }]))
         allow(subscription).to receive(:india_card_mandate_reliability_enabled?).and_return(true)
-        allow(subscription).to receive(:indian_card_mandate_terms).and_return(
-          amount: 12_34,
-          currency: Currency::USD,
-          interval: "sporadic",
-          interval_count: nil
+        allow(subscription).to receive(:indian_card_mandate_terms_with_rate).and_return(
+          [
+            {
+              amount: 12_34,
+              currency: Currency::USD,
+              interval: "sporadic",
+              interval_count: nil
+            },
+            nil
+          ]
         )
 
-        mandate_terms = controller.send(:mandate_options_for_stripe, chargeable, subscription:)
-          .dig(:payment_method_options, :card, :mandate_options)
+        mandate_options = controller.send(:mandate_options_for_stripe, chargeable, subscription:)
+        mandate_terms = mandate_options.dig(:payment_method_options, :card, :mandate_options)
 
         expect(mandate_terms).to include(interval: "sporadic")
         expect(mandate_terms).not_to have_key(:interval_count)
+        expect(mandate_options[:metadata]).to eq(gumroad_subscription_id: subscription.external_id)
       end
 
       it "uses the submitted billing location for subscription mandate terms" do
@@ -159,14 +173,19 @@ describe Stripe::SetupIntentsController, :vcr do
           )
         )
         allow(subscription).to receive(:india_card_mandate_reliability_enabled?).and_return(true)
-        expect(subscription).to receive(:indian_card_mandate_terms).with(
+        expect(subscription).to receive(:indian_card_mandate_terms_with_rate).with(
           billing_info:,
           authenticated_offer_code_buyer: nil
         ).and_return(
-          amount: 12_34,
-          currency: Currency::INR,
-          interval: "month",
-          interval_count: 1
+          [
+            {
+              amount: 12_34,
+              currency: Currency::INR,
+              interval: "month",
+              interval_count: 1
+            },
+            "80.0"
+          ]
         )
 
         controller.send(:mandate_options_for_stripe, chargeable, subscription:)

--- a/spec/models/purchase_indian_card_mandate_spec.rb
+++ b/spec/models/purchase_indian_card_mandate_spec.rb
@@ -679,6 +679,7 @@ describe "Indian card mandate reliability" do
         LaterChargePresentment,
         canonical_price_cents:,
         presentment_currency: Currency::EUR,
+        presentment_price_cents: source_purchase.displayed_price_cents,
         signup_currency_units_per_usd: BigDecimal("0.8")
       )
     )
@@ -743,6 +744,33 @@ describe "Indian card mandate reliability" do
 
     expect(subscription.indian_card_mandate_terms).to include(
       amount: 80_000,
+      currency: Currency::INR
+    )
+  end
+
+  it "keeps the tax headroom in the recovery cap when the rate moved since signup" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 96_000,
+      price_cents: 10_00,
+      tax_cents: 2_00,
+      total_transaction_cents: 12_00,
+      rate_converted_to_usd: "96"
+    )
+    subscription.reload
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("80.0")
+
+    terms = subscription.indian_card_mandate_terms(fixed_rate: "80.0")
+
+    # Price cap at the stamped rate is 1,200 USD cents, which equals the signup-rate
+    # canonical total; without the floor the ₹ tax headroom would collapse to zero. The
+    # floor scales the 200-cent signup tax to the pinned price basis (200 × 1200/1000 = 240),
+    # covering the tax a renewal recomputes at the stronger rate.
+    expect(terms).to include(
+      amount: 96_000 + (2_40 * 80),
       currency: Currency::INR
     )
   end
@@ -911,6 +939,40 @@ describe "Indian card mandate reliability" do
     )
   end
 
+  it "stores the current renewal price when it differs from the signup price" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    # The signup purchase keeps its discounted price after the discount's billing cycles
+    # ran out; the renewal now bills the full price.
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 40_000,
+      price_cents: 5_00,
+      total_transaction_cents: 5_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+    subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+    subscription.reload
+    allow(subscription).to receive(:current_subscription_price_cents).and_return(80_000)
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("80.0")
+
+    subscription.update_renewal_for_indian_card_mandate!(
+      "active",
+      expected_credit_card_id: card.id,
+      mandate_id: "mandate_inr_reauthorized",
+      clear_reauthorization: true
+    )
+
+    expect(subscription.reload.current_later_charge_presentment).to have_attributes(
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: 10_00
+    )
+  end
+
   it "stores a fixing from the pre-discount total during a temporary full discount" do
     registration = create_registration
     subscription = registration.subscription
@@ -944,6 +1006,34 @@ describe "Indian card mandate reliability" do
     )
   end
 
+  it "stores the fixing before the cleared flags leave the reauthorization lock" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 80_000,
+      price_cents: 10_00,
+      total_transaction_cents: 10_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+    subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+    subscription.reload
+    open_transactions_before = ActiveRecord::Base.connection.open_transactions
+    expect(subscription).to receive(:record_indian_card_mandate_presentment!) do
+      expect(ActiveRecord::Base.connection.open_transactions).to be > open_transactions_before
+    end
+
+    subscription.update_renewal_for_indian_card_mandate!(
+      "active",
+      expected_credit_card_id: card.id,
+      mandate_id: "mandate_inr_reauthorized",
+      clear_reauthorization: true
+    )
+  end
+
   it "does not store a fixing when an active mandate needs no reauthorization" do
     registration = create_registration
     subscription = registration.subscription
@@ -966,7 +1056,7 @@ describe "Indian card mandate reliability" do
     expect(subscription.reload.current_later_charge_presentment).to be_nil
   end
 
-  it "keeps an existing fixing when a reauthorization completes" do
+  it "supersedes a same-currency fixing at an outdated price even when the canonical value matches" do
     registration = create_registration
     subscription = registration.subscription
     product.update_column(:price_currency_type, Currency::INR)
@@ -997,8 +1087,153 @@ describe "Indian card mandate reliability" do
       clear_reauthorization: true
     )
 
-    expect(subscription.reload.later_charge_presentments.count).to eq(1)
-    expect(subscription.current_later_charge_presentment.presentment_price_cents).to eq(79_000)
+    expect(subscription.reload.later_charge_presentments.count).to eq(2)
+    expect(subscription.current_later_charge_presentment).to have_attributes(
+      presentment_price_cents: 80_000,
+      canonical_price_cents: 10_00
+    )
+  end
+
+  it "does not trust a cross-currency fixing once the signup price stopped billing" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    # The signup purchase keeps its discounted price; renewals bill the full price now.
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 40_000,
+      price_cents: 5_00,
+      total_transaction_cents: 5_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::CAD,
+      presentment_price_cents: 675,
+      canonical_price_cents: 5_00,
+      signup_currency_units_per_usd: BigDecimal("1.35")
+    )
+    allow(subscription).to receive(:current_subscription_price_cents).and_return(80_000)
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("80.0")
+
+    expect(subscription.indian_card_mandate_terms).to include(currency: Currency::INR)
+  end
+
+  it "floors the recovery cap at the exact listed price" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    # 80,000 paise at 85/USD stores 941 USD cents; converting back yields 79,985 paise,
+    # just below the exact amount the recovered fixing bills.
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 80_000,
+      price_cents: 941,
+      total_transaction_cents: 941,
+      rate_converted_to_usd: "85"
+    )
+    subscription.reload
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("85.0")
+
+    expect(subscription.indian_card_mandate_terms).to include(
+      amount: 80_000,
+      currency: Currency::INR
+    )
+  end
+
+  it "keeps the scaled tax headroom for an expired limited-duration discount" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 40_000,
+      price_cents: 5_00,
+      tax_cents: 1_00,
+      total_transaction_cents: 6_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    allow(subscription).to receive(:original_purchase).and_return(registration)
+    # The cap scales the signup total past the discount: full price plus scaled tax.
+    allow(registration).to receive(:mandate_maximum_amount_cents).and_return(12_00)
+    allow(registration).to receive(:mandate_maximum_displayed_price_cents).and_return(80_000)
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("64.0")
+
+    terms = subscription.indian_card_mandate_terms(fixed_rate: "64.0")
+
+    # At the strengthened rate the price cap is 1,250 USD cents against a 1,200-cent
+    # canonical cap. The floor keeps the 200-cent scaled tax part — not the 100-cent
+    # discounted tax — and scales it to the pinned price basis (200 × 1250/1000 = 250).
+    expect(terms).to include(
+      amount: 80_000 + (2_50 * 64),
+      currency: Currency::INR
+    )
+  end
+
+  it "trusts a fixing re-fixed to the full price after a discount ended" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 40_000,
+      price_cents: 5_00,
+      total_transaction_cents: 5_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    allow(subscription).to receive(:original_purchase).and_return(registration)
+    allow(subscription).to receive(:current_subscription_price_cents).and_return(80_000)
+    allow(subscription).to receive(:renewal_pre_discount_total_cents).and_return(80_000)
+    # The expired discount keeps the cap at the pre-discount price.
+    allow(registration).to receive(:mandate_maximum_displayed_price_cents).and_return(80_000)
+    allow(registration).to receive(:mandate_maximum_amount_cents).and_return(10_00)
+    # The renewal re-fixed the full price when the discount's billing cycles ran out.
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: LaterChargePresentment.canonical_price_cents_for(registration),
+      signup_currency_units_per_usd: BigDecimal("80")
+    )
+
+    expect(subscription.indian_card_mandate_terms).to include(
+      amount: 80_000,
+      currency: Currency::INR
+    )
+  end
+
+  it "sizes mandate terms from recovery instead of a fixing at an outdated price" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 80_000,
+      price_cents: 10_00,
+      total_transaction_cents: 10_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    # Price and rate moved together, so the canonical USD value still matches the plan.
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 79_000,
+      canonical_price_cents: 10_00,
+      signup_currency_units_per_usd: BigDecimal("79")
+    )
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("80.0")
+
+    expect(subscription.indian_card_mandate_terms).to include(
+      amount: 80_000,
+      currency: Currency::INR
+    )
   end
 
   it "keeps a matching supported fixing in another currency when a reauthorization completes" do
@@ -1035,6 +1270,144 @@ describe "Indian card mandate reliability" do
     subscription.reload
     expect(subscription.later_charge_presentments.count).to eq(1)
     expect(subscription.current_later_charge_presentment.presentment_currency).to eq(Currency::CAD)
+  end
+
+  it "keeps an FX re-fixed fixing at the plan price when a reauthorization completes" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 80_000,
+      price_cents: 10_00,
+      total_transaction_cents: 10_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: 9_50,
+      signup_currency_units_per_usd: BigDecimal("84")
+    )
+    subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+    subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+    subscription.reload
+
+    subscription.update_renewal_for_indian_card_mandate!(
+      "active",
+      expected_credit_card_id: card.id,
+      mandate_id: "mandate_inr_reauthorized",
+      clear_reauthorization: true
+    )
+
+    subscription.reload
+    expect(subscription.later_charge_presentments.count).to eq(1)
+    expect(subscription.current_later_charge_presentment.canonical_price_cents).to eq(9_50)
+  end
+
+  it "supersedes a stale fixing in the mandate currency when a reauthorization completes" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 80_000,
+      price_cents: 10_00,
+      total_transaction_cents: 10_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 72_000,
+      canonical_price_cents: 9_00,
+      signup_currency_units_per_usd: BigDecimal("80")
+    )
+    subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+    subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+    subscription.reload
+
+    subscription.update_renewal_for_indian_card_mandate!(
+      "active",
+      expected_credit_card_id: card.id,
+      mandate_id: "mandate_inr_reauthorized",
+      clear_reauthorization: true
+    )
+
+    subscription.reload
+    expect(subscription.later_charge_presentments.count).to eq(2)
+    expect(subscription.current_later_charge_presentment).to have_attributes(
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: 10_00
+    )
+  end
+
+  it "pins the free-trial mandate cap to the passed rate" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 0,
+      price_cents: 0,
+      total_transaction_cents: 0,
+      rate_converted_to_usd: "80"
+    )
+    registration.update_flag!(:is_free_trial_purchase, true, true)
+    allow(subscription).to receive(:current_subscription_price_cents).and_return(80_000)
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("75.0")
+
+    expect(registration.mandate_maximum_amount_cents(fixed_rate: "80.0")).to eq(10_00)
+    expect(registration.mandate_maximum_amount_cents).to eq(1_067)
+  end
+
+  it "supersedes a cross-currency fixing whose signup price stopped billing" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 40_000,
+      price_cents: 5_00,
+      total_transaction_cents: 5_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    # Canonical still matches the discounted signup, but renewals bill the full price, so
+    # the mandate was approved in INR — not in the row's currency.
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::CAD,
+      presentment_price_cents: 675,
+      canonical_price_cents: 5_00,
+      signup_currency_units_per_usd: BigDecimal("1.35")
+    )
+    subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+    subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+    subscription.reload
+    allow(subscription).to receive(:current_subscription_price_cents).and_return(80_000)
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("80.0")
+
+    subscription.update_renewal_for_indian_card_mandate!(
+      "active",
+      expected_credit_card_id: card.id,
+      mandate_id: "mandate_inr_reauthorized",
+      clear_reauthorization: true
+    )
+
+    subscription.reload
+    expect(subscription.later_charge_presentments.count).to eq(2)
+    expect(subscription.current_later_charge_presentment).to have_attributes(
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000
+    )
   end
 
   it "supersedes a fixing in another currency when a reauthorization completes" do

--- a/spec/models/purchase_indian_card_mandate_spec.rb
+++ b/spec/models/purchase_indian_card_mandate_spec.rb
@@ -747,6 +747,30 @@ describe "Indian card mandate reliability" do
     )
   end
 
+  it "pins recovery mandate terms to the captured conversion rate" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 80_000,
+      price_cents: 10_00,
+      total_transaction_cents: 10_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("80.0")
+
+    terms, rate = subscription.indian_card_mandate_terms_with_rate
+    expect(rate).to eq("80.0")
+    expect(terms).to include(amount: 80_000, currency: Currency::INR)
+
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("85.0")
+
+    expect(subscription.indian_card_mandate_terms(fixed_rate: rate)).to eq(terms)
+    expect(subscription.indian_card_mandate_terms).not_to eq(terms)
+  end
+
   it "keeps canonical USD mandate terms for a listed-INR membership when the feature is off" do
     registration = create_registration
     subscription = registration.subscription
@@ -855,6 +879,71 @@ describe "Indian card mandate reliability" do
     expect(subscription.stripe_mandate_id).to eq("mandate_inr_reauthorized")
   end
 
+  it "stores a fixing from renewal terms when the registration was free" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 0,
+      price_cents: 0,
+      total_transaction_cents: 0,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+    subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+    subscription.reload
+    allow(subscription).to receive(:current_subscription_price_cents).and_return(80_000)
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("80.0")
+
+    subscription.update_renewal_for_indian_card_mandate!(
+      "active",
+      expected_credit_card_id: card.id,
+      mandate_id: "mandate_inr_reauthorized",
+      clear_reauthorization: true
+    )
+
+    expect(subscription.reload.current_later_charge_presentment).to have_attributes(
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: 10_00
+    )
+  end
+
+  it "stores a fixing from the pre-discount total during a temporary full discount" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 0,
+      price_cents: 0,
+      total_transaction_cents: 0,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+    subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+    subscription.reload
+    allow(subscription).to receive(:current_subscription_price_cents).and_return(0)
+    allow(subscription).to receive(:renewal_pre_discount_total_cents).and_return(80_000)
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("80.0")
+
+    subscription.update_renewal_for_indian_card_mandate!(
+      "active",
+      expected_credit_card_id: card.id,
+      mandate_id: "mandate_inr_reauthorized",
+      clear_reauthorization: true
+    )
+
+    expect(subscription.reload.current_later_charge_presentment).to have_attributes(
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: 10_00
+    )
+  end
+
   it "does not store a fixing when an active mandate needs no reauthorization" do
     registration = create_registration
     subscription = registration.subscription
@@ -910,6 +999,82 @@ describe "Indian card mandate reliability" do
 
     expect(subscription.reload.later_charge_presentments.count).to eq(1)
     expect(subscription.current_later_charge_presentment.presentment_price_cents).to eq(79_000)
+  end
+
+  it "keeps a matching supported fixing in another currency when a reauthorization completes" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 80_000,
+      price_cents: 10_00,
+      total_transaction_cents: 10_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::CAD,
+      presentment_price_cents: 1_350,
+      canonical_price_cents: 10_00,
+      signup_currency_units_per_usd: BigDecimal("1.35")
+    )
+    subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+    subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+    subscription.reload
+
+    subscription.update_renewal_for_indian_card_mandate!(
+      "active",
+      expected_credit_card_id: card.id,
+      mandate_id: "mandate_cad_reauthorized",
+      clear_reauthorization: true
+    )
+
+    subscription.reload
+    expect(subscription.later_charge_presentments.count).to eq(1)
+    expect(subscription.current_later_charge_presentment.presentment_currency).to eq(Currency::CAD)
+  end
+
+  it "supersedes a fixing in another currency when a reauthorization completes" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 80_000,
+      price_cents: 10_00,
+      total_transaction_cents: 10_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::NZD,
+      presentment_price_cents: 1_700,
+      canonical_price_cents: 10_00,
+      signup_currency_units_per_usd: BigDecimal("1.7")
+    )
+    subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+    subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+    subscription.reload
+
+    subscription.update_renewal_for_indian_card_mandate!(
+      "active",
+      expected_credit_card_id: card.id,
+      mandate_id: "mandate_inr_reauthorized",
+      clear_reauthorization: true
+    )
+
+    subscription.reload
+    expect(subscription.later_charge_presentments.count).to eq(2)
+    expect(subscription.current_later_charge_presentment).to have_attributes(
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: 10_00
+    )
   end
 
   it "rejects a stored mandate for a different payment method" do

--- a/spec/models/purchase_indian_card_mandate_spec.rb
+++ b/spec/models/purchase_indian_card_mandate_spec.rb
@@ -727,6 +727,191 @@ describe "Indian card mandate reliability" do
     ).to include(amount: 10_00, currency: Currency::USD)
   end
 
+  it "presents INR mandate terms when a listed-INR membership has no stored fixing" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    allow(subscription).to receive(:original_purchase).and_return(registration)
+    allow(registration).to receive(:mandate_maximum_amount_cents).and_return(10_00)
+    allow(registration).to receive(:mandate_maximum_displayed_price_cents).and_return(80_000)
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("80.0")
+
+    expect(subscription.indian_card_mandate_terms).to include(
+      amount: 80_000,
+      currency: Currency::INR
+    )
+  end
+
+  it "keeps canonical USD mandate terms for a listed-INR membership when the feature is off" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    allow(subscription).to receive(:original_purchase).and_return(registration)
+    allow(registration).to receive(:mandate_maximum_amount_cents).and_return(10_00)
+    allow(registration).to receive(:mandate_maximum_displayed_price_cents).and_return(80_000)
+    Feature.deactivate_user(StripeChargeProcessor::INDIA_CARD_MANDATE_RELIABILITY_FEATURE, seller)
+
+    expect(subscription.indian_card_mandate_terms).to include(
+      amount: 10_00,
+      currency: Currency::USD
+    )
+  end
+
+  it "keeps canonical USD mandate terms when the purchase was not displayed in INR" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    subscription.reload
+    allow(subscription).to receive(:original_purchase).and_return(registration)
+    allow(registration).to receive(:mandate_maximum_amount_cents).and_return(10_00)
+    allow(registration).to receive(:mandate_maximum_displayed_price_cents).and_return(10_00)
+
+    expect(subscription.indian_card_mandate_terms).to include(
+      amount: 10_00,
+      currency: Currency::USD
+    )
+  end
+
+  it "stops an off-session renewal for a listed-INR membership with no stored fixing before Stripe" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 80_000,
+      price_cents: 10_00,
+      total_transaction_cents: 10_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    allow(subscription).to receive(:get_rate).with(Currency::INR).and_return("80.0")
+    renewal = build(
+      :purchase,
+      link: product,
+      seller:,
+      purchaser: buyer,
+      subscription:,
+      credit_card: card,
+      merchant_account:,
+      charge_processor_id: StripeChargeProcessor.charge_processor_id,
+      is_original_subscription_purchase: false,
+      price_cents: 10_00,
+      displayed_price_cents: 80_000,
+      displayed_price_currency_type: Currency::INR,
+      total_transaction_cents: 10_00
+    )
+    allow(ErrorNotifier).to receive(:notify)
+
+    expect do
+      renewal.send(:later_charge_presentment_processor_args, off_session: true)
+    end.to raise_error(ChargeProcessorCardError) do |error|
+      expect(error.error_code).to eq(PurchaseErrorCode::INDIA_CARD_MANDATE_MISSING)
+    end
+  end
+
+  it "stores the listed-INR fixing when a reauthorization completes" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 80_000,
+      price_cents: 10_00,
+      total_transaction_cents: 10_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+    subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+    subscription.reload
+
+    subscription.update_renewal_for_indian_card_mandate!(
+      "active",
+      expected_credit_card_id: card.id,
+      mandate_id: "mandate_inr_reauthorized",
+      clear_reauthorization: true
+    )
+
+    subscription.reload
+    fixing = subscription.current_later_charge_presentment
+    expect(fixing).to have_attributes(
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: 10_00
+    )
+    expect(fixing.signup_currency_units_per_usd).to eq(BigDecimal("80"))
+    expect(subscription).not_to be_renewal_disabled_due_to_indian_card_mandate
+    expect(subscription).not_to be_indian_card_mandate_requires_reauthorization
+    expect(subscription.stripe_mandate_id).to eq("mandate_inr_reauthorized")
+  end
+
+  it "does not store a fixing when an active mandate needs no reauthorization" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 80_000,
+      price_cents: 10_00,
+      total_transaction_cents: 10_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+
+    subscription.update_renewal_for_indian_card_mandate!(
+      "active",
+      expected_credit_card_id: card.id,
+      mandate_id: "mandate_no_reauthorization"
+    )
+
+    expect(subscription.reload.current_later_charge_presentment).to be_nil
+  end
+
+  it "keeps an existing fixing when a reauthorization completes" do
+    registration = create_registration
+    subscription = registration.subscription
+    product.update_column(:price_currency_type, Currency::INR)
+    registration.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 80_000,
+      price_cents: 10_00,
+      total_transaction_cents: 10_00,
+      rate_converted_to_usd: "80"
+    )
+    subscription.reload
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 79_000,
+      canonical_price_cents: 10_00,
+      signup_currency_units_per_usd: BigDecimal("79")
+    )
+    subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+    subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+    subscription.reload
+
+    subscription.update_renewal_for_indian_card_mandate!(
+      "active",
+      expected_credit_card_id: card.id,
+      mandate_id: "mandate_inr_reauthorized",
+      clear_reauthorization: true
+    )
+
+    expect(subscription.reload.later_charge_presentments.count).to eq(1)
+    expect(subscription.current_later_charge_presentment.presentment_price_cents).to eq(79_000)
+  end
+
   it "rejects a stored mandate for a different payment method" do
     registration = create_registration
     subscription = registration.subscription

--- a/spec/services/onetime/pause_indian_card_mandate_renewals_spec.rb
+++ b/spec/services/onetime/pause_indian_card_mandate_renewals_spec.rb
@@ -180,12 +180,31 @@ describe Onetime::PauseIndianCardMandateRenewals do
       owner: subscription,
       presentment_currency: Currency::INR,
       presentment_price_cents: 80_000,
-      canonical_price_cents: 10_00,
+      canonical_price_cents: LaterChargePresentment.canonical_price_cents_for(subscription.original_purchase),
       signup_currency_units_per_usd: BigDecimal("80")
     )
     mandate = Stripe::Mandate.construct_from(id: "mandate_active", status: "active", payment_method: "pm_shared")
     allow_any_instance_of(Subscription).to receive(:indian_card_mandate_for)
       .with(card.id).and_return([mandate, "active", nil])
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 0, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription.reload).not_to be_renewal_disabled_due_to_indian_card_mandate
+  end
+
+  it "leaves a pending registration to the mandate check job" do
+    subscription = create_membership
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: LaterChargePresentment.canonical_price_cents_for(subscription.original_purchase),
+      signup_currency_units_per_usd: BigDecimal("80")
+    )
+    allow_any_instance_of(Subscription).to receive(:indian_card_mandate_for)
+      .with(card.id).and_return([nil, "pending", nil])
 
     result = described_class.process(seller_id: seller.id, dry_run: false)
 
@@ -200,7 +219,7 @@ describe Onetime::PauseIndianCardMandateRenewals do
       owner: subscription,
       presentment_currency: Currency::INR,
       presentment_price_cents: 80_000,
-      canonical_price_cents: 10_00,
+      canonical_price_cents: LaterChargePresentment.canonical_price_cents_for(subscription.original_purchase),
       signup_currency_units_per_usd: BigDecimal("80")
     )
     allow_any_instance_of(Subscription).to receive(:indian_card_mandate_for)
@@ -212,6 +231,178 @@ describe Onetime::PauseIndianCardMandateRenewals do
     expect(subscription.reload).to be_renewal_disabled_due_to_indian_card_mandate
   end
 
+  it "pauses a membership whose fixing cannot satisfy the required renewal currency" do
+    inr_product = create(:subscription_product, user: seller)
+    Redis::Namespace.new(:currencies, redis: $redis).set("INR", "80")
+    subscription = create_membership(link: inr_product)
+    inr_product.update_column(:price_currency_type, Currency::INR)
+    subscription.original_purchase.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      rate_converted_to_usd: "80"
+    )
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::NZD,
+      presentment_price_cents: 1_700,
+      canonical_price_cents: LaterChargePresentment.canonical_price_cents_for(subscription.original_purchase),
+      signup_currency_units_per_usd: BigDecimal("1.7")
+    )
+
+    expect_any_instance_of(Subscription).not_to receive(:indian_card_mandate_for)
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 1, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription.reload).to be_renewal_disabled_due_to_indian_card_mandate
+  end
+
+  it "pauses a membership whose fixing predates the current plan" do
+    inr_product = create(:subscription_product, user: seller)
+    Redis::Namespace.new(:currencies, redis: $redis).set("INR", "80")
+    subscription = create_membership(link: inr_product)
+    inr_product.update_column(:price_currency_type, Currency::INR)
+    subscription.original_purchase.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      rate_converted_to_usd: "80"
+    )
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 72_000,
+      canonical_price_cents: LaterChargePresentment.canonical_price_cents_for(subscription.original_purchase) + 1_00,
+      signup_currency_units_per_usd: BigDecimal("80")
+    )
+
+    expect_any_instance_of(Subscription).not_to receive(:indian_card_mandate_for)
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 1, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription.reload).to be_renewal_disabled_due_to_indian_card_mandate
+  end
+
+  it "does not treat a cross-currency fixing price as a plan change" do
+    subscription = create_membership
+    # A quote-lane INR fixing on a USD-listed membership: its fixed price never equals the
+    # listed USD price, and that difference alone must not pause an active mandate.
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: LaterChargePresentment.canonical_price_cents_for(subscription.original_purchase),
+      signup_currency_units_per_usd: BigDecimal("80")
+    )
+    mandate = Stripe::Mandate.construct_from(id: "mandate_active", status: "active", payment_method: "pm_shared")
+    allow_any_instance_of(Subscription).to receive(:indian_card_mandate_for)
+      .with(card.id).and_return([mandate, "active", nil])
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 0, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription.reload).not_to be_renewal_disabled_due_to_indian_card_mandate
+  end
+
+  it "leaves a membership alone after a normal FX re-fixing" do
+    inr_product = create(:subscription_product, user: seller)
+    Redis::Namespace.new(:currencies, redis: $redis).set("INR", "80")
+    subscription = create_membership(link: inr_product)
+    inr_product.update_column(:price_currency_type, Currency::INR)
+    subscription.original_purchase.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 80_000,
+      rate_converted_to_usd: "80"
+    )
+    # An FX re-fixing keeps the fixed price and moves only the canonical USD value.
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: LaterChargePresentment.canonical_price_cents_for(subscription.original_purchase) + 1_00,
+      signup_currency_units_per_usd: BigDecimal("85")
+    )
+    mandate = Stripe::Mandate.construct_from(id: "mandate_active", status: "active", payment_method: "pm_shared")
+    allow_any_instance_of(Subscription).to receive(:indian_card_mandate_for)
+      .with(card.id).and_return([mandate, "active", nil])
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 0, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription.reload).not_to be_renewal_disabled_due_to_indian_card_mandate
+  end
+
+  it "pauses a membership whose fixing collapses to canonical USD terms" do
+    subscription = create_membership
+    # An NZD fixing cannot carry an India mandate, and the USD-listed product offers no
+    # recovery currency, so terms fall back to USD — incoherent with the stored fixing.
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::NZD,
+      presentment_price_cents: 1_700,
+      canonical_price_cents: LaterChargePresentment.canonical_price_cents_for(subscription.original_purchase),
+      signup_currency_units_per_usd: BigDecimal("1.7")
+    )
+
+    expect_any_instance_of(Subscription).not_to receive(:indian_card_mandate_for)
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 1, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription.reload).to be_renewal_disabled_due_to_indian_card_mandate
+  end
+
+  it "leaves a full-price fixing alone after a limited-duration discount expires" do
+    inr_product = create(:subscription_product, user: seller)
+    Redis::Namespace.new(:currencies, redis: $redis).set("INR", "80")
+    subscription = create_membership(link: inr_product)
+    inr_product.update_column(:price_currency_type, Currency::INR)
+    # The signup purchase keeps the discounted price; the renewal lane re-fixed the full
+    # price when the discount ran out.
+    subscription.original_purchase.update_columns(
+      displayed_price_currency_type: Currency::INR,
+      displayed_price_cents: 40_000,
+      rate_converted_to_usd: "80"
+    )
+    allow_any_instance_of(Subscription).to receive(:current_subscription_price_cents).and_return(80_000)
+    allow_any_instance_of(Subscription).to receive(:renewal_pre_discount_total_cents).and_return(80_000)
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: 10_00,
+      signup_currency_units_per_usd: BigDecimal("80")
+    )
+    mandate = Stripe::Mandate.construct_from(id: "mandate_active", status: "active", payment_method: "pm_shared")
+    allow_any_instance_of(Subscription).to receive(:indian_card_mandate_for)
+      .with(card.id).and_return([mandate, "active", nil])
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 0, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription.reload).not_to be_renewal_disabled_due_to_indian_card_mandate
+  end
+
+  it "does not pause a membership that recovers during the scan" do
+    subscription = create_membership
+    service = described_class.new(seller_id: seller.id, dry_run: false)
+    allow(service).to receive(:at_risk?).and_wrap_original do |original, sub, checked_card|
+      sub.update!(stripe_mandate_id: "mandate_recovered_mid_scan")
+      original.call(sub, checked_card)
+    end
+
+    result = service.process
+
+    expect(result).to eq(scanned: 1, paused: 0, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription.reload).not_to be_renewal_disabled_due_to_indian_card_mandate
+    expect(subscription).not_to be_indian_card_mandate_requires_reauthorization
+    expect(CustomerLowPriorityMailer).not_to have_received(:subscription_indian_card_mandate_invalid)
+  end
+
   it "skips a membership when the mandate check fails" do
     subscription = create_membership
     create(
@@ -219,7 +410,7 @@ describe Onetime::PauseIndianCardMandateRenewals do
       owner: subscription,
       presentment_currency: Currency::INR,
       presentment_price_cents: 80_000,
-      canonical_price_cents: 10_00,
+      canonical_price_cents: LaterChargePresentment.canonical_price_cents_for(subscription.original_purchase),
       signup_currency_units_per_usd: BigDecimal("80")
     )
     allow_any_instance_of(Subscription).to receive(:indian_card_mandate_for)
@@ -240,7 +431,7 @@ describe Onetime::PauseIndianCardMandateRenewals do
       owner: subscription,
       presentment_currency: Currency::INR,
       presentment_price_cents: 80_000,
-      canonical_price_cents: 10_00,
+      canonical_price_cents: LaterChargePresentment.canonical_price_cents_for(subscription.original_purchase),
       signup_currency_units_per_usd: BigDecimal("80")
     )
     allow_any_instance_of(Subscription).to receive(:indian_card_mandate_for)

--- a/spec/services/onetime/pause_indian_card_mandate_renewals_spec.rb
+++ b/spec/services/onetime/pause_indian_card_mandate_renewals_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Onetime::PauseIndianCardMandateRenewals do
+  let(:seller) { create(:user) }
+  let(:product) { create(:subscription_product, user: seller) }
+  let(:buyer) { create(:user) }
+  let(:card) do
+    CreditCard.create!(
+      charge_processor_id: StripeChargeProcessor.charge_processor_id,
+      stripe_customer_id: "cus_shared",
+      processor_payment_method_id: "pm_shared",
+      stripe_fingerprint: "fingerprint_shared",
+      visual: "**** **** **** 4242",
+      card_type: CardType::VISA,
+      card_country: Compliance::Countries::IND.alpha2,
+      expiry_month: 12,
+      expiry_year: 2030
+    )
+  end
+  let(:merchant_account) do
+    create(
+      :merchant_account,
+      user: nil,
+      charge_processor_id: StripeChargeProcessor.charge_processor_id,
+      charge_processor_merchant_id: nil
+    )
+  end
+  let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+  before do
+    allow(MerchantAccount).to receive(:gumroad)
+      .with(StripeChargeProcessor.charge_processor_id)
+      .and_return(merchant_account)
+    allow(CustomerLowPriorityMailer).to receive(:subscription_indian_card_mandate_invalid).and_return(mail)
+    Feature.activate_user(StripeChargeProcessor::INDIA_CARD_MANDATE_RELIABILITY_FEATURE, seller)
+  end
+
+  after do
+    Feature.deactivate_user(StripeChargeProcessor::INDIA_CARD_MANDATE_RELIABILITY_FEATURE, seller)
+  end
+
+  def create_membership(credit_card: card, link: product, created_at: 2.months.ago)
+    purchase = create(
+      :membership_purchase,
+      link:,
+      seller: link.user,
+      purchaser: buyer,
+      credit_card:,
+      merchant_account:,
+      stripe_transaction_id: "ch_registration",
+      created_at:
+    )
+    purchase.subscription.update!(user: buyer, credit_card:)
+    purchase.subscription
+  end
+
+  it "does not write, email, or enqueue on a dry run" do
+    subscription = create_membership
+
+    result = nil
+    expect do
+      result = described_class.process(seller_id: seller.id, dry_run: true)
+    end.not_to change { subscription.reload.flags }
+
+    expect(result).to eq(scanned: 1, paused: 1, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription).not_to be_renewal_disabled_due_to_indian_card_mandate
+    expect(subscription).not_to be_indian_card_mandate_requires_reauthorization
+    expect(CustomerLowPriorityMailer).not_to have_received(:subscription_indian_card_mandate_invalid)
+    expect(UnsubscribeAndFailWorker.jobs.size).to eq(0)
+  end
+
+  it "pauses the at-risk membership, keeps access, and emails once" do
+    subscription = create_membership
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 1, already_paused: 0, mandate_check_errors: 0)
+    subscription.reload
+    expect(subscription).to be_alive
+    expect(subscription).to be_renewal_disabled_due_to_indian_card_mandate
+    expect(subscription).to be_indian_card_mandate_requires_reauthorization
+    expect(subscription.status).to eq("payment_method_update_required")
+    expect(CustomerLowPriorityMailer).to have_received(:subscription_indian_card_mandate_invalid)
+      .with(subscription.id).once
+  end
+
+  it "does not email again on a second run" do
+    subscription = create_membership
+    described_class.process(seller_id: seller.id, dry_run: false)
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 0, already_paused: 1, mandate_check_errors: 0)
+    expect(CustomerLowPriorityMailer).to have_received(:subscription_indian_card_mandate_invalid)
+      .with(subscription.id).once
+  end
+
+  it "leaves UnsubscribeAndFailWorker a no-op for a paused membership" do
+    subscription = create_membership
+    described_class.process(seller_id: seller.id, dry_run: false)
+
+    UnsubscribeAndFailWorker.new.perform(subscription.id)
+
+    subscription.reload
+    expect(subscription).to be_alive
+    expect(subscription.failed_at).to be_nil
+  end
+
+  it "skips memberships whose card is not an Indian Stripe card" do
+    non_indian_card = CreditCard.create!(
+      charge_processor_id: StripeChargeProcessor.charge_processor_id,
+      stripe_customer_id: "cus_non_indian",
+      processor_payment_method_id: "pm_non_indian",
+      stripe_fingerprint: "fingerprint_non_indian",
+      visual: "**** **** **** 4242",
+      card_type: CardType::VISA,
+      card_country: Compliance::Countries::USA.alpha2,
+      expiry_month: 12,
+      expiry_year: 2030
+    )
+    subscription = create_membership(credit_card: non_indian_card)
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 0, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription.reload).not_to be_renewal_disabled_due_to_indian_card_mandate
+  end
+
+  it "skips memberships of a seller without the feature flag" do
+    other_seller = create(:user)
+    other_product = create(:subscription_product, user: other_seller)
+    subscription = create_membership(link: other_product)
+
+    result = described_class.process(seller_id: other_seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 0, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription.reload).not_to be_renewal_disabled_due_to_indian_card_mandate
+    expect(CustomerLowPriorityMailer).not_to have_received(:subscription_indian_card_mandate_invalid)
+  end
+
+  it "skips dead memberships" do
+    subscription = create_membership
+    subscription.update!(failed_at: Time.current, deactivated_at: Time.current)
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 0, paused: 0, already_paused: 0, mandate_check_errors: 0)
+  end
+
+  it "leaves a membership with a non-USD fixing and an active mandate alone" do
+    subscription = create_membership
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: 10_00,
+      signup_currency_units_per_usd: BigDecimal("80")
+    )
+    mandate = Stripe::Mandate.construct_from(id: "mandate_active", status: "active", payment_method: "pm_shared")
+    allow_any_instance_of(Subscription).to receive(:indian_card_mandate_for)
+      .with(card.id).and_return([mandate, "active", nil])
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 0, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription.reload).not_to be_renewal_disabled_due_to_indian_card_mandate
+  end
+
+  it "pauses a membership with a non-USD fixing whose mandate is not active" do
+    subscription = create_membership
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: 10_00,
+      signup_currency_units_per_usd: BigDecimal("80")
+    )
+    allow_any_instance_of(Subscription).to receive(:indian_card_mandate_for)
+      .with(card.id).and_return([nil, "inactive", nil])
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 1, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription.reload).to be_renewal_disabled_due_to_indian_card_mandate
+  end
+
+  it "skips a membership when the mandate check fails" do
+    subscription = create_membership
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: 10_00,
+      signup_currency_units_per_usd: BigDecimal("80")
+    )
+    allow_any_instance_of(Subscription).to receive(:indian_card_mandate_for)
+      .and_raise(ChargeProcessorUnavailableError)
+    allow(ErrorNotifier).to receive(:notify)
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 0, already_paused: 0, mandate_check_errors: 1)
+    expect(subscription.reload).not_to be_renewal_disabled_due_to_indian_card_mandate
+  end
+
+  it "does not check Stripe for memberships without a stored fixing" do
+    create_membership
+
+    expect_any_instance_of(Subscription).not_to receive(:indian_card_mandate_for)
+
+    described_class.process(seller_id: seller.id, dry_run: true)
+  end
+end

--- a/spec/services/onetime/pause_indian_card_mandate_renewals_spec.rb
+++ b/spec/services/onetime/pause_indian_card_mandate_renewals_spec.rb
@@ -140,6 +140,30 @@ describe Onetime::PauseIndianCardMandateRenewals do
     expect(CustomerLowPriorityMailer).not_to have_received(:subscription_indian_card_mandate_invalid)
   end
 
+  it "skips memberships with no future charge" do
+    subscription = create_membership
+    subscription.update!(charge_occurrence_count: 1)
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 0, already_paused: 0, mandate_check_errors: 0)
+    expect(subscription.reload).not_to be_renewal_disabled_due_to_indian_card_mandate
+    expect(CustomerLowPriorityMailer).not_to have_received(:subscription_indian_card_mandate_invalid)
+  end
+
+  it "pauses and emails a membership that was renewal-disabled without reauthorization" do
+    subscription = create_membership
+    subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+
+    result = described_class.process(seller_id: seller.id, dry_run: false)
+
+    expect(result).to eq(scanned: 1, paused: 1, already_paused: 0, mandate_check_errors: 0)
+    subscription.reload
+    expect(subscription).to be_indian_card_mandate_requires_reauthorization
+    expect(CustomerLowPriorityMailer).to have_received(:subscription_indian_card_mandate_invalid)
+      .with(subscription.id).once
+  end
+
   it "skips dead memberships" do
     subscription = create_membership
     subscription.update!(failed_at: Time.current, deactivated_at: Time.current)
@@ -206,6 +230,27 @@ describe Onetime::PauseIndianCardMandateRenewals do
 
     expect(result).to eq(scanned: 1, paused: 0, already_paused: 0, mandate_check_errors: 1)
     expect(subscription.reload).not_to be_renewal_disabled_due_to_indian_card_mandate
+    expect(ErrorNotifier).to have_received(:notify).once
+  end
+
+  it "does not notify the error tracker when a mandate check fails on a dry run" do
+    subscription = create_membership
+    create(
+      :later_charge_presentment,
+      owner: subscription,
+      presentment_currency: Currency::INR,
+      presentment_price_cents: 80_000,
+      canonical_price_cents: 10_00,
+      signup_currency_units_per_usd: BigDecimal("80")
+    )
+    allow_any_instance_of(Subscription).to receive(:indian_card_mandate_for)
+      .and_raise(ChargeProcessorUnavailableError)
+
+    expect(ErrorNotifier).not_to receive(:notify)
+
+    result = described_class.process(seller_id: seller.id, dry_run: true)
+
+    expect(result).to eq(scanned: 1, paused: 0, already_paused: 0, mandate_check_errors: 1)
   end
 
   it "does not check Stripe for memberships without a stored fixing" do

--- a/spec/services/subscription/updater_service_spec.rb
+++ b/spec/services/subscription/updater_service_spec.rb
@@ -3637,7 +3637,8 @@ describe Subscription::UpdaterService, :vcr do
       allow(ChargeProcessor).to receive(:get_mandate).and_return(mandate)
       expect(subscription).to receive(:indian_card_mandate_terms).with(
         billing_info: nil,
-        authenticated_offer_code_buyer: nil
+        authenticated_offer_code_buyer: nil,
+        fixed_rate: nil
       ).and_call_original
 
       mandate_validation = service.send(:validate_indian_card_mandate!, replacement_card)
@@ -3648,6 +3649,64 @@ describe Subscription::UpdaterService, :vcr do
       expect(subscription).not_to be_renewal_disabled_due_to_indian_card_mandate
       expect(subscription).not_to be_indian_card_mandate_requires_reauthorization
       expect(subscription.stripe_mandate_id).to eq("mandate_active")
+    end
+
+    it "validates against the rate stamped on the setup intent after a cache refresh" do
+      product.update_column(:price_currency_type, Currency::INR)
+      original_purchase.update_columns(
+        displayed_price_currency_type: Currency::INR,
+        displayed_price_cents: 80_000,
+        price_cents: 10_00,
+        total_transaction_cents: 10_00,
+        rate_converted_to_usd: "80"
+      )
+      currencies = Redis::Namespace.new(:currencies, redis: $redis)
+      currencies.set("INR", "80")
+      subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+      subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+      subscription.reload
+
+      terms, mandate_rate = subscription.indian_card_mandate_terms_with_rate
+      expect(terms).to include(currency: Currency::INR)
+      expect(mandate_rate).to eq("80.0")
+      stamped_mandate_options = Stripe::StripeObject.construct_from(
+        amount_type: "maximum",
+        amount: terms[:amount],
+        currency: terms[:currency],
+        reference: StripeChargeProcessor.indian_card_mandate_reference(subscription.external_id),
+        interval: terms[:interval],
+        interval_count: terms[:interval_count],
+        supported_types: ["india"]
+      )
+      setup_intent = instance_double(
+        StripeSetupIntent,
+        succeeded?: true,
+        mandate: "mandate_inr_pinned",
+        payment_method_id: "pm_replacement",
+        customer_id: "cus_replacement",
+        usage: "off_session",
+        metadata: {
+          gumroad_subscription_id: subscription.external_id,
+          gumroad_mandate_rate: mandate_rate
+        },
+        card_mandate_options: stamped_mandate_options
+      )
+      mandate = Stripe::Mandate.construct_from(
+        id: "mandate_inr_pinned",
+        status: "active",
+        payment_method: "pm_replacement"
+      )
+      allow(ChargeProcessor).to receive(:get_setup_intent).and_return(setup_intent)
+      allow(ChargeProcessor).to receive(:get_mandate).and_return(mandate)
+
+      currencies.set("INR", "85")
+
+      mandate_validation = service.send(:validate_indian_card_mandate!, replacement_card)
+      service.send(:update_subscription_credit_card!, replacement_card, **mandate_validation)
+
+      subscription.reload
+      expect(subscription.stripe_mandate_id).to eq("mandate_inr_pinned")
+      expect(subscription).not_to be_indian_card_mandate_requires_reauthorization
     end
 
     it "recovers a listed-INR membership with no stored fixing through an INR reauthorization" do

--- a/spec/services/subscription/updater_service_spec.rb
+++ b/spec/services/subscription/updater_service_spec.rb
@@ -3709,6 +3709,73 @@ describe Subscription::UpdaterService, :vcr do
       expect(subscription).not_to be_indian_card_mandate_requires_reauthorization
     end
 
+    it "restores the renewal fixing after a prorated upgrade re-fixes its own amount" do
+      product.update_column(:price_currency_type, Currency::INR)
+      original_purchase.update_columns(
+        displayed_price_currency_type: Currency::INR,
+        displayed_price_cents: 80_000,
+        price_cents: 10_00,
+        total_transaction_cents: 10_00,
+        rate_converted_to_usd: "80"
+      )
+      Redis::Namespace.new(:currencies, redis: $redis).set("INR", "80")
+      subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+      subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+      subscription.reload
+      terms = subscription.indian_card_mandate_terms
+      stamped_mandate_options = Stripe::StripeObject.construct_from(
+        amount_type: "maximum",
+        amount: terms[:amount],
+        currency: terms[:currency],
+        reference: StripeChargeProcessor.indian_card_mandate_reference(subscription.external_id),
+        interval: terms[:interval],
+        interval_count: terms[:interval_count],
+        supported_types: ["india"]
+      )
+      setup_intent = instance_double(
+        StripeSetupIntent,
+        succeeded?: true,
+        mandate: "mandate_inr_upgrade",
+        payment_method_id: "pm_replacement",
+        customer_id: "cus_replacement",
+        usage: "off_session",
+        metadata: { gumroad_subscription_id: subscription.external_id },
+        card_mandate_options: stamped_mandate_options
+      )
+      mandate = Stripe::Mandate.construct_from(
+        id: "mandate_inr_upgrade",
+        status: "active",
+        payment_method: "pm_replacement"
+      )
+      allow(ChargeProcessor).to receive(:get_setup_intent).and_return(setup_intent)
+      allow(ChargeProcessor).to receive(:get_mandate).and_return(mandate)
+
+      mandate_validation = service.send(:validate_indian_card_mandate!, replacement_card)
+      service.send(:update_subscription_credit_card!, replacement_card, **mandate_validation)
+
+      # The fixing exists before the charge, so a required-INR upgrade can proceed.
+      expect(subscription.reload.current_later_charge_presentment).to have_attributes(
+        presentment_price_cents: 80_000
+      )
+
+      # The prorated upgrade re-fixed its own amount during the charge.
+      subscription.later_charge_presentments.create!(
+        processor: StripeChargeProcessor.charge_processor_id,
+        presentment_currency: Currency::INR,
+        presentment_price_cents: 30_000,
+        canonical_price_cents: 3_75,
+        signup_currency_units_per_usd: BigDecimal("80"),
+        effective_from: Time.current
+      )
+
+      service.send(:record_mandate_presentment_after_charge!)
+
+      expect(subscription.reload.current_later_charge_presentment).to have_attributes(
+        presentment_currency: Currency::INR,
+        presentment_price_cents: 80_000
+      )
+    end
+
     it "recovers a listed-INR membership with no stored fixing through an INR reauthorization" do
       product.update_column(:price_currency_type, Currency::INR)
       original_purchase.update_columns(

--- a/spec/services/subscription/updater_service_spec.rb
+++ b/spec/services/subscription/updater_service_spec.rb
@@ -3650,6 +3650,54 @@ describe Subscription::UpdaterService, :vcr do
       expect(subscription.stripe_mandate_id).to eq("mandate_active")
     end
 
+    it "recovers a listed-INR membership with no stored fixing through an INR reauthorization" do
+      product.update_column(:price_currency_type, Currency::INR)
+      original_purchase.update_columns(
+        displayed_price_currency_type: Currency::INR,
+        displayed_price_cents: 80_000,
+        price_cents: 10_00,
+        total_transaction_cents: 10_00,
+        rate_converted_to_usd: "80"
+      )
+      Redis::Namespace.new(:currencies, redis: $redis).set("INR", "80")
+      subscription.update_flag!(:renewal_disabled_due_to_indian_card_mandate, true, true)
+      subscription.update_flag!(:indian_card_mandate_requires_reauthorization, true, true)
+      subscription.reload
+
+      expect(subscription.indian_card_mandate_terms).to include(currency: Currency::INR)
+
+      setup_intent = instance_double(
+        StripeSetupIntent,
+        succeeded?: true,
+        mandate: "mandate_inr_recovery",
+        payment_method_id: "pm_replacement",
+        customer_id: "cus_replacement",
+        usage: "off_session",
+        metadata: { gumroad_subscription_id: subscription.external_id },
+        card_mandate_options: mandate_options
+      )
+      mandate = Stripe::Mandate.construct_from(
+        id: "mandate_inr_recovery",
+        status: "active",
+        payment_method: "pm_replacement"
+      )
+      allow(ChargeProcessor).to receive(:get_setup_intent).and_return(setup_intent)
+      allow(ChargeProcessor).to receive(:get_mandate).and_return(mandate)
+
+      mandate_validation = service.send(:validate_indian_card_mandate!, replacement_card)
+      service.send(:update_subscription_credit_card!, replacement_card, **mandate_validation)
+
+      subscription.reload
+      expect(subscription).not_to be_renewal_disabled_due_to_indian_card_mandate
+      expect(subscription).not_to be_indian_card_mandate_requires_reauthorization
+      expect(subscription.stripe_mandate_id).to eq("mandate_inr_recovery")
+      expect(subscription.current_later_charge_presentment).to have_attributes(
+        presentment_currency: Currency::INR,
+        presentment_price_cents: 80_000,
+        canonical_price_cents: 10_00
+      )
+    end
+
     it "rejects a replacement card without an active mandate" do
       setup_intent = instance_double(
         StripeSetupIntent,


### PR DESCRIPTION
Ref antiwork/gumroad-private#1410. Stacked on #7239, which pauses renewals when an Indian-card membership has no usable mandate. This layer adds the recovery.

## What

For flagged sellers, buyer-approved reauthorization of an Indian card now happens in rupees:

- A listed-INR membership with no stored INR amount collects its replacement mandate in INR instead of USD. Stripe rejects USD e-mandates for many Indian issuers, so USD reauthorization could never succeed for the affected cohort.
- When reauthorization completes, the subscription records its listed-INR renewal amount. Later renewals bill in INR against the new mandate instead of pausing again.
- Before reauthorization, a renewal for this cohort stops before any Stripe call and lands on the #7239 pause path. No saved card is ever retried in INR without the buyer's approval.
- `Onetime::PauseIndianCardMandateRenewals` pauses the whole at-risk cohort for one seller up front: one "update your payment method" email, access kept, no scheduled termination. It takes `seller_id:` and defaults to a dry run.

## Why

#7239 stops the bleeding but leaves the known cohort stuck: the product lists INR, historical charges settled in USD, and Stripe will not issue an India recurring mandate in USD for those cards. Stripe's instruction is to collect the mandate in INR. This PR follows it on the reauthorization, renewal, and one-time paths, without a product currency change and without touching historical records outside the buyer-approved flow.

## Before / after

No UI or email copy changes in this layer; the banner and email from #7239 stay as they are (see the before/after in #7239). The buyer-visible difference is the Stripe bank sheet showing a rupee amount during reauthorization.

## Test results

- `spec/services/onetime/pause_indian_card_mandate_renewals_spec.rb` (new)
- `spec/models/purchase_indian_card_mandate_spec.rb`
- `spec/services/subscription/updater_service_spec.rb` (full suite)
- `spec/controllers/stripe/setup_intents_controller_spec.rb`, `spec/sidekiq/recurring_charge_worker_spec.rb`
- `spec/services/purchase/later_charge_presentment_service_spec.rb`, `spec/models/later_charge_presentment_spec.rb`
- Revert check: the new specs fail with the application change reverted
- `bundle exec rubocop` clean on changed files

## Rollout

Off by default; the flag stays off. After deploy: enable the flag for the seller, dry-run the onetime with `seller_id:`, then run it for real. The real run is what pauses and emails.

---

This PR was implemented with AI assistance using Claude Fable 5.
