### PR TITLE
Decide unique clicks with a conditional CLICKER# marker

### DIFF
--- a/app/services/email_engagement_dynamo_store.rb
+++ b/app/services/email_engagement_dynamo_store.rb
@@ -6,12 +6,12 @@
 # Partition key `pk` (S, the stringified installment id), sort key `sk` (S), one of:
 #   SUMMARY                    — open_count / click_count counters for the installment
 #   OPEN#<recipient>           — one item per recipient who opened
+#   CLICKER#<recipient>        — claims the recipient's first click; drives click_count
 #   CLICK#<recipient>#<url>    — one item per recipient + url first click
 #   URL#<url>                  — unique-click total for one url
 # <recipient> and <url> are SHA256 hex digests (raw values are attributes on the
-# items). CLICK keys are recipient-first so "has this recipient clicked anything?"
-# is a begins_with query; per-url totals are separate items rather than a map on
-# SUMMARY so link-heavy posts can't grow SUMMARY toward the 400KB item cap.
+# items). Per-url totals are separate items rather than a map on SUMMARY so
+# link-heavy posts can't grow SUMMARY toward the 400KB item cap.
 class EmailEngagementDynamoStore
   TABLE_BASE_NAME = "email_engagement"
   SUMMARY_SORT_KEY = "SUMMARY"
@@ -30,14 +30,18 @@ class EmailEngagementDynamoStore
       with_dual_write_guard do
         installment_id = installment_id.to_i
         recipient = recipient_digest(mailer_method:, mailer_args:)
-        first_click_for_recipient = !recipient_clicked_any_url?(installment_id:, recipient:)
 
         # A repeat click of the same url by the same recipient counts nothing,
         # matching the Mongo path's early return.
         next unless put_click_item(installment_id:, mailer_method:, mailer_args:, click_url:, recipient:)
 
         increment_url_click_count(installment_id:, click_url:)
-        increment_summary(installment_id:, attribute: "click_count") if first_click_for_recipient
+        # The conditional marker put is both the "has this recipient clicked
+        # anything?" check and the claim, so concurrent first clicks on
+        # different urls can't double-increment the counter.
+        if put_clicker_marker(installment_id:, mailer_method:, mailer_args:, recipient:)
+          increment_summary(installment_id:, attribute: "click_count")
+        end
         # A click implies an open; compensates for blocked tracking pixels.
         ensure_open_item(installment_id:, mailer_method:, mailer_args:)
       end
@@ -97,6 +101,10 @@ class EmailEngagementDynamoStore
 
     def click_sort_key(mailer_method:, mailer_args:, click_url:)
       "CLICK##{recipient_digest(mailer_method:, mailer_args:)}##{url_digest(click_url)}"
+    end
+
+    def clicker_sort_key(mailer_method:, mailer_args:)
+      "CLICKER##{recipient_digest(mailer_method:, mailer_args:)}"
     end
 
     def url_sort_key(click_url)
@@ -168,15 +176,21 @@ class EmailEngagementDynamoStore
         false
       end
 
-      def recipient_clicked_any_url?(installment_id:, recipient:)
-        client.query(
+      def put_clicker_marker(installment_id:, mailer_method:, mailer_args:, recipient:)
+        client.put_item(
           table_name:,
-          key_condition_expression: "pk = :pk AND begins_with(sk, :sk_prefix)",
-          expression_attribute_values: { ":pk" => partition_key(installment_id), ":sk_prefix" => "CLICK##{recipient}#" },
-          select: "COUNT",
-          limit: 1,
-          consistent_read: true
-        ).count.positive?
+          item: {
+            "pk" => partition_key(installment_id),
+            "sk" => "CLICKER##{recipient}",
+            "mailer_method" => mailer_method,
+            "mailer_args" => mailer_args,
+            "first_click_at" => timestamp,
+          },
+          condition_expression: "attribute_not_exists(pk)"
+        )
+        true
+      rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException
+        false
       end
 
       def increment_url_click_count(installment_id:, click_url:)

