### PR TITLE
Fix leftover Stripe merchant rows blocking payout setup retries

### DIFF
--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -1838,8 +1838,10 @@ module StripeMerchantAccountManager
 
   def self.blocks_new_managed_account?(user)
     user.merchant_accounts.alive.stripe.any? do |ma|
-      next true if ma.charge_processor_alive?
+      # Connect is a different path — create_account has always ignored it.
+      # Check first: a live Connect row is charge_processor_alive?.
       next if ma.is_a_stripe_connect_account?
+      next true if ma.charge_processor_alive?
 
       ma.charge_processor_merchant_id.present? || ma.created_at > STALE_HOLLOW_ACCOUNT_AGE.ago
     end

--- a/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/stripe/stripe_merchant_account_manager.rb
@@ -168,6 +168,12 @@ module StripeMerchantAccountManager
   # below the 25% share that makes someone a reportable beneficial owner in the first place.
   FULLY_ACCOUNTED_OWNERSHIP_PERCENT = 99.5
 
+  # A just-created local row (Stripe::Account.create still in flight) must keep
+  # blocking a second create. Older leftover rows with no Stripe id do not —
+  # they are failed creates that never cleaned up, and counting them as an
+  # existing account permanently skips self-serve retries.
+  STALE_HOLLOW_ACCOUNT_AGE = 10.minutes
+
   def self.create_account(user, passphrase:, from_admin: false, notify: true)
     tos_agreement = nil
     user_compliance_info = nil
@@ -179,10 +185,11 @@ module StripeMerchantAccountManager
     user.with_lock do
       raise MerchantRegistrationUserNotReadyError.new(user.id, "is not supported yet") unless user.native_payouts_supported?
 
+      discard_stale_hollow_managed_accounts!(user)
       user_has_a_merchant_account = if from_admin
         user_has_stripe_connect_merchant_account?(user)
       else
-        user.merchant_accounts.alive.stripe.find { |ma| !ma.is_a_stripe_connect_account? }.present?
+        blocks_new_managed_account?(user)
       end
       raise MerchantRegistrationUserAlreadyHasAccountError.new(user.id, StripeChargeProcessor.charge_processor_id) if user_has_a_merchant_account
       raise MerchantRegistrationUserNotReadyError.new(user.id, "has not agreed to TOS") if user.tos_agreements.empty?
@@ -1828,6 +1835,27 @@ module StripeMerchantAccountManager
     end
     merchant_account.mark_deleted!
   end
+
+  def self.blocks_new_managed_account?(user)
+    user.merchant_accounts.alive.stripe.any? do |ma|
+      next true if ma.charge_processor_alive?
+      next if ma.is_a_stripe_connect_account?
+
+      ma.charge_processor_merchant_id.present? || ma.created_at > STALE_HOLLOW_ACCOUNT_AGE.ago
+    end
+  end
+
+  def self.discard_stale_hollow_managed_accounts!(user)
+    user.merchant_accounts.alive.stripe.each do |ma|
+      next if ma.is_a_stripe_connect_account?
+      next if ma.charge_processor_alive?
+      next if ma.charge_processor_merchant_id.present?
+      next if ma.created_at > STALE_HOLLOW_ACCOUNT_AGE.ago
+
+      cleanup_failed_merchant_account(ma)
+    end
+  end
+  private_class_method :discard_stale_hollow_managed_accounts!
 
   # Strongbox decrypts (account number, tax ids) return ASCII-8BIT (binary) strings. When the
   # Stripe gem serializes the params it concatenates them with the other UTF-8 fields; if a

--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -131,7 +131,7 @@ class Settings::PaymentsController < Settings::BaseController
 
     # Once the user has submitted all their information, and a bank account record was created for them,
     # we can create a stripe merchant account for them if they don't already have one.
-    if current_seller.active_bank_account && current_seller.native_payouts_supported? && !StripeMerchantAccountManager.blocks_new_managed_account?(current_seller)
+    if current_seller.active_bank_account && current_seller.native_payouts_supported? && current_seller.stripe_connect_account.blank? && !StripeMerchantAccountManager.blocks_new_managed_account?(current_seller)
       begin
         StripeMerchantAccountManager.create_account(current_seller, passphrase: GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))
       rescue Stripe::StripeError, MerchantRegistrationUserNotReadyError => e

