### PR TITLE
Block no-refunds claims in refund-policy fine print

### DIFF
--- a/app/controllers/settings/main_controller.rb
+++ b/app/controllers/settings/main_controller.rb
@@ -28,8 +28,8 @@ class Settings::MainController < Settings::BaseController
     current_seller.update_product_level_support_emails!(params[:user][:product_level_support_emails])
 
     redirect_to settings_main_path, status: :see_other, notice: "Your account has been updated!"
-  rescue ActiveRecord::RecordInvalid
-    error_message = current_seller.errors.full_messages.to_sentence.presence ||
+  rescue ActiveRecord::RecordInvalid => e
+    error_message = e.record.errors.full_messages.to_sentence.presence ||
       "Something broke. We're looking into what happened. Sorry about this!"
     redirect_to settings_main_path, alert: error_message
   rescue StandardError => e

--- a/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx
@@ -438,7 +438,7 @@ export const CreateProduct = () => (
       />
       <ApiParameter
         name="refund_fine_print"
-        description='(optional) fine print for the product-level refund policy; requires refund_period unless the product already has one enabled, and cannot be combined with refund_period "inherit". Empty string clears it'
+        description='(optional) fine print for the product-level refund policy; requires refund_period unless the product already has one enabled, and cannot be combined with refund_period "inherit". Empty string clears it. Rejected if it states that refunds are not allowed for a non-physical product'
       />
       <ApiParameter
         name="rich_content"
@@ -543,7 +543,7 @@ export const UpdateProduct = () => (
       />
       <ApiParameter
         name="refund_fine_print"
-        description='(optional) fine print for the product-level refund policy; requires refund_period unless the product already has one enabled, and cannot be combined with refund_period "inherit". Empty string clears it'
+        description='(optional) fine print for the product-level refund policy; requires refund_period unless the product already has one enabled, and cannot be combined with refund_period "inherit". Empty string clears it. Rejected if it states that refunds are not allowed for a non-physical product'
       />
       <ApiParameter
         name="custom_html"

--- a/app/javascript/components/ApiDocumentation/Endpoints/RefundPolicy.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/RefundPolicy.tsx
@@ -62,7 +62,7 @@ export const UpdateRefundPolicy = () => (
       />
       <ApiParameter
         name="fine_print"
-        description="Optional. Max 3000 characters. HTML is stripped. Send an empty value to clear it."
+        description="Optional. Max 3000 characters. HTML is stripped. Send an empty value to clear it. Rejected if it states that refunds are not allowed."
       />
     </ApiParameters>
     <ApiResponseFields>

--- a/app/models/product_refund_policy.rb
+++ b/app/models/product_refund_policy.rb
@@ -128,15 +128,4 @@ class ProductRefundPolicy < RefundPolicy
 
       errors.add(:product, :invalid)
     end
-
-    def ask_ai(prompt)
-      OpenAI::Client.new.chat(
-        parameters: {
-          messages: [{ role: "user", content: prompt }],
-          model: "gpt-4o-mini",
-          temperature: 0.0,
-          max_tokens: 10
-        }
-      )
-    end
 end

--- a/app/models/refund_policy.rb
+++ b/app/models/refund_policy.rb
@@ -27,6 +27,8 @@ class RefundPolicy < ApplicationRecord
 
   validates :max_refund_period_in_days, inclusion: { in: ALLOWED_REFUND_PERIODS_IN_DAYS.keys }
 
+  validate :fine_print_cannot_claim_no_refunds, if: -> { fine_print.present? && fine_print_changed? && !allows_no_refunds? }
+
   def self.periods_in_days(allow_no_refunds: false)
     keys = ALLOWED_REFUND_PERIODS_IN_DAYS.keys
     allow_no_refunds ? keys : keys.excluding(NO_REFUNDS_PERIOD_IN_DAYS)
@@ -62,4 +64,48 @@ class RefundPolicy < ApplicationRecord
       title:,
     }
   end
+
+  # Fine print may condition refunds ("refunds only for duplicate purchases") but must not
+  # deny them outright — that would contradict the guaranteed window. Fails open so an
+  # OpenAI outage never blocks saves.
+  def fine_print_claims_no_refunds?
+    response = ask_ai(fine_print_no_refunds_prompt)
+    JSON.parse(response.dig("choices", 0, "message", "content"))["no_refunds"]
+  rescue => e
+    Rails.logger.warn("Error moderating fine print for refund policy #{id}: #{e.message}")
+    false
+  end
+
+  private
+    def fine_print_cannot_claim_no_refunds
+      return unless fine_print_claims_no_refunds?
+
+      errors.add(:fine_print, "cannot state that refunds are not allowed")
+    end
+
+    def fine_print_no_refunds_prompt
+      <<~PROMPT
+        This refund policy guarantees buyers "#{title}". Return {"no_refunds": true} only if you
+        are 100% confident the fine print asserts that refunds are never given at all (e.g.
+        "no refunds", "all sales are final", "this product is non-refundable"), contradicting
+        that guarantee. Fine print that only conditions or limits refunds (e.g. "no refunds
+        after the refund window", "refunds only for duplicate purchases") is allowed: return
+        {"no_refunds": false}.
+
+        <refund policy fine print>
+          #{fine_print}
+        </refund policy fine print>
+      PROMPT
+    end
+
+    def ask_ai(prompt)
+      OpenAI::Client.new.chat(
+        parameters: {
+          messages: [{ role: "user", content: prompt }],
+          model: "gpt-4o-mini",
+          temperature: 0.0,
+          max_tokens: 10
+        }
+      )
+    end
 end

--- a/spec/controllers/api/v2/refund_policies_controller_spec.rb
+++ b/spec/controllers/api/v2/refund_policies_controller_spec.rb
@@ -145,6 +145,23 @@ describe Api::V2::RefundPoliciesController do
         expect(refund_policy.fine_print).to eq("Existing fine print")
       end
 
+      it "rejects fine print that denies refunds" do
+        allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(
+          { "choices" => [{ "message" => { "content" => %({"no_refunds": true}) } }] }
+        )
+        seller.refund_policy.update_columns(max_refund_period_in_days: 30, fine_print: "Existing fine print")
+
+        put :update, params: { access_token: token.token, refund_period: "14", fine_print: "All sales are final. No refunds." }
+
+        expect(response.parsed_body).to eq(
+          "success" => false,
+          "message" => "Fine print cannot state that refunds are not allowed"
+        )
+        refund_policy = seller.refund_policy.reload
+        expect(refund_policy.max_refund_period_in_days).to eq(30)
+        expect(refund_policy.fine_print).to eq("Existing fine print")
+      end
+
       it "strips HTML from fine print" do
         put :update, params: { access_token: token.token, refund_period: "14", fine_print: "<p>Refunds <strong>approved</strong></p>" }
 

--- a/spec/controllers/settings/main_controller_spec.rb
+++ b/spec/controllers/settings/main_controller_spec.rb
@@ -388,6 +388,18 @@ describe Settings::MainController, type: :controller, inertia: true do
           expect(seller.refund_policy.fine_print).to eq("This is a fine print")
         end
 
+        it "rejects fine print that denies refunds with a visible error" do
+          allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(
+            { "choices" => [{ "message" => { "content" => %({"no_refunds": true}) } }] }
+          )
+
+          put :update, params: { user: { seller_refund_policy: { max_refund_period_in_days: "30", fine_print: "All sales are final. No refunds." } } }
+          expect(response).to redirect_to(settings_main_path)
+          expect(flash[:alert]).to eq("Fine print cannot state that refunds are not allowed")
+
+          expect(seller.refund_policy.reload.fine_print).to be_nil
+        end
+
         context "when seller_refund_policy_disabled_for_all feature flag is set to true" do
           before do
             Feature.activate(:seller_refund_policy_disabled_for_all)

--- a/spec/models/product_refund_policy_spec.rb
+++ b/spec/models/product_refund_policy_spec.rb
@@ -170,4 +170,57 @@ describe ProductRefundPolicy do
       expect(refund_policy.published_and_no_refunds?).to be false
     end
   end
+
+  describe "fine print no-refunds moderation" do
+    # let! so the factory (whose fine print trips the stubbed moderation) saves before stubbing
+    let!(:refund_policy) { create(:product_refund_policy) }
+
+    def stub_fine_print_moderation(no_refunds)
+      allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(
+        { "choices" => [{ "message" => { "content" => %({"no_refunds": #{no_refunds}}) } }] }
+      )
+    end
+
+    it "rejects fine print that denies refunds on a digital product" do
+      stub_fine_print_moderation(true)
+      refund_policy.fine_print = "All sales are final. No refunds."
+
+      expect(refund_policy.valid?).to be false
+      expect(refund_policy.errors.full_messages).to include("Fine print cannot state that refunds are not allowed")
+    end
+
+    it "allows fine print that only conditions refunds" do
+      stub_fine_print_moderation(false)
+      refund_policy.fine_print = "Refunds are only issued for duplicate purchases."
+
+      expect(refund_policy.valid?).to be true
+    end
+
+    it "allows no-refunds fine print on a physical product" do
+      refund_policy.product.update_columns(
+        flags: refund_policy.product.flags | Link.flag_mapping["flags"][:is_physical],
+        native_type: "physical"
+      )
+      refund_policy.product.reload
+      expect(OpenAI::Client).not_to receive(:new)
+      refund_policy.fine_print = "All sales are final. No refunds."
+
+      expect(refund_policy.valid?).to be true
+    end
+
+    it "skips moderation when the fine print is unchanged" do
+      refund_policy.update_columns(fine_print: "All sales are final. No refunds.")
+      expect(OpenAI::Client).not_to receive(:new)
+      refund_policy.max_refund_period_in_days = 14
+
+      expect(refund_policy.valid?).to be true
+    end
+
+    it "fails open when the moderation call errors" do
+      allow_any_instance_of(OpenAI::Client).to receive(:chat).and_raise(StandardError.new("timeout"))
+      refund_policy.fine_print = "All sales are final. No refunds."
+
+      expect(refund_policy.valid?).to be true
+    end
+  end
 end

--- a/spec/models/seller_refund_policy_spec.rb
+++ b/spec/models/seller_refund_policy_spec.rb
@@ -65,6 +65,25 @@ describe SellerRefundPolicy do
         expect(refund_policy.max_refund_period_in_days).to eq(7)
       end
     end
+
+    it "rejects fine print that denies refunds" do
+      allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(
+        { "choices" => [{ "message" => { "content" => %({"no_refunds": true}) } }] }
+      )
+      refund_policy.fine_print = "All sales are final. No refunds."
+
+      expect(refund_policy.valid?).to be false
+      expect(refund_policy.errors.full_messages).to include("Fine print cannot state that refunds are not allowed")
+    end
+
+    it "allows fine print that only conditions refunds" do
+      allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(
+        { "choices" => [{ "message" => { "content" => %({"no_refunds": false}) } }] }
+      )
+      refund_policy.fine_print = "Refunds are only issued for duplicate purchases."
+
+      expect(refund_policy.valid?).to be true
+    end
   end
 
   describe "stripped_fields" do


### PR DESCRIPTION
## What

Refund-policy fine print stays, but it can no longer assert that refunds are never given. Saving a policy whose fine print claims "no refunds" / "all sales are final" is rejected with a validation error — in seller settings, the product and bundle editors, and the public API (`PUT /v2/refund_policy`, `POST/PUT /v2/products`). Physical products are exempt: they may still choose a no-refunds policy outright, so their fine print may say so.

Fine print that merely conditions refunds ("refunds only for duplicate purchases", "no refunds after the refund window") is allowed.

Also fixes settings error surfacing: a refund-policy validation failure previously read `current_seller.errors` (empty) and showed the generic "Something broke" message; it now reports the invalid record's actual error.

## Why

Sahil on #7287: fine print is good — sellers can specify what qualifies for a refund — but they "shouldn't be allowed to say no refunds allowed, via AI content moderation." With #7286 flooring digital refund policies at 7 days, free-text fine print was the remaining channel to contradict the guaranteed window a buyer sees.

## How

- New validation on `RefundPolicy` (covers both account-level and product-level policies, and every write path since all go through the model): when fine print is present, changed, and the policy doesn't allow no-refunds (`allows_no_refunds?` from #7286), ask AI whether the fine print denies refunds outright; reject with "Fine print cannot state that refunds are not allowed"
- The prompt explicitly distinguishes blanket denial from conditional limits, and receives the full fine print (not a truncation)
- Fails open: any moderation error (OpenAI outage, timeout) allows the save — consistent with the model's existing AI helpers, and the global 3s OpenAI client timeout bounds save latency
- Runs only when fine print actually changed, so unrelated saves and leftover rows never trigger AI calls; checkout is unaffected (`PurchaseRefundPolicy` is a separate model)
- `ask_ai` moved from `ProductRefundPolicy` to the `RefundPolicy` base so the account-level policy can use it; API docs updated

## Before/After

**TODO — capture on a preview app before marking ready:** saving fine print reading "All sales are final. No refunds." on a digital product shows the validation error in settings and the product editor; conditional fine print saves normally.

## QA steps

1. Settings → Refund policy: set fine print to "No refunds. All sales are final." → save fails with "Fine print cannot state that refunds are not allowed"
2. Same in a digital product's editor refund policy
3. A physical product accepts that fine print
4. Fine print "Refunds are only issued for duplicate purchases." saves fine everywhere
5. `PUT /v2/refund_policy` with denying fine print → `success: false` with the same message

## Test Results

- `bundle exec rspec spec/models/product_refund_policy_spec.rb spec/models/seller_refund_policy_spec.rb spec/models/refund_policy_spec.rb spec/controllers/api/v2/refund_policies_controller_spec.rb` — 55 examples, 0 failures
- `bundle exec rspec spec/controllers/settings/main_controller_spec.rb` — 44 examples, 0 failures
- `bundle exec rspec spec/controllers/api/v2/links_controller_refund_policy_spec.rb` — 19 examples, 0 failures
- `bundle exec rubocop` on changed Ruby files — no offenses; `npx eslint` on changed TS files — clean; `npm run typecheck` — clean
- Full suite via CI (`run-all-specs`)

Existing rows whose fine print already denies refunds are untouched (the check runs on change only); auditing that stock would be a separate Onetime task if wanted.

---

AI disclosure: built with Claude Fable 5.