--- a/spec/services/email_engagement_dynamo_store_spec.rb
+++ b/spec/services/email_engagement_dynamo_store_spec.rb
@@ -90,32 +90,30 @@ describe EmailEngagementDynamoStore do
       expect(requests).to be_empty
     end
 
-    it "records a first-ever click with the url total, the summary click count, and a compensating open" do
-      client.stub_responses(:query, { count: 0 })
-
+    it "records a first-ever click with the url total, the clicker marker, the summary click count, and a compensating open" do
       described_class.record_click(installment_id: 123, mailer_method:, mailer_args:, click_url:)
 
       expect(requests.map { _1[:operation_name] }).to eq(
-        [:query, :put_item, :update_item, :update_item, :put_item, :update_item]
+        [:put_item, :update_item, :put_item, :update_item, :put_item, :update_item]
       )
 
-      query = requests[0][:params]
-      expect(query[:key_condition_expression]).to eq("pk = :pk AND begins_with(sk, :sk_prefix)")
-      expect(plain_hash(query[:expression_attribute_values])).to eq(":pk" => "123", ":sk_prefix" => "CLICK##{recipient_digest}#")
-      expect(query[:select]).to eq("COUNT")
-      expect(query[:consistent_read]).to be(true)
-
-      click_put = requests[1][:params]
+      click_put = requests[0][:params]
       expect(plain(click_put[:item]["pk"])).to eq("123")
       expect(plain(click_put[:item]["sk"])).to eq("CLICK##{recipient_digest}##{url_digest}")
       expect(plain(click_put[:item]["click_url"])).to eq(click_url)
       expect(plain(click_put[:item]["click_count"])).to eq(1)
       expect(click_put[:condition_expression]).to eq("attribute_not_exists(pk)")
 
-      url_update = requests[2][:params]
+      url_update = requests[1][:params]
       expect(plain_hash(url_update[:key])).to eq("pk" => "123", "sk" => "URL##{url_digest}")
       expect(url_update[:update_expression]).to eq("ADD click_count :one SET click_url = :click_url")
       expect(plain(url_update[:expression_attribute_values][":click_url"])).to eq(click_url)
+
+      marker_put = requests[2][:params]
+      expect(plain(marker_put[:item]["pk"])).to eq("123")
+      expect(plain(marker_put[:item]["sk"])).to eq("CLICKER##{recipient_digest}")
+      expect(plain(marker_put[:item]["mailer_args"])).to eq(mailer_args)
+      expect(marker_put[:condition_expression]).to eq("attribute_not_exists(pk)")
 
       summary_click_update = requests[3][:params]
       expect(plain_hash(summary_click_update[:key])).to eq("pk" => "123", "sk" => "SUMMARY")
@@ -133,27 +131,26 @@ describe EmailEngagementDynamoStore do
     end
 
     it "does not increment the summary click count when the recipient has clicked another url before" do
-      client.stub_responses(:query, { count: 1 })
-      # The click item put succeeds; the compensating open put finds an existing open item.
-      client.stub_responses(:put_item, [{}, "ConditionalCheckFailedException"])
+      # The click item put succeeds; the clicker marker already exists, as does the open item.
+      client.stub_responses(:put_item, [{}, "ConditionalCheckFailedException", "ConditionalCheckFailedException"])
 
       described_class.record_click(installment_id: 123, mailer_method:, mailer_args:, click_url:)
 
-      expect(requests.map { _1[:operation_name] }).to eq([:query, :put_item, :update_item, :put_item])
-      expect(plain(requests[2][:params][:key]["sk"])).to eq("URL##{url_digest}")
+      expect(requests.map { _1[:operation_name] }).to eq([:put_item, :update_item, :put_item, :put_item])
+      expect(plain(requests[1][:params][:key]["sk"])).to eq("URL##{url_digest}")
+      expect(plain(requests[2][:params][:item]["sk"])).to eq("CLICKER##{recipient_digest}")
     end
 
     it "counts nothing on a repeat click of the same url by the same recipient" do
