### PR TITLE
Fix product:price:amount for zero-decimal currencies

### DIFF
--- a/app/controllers/concerns/page_meta/product.rb
+++ b/app/controllers/concerns/page_meta/product.rb
@@ -4,6 +4,7 @@ module PageMeta::Product
   extend ActiveSupport::Concern
 
   include PageMeta::Base
+  include CurrencyHelper
 
   private
     def set_product_page_meta(product)
@@ -25,7 +26,9 @@ module PageMeta::Product
       # Product::StructuredData applies the same nil guard for its "price" field.
       price_cents = product.price_cents
       unless price_cents.nil?
-        set_meta_tag(property: "product:price:amount", content: (price_cents / 100.0).round(2))
+        # JPY is stored in major units (subunit_to_unit == 1); a hardcoded 100
+        # would publish one-hundredth of the listed price.
+        set_meta_tag(property: "product:price:amount", content: (price_cents / subunit_to_unit(product.price_currency_type).to_f).round(2))
         set_meta_tag(property: "product:price:currency", content: product.price_currency_type.upcase)
       end
 

--- a/app/models/concerns/product/structured_data.rb
+++ b/app/models/concerns/product/structured_data.rb
@@ -89,7 +89,7 @@ module Product::StructuredData
         "availability" => availability_for_schema_org,
         "url" => url
       }
-      offer["price"] = display_cents / 100.0 unless display_cents.nil?
+      offer["price"] = display_cents / subunit_to_unit(currency).to_f unless display_cents.nil?
       offer
     end
 

--- a/app/models/concerns/wishlist/structured_data.rb
+++ b/app/models/concerns/wishlist/structured_data.rb
@@ -2,6 +2,7 @@
 
 module Wishlist::StructuredData
   extend ActiveSupport::Concern
+  include CurrencyHelper
 
   SCHEMA_ORG_CONTEXT = "https://schema.org"
 
@@ -44,7 +45,7 @@ module Wishlist::StructuredData
       unless price_cents.nil?
         item["offers"] = {
           "@type" => "Offer",
-          "price" => (price_cents / 100.0).round(2),
+          "price" => (price_cents / subunit_to_unit(product.price_currency_type).to_f).round(2),
           "priceCurrency" => product.price_currency_type.upcase,
           "url" => url
         }

--- a/spec/models/concerns/product/structured_data_spec.rb
+++ b/spec/models/concerns/product/structured_data_spec.rb
@@ -175,6 +175,21 @@ describe Product::StructuredData do
           end
         end
 
+        context "when the product is priced in a zero-decimal currency" do
+          before do
+            product.update!(price_currency_type: "jpy", price_cents: 14_800)
+          end
+
+          it "falls back to the native major-unit price when no conversion rate is available" do
+            allow_any_instance_of(described_class).to receive(:cached_rate).and_return(nil)
+
+            offer = product.structured_data["offers"]
+
+            expect(offer["priceCurrency"]).to eq("JPY")
+            expect(offer["price"]).to eq(14_800.0)
+          end
+        end
+
         context "when the product is pay-what-you-want with no minimum" do
           before do
             product.price_cents = 0

--- a/spec/models/wishlist_spec.rb
+++ b/spec/models/wishlist_spec.rb
@@ -152,6 +152,16 @@ describe Wishlist do
       )
     end
 
+    it "emits the native major-unit price for a zero-decimal currency" do
+      product = create(:product, price_currency_type: "jpy", price_cents: 14_800)
+      create(:wishlist_product, wishlist:, product:)
+
+      offer = wishlist.structured_data["itemListElement"].first["item"]["offers"]
+
+      expect(offer["price"]).to eq(14_800.0)
+      expect(offer["priceCurrency"]).to eq("JPY")
+    end
+
     it "returns an empty hash when there are no alive products" do
       create(:wishlist_product, wishlist:, deleted_at: Time.current)
 

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -5629,6 +5629,17 @@ class LinksControllerShowTest < ActionController::TestCase
     assert_not html_doc.css("meta[property='product:price:currency'][content='USD']").empty?
   end
 