--- a/app/controllers/settings/payments_controller.rb
+++ b/app/controllers/settings/payments_controller.rb
@@ -131,7 +131,7 @@ class Settings::PaymentsController < Settings::BaseController
 
     # Once the user has submitted all their information, and a bank account record was created for them,
     # we can create a stripe merchant account for them if they don't already have one.
-    if current_seller.active_bank_account && current_seller.merchant_accounts.stripe.alive.empty? && current_seller.native_payouts_supported?
+    if current_seller.active_bank_account && current_seller.native_payouts_supported? && !StripeMerchantAccountManager.blocks_new_managed_account?(current_seller)
       begin
         StripeMerchantAccountManager.create_account(current_seller, passphrase: GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD"))
       rescue Stripe::StripeError, MerchantRegistrationUserNotReadyError => e

--- a/app/services/onetime/cleanup_wedged_stripe_merchant_accounts.rb
+++ b/app/services/onetime/cleanup_wedged_stripe_merchant_accounts.rb
@@ -87,7 +87,6 @@ module Onetime
         scope = MerchantAccount
                   .where(charge_processor_id: StripeChargeProcessor.charge_processor_id)
                   .where(charge_processor_alive_at: nil, charge_processor_deleted_at: nil, deleted_at: nil)
-                  .where.not(charge_processor_merchant_id: nil)
                   .where("created_at < ?", MIN_AGE.ago)
         scope = scope.where(id: merchant_account_ids) if merchant_account_ids.present?
         scope

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -9035,6 +9035,27 @@ describe StripeMerchantAccountManager, :vcr do
         end
       end
     end
+
+    describe "user has a stale leftover merchant account with no Stripe id" do
+      let(:user) { create(:user) }
+      let(:user_compliance_info) { create(:user_compliance_info, user:) }
+      let(:bank_account) { create(:ach_account_stripe_succeed, user:) }
+      let(:tos_agreement) { create(:tos_agreement, user:) }
+
+      before do
+        user_compliance_info
+        bank_account
+        tos_agreement
+        create(:merchant_account, user:, charge_processor_merchant_id: nil, charge_processor_alive_at: nil, created_at: 1.year.ago)
+      end
+
+      it "discards the leftover row and creates a real account" do
+        expect { subject.create_account(user, passphrase: "1234") }.not_to raise_error
+        expect(user.reload.stripe_account).to be_present
+        expect(user.merchant_accounts.alive.stripe.count).to eq(1)
+        expect(user.stripe_account.charge_processor_merchant_id).to be_present
+      end
+    end
   end
 
   describe "#update_account" do

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -9036,6 +9036,36 @@ describe StripeMerchantAccountManager, :vcr do
       end
     end
 
+    describe ".blocks_new_managed_account?" do
+      it "does not treat a live Stripe Connect account as a managed account" do
+        user = create(:user)
+        create(:merchant_account_stripe_connect, user:)
+
+        expect(described_class.blocks_new_managed_account?(user)).to eq(false)
+      end
+
+      it "blocks a live managed account" do
+        user = create(:user)
+        create(:merchant_account, user:, charge_processor_merchant_id: "acct_test_live_managed")
+
+        expect(described_class.blocks_new_managed_account?(user)).to eq(true)
+      end
+
+      it "blocks a leftover managed account that already has a Stripe id" do
+        user = create(:user)
+        create(:merchant_account, user:, charge_processor_merchant_id: "acct_test_leftover_id", charge_processor_alive_at: nil)
+
+        expect(described_class.blocks_new_managed_account?(user)).to eq(true)
+      end
+
+      it "does not block a stale hollow leftover with no Stripe id" do
+        user = create(:user)
+        create(:merchant_account, user:, charge_processor_merchant_id: nil, charge_processor_alive_at: nil, created_at: 1.year.ago)
+
+        expect(described_class.blocks_new_managed_account?(user)).to eq(false)
+      end
+    end
+
     describe "user has a stale leftover merchant account with no Stripe id" do
       let(:user) { create(:user) }
       let(:user_compliance_info) { create(:user_compliance_info, user:) }

--- a/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb
@@ -9064,6 +9064,13 @@ describe StripeMerchantAccountManager, :vcr do
 
         expect(described_class.blocks_new_managed_account?(user)).to eq(false)
       end
+
+      it "blocks a young hollow leftover still inside the mid-flight window" do
+        user = create(:user)
+        create(:merchant_account, user:, charge_processor_merchant_id: nil, charge_processor_alive_at: nil, created_at: 5.minutes.ago)
+
+        expect(described_class.blocks_new_managed_account?(user)).to eq(true)
+      end
     end
 
     describe "user has a stale leftover merchant account with no Stripe id" do
@@ -9084,6 +9091,24 @@ describe StripeMerchantAccountManager, :vcr do
         expect(user.reload.stripe_account).to be_present
         expect(user.merchant_accounts.alive.stripe.count).to eq(1)
         expect(user.stripe_account.charge_processor_merchant_id).to be_present
+      end
+    end
+
+    describe "user has a young hollow leftover still inside the mid-flight window" do
+      let(:user) { create(:user) }
+      let(:user_compliance_info) { create(:user_compliance_info, user:) }
+      let(:tos_agreement) { create(:tos_agreement, user:) }
+
+      before do
+        user_compliance_info
+        tos_agreement
+        create(:merchant_account, user:, charge_processor_merchant_id: nil, charge_processor_alive_at: nil, created_at: 5.minutes.ago)
+      end
+
+      it "does not discard the in-flight row or call Stripe" do
+        expect(Stripe::Account).not_to receive(:create)
+        expect { subject.create_account(user, passphrase: "1234") }.to raise_error(MerchantRegistrationUserAlreadyHasAccountError)
+        expect(user.merchant_accounts.alive.stripe.count).to eq(1)
       end
     end
   end

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -472,6 +472,31 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
           end
         end
 
+        describe "user has a bank account and a Stripe Connect account" do
+          before do
+            all_params.merge!(
+              bank_account: {
+                type: AchAccount.name,
+                account_number: "000123456789",
+                account_number_confirmation: "000123456789",
+                routing_number: "110000000",
+                account_holder_full_name: "gumbot"
+              }
+            )
+            create(:merchant_account_stripe_connect, user:)
+          end
+
+          it "does not create a gumroad-managed Stripe account next to Connect" do
+            expect(StripeMerchantAccountManager).not_to receive(:create_account)
+
+            put :update, params: all_params
+
+            expect(response).to redirect_to(settings_payments_path)
+            expect(response).to have_http_status :see_other
+            expect(flash[:notice]).to eq("Thanks! You're all set.")
+          end
+        end
+
         describe "user has only a stale hollow merchant account" do
           before do
             all_params.merge!(

--- a/spec/controllers/settings/payments_controller_spec.rb
+++ b/spec/controllers/settings/payments_controller_spec.rb
@@ -472,6 +472,32 @@ describe Settings::PaymentsController, :vcr, type: :controller, inertia: true do
           end
         end
 
+        describe "user has only a stale hollow merchant account" do
+          before do
+            all_params.merge!(
+              bank_account: {
+                type: AchAccount.name,
+                account_number: "000123456789",
+                account_number_confirmation: "000123456789",
+                routing_number: "110000000",
+                account_holder_full_name: "gumbot"
+              }
+            )
+            create(:merchant_account, user:, charge_processor_merchant_id: nil, charge_processor_alive_at: nil, created_at: 1.year.ago)
+          end
+
+          it "creates a stripe merchant account instead of treating the leftover row as done" do
+            expect(StripeMerchantAccountManager).to receive(:create_account).with(user, passphrase: GlobalConfig.get("STRONGBOX_GENERAL_PASSWORD")).and_call_original
+
+            put :update, params: all_params
+
+            expect(user.reload.stripe_account).to be_present
+            expect(response).to redirect_to(settings_payments_path)
+            expect(response).to have_http_status :see_other
+            expect(flash[:notice]).to eq("Thanks! You're all set.")
+          end
+        end
+
         describe "user does not have a bank account, or a merchant account" do
           it "does not try to create a new stripe account because user does not have a bank account" do
             expect(StripeMerchantAccountManager).not_to receive(:create_account)

--- a/spec/services/onetime/cleanup_wedged_stripe_merchant_accounts_spec.rb
+++ b/spec/services/onetime/cleanup_wedged_stripe_merchant_accounts_spec.rb
@@ -97,5 +97,16 @@ describe Onetime::CleanupWedgedStripeMerchantAccounts do
 
       expect(result[:wedged_with_balance]).to eq(1)
     end
+
+    it "soft-deletes a leftover row that never received a Stripe id" do
+      user = create(:user)
+      hollow = create(:merchant_account, user:, charge_processor_merchant_id: nil, charge_processor_alive_at: nil, created_at: 8.days.ago)
+
+      result = described_class.process(dry_run: false)
+
+      expect(hollow.reload.alive?).to be(false)
+      expect(result[:cleaned]).to eq(1)
+      expect(Stripe::Account).not_to have_received(:delete)
+    end
   end
 end

--- a/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/PUT_update/individual/immediate_stripe_account_creation/user_has_only_a_stale_hollow_merchant_account/creates_a_stripe_merchant_account_instead_of_treating_the_leftover_row_as_done.yml
+++ b/spec/support/fixtures/vcr_cassettes/Settings_PaymentsController/PUT_update/individual/immediate_stripe_account_creation/user_has_only_a_stale_hollow_merchant_account/creates_a_stripe_merchant_account_instead_of_treating_the_leftover_row_as_done.yml
@@ -1,0 +1,368 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=6&metadata[tos_agreement_id]=7-RrdvIoUS_D2srgUHAytg%3D%3D&metadata[user_compliance_info_id]=OKW5T4NMBrWG_MhdAf9kiQ%3D%3D&metadata[bank_account_id]=7-RrdvIoUS_D2srgUHAytg%3D%3D&tos_acceptance[date]=1787098582&tos_acceptance[ip]=0.0.0.0&business_type=individual&business_profile[name]=barnabas+barnabastein&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=barnabas+barnabastein&individual[first_name]=barnabas&individual[last_name]=barnabastein&individual[email]=seller%40example.com&individual[phone]=%2B16507423913&individual[dob][day]=4&individual[dob][month]=3&individual[dob][year]=1955&individual[address][line1]=123+barnabas+st&individual[address][city]=barnabasville&individual[address][state]=NY&individual[address][postal_code]=94104&individual[address][country]=US&individual[ssn_last_4]=6789&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 9c2c62db-037f-48a9-885a-b1ffab1c9dad
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 00:16:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6762'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=kvwbRvi3TdgyR3x4US_mIBQCEFh4G5bbBUb6ddyMU-Z4-KokCtz5HTYk61vUaie9aMlMJ_Jib1L12NSU;
+        report-to csp
+      Idempotency-Key:
+      - 9c2c62db-037f-48a9-885a-b1ffab1c9dad
+      Original-Request:
+      - req_nvJAoO31q3wr9D
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=kvwbRvi3TdgyR3x4US_mIBQCEFh4G5bbBUb6ddyMU-Z4-KokCtz5HTYk61vUaie9aMlMJ_Jib1L12NSU&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=kvwbRvi3TdgyR3x4US_mIBQCEFh4G5bbBUb6ddyMU-Z4-KokCtz5HTYk61vUaie9aMlMJ_Jib1L12NSU&t=1"
+      Request-Id:
+      - req_nvJAoO31q3wr9D
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1U5xB4EVkeEbJfvK",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "barnabas barnabastein",
+            "product_description": "barnabas barnabastein",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "barnabasville",
+              "country": "US",
+              "line1": "123 barnabas st",
+              "line2": null,
+              "postal_code": "94104",
+              "state": "NY"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+16507423913",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1787098584,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1U5xB4EVkeEbJfvKdqcODQQx",
+                "object": "bank_account",
+                "account": "acct_1U5xB4EVkeEbJfvK",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1U5xB4EVkeEbJfvK/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1U5xB4EVkeEbJfvKNqn5SAhe",
+            "object": "person",
+            "account": "acct_1U5xB4EVkeEbJfvK",
+            "address": {
+              "city": "barnabasville",
+              "country": "US",
+              "line1": "123 barnabas st",
+              "line2": null,
+              "postal_code": "94104",
+              "state": "NY"
+            },
+            "created": 1787098583,
+            "dob": {
+              "day": 4,
+              "month": 3,
+              "year": 1955
+            },
+            "email": "seller@example.com",
+            "first_name": "barnabas",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": false,
+            "last_name": "barnabastein",
+            "metadata": {},
+            "phone": "+16507423913",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "7-RrdvIoUS_D2srgUHAytg==",
+            "tos_agreement_id": "7-RrdvIoUS_D2srgUHAytg==",
+            "user_compliance_info_id": "OKW5T4NMBrWG_MhdAf9kiQ==",
+            "user_id": "6"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "BARNABAS B",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "barnabas barnabastein",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "BARNABAS BARNABASTEIN",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1787098582,
+            "ip": "0.0.0.0",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Wed, 19 Aug 2026 00:16:25 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/_create_account/user_has_a_stale_leftover_merchant_account_with_no_Stripe_id/discards_the_leftover_row_and_creates_a_real_account.yml
+++ b/spec/support/fixtures/vcr_cassettes/StripeMerchantAccountManager/_create_account/user_has_a_stale_leftover_merchant_account_with_no_Stripe_id/discards_the_leftover_row_and_creates_a_real_account.yml
@@ -1,0 +1,370 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts
+    body:
+      encoding: UTF-8
+      string: type=custom&requested_capabilities[0]=card_payments&requested_capabilities[1]=transfers&country=US&default_currency=usd&metadata[user_id]=420951887427&metadata[tos_agreement_id]=Dpy_wNcsAa0jANXMy2eF3w%3D%3D&metadata[user_compliance_info_id]=y8TaBjObeFjYTCZgPWOozw%3D%3D&metadata[bank_account_id]=Dpy_wNcsAa0jANXMy2eF3w%3D%3D&tos_acceptance[date]=1787098694&tos_acceptance[ip]=54.234.242.13&business_type=individual&business_profile[name]=Chuck+Bartowski&business_profile[url]=https%3A%2F%2Fvipul.gumroad.com%2F&business_profile[product_description]=Chuck+Bartowski&individual[first_name]=Chuck&individual[last_name]=Bartowski&individual[email]=edgarb8588e5b_1%40gumroad.com&individual[phone]=0000000000&individual[dob][day]=1&individual[dob][month]=1&individual[dob][year]=1901&individual[address][line1]=address_full_match&individual[address][city]=San+Francisco&individual[address][state]=California&individual[address][postal_code]=94107&individual[address][country]=US&individual[id_number]=000000000&bank_account[country]=US&bank_account[currency]=usd&bank_account[account_number]=000<STRONGBOX_GENERAL_PASSWORD>56789&bank_account[routing_number]=110000000&settings[payouts][schedule][interval]=manual&settings[payouts][debit_negative_balances]=true
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 7b98a407-d5c8-4b65-82ac-1c48cc28ef49
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 00:18:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6854'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=U5Mt0IzIPyZyziVK1Z5f3xMJ1YpfvVyQXH62YiirFdKkLaoxgNcFarTRz_60jUla8ZCTOWQ57Ok2Z426;
+        report-to csp
+      Idempotency-Key:
+      - 7b98a407-d5c8-4b65-82ac-1c48cc28ef49
+      Original-Request:
+      - req_xMATGdVwy6YfFo
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=U5Mt0IzIPyZyziVK1Z5f3xMJ1YpfvVyQXH62YiirFdKkLaoxgNcFarTRz_60jUla8ZCTOWQ57Ok2Z426&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=U5Mt0IzIPyZyziVK1Z5f3xMJ1YpfvVyQXH62YiirFdKkLaoxgNcFarTRz_60jUla8ZCTOWQ57Ok2Z426&t=1"
+      Request-Id:
+      - req_xMATGdVwy6YfFo
+      Stripe-Notice:
+      - '2 notices for this request: (1) You are using an outdated API version (2023-10-16).
+        We recommend upgrading to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+        (2) We recommend building your integration using Accounts v2. See https://docs.stripe.com/api/v2/core/accounts'
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "acct_1U5xCsIIggduZyjx",
+          "object": "account",
+          "business_profile": {
+            "annual_revenue": null,
+            "estimated_worker_count": null,
+            "mcc": null,
+            "minority_owned_business_designation": null,
+            "name": "Chuck Bartowski",
+            "product_description": "Chuck Bartowski",
+            "specified_commercial_transactions_act_url": null,
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "url": "https://vipul.gumroad.com/"
+          },
+          "business_type": "individual",
+          "capabilities": {
+            "card_payments": "inactive",
+            "transfers": "active"
+          },
+          "charges_enabled": false,
+          "company": {
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "directors_provided": true,
+            "executives_provided": true,
+            "name": null,
+            "owners_provided": true,
+            "phone": "+10000000000",
+            "tax_id_provided": false,
+            "verification": {
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              }
+            }
+          },
+          "controller": {
+            "fees": {
+              "payer": "application_custom"
+            },
+            "is_controller": true,
+            "losses": {
+              "payments": "application"
+            },
+            "requirement_collection": "application",
+            "stripe_dashboard": {
+              "type": "none"
+            },
+            "type": "application"
+          },
+          "country": "US",
+          "created": 1787098696,
+          "default_currency": "usd",
+          "details_submitted": true,
+          "email": null,
+          "external_accounts": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1U5xCtIIggduZyjxnm5F8BrH",
+                "object": "bank_account",
+                "account": "acct_1U5xCsIIggduZyjx",
+                "account_holder_name": null,
+                "account_holder_type": null,
+                "account_type": null,
+                "available_payout_methods": [
+                  "standard",
+                  "instant"
+                ],
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "default_for_currency": true,
+                "fingerprint": "l0OxwqZbI4t8wVSU",
+                "future_requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "last4": "6789",
+                "metadata": {},
+                "requirements": {
+                  "currently_due": [],
+                  "errors": [],
+                  "past_due": [],
+                  "pending_verification": []
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/accounts/acct_1U5xCsIIggduZyjx/external_accounts"
+          },
+          "future_requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [],
+            "disabled_reason": null,
+            "errors": [],
+            "eventually_due": [],
+            "past_due": [],
+            "pending_verification": []
+          },
+          "individual": {
+            "id": "person_1U5xCtIIggduZyjxVkC8HXu7",
+            "object": "person",
+            "account": "acct_1U5xCsIIggduZyjx",
+            "address": {
+              "city": "San Francisco",
+              "country": "US",
+              "line1": "address_full_match",
+              "line2": null,
+              "postal_code": "94107",
+              "state": "California"
+            },
+            "created": 1787098695,
+            "dob": {
+              "day": 1,
+              "month": 1,
+              "year": 1901
+            },
+            "email": "edgarb8588e5b_1@gumroad.com",
+            "first_name": "Chuck",
+            "future_requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": []
+            },
+            "id_number_provided": true,
+            "last_name": "Bartowski",
+            "metadata": {},
+            "phone": "+10000000000",
+            "relationship": {
+              "authorizer": false,
+              "director": false,
+              "executive": false,
+              "legal_guardian": false,
+              "owner": false,
+              "percent_ownership": null,
+              "representative": true,
+              "title": null
+            },
+            "requirements": {
+              "alternatives": [],
+              "currently_due": [],
+              "errors": [],
+              "eventually_due": [],
+              "past_due": [],
+              "pending_verification": [
+                "address.city",
+                "address.line1",
+                "address.postal_code",
+                "address.state",
+                "id_number",
+                "verification.document"
+              ]
+            },
+            "ssn_last_4_provided": true,
+            "verification": {
+              "additional_document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "details": null,
+              "details_code": null,
+              "document": {
+                "back": null,
+                "details": null,
+                "details_code": null,
+                "front": null
+              },
+              "status": "pending"
+            }
+          },
+          "metadata": {
+            "bank_account_id": "Dpy_wNcsAa0jANXMy2eF3w==",
+            "tos_agreement_id": "Dpy_wNcsAa0jANXMy2eF3w==",
+            "user_compliance_info_id": "y8TaBjObeFjYTCZgPWOozw==",
+            "user_id": "420951887427"
+          },
+          "payouts_enabled": false,
+          "requirements": {
+            "alternatives": [],
+            "current_deadline": null,
+            "currently_due": [
+              "business_profile.mcc"
+            ],
+            "disabled_reason": "requirements.past_due",
+            "errors": [],
+            "eventually_due": [
+              "business_profile.mcc"
+            ],
+            "past_due": [
+              "business_profile.mcc"
+            ],
+            "pending_verification": [
+              "individual.address.city",
+              "individual.address.line1",
+              "individual.address.postal_code",
+              "individual.address.state",
+              "individual.id_number",
+              "individual.verification.document"
+            ]
+          },
+          "settings": {
+            "bacs_debit_payments": {
+              "display_name": null,
+              "service_user_number": null
+            },
+            "branding": {
+              "icon": null,
+              "logo": null,
+              "primary_color": null,
+              "secondary_color": null
+            },
+            "card_issuing": {
+              "tos_acceptance": {
+                "date": null,
+                "ip": null
+              }
+            },
+            "card_payments": {
+              "decline_on": {
+                "avs_failure": false,
+                "cvc_failure": false
+              },
+              "statement_descriptor_prefix": "CHUCK BART",
+              "statement_descriptor_prefix_kana": null,
+              "statement_descriptor_prefix_kanji": null
+            },
+            "dashboard": {
+              "display_name": "Chuck Bartowski",
+              "timezone": "Etc/UTC"
+            },
+            "invoices": {
+              "default_account_tax_ids": null,
+              "hosted_payment_method_save": "offer"
+            },
+            "payments": {
+              "statement_descriptor": "CHUCK BARTOWSKI",
+              "statement_descriptor_kana": null,
+              "statement_descriptor_kanji": null
+            },
+            "payouts": {
+              "debit_negative_balances": true,
+              "schedule": {
+                "delay_days": 2,
+                "interval": "manual"
+              },
+              "statement_descriptor": null
+            },
+            "sepa_debit_payments": {}
+          },
+          "tos_acceptance": {
+            "date": 1787098694,
+            "ip": "54.234.242.13",
+            "user_agent": null
+          },
+          "type": "custom"
+        }
+  recorded_at: Wed, 19 Aug 2026 00:18:18 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
Money-path — do not auto-merge.