-      client.stub_responses(:query, { count: 1 })
       client.stub_responses(:put_item, "ConditionalCheckFailedException")
 
       described_class.record_click(installment_id: 123, mailer_method:, mailer_args:, click_url:)
 
-      expect(requests.map { _1[:operation_name] }).to eq([:query, :put_item])
+      expect(requests.map { _1[:operation_name] }).to eq([:put_item])
     end
 
     it "notifies instead of raising when DynamoDB fails" do
-      client.stub_responses(:query, "ProvisionedThroughputExceededException")
+      client.stub_responses(:put_item, "ProvisionedThroughputExceededException")
       expect(ErrorNotifier).to receive(:notify).with(kind_of(Aws::Errors::ServiceError))
 
       expect do


### PR DESCRIPTION
## What

Replaces `EmailEngagementDynamoStore`'s clicked-anything check — a strongly consistent `Query` over the recipient's `CLICK#` prefix — with a conditional `PutItem` on a new `CLICKER#<recipient>` item. The put succeeding *is* the "first click by this recipient" decision, and it and the `click_count` increment can no longer disagree. `clicker_sort_key` is exposed publicly alongside the other key-derivation helpers so the backfill emits identical keys.

## Why

The Query-then-increment shape had a race: two concurrent first clicks by the same recipient on different urls could both see "no clicks yet" and double-increment the summary's `click_count`. That's parity with the Mongo path's read-then-inc (and self-healing, since counters are recomputable from items), but the conditional put closes it outright — the check and the claim are one atomic operation. It also strictly reduces work: the repeat-click path (the most common click event) drops from two DynamoDB calls to one, and every other path swaps a strongly consistent read for a write of the same round-trip cost. Reconciliation simplifies as a side effect: `click_count` becomes a count of `CLICKER#` items, the same shape as `open_count`, instead of a distinct-recipient walk over `CLICK#` keys.

Sequencing matters: this needs to land before the backfill runs so the loader emits markers for historical clickers — retrofitting them later means a full-table sweep.

## Before/After

No user-facing change: the `email_engagement_dynamodb_dual_write` flag is still off in production. Functional evidence — the adapter run against `amazon/dynamodb-local` with the table created exactly as Terraform creates it, exercising repeat opens, repeat clicks, a second URL, and a click-without-open:

```
pk=123  CLICK#80c48106…#2dce0a4c…  click_count=1 click_url=https://example.com/a
pk=123  CLICK#cad630d0…#2dce0a4c…  click_count=1 click_url=https://example.com/a
pk=123  CLICK#cad630d0…#d7fe568b…  click_count=1 click_url=https://example.com/b
pk=123  CLICKER#80c48106…          (carol — click with no prior open)
pk=123  CLICKER#cad630d0…          (alice)
pk=123  OPEN#435f1e63…             open_count=1
pk=123  OPEN#80c48106…             open_count=1   (compensating open from click)
pk=123  OPEN#cad630d0…             open_count=2
pk=123  SUMMARY                    click_count=2 open_count=3
pk=123  URL#2dce0a4c…              click_count=2 click_url=https://example.com/a
pk=123  URL#d7fe568b…              click_count=1 click_url=https://example.com/b
```

`click_count` is 2 (alice + carol), unchanged from the Query-based run of the same scenario. Walkthrough video: TODO before marking ready for review.

## QA steps

1. Against a local DynamoDB with the flag active, replay a click webhook event and confirm a `CLICKER#<recipient>` item appears alongside the `CLICK#` item, with `SUMMARY.click_count` incremented once.
2. Replay a click on a different url by the same recipient and confirm `click_count` does not increment again (the marker put fails its condition).
3. Confirm a repeat click of the same url issues a single failed conditional put and writes nothing.

## Test Results

- `bundle exec rspec spec/services/email_engagement_dynamo_store_spec.rb` — 14 examples, 0 failures (click-path expectations rewritten: no `Query`, marker put asserted, operation sequences per scenario)
- End-to-end run against `amazon/dynamodb-local` with the Terraform-shaped `pk`/`sk` table (output above)
- `bundle exec rubocop` on both changed files — clean

---

AI disclosure: implemented with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)