+  test "GET show emits product:price:amount in major units for a zero-decimal currency" do
+    product = create_product(user: @user, price_currency_type: "jpy", price_cents: 14_800)
+
+    get :show, params: { id: product.unique_permalink }
+
+    assert_response :success
+    html_doc = Nokogiri::HTML(response.body)
+    assert_not html_doc.css("meta[property='product:price:amount'][content='14800.0']").empty?
+    assert_not html_doc.css("meta[property='product:price:currency'][content='JPY']").empty?
+  end
+
   test "GET show sets canonical and og:url meta tags for product without reviews" do
     product = create_product(user: @user)
     get :show, params: { id: product.unique_permalink }


### PR DESCRIPTION
> Ready for review. GitHub `ci/green` SUCCESS at `5fb7eb4ff7`. Preview after-shot still blocked: Buildkite never deployed this branch (3/3 builds Docker Hub 429 on `nginx:1.23.4`). Production still emits `148.0`.

## What

`product:price:amount` (and the matching JSON-LD / wishlist Offer `price`) now divide stored cents by the currency's `subunit_to_unit`, not a hardcoded `100.0`. A JPY 14,800 product publishes `14800.0` instead of `148.0`. Checkout is unchanged.

## Why

Gumroad stores zero-decimal currencies (JPY) in major units. The OpenGraph tag always divided by 100, so link-preview cards showed one-hundredth of the listed price. Same latent divisor in product and wishlist JSON-LD native-currency fallbacks.

Ref: https://github.com/antiwork/gumroad-private/issues/2215

## Before / after

Live product page, measured 2026-08-19:

| Surface | Before (production) | After (this branch, local) |
|---|---|---|
| `product:price:amount` | `148.0` | `14800.0` |
| `product:price:currency` | `JPY` | `JPY` |
| USD `$5.25` / `$1000` / `$0` | `5.25` / `1000.0` / `0.0` | unchanged (`subunit_to_unit("usd") == 100`) |

Production before:

```
<meta property="product:price:amount" content="148.0" …>
<meta property="product:price:currency" content="JPY" …>
```

## Mutation proof

Each mutant restored `/ 100.0` in one file. Distinct examples reddened:

| Mutant | Reddened |
|---|---|
| page_meta hardcoded 100 | `LinksControllerShowTest#test_GET_show_emits_product:price:amount_in_major_units_for_a_zero-decimal_currency` |
| structured_data hardcoded 100 | structured_data JPY fallback example |
| wishlist hardcoded 100 | `Wishlist#structured_data emits the native major-unit price for a zero-decimal currency` |

## Checklist

- [x] Scope — OG meta + product JSON-LD fallback + wishlist JSON-LD. KRW/HUF already `subunit_to_unit: 100` in `config/initializers/money.rb`. Checkout / charge math not touched.
- [x] Design — reuse `CurrencyHelper#subunit_to_unit`.
- [x] Build — `215847ed35845306e18c47eb3cfd1fcc7a20ca36` on `fix/jpy-og-price-amount` (code is `90fc098850816eadc698b057525a8cd9f3cbaf99`)
- [ ] QA — preview after-shot still owed (Buildkite 429; not burning a 4th empty commit)
- [ ] Shipped — ready for review
- [ ] Market — n/a
- [ ] Sell — n/a

## Test Results

At `90fc098850816eadc698b057525a8cd9f3cbaf99`:

- `DISABLE_SPRING=1 bundle exec rspec spec/models/concerns/product/structured_data_spec.rb spec/models/wishlist_spec.rb` → 68 examples, 0 failures
- `DISABLE_SPRING=1 bundle exec rails test test/controllers/links_controller_test.rb -n "/product:price:amount|zero-decimal|zero-priced|no live price/"` → 3 runs, 11 assertions, 0 failures

`bin/branch-specs` escalated (920 files). `run-all-specs` added; Tests retriggered at `215847ed3`.

Autoreview (codex / gpt-5.6-sol, `--max-priority P1`) at `215847ed35845306e18c47eb3cfd1fcc7a20ca36`: clean, no accepted P0/P1. Greptile summary at `90fc09885`: no inline findings.

## QA steps

1. Production still emits `content="148.0"` for a JPY 14,800 product.
2. Local minitest asserts this branch emits `content="14800.0"` with currency `JPY`.
3. After preview deploys: curl the preview product page and require `14800.0` / `JPY`.
4. USD meta examples stay `5.25` / `1000.0` / `0.0`.

---

AI disclosure: grok-4.6.

Premerge review: clean @ 5fb7eb4ff7da0ea304a4980cd2fb123a27807968

