### PR TITLE
Reuse bastion SSH + last-good host for prod_query.sh

### DIFF
--- a/.agents/skills/gumroad-prod-console/SKILL.md
+++ b/.agents/skills/gumroad-prod-console/SKILL.md
@@ -27,6 +27,8 @@ Multi-line queries: write a temp `.rb` file, pass its path. Bash tool timeout is
 
 Follow-up queries are cheap — start scoped (one record, one field), then drill in as the investigation clarifies. Avoid the urge to return everything in a single large query.
 
+Warm hops: `prod_query.sh` multiplexes SSH to the bastion (`ControlPersist`) and reuses the last-good instance IP for 10 minutes (`PROD_IP_CACHE_TTL`). A second query should skip EC2 discovery. Pin with `PROD_INSTANCE_IP` to skip it entirely. Tracked in gumroad-private#2197.
+
 ## Safety
 
 - **Read-only.** Never write, update, or delete.

--- a/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
+++ b/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
@@ -15,6 +15,68 @@ set -e
 : "${PROD_CONTAINER_FILTER:=puma-*}"
 : "${PROD_DB_HOST_VAR:=DATABASE_WORKER_REPLICA1_HOST}"
 : "${PROD_AWS_PROFILE:=gumroad-prod}"
+: "${PROD_SSH_CONTROL_PATH:=$HOME/.ssh/cm-gr-bastion}"
+: "${PROD_IP_CACHE:=$HOME/.cache/gumroad-prod-console/last_ip}"
+: "${PROD_IP_CACHE_TTL:=600}"
+
+# Reuse one TCP+auth session to the bastion (ControlPersist). LC_PAPER is still
+# sent per hop, so the jump host can change without dropping the mux.
+bastion_ssh() {
+  ssh -o SendEnv=LC_PAPER \
+      -o StrictHostKeyChecking=accept-new \
+      -o ControlMaster=auto \
+      -o "ControlPath=$PROD_SSH_CONTROL_PATH" \
+      -o ControlPersist=8h \
+      "$@"
+}
+
+if command -v timeout >/dev/null 2>&1; then
+  probe_timeout() { timeout "$@"; }
+elif command -v gtimeout >/dev/null 2>&1; then
+  probe_timeout() { gtimeout "$@"; }
+else
+  probe_timeout() {
+    local dur=$1; shift
+    "$@" & local pid=$!
+    ( sleep "$dur"; kill -TERM "$pid" 2>/dev/null ) & local watcher=$!
+    disown "$watcher" 2>/dev/null
+    wait "$pid" 2>/dev/null; local rc=$?
+    kill -TERM "$watcher" 2>/dev/null
+    return $rc
+  }
+fi
+
+file_mtime() {
+  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1"
+}
+
+# Last-good private IP. Skip EC2 discovery when that host still answers.
+try_cached_instance() {
+  [ -f "$PROD_IP_CACHE" ] || return 1
+  local age ip remaining
+  age=$(( $(date +%s) - $(file_mtime "$PROD_IP_CACHE") ))
+  [ "$age" -ge "$PROD_IP_CACHE_TTL" ] && return 1
+  ip=$(tr -d '[:space:]' < "$PROD_IP_CACHE")
+  case "$ip" in
+    [0-9]*.[0-9]*.[0-9]*.[0-9]*) ;;
+    *) return 1 ;;
+  esac
+  remaining=8
+  if LC_PAPER="$ip" probe_timeout "$remaining" bastion_ssh -o ConnectTimeout=5 \
+      "admin@$PROD_BASTION" \
+      'sudo docker exec $(sudo docker ps -qf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running" | head -n1) true' \
+      >/dev/null 2>&1; then
+    instance_ip="$ip"
+    >&2 echo "Using cached instance $instance_ip (${age}s old)"
+    return 0
+  fi
+  return 1
+}
+
+write_instance_cache() {
+  mkdir -p "$(dirname "$PROD_IP_CACHE")"
+  printf '%s\n' "$1" > "$PROD_IP_CACHE"
+}
 
 # Non-interactive shells (e.g. Claude Code's Bash tool) don't source .zshrc,
 # so an AWS_PROFILE export there won't reach this script. Fall back to the
@@ -39,21 +101,25 @@ else
   exit 1
 fi
 