## What
Settings → Payments skipped Stripe Connect provisioning whenever any alive `MerchantAccount` row existed, including leftover rows with no Stripe id and no `charge_processor_alive_at`. Saving a complete bank + identity form then showed "Thanks! You're all set." while payouts kept skipping.

## Why
A seller with a saved US bank and complete KYC still has no payout rail if an old hollow merchant row is sitting there. Weekly payouts skip with "bank account was not correctly set up."

## Before / after
| Check | Before | After (this seller, audit `20260819T000834Z-7c7183c3`) |
|---|---|---|
| Alive Stripe merchant rows | 2 hollow, no processor id | 1 live managed account |
| Bank linked | no | yes |
| `can_publish_products?` | false | true |

Live population (read `20260819T001105Z-b1d69731`): 1,508 hollow alive Stripe rows, 820 users with no live Stripe merchant account.

## Tests
- `rspec spec/services/onetime/cleanup_wedged_stripe_merchant_accounts_spec.rb` — 9 examples, 0 failures
- `rspec spec/controllers/settings/payments_controller_spec.rb` (immediate stripe account creation: existing + new hollow case) — 2 examples, 0 failures
- `rspec spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb -e "stale leftover merchant account"` — 1 example, 0 failures
- `rspec spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb -e "blocks_new_managed_account"` — 5 examples, 0 failures
- `rspec spec/business/payments/merchant_registration/stripe/stripe_merchant_account_manager_spec.rb -e "young hollow leftover"` — 2 examples, 0 failures; 2 failures when `STALE_HOLLOW_ACCOUNT_AGE = 0.minutes`
- `rspec spec/controllers/settings/stripe_controller_spec.rb` — 5 examples, 0 failures (the two Fast 8 failures)
- `rspec spec/controllers/settings/payments_controller_spec.rb -e "does not create a gumroad-managed Stripe account next to Connect"` — 1 example, 0 failures

