### PR TITLE
Point the Gumhead download at the public rolling release

### DIFF
--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -453,7 +453,10 @@ export const DashboardPage = ({
                   <NavigationButton href={gumhead.download_url} color="primary" target="_blank" rel="noreferrer">
                     Download for Mac
                   </NavigationButton>
-                  <span className="text-sm text-muted">Windows coming soon</span>
+                  {/* The build ships only the arm64 slice (app binary and bundled
+                      Node runtime). Drop the Apple Silicon note when a universal
+                      build exists — the download URL stays the same. */}
+                  <span className="text-sm text-muted">Apple Silicon &middot; Windows coming soon</span>
                 </div>
               </div>
             </CardContent>

--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -6,8 +6,7 @@ class CreatorHomePresenter
   ACTIVITY_ITEMS_LIMIT = 10
   BALANCE_ITEMS_LIMIT = 3
   GUMHEAD_FEATURE = :gumhead
-  # A rolling release in this repo, refreshed by antiwork/gumhead's release
-  # workflow. A fixed tag, because releases/latest here is a deploy release.
+  # A fixed tag, because releases/latest here is a deploy release.
   GUMHEAD_DOWNLOAD_URL = "https://github.com/antiwork/gumroad/releases/download/gumhead-latest/Gumhead.zip"
 
   attr_reader :pundit_user, :seller

--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -6,7 +6,9 @@ class CreatorHomePresenter
   ACTIVITY_ITEMS_LIMIT = 10
   BALANCE_ITEMS_LIMIT = 3
   GUMHEAD_FEATURE = :gumhead
-  GUMHEAD_DOWNLOAD_URL = "https://github.com/antiwork/gumhead/releases/latest"
+  # A rolling release in this repo, refreshed by antiwork/gumhead's release
+  # workflow. A fixed tag, because releases/latest here is a deploy release.
+  GUMHEAD_DOWNLOAD_URL = "https://github.com/antiwork/gumroad/releases/download/gumhead-latest/Gumhead.zip"
 
   attr_reader :pundit_user, :seller
 


### PR DESCRIPTION
## What

Two small changes to the Gumhead Dashboard card (flag `:gumhead`, default off):

1. `CreatorHomePresenter::GUMHEAD_DOWNLOAD_URL` now points at the public rolling release:
   ```
   https://github.com/antiwork/gumroad/releases/download/gumhead-latest/Gumhead.zip
   ```
2. The muted note beside the button now reads **Apple Silicon · Windows coming soon**.

## Why

The current URL is `antiwork/gumhead/releases/latest`, which 404s — that repo is private ([gumroad-private#2007](https://github.com/antiwork/gumroad-private/issues/2007)). The new URL is a fixed-tag asset in this repo, uploaded by Gumhead's release workflow on every Gumhead release.

A fixed tag is required: this repo publishes deploy releases many times a day, so `releases/latest` here can never point at Gumhead. The direct asset URL also downloads in one click, with no release page in between.

The Apple Silicon note is honesty: the zip ships only the arm64 slice (the app binary and its bundled Node runtime), so an Intel Mac downloads an app that cannot launch. The note goes away when a universal build ships; the URL stays the same.

## Ordering

Safe to merge before the asset exists: the flag is default-off, so no creator sees the card. The URL goes live when `antiwork/gumhead` ships its first tagged release.

## QA steps

1. Flag off (default): Dashboard has no Gumhead card — unchanged.
2. Flag on: **Download for Mac** points at the URL above, and the muted note reads "Apple Silicon · Windows coming soon".
3. After the first Gumhead release ships, the link downloads `Gumhead.zip`.

## AI disclosure

claude-fable-5.