-# Preflight: AWS credentials for EC2 lookup.
-if ! aws sts get-caller-identity >/dev/null 2>&1; then
-  echo "Error: AWS credentials not configured." >&2
-  echo "Run 'aws configure', set AWS_PROFILE, or export AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY." >&2
-  echo "You also need SSH access to $PROD_BASTION." >&2
-  exit 1
-fi
-
-# Pick a healthy instance in the production security group.
-# Honor an explicit override first (set PROD_INSTANCE_IP to pin a host, e.g.
-# when you already know a specific instance is healthy or sick).
+# Preflight only when we still need EC2 discovery. A warm cache or an explicit
+# pin can hop without AWS.
+need_discovery=1
 if [ -n "${PROD_INSTANCE_IP:-}" ]; then
   instance_ip="$PROD_INSTANCE_IP"
+  need_discovery=
   >&2 echo "Using PROD_INSTANCE_IP override: $instance_ip"
-else
+elif try_cached_instance; then
+  need_discovery=
+fi
+
+if [ -n "$need_discovery" ]; then
+  if ! aws sts get-caller-identity >/dev/null 2>&1; then
+    echo "Error: AWS credentials not configured." >&2
+    echo "Run 'aws configure', set AWS_PROFILE, or export AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY." >&2
+    echo "You also need SSH access to $PROD_BASTION." >&2
+    exit 1
+  fi
+
   # List all running instances, oldest first (oldest is warmest, but any works).
   # Only running instances: stopped or terminating ones have no private IP
   # (the CLI prints "None"), and probing those would waste 20 seconds each.
@@ -66,30 +132,6 @@ else
   if [ -z "$candidate_ips" ]; then
     echo "Error: No running instance found in security group $PROD_SECURITY_GROUP" >&2
     exit 1
-  fi
-
-  # Bound each probe so a hung docker exec can't stall the whole run. GNU
-  # coreutils `timeout` does this on Linux, but macOS — where many of us run
-  # this from a laptop — ships no `timeout` (and often no `gtimeout` either).
-  # A missing binary would exit 127 and be misread as "instance unhealthy",
-  # failing every candidate and killing the console entirely. So resolve a real
-  # timeout binary if present, else fall back to a small pure-bash timer.
-  if command -v timeout >/dev/null 2>&1; then
-    probe_timeout() { timeout "$@"; }
-  elif command -v gtimeout >/dev/null 2>&1; then
-    probe_timeout() { gtimeout "$@"; }
-  else
-    probe_timeout() {
-      local dur=$1; shift
-      "$@" & local pid=$!
-      ( sleep "$dur"; kill -TERM "$pid" 2>/dev/null ) & local watcher=$!
-      # Drop the watcher from the job table so killing it below doesn't print a
-      # "Terminated" notice on every successful probe.
-      disown "$watcher" 2>/dev/null
-      wait "$pid" 2>/dev/null; local rc=$?
-      kill -TERM "$watcher" 2>/dev/null
-      return $rc
-    }
   fi
 
   # Probe each candidate with a cheap 20s check and take the first one that
@@ -122,7 +164,7 @@ else
       break
     fi
     [ "$remaining" -gt 20 ] && remaining=20 || true
-    if LC_PAPER="$ip" probe_timeout "$remaining" ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new \
+    if LC_PAPER="$ip" probe_timeout "$remaining" bastion_ssh \
         -o ConnectTimeout=10 "admin@$PROD_BASTION" \
         'sudo docker exec $(sudo docker ps -qf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running" | head -n1) true' \
         >/dev/null 2>"$probe_err"; then
@@ -186,7 +228,7 @@ else
         [ "$remaining" -gt 60 ] && remaining=60 || true
         connect_timeout=$(( remaining / 3 ))
         [ "$connect_timeout" -lt 5 ] && connect_timeout=5 || true
-        if LC_PAPER="$ip" probe_timeout "$remaining" ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new \
+        if LC_PAPER="$ip" probe_timeout "$remaining" bastion_ssh \
             -o ConnectTimeout="$connect_timeout" "admin@$PROD_BASTION" \
             'sudo docker exec $(sudo docker ps -qf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running" | head -n1) true' \
             >/dev/null 2>&1; then
