### PR TITLE
Derive the DynamoDB table prefix from Rails.env

### DIFF
--- a/app/services/email_engagement_dynamo_store.rb
+++ b/app/services/email_engagement_dynamo_store.rb
@@ -50,7 +50,14 @@ class EmailEngagementDynamoStore
     end
 
     def table_name
-      "#{ENV["DYNAMODB_TABLE_PREFIX"]}#{TABLE_BASE_NAME}"
+      "#{table_prefix}#{TABLE_BASE_NAME}"
+    end
+
+    # Production and staging default to the Terraform-owned <env>- tables;
+    # DYNAMODB_TABLE_PREFIX overrides for dev lanes and branch apps.
+    def table_prefix
+      ENV["DYNAMODB_TABLE_PREFIX"].presence ||
+        (Rails.env.production? || Rails.env.staging? ? "#{Rails.env}-" : "")
     end
 
     # Staging and production tables are Terraform-owned (antiwork/infrastructure#998)

--- a/spec/services/email_engagement_dynamo_store_spec.rb
+++ b/spec/services/email_engagement_dynamo_store_spec.rb
@@ -171,6 +171,22 @@ describe EmailEngagementDynamoStore do
     ensure
       ENV.delete("DYNAMODB_TABLE_PREFIX")
     end
+
+    it "defaults to the Terraform-owned per-environment table in production and staging" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+      expect(described_class.table_name).to eq("production-email_engagement")
+
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("staging"))
+      expect(described_class.table_name).to eq("staging-email_engagement")
+    end
+
+    it "lets DYNAMODB_TABLE_PREFIX override the environment default for branch apps" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("staging"))
+      ENV["DYNAMODB_TABLE_PREFIX"] = "branchapp-foo-"
+      expect(described_class.table_name).to eq("branchapp-foo-email_engagement")
+    ensure
+      ENV.delete("DYNAMODB_TABLE_PREFIX")
+    end
   end
 
   describe ".partition_key" do


### PR DESCRIPTION
## What

`EmailEngagementDynamoStore.table_name` now defaults its prefix to `"#{Rails.env}-"` in production and staging, resolving to the Terraform-owned `production-email_engagement` / `staging-email_engagement` tables (antiwork/infrastructure#998). `DYNAMODB_TABLE_PREFIX` keeps precedence as an override; development and test stay unprefixed, so local environments, CI, and `laneN_` dev lanes are unchanged.

## Why

Nothing sets `DYNAMODB_TABLE_PREFIX` in the app environments, so once the `email_engagement_dynamodb_dual_write` flag flips, every write would target the nonexistent unprefixed `email_engagement` table and fail (swallowed by the guard, but 100% failure into the error tracker and zero data written). The alternative was adding the env var to every Nomad job template in the deployment repo; deriving it from `Rails.env` is less configuration to keep in sync, works because branch apps run `RAILS_ENV=staging` and the Terraform names are literally `#{Rails.env}-email_engagement`, and keeps the env-var override intact for the planned per-branch-app `branchapp-<app>-*` tables. Until those are wired, branch apps inherit the shared staging table — acceptable since the staging flag stays off until then.

With this deployed, the only remaining gate before enabling the flag in production is the deploy itself.

## Before/After

No user-facing change: the feature flag is off, and with it on the only behavioral difference is that dual writes resolve to the real per-environment table instead of a nonexistent one. Walkthrough video: TODO before marking ready for review.

## QA steps

1. In a production or staging console, confirm `EmailEngagementDynamoStore.table_name` returns the env-prefixed name and `EmailEngagementDynamoStore.client.describe_table(table_name: EmailEngagementDynamoStore.table_name).table.table_status` returns `ACTIVE`.
2. Locally, confirm `table_name` is `email_engagement` by default and honors `DYNAMODB_TABLE_PREFIX`.

## Test Results

- `bundle exec rspec spec/services/email_engagement_dynamo_store_spec.rb` — 14 examples, 0 failures (adds production/staging defaults and the branch-app override case)
- `bundle exec rubocop` on both changed files — clean

---

AI disclosure: implemented with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)