### PR TITLE
Stop the ffprobe rotation specs racing the garbage collector

### DIFF
--- a/spec/lib/utilities/ffprobe_spec.rb
+++ b/spec/lib/utilities/ffprobe_spec.rb
@@ -6,7 +6,7 @@ describe Ffprobe do
   describe "#parse" do
     context "when a valid movie file is supplied" do
       let(:ffprobe_parsed) do
-        Ffprobe.new(fixture_file_upload("sample.mov")).parse
+        Ffprobe.new(file_fixture("sample.mov")).parse
       end
 
       expected_ffprobe_data = {
@@ -71,8 +71,11 @@ describe Ffprobe do
     # viewer sees, which is what streamio-ffmpeg already reports for every other
     # format we accept. See https://github.com/antiwork/gumroad-private/issues/1392
     context "when the video carries rotation metadata" do
+      # file_fixture, not fixture_file_upload: the latter hands back a Tempfile
+      # that nothing references once Ffprobe has copied the path out, and a GC
+      # during the stubbing below unlinks it before parse reads it.
       def parsed_with(stream_attributes)
-        probe = Ffprobe.new(fixture_file_upload("sample.mov"))
+        probe = Ffprobe.new(file_fixture("sample.mov"))
         allow(probe).to receive(:`).and_return({ streams: [{ width: 1920, height: 1080, r_frame_rate: "30/1" }.merge(stream_attributes)] }.to_json)
         probe.parse
       end


### PR DESCRIPTION
## What

`spec/lib/utilities/ffprobe_spec.rb` builds its subject from
`fixture_file_upload("sample.mov")`, which hands back a `Tempfile` copy.
`Ffprobe` keeps only the path:

```ruby
def initialize(path)
  @path = File.expand_path(path)
end
```

Once the path is copied out, nothing references the `Tempfile`. If a garbage
collection lands before `parse` runs, the finalizer unlinks the file and the
example dies on `File not found`.

Both call sites now use `file_fixture`, which returns a path to the real fixture
and never goes away. The context on line 37 already did this, so the file is
consistent with itself now.

## Why

Seen on #7271
([job](https://github.com/antiwork/gumroad/actions/runs/32031373448/job/95391998794)),
where it took a shard down and fail-fast cancelled 13 more:

```
Ffprobe#parse when the video carries rotation metadata reports the displayed
dimensions when a leftover zero rotate tag sits next to a three-quarter turn
in the display matrix
  ArgumentError: File not found /tmp/sample20260817-28-lk15x8.mov
```

Five sibling examples share the pattern and passed in the same run, so the
trigger is collection timing, not the assertion.

The rotation context is the one that fails because it stubs the backtick
between building the subject and parsing. That work allocates, which is what
invites the collection. The other two contexts have a much smaller window, and
the same latent problem, so they are fixed here too.

Only the test is affected. Real callers hand `Ffprobe` a path that outlives the
call.

## Before / After

No video: this is a test-only change with no user-facing surface.

Adding `GC.start` between building the subject and parsing makes the timing
certain, which shows the difference:

Before, with `fixture_file_upload`:

```
$ bundle exec rspec spec/lib/utilities/ffprobe_spec.rb -e "rotation metadata"
Failure/Error: raise ArgumentError, "File not found #{path}" unless File.exist?(path)
  File not found /var/folders/48/.../T/sample20260817-8533-ln74oo.mov
```

After, with `file_fixture`:

```
$ bundle exec rspec spec/lib/utilities/ffprobe_spec.rb -e "rotation metadata"
8 examples, 0 failures
```

The `GC.start` was for the demonstration and is not in the diff.

## Test Results

- `bundle exec rspec spec/lib/utilities/ffprobe_spec.rb` — 20 examples, 0 failures.
- The same file with `fixture_file_upload` restored and a forced collection reproduces the CI failure. With `file_fixture` it passes.
- `bundle exec rubocop spec/lib/utilities/ffprobe_spec.rb` — clean.
- No other spec passes `fixture_file_upload` to `Ffprobe`.
- `ruby bin/branch-specs` maps this diff to the spec itself, so no label is needed.

---

AI disclosure: written with Claude Opus 5.