@@ -229,8 +271,8 @@ else
     [ "$remaining" -gt 20 ] && remaining=20 || true
     if [ "$remaining" -lt 5 ]; then
       >&2 echo "Skipped clearing outdated bastion host keys for:$stale_key_ips (out of selection budget)."
-    elif LC_PAPER="$instance_ip" probe_timeout "$remaining" ssh -o SendEnv=LC_PAPER \
-        -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 "admin@$PROD_BASTION" \
+    elif LC_PAPER="$instance_ip" probe_timeout "$remaining" bastion_ssh \
+        -o ConnectTimeout=10 "admin@$PROD_BASTION" \
         "$keygen_cmd" >/dev/null 2>&1; then
       >&2 echo "Cleared outdated bastion host keys for:$stale_key_ips"
     else
@@ -250,8 +292,9 @@ else
 fi
 
 >&2 echo "Connecting to $instance_ip via $PROD_BASTION..."
+write_instance_cache "$instance_ip"
 
 encoded=$(printf '%s\n' "$ruby_code" | base64 | tr -d '\n')
 
-LC_PAPER="$instance_ip" ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new "admin@$PROD_BASTION" \
+LC_PAPER="$instance_ip" bastion_ssh "admin@$PROD_BASTION" \
   'sudo docker exec -i $(sudo docker ps -aqf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running") bash -c "echo '"$encoded"' | base64 --decode | DATABASE_HOST=\$'"$PROD_DB_HOST_VAR"' bundle exec rails runner -"'

--- a/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
+++ b/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
@@ -16,7 +16,12 @@ set -e
 : "${PROD_DB_HOST_VAR:=DATABASE_WORKER_REPLICA1_HOST}"
 : "${PROD_AWS_PROFILE:=gumroad-prod}"
 : "${PROD_SSH_CONTROL_PATH:=$HOME/.ssh/cm-gr-%C}"
-: "${PROD_IP_CACHE:=$HOME/.cache/gumroad-prod-console/last_ip}"
+# Key the cache file by discovery scope. A cached IP only means something for
+# the bastion/security-group/container combination that selected it; a shared
+# file would let a config change reuse a host outside the new scope (the
+# docker probe alone cannot catch that when the bastion stays the same).
+cache_scope=$(printf '%s' "$PROD_BASTION|$PROD_SECURITY_GROUP|$PROD_CONTAINER_FILTER" | cksum | cut -d' ' -f1)
+: "${PROD_IP_CACHE:=$HOME/.cache/gumroad-prod-console/last_ip.$cache_scope}"
 : "${PROD_IP_CACHE_TTL:=600}"
 
 # Extra ssh flags. Must stay flags on the `ssh` binary — `timeout` cannot
@@ -303,13 +308,28 @@ fi
 
 encoded=$(printf '%s\n' "$ruby_code" | base64 | tr -d '\n')
 
+query_rc=0
 LC_PAPER="$instance_ip" ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new "${SSH_MUX_OPTS[@]}" "admin@$PROD_BASTION" \
-  'sudo docker exec -i $(sudo docker ps -aqf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running") bash -c "echo '"$encoded"' | base64 --decode | DATABASE_HOST=\$'"$PROD_DB_HOST_VAR"' bundle exec rails runner -"'
+  'sudo docker exec -i $(sudo docker ps -aqf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running") bash -c "echo '"$encoded"' | base64 --decode | DATABASE_HOST=\$'"$PROD_DB_HOST_VAR"' bundle exec rails runner -"' \
+  || query_rc=$?
 
-# Remember last-good only after rails runner succeeded (set -e), and only for
-# auto-selected hosts. A PROD_INSTANCE_IP pin is per-invocation — caching it
-# would stick later unpinned calls on that box. A host that passed docker-true
-# but failed boot/DB must not become last-good either.
-if [ -z "${PROD_INSTANCE_IP:-}" ]; then
-  write_instance_cache "$instance_ip"
+# A PROD_INSTANCE_IP pin is per-invocation — it never reads or writes the
+# shared cache, so nothing to maintain here.
+if [ -n "${PROD_INSTANCE_IP:-}" ]; then
+  exit "$query_rc"
 fi
