### PR TITLE
Match EmailEngagementDynamoStore to the Terraform pk/sk table schema

### DIFF
--- a/app/services/email_engagement_dynamo_store.rb
+++ b/app/services/email_engagement_dynamo_store.rb
@@ -3,7 +3,7 @@
 # Dual-write adapter for the DynamoDB table replacing the CreatorEmailOpenEvent /
 # CreatorEmailClickEvent / CreatorEmailClickSummary Mongo collections.
 #
-# Partition key `installment_id` (N), sort key `sk` (S), one of:
+# Partition key `pk` (S, the stringified installment id), sort key `sk` (S), one of:
 #   SUMMARY                    — open_count / click_count counters for the installment
 #   OPEN#<recipient>           — one item per recipient who opened
 #   CLICK#<recipient>#<url>    — one item per recipient + url first click
@@ -53,15 +53,17 @@ class EmailEngagementDynamoStore
       "#{ENV["DYNAMODB_TABLE_PREFIX"]}#{TABLE_BASE_NAME}"
     end
 
+    # Staging and production tables are Terraform-owned (antiwork/infrastructure#998)
+    # and deletion-protected; this bootstrap is for dev, test, and branch apps.
     def create_table!
       client.create_table(
         table_name:,
         attribute_definitions: [
-          { attribute_name: "installment_id", attribute_type: "N" },
+          { attribute_name: "pk", attribute_type: "S" },
           { attribute_name: "sk", attribute_type: "S" },
         ],
         key_schema: [
-          { attribute_name: "installment_id", key_type: "HASH" },
+          { attribute_name: "pk", key_type: "HASH" },
           { attribute_name: "sk", key_type: "RANGE" },
         ],
         billing_mode: "PAY_PER_REQUEST"
@@ -70,6 +72,10 @@ class EmailEngagementDynamoStore
 
     # The backfill must derive identical keys from the Mongo documents, so key
     # derivation is public and must not change while Mongo remains around.
+    def partition_key(installment_id)
+      installment_id.to_i.to_s
+    end
+
     def recipient_digest(mailer_method:, mailer_args:)
       Digest::SHA256.hexdigest("#{mailer_method}\n#{mailer_args}")
     end
@@ -121,7 +127,7 @@ class EmailEngagementDynamoStore
         client.put_item(
           table_name:,
           item: {
-            "installment_id" => installment_id,
+            "pk" => partition_key(installment_id),
             "sk" => open_sort_key(mailer_method:, mailer_args:),
             "mailer_method" => mailer_method,
             "mailer_args" => mailer_args,
@@ -129,7 +135,7 @@ class EmailEngagementDynamoStore
             "first_open_at" => now,
             "last_open_at" => now,
           },
-          condition_expression: "attribute_not_exists(installment_id)"
+          condition_expression: "attribute_not_exists(pk)"
         )
         increment_summary(installment_id:, attribute: "open_count")
       rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException
@@ -140,7 +146,7 @@ class EmailEngagementDynamoStore
         client.put_item(
           table_name:,
           item: {
-            "installment_id" => installment_id,
+            "pk" => partition_key(installment_id),
             "sk" => "CLICK##{recipient}##{url_digest(click_url)}",
             "mailer_method" => mailer_method,
             "mailer_args" => mailer_args,
@@ -148,7 +154,7 @@ class EmailEngagementDynamoStore
             "click_count" => 1,
             "first_click_at" => timestamp,
           },
-          condition_expression: "attribute_not_exists(installment_id)"
+          condition_expression: "attribute_not_exists(pk)"
         )
         true
       rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException
@@ -158,8 +164,8 @@ class EmailEngagementDynamoStore
       def recipient_clicked_any_url?(installment_id:, recipient:)
         client.query(
           table_name:,
-          key_condition_expression: "installment_id = :installment_id AND begins_with(sk, :sk_prefix)",
-          expression_attribute_values: { ":installment_id" => installment_id, ":sk_prefix" => "CLICK##{recipient}#" },
+          key_condition_expression: "pk = :pk AND begins_with(sk, :sk_prefix)",
+          expression_attribute_values: { ":pk" => partition_key(installment_id), ":sk_prefix" => "CLICK##{recipient}#" },
           select: "COUNT",
           limit: 1,
           consistent_read: true
@@ -186,7 +192,7 @@ class EmailEngagementDynamoStore
       end
 
       def item_key(installment_id, sort_key)
-        { "installment_id" => installment_id, "sk" => sort_key }
+        { "pk" => partition_key(installment_id), "sk" => sort_key }
       end
 
       def timestamp

--- a/spec/services/email_engagement_dynamo_store_spec.rb
+++ b/spec/services/email_engagement_dynamo_store_spec.rb
@@ -50,7 +50,7 @@ describe EmailEngagementDynamoStore do
 
       open_upsert = requests.first[:params]
       expect(open_upsert[:table_name]).to eq("email_engagement")
-      expect(plain_hash(open_upsert[:key])).to eq("installment_id" => 123, "sk" => "OPEN##{recipient_digest}")
+      expect(plain_hash(open_upsert[:key])).to eq("pk" => "123", "sk" => "OPEN##{recipient_digest}")
       expect(open_upsert[:update_expression]).to include("ADD open_count :one")
       expect(open_upsert[:update_expression]).to include("first_open_at = if_not_exists(first_open_at, :now)")
       expect(plain(open_upsert[:expression_attribute_values][":mailer_method"])).to eq(mailer_method)
@@ -58,7 +58,7 @@ describe EmailEngagementDynamoStore do
       expect(open_upsert[:return_values]).to eq("ALL_OLD")
 
       summary_update = requests.last[:params]
-      expect(plain_hash(summary_update[:key])).to eq("installment_id" => 123, "sk" => "SUMMARY")
+      expect(plain_hash(summary_update[:key])).to eq("pk" => "123", "sk" => "SUMMARY")
       expect(summary_update[:update_expression]).to eq("ADD #counter :one")
       expect(summary_update[:expression_attribute_names]).to eq("#counter" => "open_count")
     end
@@ -100,33 +100,35 @@ describe EmailEngagementDynamoStore do
       )
 
       query = requests[0][:params]
-      expect(query[:key_condition_expression]).to eq("installment_id = :installment_id AND begins_with(sk, :sk_prefix)")
-      expect(plain_hash(query[:expression_attribute_values])).to eq(":installment_id" => 123, ":sk_prefix" => "CLICK##{recipient_digest}#")
+      expect(query[:key_condition_expression]).to eq("pk = :pk AND begins_with(sk, :sk_prefix)")
+      expect(plain_hash(query[:expression_attribute_values])).to eq(":pk" => "123", ":sk_prefix" => "CLICK##{recipient_digest}#")
       expect(query[:select]).to eq("COUNT")
       expect(query[:consistent_read]).to be(true)
 
       click_put = requests[1][:params]
+      expect(plain(click_put[:item]["pk"])).to eq("123")
       expect(plain(click_put[:item]["sk"])).to eq("CLICK##{recipient_digest}##{url_digest}")
       expect(plain(click_put[:item]["click_url"])).to eq(click_url)
       expect(plain(click_put[:item]["click_count"])).to eq(1)
-      expect(click_put[:condition_expression]).to eq("attribute_not_exists(installment_id)")
+      expect(click_put[:condition_expression]).to eq("attribute_not_exists(pk)")
 
       url_update = requests[2][:params]
-      expect(plain_hash(url_update[:key])).to eq("installment_id" => 123, "sk" => "URL##{url_digest}")
+      expect(plain_hash(url_update[:key])).to eq("pk" => "123", "sk" => "URL##{url_digest}")
       expect(url_update[:update_expression]).to eq("ADD click_count :one SET click_url = :click_url")
       expect(plain(url_update[:expression_attribute_values][":click_url"])).to eq(click_url)
 
       summary_click_update = requests[3][:params]
-      expect(plain_hash(summary_click_update[:key])).to eq("installment_id" => 123, "sk" => "SUMMARY")
+      expect(plain_hash(summary_click_update[:key])).to eq("pk" => "123", "sk" => "SUMMARY")
       expect(summary_click_update[:expression_attribute_names]).to eq("#counter" => "click_count")
 
       open_put = requests[4][:params]
+      expect(plain(open_put[:item]["pk"])).to eq("123")
       expect(plain(open_put[:item]["sk"])).to eq("OPEN##{recipient_digest}")
       expect(plain(open_put[:item]["open_count"])).to eq(1)
-      expect(open_put[:condition_expression]).to eq("attribute_not_exists(installment_id)")
+      expect(open_put[:condition_expression]).to eq("attribute_not_exists(pk)")
 
       summary_open_update = requests[5][:params]
-      expect(plain_hash(summary_open_update[:key])).to eq("installment_id" => 123, "sk" => "SUMMARY")
+      expect(plain_hash(summary_open_update[:key])).to eq("pk" => "123", "sk" => "SUMMARY")
       expect(summary_open_update[:expression_attribute_names]).to eq("#counter" => "open_count")
     end
 
@@ -171,17 +173,30 @@ describe EmailEngagementDynamoStore do
     end
   end
 
+  describe ".partition_key" do
+    it "stringifies the installment id" do
+      expect(described_class.partition_key(123)).to eq("123")
+      expect(described_class.partition_key("123")).to eq("123")
+    end
+  end
+
   describe ".create_table!" do
-    it "creates the on-demand table keyed by installment id and sort key" do
+    it "creates the on-demand table with the generic pk/sk string key schema" do
       described_class.create_table!
 
       request = requests.sole
       expect(request[:operation_name]).to eq(:create_table)
       expect(request[:params][:table_name]).to eq("email_engagement")
       expect(request[:params][:billing_mode]).to eq("PAY_PER_REQUEST")
+      expect(request[:params][:attribute_definitions]).to eq(
+        [
+          { attribute_name: "pk", attribute_type: "S" },
+          { attribute_name: "sk", attribute_type: "S" },
+        ]
+      )
       expect(request[:params][:key_schema]).to eq(
         [
-          { attribute_name: "installment_id", key_type: "HASH" },
+          { attribute_name: "pk", key_type: "HASH" },
           { attribute_name: "sk", key_type: "RANGE" },
         ]
       )


### PR DESCRIPTION
## What

Adapts `EmailEngagementDynamoStore` (#7297) to the actual key schema of the `email_engagement` tables that antiwork/infrastructure#998 created in staging and production: generic `pk` (S) / `sk` (S) instead of `installment_id` (N) / `sk` (S).

- Every write, condition expression (`attribute_not_exists(pk)`), and the recipient-click `Query` now key on `pk`, a stringified installment id.
- The stringification lives in a public `partition_key` helper alongside `recipient_digest`/`url_digest`, since the backfill must derive identical keys from the Mongo documents.
- `create_table!` (dev/test/branch-app bootstrap; the staging/production tables are Terraform-owned and deletion-protected) now emits the same generic schema, so every environment exercises the exact production table shape.

## Why

The infra PR deliberately chose generic `pk`/`sk` string keys so the key schema never forces a table rebuild, and its description assumed the app adapter would map `installment_id` → `pk` — but that adapter change didn't exist yet. Against the live table, every dual write would fail validation (missing key `pk`); harmlessly, since the guard swallows and reports, but 100% of writes would land in the error tracker instead of DynamoDB. This has to deploy before the `email_engagement_dynamodb_dual_write` flag flips. Renaming the app-side key was chosen over recreating the tables with `installment_id` keys because the infra rationale (schema-agnostic keys, deletion protection, PITR already applied) holds, and with the flag off this is a pure no-op.

Not in this PR: setting `DYNAMODB_TABLE_PREFIX=production-`/`staging-` in the app environment, which happens in the deployment repo before the flag flips.

## Before/After

No user-facing change: the feature flag is off (default), making this a no-op in production today. Functional evidence — the adapter run against `amazon/dynamodb-local` with the table created exactly as Terraform creates it (`pk`/`sk` string keys), exercising repeat opens, repeat clicks, a second URL, and a click-without-open:

```
pk=123  CLICK#80c48106…#2dce0a4c…  click_count=1 click_url=https://example.com/a
pk=123  CLICK#cad630d0…#2dce0a4c…  click_count=1 click_url=https://example.com/a
pk=123  CLICK#cad630d0…#d7fe568b…  click_count=1 click_url=https://example.com/b
pk=123  OPEN#435f1e63…             open_count=1
pk=123  OPEN#80c48106…             open_count=1   (compensating open from click)
pk=123  OPEN#cad630d0…             open_count=2
pk=123  SUMMARY                    click_count=2 open_count=3
pk=123  URL#2dce0a4c…              click_count=2 click_url=https://example.com/a
pk=123  URL#d7fe568b…              click_count=1 click_url=https://example.com/b
```

Walkthrough video: TODO before marking ready for review.

## QA steps

1. Against a local DynamoDB (`DYNAMODB_ENDPOINT=http://localhost:8000`), create the table with `EmailEngagementDynamoStore.create_table!` and confirm `describe_table` shows `pk`/`sk` string keys — the same schema as `production-email_engagement`.
2. `Feature.activate(:email_engagement_dynamodb_dual_write)`, trigger open and click webhook events, and confirm `OPEN#`/`CLICK#`/`URL#`/`SUMMARY` items appear under the stringified installment id with correct counters.
3. Confirm no `ValidationException` errors are reported during processing.

## Test Results

- `bundle exec rspec spec/services/email_engagement_dynamo_store_spec.rb` — 12 examples, 0 failures
- `bundle exec rspec spec/services/handle_email_event_info/for_abandoned_cart_email_spec.rb` — 22 examples, 0 failures
- `spec/services/handle_email_event_info/for_installment_email_spec.rb` needs a successful-purchase factory that doesn't work in my local environment (fails the same way on `main`), so relying on CI for that file; this PR doesn't touch that service and its `EmailEngagementDynamoStore` expectations are on the unchanged public API
- End-to-end run of the adapter against `amazon/dynamodb-local` with the Terraform-shaped table (output above), including a `create_table!` schema match assertion
- `bundle exec rubocop` on both changed files — clean

---

AI disclosure: implemented with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)