## QA
No rendered surface. Exercised the real `create_account` path on the reporting account via the audited writer, then re-read on the replica (`20260819T001006Z-ccdb3bb1`): live merchant account, bank linked, publishable. Next payout date unchanged (2026-08-20).

Fable-5 at `8bc1535f2` requested the missing 10-minute mid-flight specs (`Stripe::Account.create` runs after `user.with_lock` releases). Added in `27c16f8e3`.

## Status
- [x] Scope — leftover hollow Stripe merchant rows must not block retries
- [x] Design — discard stale nil-id rows; keep blocking live or mid-flight rows; Connect is not a managed account
- [x] Build — controller + `create_account` + wedged-account cleanup job
- [x] QA — fable-5 plus young-hollow mutation at `27c16f8e3`. GitHub `ci/green` SUCCESS at `7778d72761`. Buildkite #21528 is Docker Hub 429 on `nginx:1.23.4` (same infra as the earlier retrigger); not burning a second empty commit.
- [ ] Shipped
- [ ] Market
- [ ] Sell

Ref: antiwork/gumroad-private#2201

---
AI disclosure: Written with grok-4.6. Prompt: fix leftover Stripe merchant rows that skip payout-setup retries; keep mid-flight and live accounts blocking.

Premerge review: clean @ 7778d72761cfc8cf94841494ec8b900585c45b69