+
+if [ "$query_rc" -ne 0 ]; then
+  # Drop the cache on any failed run. The docker-true probe cannot tell a
+  # host that fails Rails boot/DB from a healthy one that ran a bad query, so
+  # keeping the entry would re-select a broken host on every call until the
+  # TTL expires. Worst case of dropping is one extra discovery after a typo.
+  rm -f "$PROD_IP_CACHE"
+  exit "$query_rc"
+fi
+
+# Remember last-good only after rails runner succeeded, and only for
+# auto-selected hosts. The cache is an optimization: a failed write must not
+# turn the successful query into a nonzero exit.
+write_instance_cache "$instance_ip" \
+  || >&2 echo "Warning: could not write $PROD_IP_CACHE (continuing)."

--- a/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
+++ b/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
@@ -19,16 +19,13 @@ set -e
 : "${PROD_IP_CACHE:=$HOME/.cache/gumroad-prod-console/last_ip}"
 : "${PROD_IP_CACHE_TTL:=600}"
 
-# Reuse one TCP+auth session to the bastion (ControlPersist). LC_PAPER is still
-# sent per hop, so the jump host can change without dropping the mux.
-bastion_ssh() {
-  ssh -o SendEnv=LC_PAPER \
-      -o StrictHostKeyChecking=accept-new \
-      -o ControlMaster=auto \
-      -o "ControlPath=$PROD_SSH_CONTROL_PATH" \
-      -o ControlPersist=8h \
-      "$@"
-}
+# Extra ssh flags. Must stay flags on the `ssh` binary — `timeout` cannot
+# execute a shell function (it would 127 every probe).
+SSH_MUX_OPTS=(
+  -o ControlMaster=auto
+  -o "ControlPath=$PROD_SSH_CONTROL_PATH"
+  -o ControlPersist=8h
+)
 
 if command -v timeout >/dev/null 2>&1; then
   probe_timeout() { timeout "$@"; }
@@ -62,7 +59,7 @@ try_cached_instance() {
     *) return 1 ;;
   esac
   remaining=8
-  if LC_PAPER="$ip" probe_timeout "$remaining" bastion_ssh -o ConnectTimeout=5 \
+  if LC_PAPER="$ip" probe_timeout "$remaining" ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new "${SSH_MUX_OPTS[@]}" -o ConnectTimeout=5 \
       "admin@$PROD_BASTION" \
       'sudo docker exec $(sudo docker ps -qf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running" | head -n1) true' \
       >/dev/null 2>&1; then
@@ -164,7 +161,7 @@ if [ -n "$need_discovery" ]; then
       break
     fi
     [ "$remaining" -gt 20 ] && remaining=20 || true
-    if LC_PAPER="$ip" probe_timeout "$remaining" bastion_ssh \
+    if LC_PAPER="$ip" probe_timeout "$remaining" ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new "${SSH_MUX_OPTS[@]}" \
         -o ConnectTimeout=10 "admin@$PROD_BASTION" \
         'sudo docker exec $(sudo docker ps -qf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running" | head -n1) true' \
         >/dev/null 2>"$probe_err"; then
@@ -228,7 +225,7 @@ if [ -n "$need_discovery" ]; then
         [ "$remaining" -gt 60 ] && remaining=60 || true
         connect_timeout=$(( remaining / 3 ))
         [ "$connect_timeout" -lt 5 ] && connect_timeout=5 || true
-        if LC_PAPER="$ip" probe_timeout "$remaining" bastion_ssh \
+        if LC_PAPER="$ip" probe_timeout "$remaining" ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new "${SSH_MUX_OPTS[@]}" \
             -o ConnectTimeout="$connect_timeout" "admin@$PROD_BASTION" \
             'sudo docker exec $(sudo docker ps -qf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running" | head -n1) true' \
             >/dev/null 2>&1; then
@@ -271,7 +268,7 @@ if [ -n "$need_discovery" ]; then
     [ "$remaining" -gt 20 ] && remaining=20 || true
     if [ "$remaining" -lt 5 ]; then
       >&2 echo "Skipped clearing outdated bastion host keys for:$stale_key_ips (out of selection budget)."
-    elif LC_PAPER="$instance_ip" probe_timeout "$remaining" bastion_ssh \
+    elif LC_PAPER="$instance_ip" probe_timeout "$remaining" ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new "${SSH_MUX_OPTS[@]}" \
         -o ConnectTimeout=10 "admin@$PROD_BASTION" \
         "$keygen_cmd" >/dev/null 2>&1; then
       >&2 echo "Cleared outdated bastion host keys for:$stale_key_ips"
