### PR TITLE
Trim omit_product_in_search_total? comment to the non-obvious invariant

### DIFF
--- a/app/presenters/profile_sections_presenter.rb
+++ b/app/presenters/profile_sections_presenter.rb
@@ -213,11 +213,9 @@ class ProfileSectionsPresenter
       cached_props
     end
 
-    # Mirrors the section's ES query (is_alive_on_profile + shown_products) so we only shrink
-    # the total when the search actually counted the omitted product. Deliberately no sold-out
-    # check: ES totals include sold-out products (the sold-out reject above only prunes the
-    # fetched page and decrements the total for what it pruned), so a sold-out omitted product
-    # beyond the page is still in the total and must still shrink it.
+    # Mirrors the section's ES query so we only shrink the total when the search counted the
+    # omitted product. No sold-out check: ES totals include sold-out products, so a sold-out
+    # omitted product beyond the fetched page must still shrink the total.
     def omit_product_in_search_total?(section, omit_product)
       return false unless omit_product.alive? && !omit_product.archived?
       return omit_product.user_id == seller.id if section.nil?


### PR DESCRIPTION
## What

Trims the `omit_product_in_search_total?` comment in `ProfileSectionsPresenter` from 5 lines to 3, keeping only the non-obvious ES-total invariant (ES totals include sold-out products, so a sold-out omitted product beyond the fetched page must still shrink the total).

## Why

Greptile P2 on #7300 (merged before the finding was addressed): the comment restated implementation details readable in the predicate itself, violating the repo's concise-comment standard in AGENTS.md.

## Before / After

Comment-only diff — the diff is the reviewable artifact; no executable change (`gh pr diff` filtered to non-comment/non-blank lines returns empty). Before: 5-line comment repeating the query mirror details. After: 3 lines stating only the sold-out/ES-total invariant.

## Status

- [x] Scope — Greptile P2 on merged #7300; single comment in `app/presenters/profile_sections_presenter.rb`.
- [x] Design — condense to the one non-obvious invariant per AGENTS.md comment standard.
- [x] Build — pushed; `ruby -c` Syntax OK; comment-only grep returns 0 non-comment changed lines.
- [x] QA — no rendered surface and no executable change; the diff is the artifact.
- [ ] Shipped — merge pending.
- [ ] Market — n/a (internal comment hygiene).
- [ ] Sell — n/a.

## Test Results

- `ruby -c app/presenters/profile_sections_presenter.rb` — Syntax OK.
- No behavior change; comment-only diff verified with the non-comment-line grep (0 hits).

## QA steps

None applicable — comment-only diff, no rendered surface and no executable change.

Premerge review: exempt (comment-only diff, no executable change)

---

AI disclosure: authored by gumclaw (claude-fable-5) via Hermes Agent.
