### PR TITLE
Add mobile products list and delete API

### DIFF
--- a/app/controllers/api/mobile/products_controller.rb
+++ b/app/controllers/api/mobile/products_controller.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class Api::Mobile::ProductsController < Api::Mobile::BaseController
+  PRODUCTS_PER_PAGE = 20
+
+  before_action { doorkeeper_authorize! :mobile_api }
+
+  def index
+    page = [params[:page].to_i, 1].max
+    products = current_resource_owner.products.visible.not_archived
+    if params[:query].present?
+      products = products.where("links.name LIKE ?", "%#{Link.sanitize_sql_like(params[:query])}%")
+    end
+    products = products.order(created_at: :desc, id: :desc)
+
+    pagination, records = pagy(products, page:, limit: PRODUCTS_PER_PAGE)
+    ActiveRecord::Associations::Preloader.new(records:, associations: DashboardProductsPagePresenter::THUMBNAIL_INCLUDES).call
+
+    presenter = DashboardProductsPagePresenter.new(pundit_user: seller_context)
+    render json: {
+      success: true,
+      products: records.map { product_json(_1, presenter) },
+      pagination: {
+        count: pagination.count,
+        page: pagination.page,
+        pages: pagination.pages,
+        next: pagination.next,
+      },
+    }
+  end
+
+  def destroy
+    product = current_resource_owner.products.visible.find_by(unique_permalink: params[:id])
+    return fetch_error("Product not found") if product.nil?
+    return fetch_error("You cannot delete this product", status: :forbidden) unless Pundit.policy!(seller_context, product).destroy?
+
+    product.delete!
+    render json: { success: true }
+  end
+
+  private
+    def seller_context
+      SellerContext.new(user: current_resource_owner, seller: current_resource_owner)
+    end
+
+    def product_json(product, presenter)
+      props = presenter.product_props(product)
+      {
+        id: product.unique_permalink,
+        name: props["name"],
+        permalink: props["permalink"],
+        price_formatted: props["price_formatted"],
+        status: props["status"],
+        thumbnail_url: props.dig("thumbnail", "url"),
+        can_edit: props["can_edit"],
+        can_destroy: props["can_destroy"],
+      }
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -390,6 +390,7 @@ Rails.application.routes.draw do
             get :products
           end
         end
+        resources :products, only: [:index, :destroy]
         get "/agent/meta", to: "agent#meta"
         get "/agent/conversations/latest", to: "agent#latest_conversation"
         get "/agent/turns/:client_turn_id", to: "agent#turn_status"

--- a/spec/controllers/api/mobile/products_controller_spec.rb
+++ b/spec/controllers/api/mobile/products_controller_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Api::Mobile::ProductsController do
+  before do
+    @seller = create(:user)
+    @app = create(:oauth_application, owner: @seller)
+    @params = {
+      mobile_token: Api::Mobile::BaseController::MOBILE_TOKEN,
+      access_token: create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "mobile_api").token
+    }
+  end
+
+  describe "GET index" do
+    it "returns the seller's visible products newest first" do
+      older = create(:product, user: @seller, name: "Older course")
+      newer = create(:product, user: @seller, name: "Newer course")
+      create(:product, name: "Someone else's")
+      create(:product, user: @seller, name: "Archived").update!(archived: true)
+      deleted = create(:product, user: @seller, name: "Deleted")
+      deleted.mark_deleted!
+
+      get :index, params: @params
+
+      expect(response).to be_successful
+      body = response.parsed_body
+      expect(body["success"]).to eq(true)
+      expect(body["products"].map { _1["id"] }).to eq([newer.unique_permalink, older.unique_permalink])
+      expect(body["products"].first).to include(
+        "name" => "Newer course",
+        "permalink" => newer.unique_permalink,
+        "status" => "published",
+        "can_edit" => true,
+        "can_destroy" => true,
+      )
+      expect(body["pagination"]).to eq("count" => 2, "page" => 1, "pages" => 1, "next" => nil)
+    end
+
+    it "filters products by name" do
+      create(:product, user: @seller, name: "Photo pack")
+      match = create(:product, user: @seller, name: "Writing guide")
+
+      get :index, params: @params.merge(query: "writing")
+
+      expect(response.parsed_body["products"].map { _1["id"] }).to eq([match.unique_permalink])
+    end
+
+    it "paginates products" do
+      stub_const("#{described_class}::PRODUCTS_PER_PAGE", 1)
+      create(:product, user: @seller, name: "First")
+      create(:product, user: @seller, name: "Second")
+
+      get :index, params: @params.merge(page: 1)
+
+      body = response.parsed_body
+      expect(body["products"].size).to eq(1)
+      expect(body["pagination"]).to include("count" => 2, "page" => 1, "pages" => 2, "next" => 2)
+    end
+
+    it "returns 401 when the access token is invalid" do
+      get :index, params: @params.merge(access_token: "invalid")
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "DELETE destroy" do
+    it "deletes the seller's product" do
+      product = create(:product, user: @seller, name: "To delete")
+
+      delete :destroy, params: @params.merge(id: product.unique_permalink)
+
+      expect(response).to be_successful
+      expect(response.parsed_body["success"]).to eq(true)
+      expect(product.reload.deleted?).to eq(true)
+    end
+
+    it "does not delete another seller's product" do
+      other = create(:product, name: "Not yours")
+
+      delete :destroy, params: @params.merge(id: other.unique_permalink)
+
+      expect(response).to have_http_status(:not_found)
+      expect(other.reload.deleted?).to eq(false)
+    end
+
+    it "returns 401 when the access token is invalid" do
+      product = create(:product, user: @seller)
+
+      delete :destroy, params: @params.merge(id: product.unique_permalink, access_token: "invalid")
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(product.reload.deleted?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Issue: antiwork/gumroad-mobile#350

## What

Adds `GET /api/mobile/products` and `DELETE /api/mobile/products/:id` for the mobile Products tab.

- List is the seller's visible, non-archived products (newest first), with optional name search and pagination.
- Each row uses permalink as `id`, plus name, price, status, thumbnail, and edit/delete permissions from `DashboardProductsPagePresenter`.
- Delete calls `Link#delete!` after the same policy check as the web products page.

## Why

Sahil on #350: focus the app on product list create / edit / update / delete. The app cannot list or delete products over `mobile_api` today.

## Test Results

- `bundle exec rspec spec/controllers/api/mobile/products_controller_spec.rb`: 7 examples, 0 failures
- Push Tests (run 32171434249) + Buildkite #21497 + `ci/green` SUCCESS at `46e198d258d7884da10f2f92fb7a313af83c19a5`

## Status

- [x] Scope
- [x] Design
- [x] Build
- [x] QA — controller spec + preview route live (`api.gumclaw-2026-08-18-mobile-produc.apps.staging.gumroad.org/mobile/products.json` → 401 without token, x-revision `46e198d258d7`). Device stills stay on antiwork/gumroad-mobile#352
- [ ] Shipped
- [ ] Market — n/a
- [ ] Sell — n/a

## CI

Full Fast/Slow + Minitest green at head after `run-all-specs` (routes.rb mapping gap). Preview 200 at `https://gumclaw-2026-08-18-mobile-produc.apps.staging.gumroad.org`.

---

AI disclosure: authored with Hermes Agent (grok-4.6).

Premerge review: clean @ 46e198d258d7884da10f2f92fb7a313af83c19a5