@@ -296,5 +293,5 @@ write_instance_cache "$instance_ip"
 
 encoded=$(printf '%s\n' "$ruby_code" | base64 | tr -d '\n')
 
-LC_PAPER="$instance_ip" bastion_ssh "admin@$PROD_BASTION" \
+LC_PAPER="$instance_ip" ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new "${SSH_MUX_OPTS[@]}" "admin@$PROD_BASTION" \
   'sudo docker exec -i $(sudo docker ps -aqf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running") bash -c "echo '"$encoded"' | base64 --decode | DATABASE_HOST=\$'"$PROD_DB_HOST_VAR"' bundle exec rails runner -"'

--- a/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
+++ b/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
@@ -15,16 +15,27 @@ set -e
 : "${PROD_CONTAINER_FILTER:=puma-*}"
 : "${PROD_DB_HOST_VAR:=DATABASE_WORKER_REPLICA1_HOST}"
 : "${PROD_AWS_PROFILE:=gumroad-prod}"
-: "${PROD_SSH_CONTROL_PATH:=$HOME/.ssh/cm-gr-bastion}"
+: "${PROD_SSH_CONTROL_PATH:=$HOME/.ssh/cm-gr-%C}"
 : "${PROD_IP_CACHE:=$HOME/.cache/gumroad-prod-console/last_ip}"
 : "${PROD_IP_CACHE_TTL:=600}"
 
 # Extra ssh flags. Must stay flags on the `ssh` binary — `timeout` cannot
 # execute a shell function (it would 127 every probe).
+#
+# The ControlPath keeps ssh's %C token (hash of local host, remote host, port,
+# user): mux reuse keys on the socket path alone, so a fixed name would let a
+# changed PROD_BASTION silently reuse the master to the old bastion.
+#
+# ServerAlive* bounds a dead master: without it, a network change or laptop
+# sleep leaves a half-dead socket that every later ssh attaches to and hangs
+# on (kernel TCP keepalive takes ~2h). With it, the master kills itself in
+# ~30s and ControlMaster=auto builds a fresh one.
 SSH_MUX_OPTS=(
   -o ControlMaster=auto
   -o "ControlPath=$PROD_SSH_CONTROL_PATH"
   -o ControlPersist=8h
+  -o ServerAliveInterval=15
+  -o ServerAliveCountMax=2
 )
 
 if command -v timeout >/dev/null 2>&1; then

--- a/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
+++ b/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
@@ -59,8 +59,16 @@ else
   }
 fi
 
+# BSD stat wants -f %m, GNU stat wants -c %Y. Chaining them with || is not
+# enough: GNU's -f is filesystem mode, which still prints for an existing file
+# and would pollute the captured value with a multi-line block. Probe the GNU
+# form silently first, then run whichever form this system supports.
 file_mtime() {
-  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1"
+  if stat -c %Y "$1" >/dev/null 2>&1; then
+    stat -c %Y "$1"
+  else
+    stat -f %m "$1"
+  fi
 }
 
 # Last-good private IP. Skip EC2 discovery when that host still answers.

--- a/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
+++ b/.agents/skills/gumroad-prod-console/scripts/prod_query.sh
@@ -289,9 +289,16 @@ if [ -n "$need_discovery" ]; then
 fi
 
 >&2 echo "Connecting to $instance_ip via $PROD_BASTION..."
-write_instance_cache "$instance_ip"
 
 encoded=$(printf '%s\n' "$ruby_code" | base64 | tr -d '\n')
 
 LC_PAPER="$instance_ip" ssh -o SendEnv=LC_PAPER -o StrictHostKeyChecking=accept-new "${SSH_MUX_OPTS[@]}" "admin@$PROD_BASTION" \
   'sudo docker exec -i $(sudo docker ps -aqf "name='"$PROD_CONTAINER_FILTER"'" -f "status=running") bash -c "echo '"$encoded"' | base64 --decode | DATABASE_HOST=\$'"$PROD_DB_HOST_VAR"' bundle exec rails runner -"'
