### PR TITLE
Announce version price and stock to screen readers on the product page

### DIFF
--- a/app/javascript/components/Product/ConfigurationSelector.options.test.tsx
+++ b/app/javascript/components/Product/ConfigurationSelector.options.test.tsx
@@ -18,7 +18,7 @@ const versionedProduct: Product = {
     {
       id: "opt-listener",
       name: "Listener's Edition",
-      quantity_left: null,
+      quantity_left: 5,
       description: "Enjoy the complete album in a simple digital edition.",
       price_difference_cents: 0,
       recurrence_price_values: null,
@@ -75,21 +75,28 @@ const renderSelector = () => {
   render(<Harness />);
 };
 
+const describedByTexts = (radio: HTMLElement) => {
+  const describedBy = radio.getAttribute("aria-describedby");
+  if (!describedBy) throw new Error("expected aria-describedby on the version radio");
+  return describedBy.split(" ").map((id) => document.getElementById(id)?.textContent ?? "");
+};
+
 describe("version selector accessibility", () => {
-  it("exposes each version's description to screen readers via aria-describedby", () => {
+  it("exposes price, stock, and description to screen readers via aria-describedby", () => {
     renderSelector();
 
-    const radio = screen.getByRole("radio", { name: "Listener's Edition" });
-    const describedBy = radio.getAttribute("aria-describedby");
-    if (!describedBy) throw new Error("expected aria-describedby on the version radio");
-    const description = document.getElementById(describedBy);
-    expect(description?.textContent).toBe("Enjoy the complete album in a simple digital edition.");
+    const texts = describedByTexts(screen.getByRole("radio", { name: "Listener's Edition" }));
+    expect(texts).toHaveLength(3);
+    expect(texts[0]).toContain("$9.99");
+    expect(texts[1]).toBe("5 left");
+    expect(texts[2]).toBe("Enjoy the complete album in a simple digital edition.");
   });
 
-  it("omits aria-describedby when a version has no description", () => {
+  it("omits the stock and description references when a version has neither", () => {
     renderSelector();
 
-    const radio = screen.getByRole("radio", { name: "Collector's Edition" });
-    expect(radio.getAttribute("aria-describedby")).toBeNull();
+    const texts = describedByTexts(screen.getByRole("radio", { name: "Collector's Edition" }));
+    expect(texts).toHaveLength(1);
+    expect(texts[0]).toContain("$14.99");
   });
 });

--- a/app/javascript/components/Product/ConfigurationSelector.tsx
+++ b/app/javascript/components/Product/ConfigurationSelector.tsx
@@ -327,10 +327,14 @@ export const OptionRadioButton = ({
   priceCents ??= 0;
   const { value: discountedPriceCents } = computeSelectionDiscountedPrice(priceCents, discount, product, quantity);
   const buyerLocalContext = buyerLocalContextFor(product);
-  // aria-label overrides the button's content for screen readers, so the rendered
-  // description must be re-exposed via aria-describedby or it is never announced.
+  // aria-label overrides the button's content for screen readers, so everything
+  // rendered inside (price, stock, description) must be re-exposed via
+  // aria-describedby or it is never announced.
   const uid = React.useId();
+  const priceId = hidePrice ? undefined : `${uid}-price`;
+  const quantityLeftId = quantityLeft != null ? `${uid}-quantity-left` : undefined;
   const descriptionId = description ? `${uid}-description` : undefined;
+  const describedBy = [priceId, quantityLeftId, descriptionId].filter(Boolean).join(" ") || undefined;
   return (
     <Tab isSelected={selected} asChild className={recurrence ? "flex-col" : undefined}>
       <Button
@@ -338,7 +342,7 @@ export const OptionRadioButton = ({
         aria-checked={selected}
         disabled={disabled}
         aria-label={name}
-        aria-describedby={descriptionId}
+        aria-describedby={describedBy}
         onClick={onClick}
         itemProp="offer"
         itemType="https://schema.org/Offer"
@@ -351,7 +355,7 @@ export const OptionRadioButton = ({
           </Alert>
         ) : null}
         {hidePrice ? null : (
-          <Pill className="shrink-0">
+          <Pill id={priceId} className="shrink-0">
             {discountedPriceCents < priceCents ? (
               <>
                 <s>{formatBuyerLocalOrSetPrice(priceCents, buyerLocalContext)}</s>{" "}
@@ -374,7 +378,7 @@ export const OptionRadioButton = ({
         )}
         <div>
           <h4>{name}</h4>
-          {quantityLeft != null ? <small className="block">{`${quantityLeft} left`}</small> : null}
+          {quantityLeft != null ? <small id={quantityLeftId} className="block">{`${quantityLeft} left`}</small> : null}
           {description ? (
             <div id={descriptionId}>
               <Breaklines text={description} />


### PR DESCRIPTION
Follow-up to #7282.

## What

The version selector's option buttons set `aria-label`, which overrides the rendered content for assistive tech. #7282 re-exposed the description via `aria-describedby`. The price pill and the "N left" stock note stayed silent. Each option's `aria-describedby` now references the price, the stock note, and the description, in render order. Absent parts produce no reference.

## Why

Price and remaining stock are purchase-relevant details that sighted buyers see on the same button, and a screen-reader user heard only the version name and description. Same custom-widget class as the call picker, PWYW input, and version description findings.

## Design

- The description references the existing rendered elements. No text is duplicated.
- The price pill contains hidden schema.org microdata children. Assistive tech excludes hidden descendants when it computes a description, so only the visible price text is announced.
- `aria-label` stays unchanged, so the accessible name and the schema.org `Offer` name keep their current values.

## Before / after

- Before: option announcement = name + description.
- After: option announcement = name + price + stock + description.
- An option renders no reference for a part it lacks; the tests cover this.

Video is owed on the hosted branch app.

## Test Results

- `npx vitest run app/javascript/components/Product/ConfigurationSelector.options.test.tsx` — 2 passed at `23547d2bc` (re-run after the rebase onto `main`).
- Same file against the pre-change component (`git stash`) — both tests fail, so the tests guard the change.
- `npx prettier --check` and `DISABLE_TYPE_CHECKED=1 npx eslint` on both files — clean.

## QA steps

Owed on the hosted preview:

1. Open a product with versions that have descriptions and limited stock.
2. With VoiceOver, reach the version selector. Confirm each version announces its name, then its price, stock, and description.
3. Confirm a version without a stock note or description announces only the parts it renders.
4. Confirm mouse and keyboard selection behavior is unchanged.

---

AI disclosure: Claude Fable 5.
