### PR TITLE
Expose per-version descriptions to screen readers on the product page

### DIFF
--- a/app/javascript/components/Product/ConfigurationSelector.options.test.tsx
+++ b/app/javascript/components/Product/ConfigurationSelector.options.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  ConfigurationSelector,
+  type PriceSelection,
+  type Product,
+} from "$app/components/Product/ConfigurationSelector";
+
+afterEach(cleanup);
+
+const versionedProduct: Product = {
+  permalink: "album",
+  rental: null,
+  options: [
+    {
+      id: "opt-listener",
+      name: "Listener's Edition",
+      quantity_left: null,
+      description: "Enjoy the complete album in a simple digital edition.",
+      price_difference_cents: 0,
+      recurrence_price_values: null,
+      is_pwyw: false,
+      duration_in_minutes: null,
+    },
+    {
+      id: "opt-collector",
+      name: "Collector's Edition",
+      quantity_left: null,
+      description: "",
+      price_difference_cents: 500,
+      recurrence_price_values: null,
+      is_pwyw: false,
+      duration_in_minutes: null,
+    },
+  ],
+  currency_code: "usd",
+  price_cents: 999,
+  installment_plan: null,
+  is_tiered_membership: false,
+  is_legacy_subscription: false,
+  is_quantity_enabled: false,
+  is_multiseat_license: false,
+  quantity_remaining: null,
+  recurrences: null,
+  pwyw: null,
+  ppp_details: null,
+  native_type: "digital",
+};
+
+const initialSelection: PriceSelection = {
+  rent: false,
+  optionId: "opt-listener",
+  price: { error: false, value: null },
+  quantity: 1,
+  recurrence: null,
+  callStartTime: null,
+  payInInstallments: false,
+};
+
+const renderSelector = () => {
+  const Harness = () => {
+    const [selection, setSelection] = React.useState(initialSelection);
+    return (
+      <ConfigurationSelector
+        product={versionedProduct}
+        selection={selection}
+        setSelection={setSelection}
+        discount={null}
+      />
+    );
+  };
+  render(<Harness />);
+};
+
+describe("version selector accessibility", () => {
+  it("exposes each version's description to screen readers via aria-describedby", () => {
+    renderSelector();
+
+    const radio = screen.getByRole("radio", { name: "Listener's Edition" });
+    const describedBy = radio.getAttribute("aria-describedby");
+    if (!describedBy) throw new Error("expected aria-describedby on the version radio");
+    const description = document.getElementById(describedBy);
+    expect(description?.textContent).toBe("Enjoy the complete album in a simple digital edition.");
+  });
+
+  it("omits aria-describedby when a version has no description", () => {
+    renderSelector();
+
+    const radio = screen.getByRole("radio", { name: "Collector's Edition" });
+    expect(radio.getAttribute("aria-describedby")).toBeNull();
+  });
+});

--- a/app/javascript/components/Product/ConfigurationSelector.tsx
+++ b/app/javascript/components/Product/ConfigurationSelector.tsx
@@ -327,6 +327,10 @@ export const OptionRadioButton = ({
   priceCents ??= 0;
   const { value: discountedPriceCents } = computeSelectionDiscountedPrice(priceCents, discount, product, quantity);
   const buyerLocalContext = buyerLocalContextFor(product);
+  // aria-label overrides the button's content for screen readers, so the rendered
+  // description must be re-exposed via aria-describedby or it is never announced.
+  const uid = React.useId();
+  const descriptionId = description ? `${uid}-description` : undefined;
   return (
     <Tab isSelected={selected} asChild className={recurrence ? "flex-col" : undefined}>
       <Button
@@ -334,6 +338,7 @@ export const OptionRadioButton = ({
         aria-checked={selected}
         disabled={disabled}
         aria-label={name}
+        aria-describedby={descriptionId}
         onClick={onClick}
         itemProp="offer"
         itemType="https://schema.org/Offer"
@@ -371,7 +376,7 @@ export const OptionRadioButton = ({
           <h4>{name}</h4>
           {quantityLeft != null ? <small className="block">{`${quantityLeft} left`}</small> : null}
           {description ? (
-            <div>
+            <div id={descriptionId}>
               <Breaklines text={description} />
             </div>
           ) : null}


### PR DESCRIPTION
# Expose per-version descriptions to screen readers on the product page

> Draft status: code and unit tests are on the branch. Preview-app keyboard/screen-reader pass and the pre-merge QA audit are still owed.

Addresses antiwork/gumroad-private#2187

## What

The version selector's `OptionRadioButton` sets `aria-label={name}`, which overrides the button's rendered content for assistive tech — so the per-version description (rendered via `<Breaklines>`) was visible to sighted buyers but never announced to a screen reader. Each option now points `aria-describedby` at its description element, so screen readers announce the version name and then its description.

## Why

A blind creator filled in per-version descriptions (saved and rendered correctly) and reported that a screen-reader user reaching the version selector hears only the radio-button names, never the descriptions. Third finding in the same custom-widget class (#2183 call picker, #2186 PWYW input).

## Before / after

- Before: option button accessible name = version name only; description not in the accessibility tree from the radio's perspective.
- After: option button has `aria-describedby` → the rendered description element; versions without a description are unchanged (no dangling `aria-describedby`).

Preview screenshots are owed on the hosted branch app.

## Checklist

- [x] Scope — product-page version selector (`OptionRadioButton`) only; rent/buy pair gets the same fix for free since it uses the same component
- [x] Design — `aria-describedby` pointing at the existing rendered description, no duplicate text node; rejected removing `aria-label` (it also names the Offer for schema.org consumers and the name-only announcement is correct)
- [x] Build — `2da38a527`
- [ ] QA — preview-app keyboard/screen-reader pass still owed
- [ ] Shipped — draft
- [x] Market — n/a (accessibility bugfix)
- [x] Sell — n/a

## Test Results

- `npx vitest run app/javascript/components/Product/ConfigurationSelector.options.test.tsx` — 2 passed (1 file) at `2da38a527`
- Same file against pre-fix code (`git stash`) — the aria-describedby example fails (attribute absent), the no-description example passes by construction
- `npx prettier --write` on both files — unchanged

## QA steps

Owed on the hosted preview after this draft is up:

1. Open a product with versions that have descriptions.
2. With VoiceOver, reach the version selector; confirm each version announces its name and then its description.
3. Confirm a version with an empty description announces only its name (no stray "describedby" artifacts).
4. Confirm mouse/keyboard selection behavior is unchanged.

---

AI disclosure: grok-4.6. Prompt/instructions: handle the opened private issue to expose per-version descriptions on the product page to screen readers.

Premerge review: clean @ 6cc9c56e2700ffbaca3d2c6ef1f66fa3d9ff3ec6