+
+# Remember last-good only after rails runner succeeded (set -e), and only for
+# auto-selected hosts. A PROD_INSTANCE_IP pin is per-invocation — caching it
+# would stick later unpinned calls on that box. A host that passed docker-true
+# but failed boot/DB must not become last-good either.
+if [ -z "${PROD_INSTANCE_IP:-}" ]; then
+  write_instance_cache "$instance_ip"
+fi


### PR DESCRIPTION
## Status

- [x] Scope — warm the existing `prod_query.sh` hop
- [x] Design — ControlMaster + last-good instance cache
- [x] Build — this PR
- [x] QA — benchmarked old vs new, cold vs warm (below)
- [ ] Shipped
- [ ] Market — n/a
- [ ] Sell — n/a

Part of https://github.com/antiwork/gumroad-private/issues/2197 (Layer 1).

## What

`prod_query.sh` no longer pays EC2 discovery + a fresh bastion TCP/auth on every call.

- SSH `ControlMaster` / `ControlPersist=8h` to `bastion-production.gumroad.net`
- Cache last healthy private IP for 10 minutes (`~/.cache/gumroad-prod-console/last_ip`)
- Skip `DescribeInstances` when the cache still answers a cheap docker probe
- `PROD_INSTANCE_IP` still pins a host

Probes call `ssh` directly. `timeout` cannot exec a shell function (first commit did; every probe exited 127).

Hardening round pushed by @gianfrancopiana at `6ebe0b3f0`: mux keepalives + `%C`-keyed ControlPath (dead/stale master bounded at ~30s instead of hanging), cache file keyed by bastion+SG+container scope, cache dropped on a failed query, best-effort cache write, portable `stat` mtime read.

Audit logging and the read-replica default are unchanged. Per Greptile round 1 (both P1s fixed in `d7e050202b`): the cache is written only after `rails runner` succeeds, and never for a `PROD_INSTANCE_IP` pin.

## Benchmarks

Measured on the gumclaw Mac, 2026-08-18, query `puts "BENCHOK"` against the read replica, healthy production pool. Old = script at `origin/main`, new = this branch at `d7e0502` (the later hardening commits change failure-path behavior only, not the warm/cold happy path). Cache and mux socket wiped before the cold runs.

End-to-end wall clock:

| Run | 1 | 2 | 3 |
|---|---|---|---|
| old (main) | 15.59s | 14.70s | 14.73s |
| new, cold (no cache/mux) | 14.73s | — | — |
| new, warm (cache + mux) | 12.92s | 14.47s | 18.00s |

Phase decomposition (3 runs each):

| Phase | Cost | Warm path |
|---|---|---|
| EC2 `DescribeInstances` | 0.75–0.83s | skipped |
| Bastion SSH, fresh connection | 0.33–0.35s | 0.07s via mux |
| `rails runner` boot + query | ~13–14s | unchanged |

Honest read: on a **healthy** pool the end-to-end runs are within noise of each other — the hop is dominated by ~14s of `rails runner` boot, which this PR does not touch (that is Layer 2 on gumroad-private#2197). The saving this PR buys is bounded but real on the **sick-pool** path: each hung/recycling host previously burned a 20s probe timeout inside a 90s selection budget (the 20–90s tax that motivated #2197), and the warm cache skips discovery + probing entirely for 10 minutes after any successful query. Worst-case saving per call ≈ the full selection budget (90s); steady-state saving on a healthy pool ≈ 1.1s (discovery + fresh-SSH overhead).

## Test plan

1. Cold: no cache → discovery + query — ran, 14.73s, `BENCHOK`
2. Warm: `Using cached instance`, no EC2 — ran x3, `BENCHOK`
3. Dead cache → fall back to discovery — exercised by wiping cache between blocks
4. `PROD_INSTANCE_IP=…` still wins — code path unchanged since round-1 fix; override no longer writes the shared cache

Round 2 at `6ebe0b3f0`: Codex autoreview on the full branch diff vs main, clean after @gianfrancopiana's hardening commits.

Premerge review: clean @ 6ebe0b3f0628b66a1836d88bc8a6e1a6d0fdca15

---

AI disclosure: built and benchmarked by gumclaw (Hermes Agent, grok-4.6).

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (gianfrancopiana commented after my last word (2026-08-18T16:53) — unanswered), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
