### PR TITLE
Add the Onetime Mongo-to-DynamoDB engagement backfill loader

### DIFF
--- a/app/services/email_engagement_dynamo_store.rb
+++ b/app/services/email_engagement_dynamo_store.rb
@@ -6,12 +6,12 @@
 # Partition key `pk` (S, the stringified installment id), sort key `sk` (S), one of:
 #   SUMMARY                    — open_count / click_count counters for the installment
 #   OPEN#<recipient>           — one item per recipient who opened
+#   CLICKER#<recipient>        — claims the recipient's first click; drives click_count
 #   CLICK#<recipient>#<url>    — one item per recipient + url first click
 #   URL#<url>                  — unique-click total for one url
 # <recipient> and <url> are SHA256 hex digests (raw values are attributes on the
-# items). CLICK keys are recipient-first so "has this recipient clicked anything?"
-# is a begins_with query; per-url totals are separate items rather than a map on
-# SUMMARY so link-heavy posts can't grow SUMMARY toward the 400KB item cap.
+# items). Per-url totals are separate items rather than a map on SUMMARY so
+# link-heavy posts can't grow SUMMARY toward the 400KB item cap.
 class EmailEngagementDynamoStore
   TABLE_BASE_NAME = "email_engagement"
   SUMMARY_SORT_KEY = "SUMMARY"
@@ -30,14 +30,18 @@ class EmailEngagementDynamoStore
       with_dual_write_guard do
         installment_id = installment_id.to_i
         recipient = recipient_digest(mailer_method:, mailer_args:)
-        first_click_for_recipient = !recipient_clicked_any_url?(installment_id:, recipient:)
 
         # A repeat click of the same url by the same recipient counts nothing,
         # matching the Mongo path's early return.
         next unless put_click_item(installment_id:, mailer_method:, mailer_args:, click_url:, recipient:)
 
         increment_url_click_count(installment_id:, click_url:)
-        increment_summary(installment_id:, attribute: "click_count") if first_click_for_recipient
+        # The conditional marker put is both the "has this recipient clicked
+        # anything?" check and the claim, so concurrent first clicks on
+        # different urls can't double-increment the counter.
+        if put_clicker_marker(installment_id:, mailer_method:, mailer_args:, recipient:)
+          increment_summary(installment_id:, attribute: "click_count")
+        end
         # A click implies an open; compensates for blocked tracking pixels.
         ensure_open_item(installment_id:, mailer_method:, mailer_args:)
       end
@@ -97,6 +101,10 @@ class EmailEngagementDynamoStore
 
     def click_sort_key(mailer_method:, mailer_args:, click_url:)
       "CLICK##{recipient_digest(mailer_method:, mailer_args:)}##{url_digest(click_url)}"
+    end
+
+    def clicker_sort_key(mailer_method:, mailer_args:)
+      "CLICKER##{recipient_digest(mailer_method:, mailer_args:)}"
     end
 
     def url_sort_key(click_url)
@@ -168,15 +176,21 @@ class EmailEngagementDynamoStore
         false
       end
 
-      def recipient_clicked_any_url?(installment_id:, recipient:)
-        client.query(
+      def put_clicker_marker(installment_id:, mailer_method:, mailer_args:, recipient:)
+        client.put_item(
           table_name:,
-          key_condition_expression: "pk = :pk AND begins_with(sk, :sk_prefix)",
-          expression_attribute_values: { ":pk" => partition_key(installment_id), ":sk_prefix" => "CLICK##{recipient}#" },
-          select: "COUNT",
-          limit: 1,
-          consistent_read: true
-        ).count.positive?
+          item: {
+            "pk" => partition_key(installment_id),
+            "sk" => "CLICKER##{recipient}",
+            "mailer_method" => mailer_method,
+            "mailer_args" => mailer_args,
+            "first_click_at" => timestamp,
+          },
+          condition_expression: "attribute_not_exists(pk)"
+        )
+        true
+      rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException
+        false
       end
 
       def increment_url_click_count(installment_id:, click_url:)

--- a/app/services/onetime/backfill_email_engagement_dynamo_table.rb
+++ b/app/services/onetime/backfill_email_engagement_dynamo_table.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+# Loads the Mongo engagement collections into the DynamoDB email_engagement
+# table (gumroad-private#2158). Run phases in order, each from a console:
+#
+#   Onetime::BackfillEmailEngagementDynamoTable.backfill_opens!
+#   Onetime::BackfillEmailEngagementDynamoTable.backfill_clicks!
+#   Onetime::BackfillEmailEngagementDynamoTable.recompute_counters!  # rerun until it reports 0 adjustments
+#   Onetime::BackfillEmailEngagementDynamoTable.verify!
+#
+# The dual-write flag must be on before the first phase starts: Mongo then
+# strictly contains every live item, so overwriting on key collision is safe.
+# Item phases checkpoint the last Mongo ObjectId in Redis and resume from it.
+# Counter phases only read DynamoDB and write ADD deltas, so they are
+# idempotent and converge even while live events keep incrementing.
+class Onetime::BackfillEmailEngagementDynamoTable
+  MONGO_BATCH_SIZE = 1_000
+  DYNAMO_BATCH_SIZE = 25 # BatchWriteItem hard limit
+  SCAN_PAGE_SIZE = 1_000
+  MAX_WRITE_ATTEMPTS = 8
+  OPENS_CURSOR_KEY = "onetime_backfill_email_engagement_opens_last_id"
+  CLICKS_CURSOR_KEY = "onetime_backfill_email_engagement_clicks_last_id"
+
+  class << self
+    def backfill_opens!
+      each_mongo_batch(CreatorEmailOpenEvent, OPENS_CURSOR_KEY) do |docs|
+        write_items(docs.filter_map { open_item(_1) })
+      end
+    end
+
+    def backfill_clicks!
+      each_mongo_batch(CreatorEmailClickEvent, CLICKS_CURSOR_KEY) do |docs|
+        write_items(docs.flat_map { click_items(_1) })
+      end
+    end
+
+    # Tallies OPEN#/CLICKER#/CLICK# items per installment in one full scan and
+    # corrects SUMMARY and URL# counters by the difference. Deltas (not
+    # absolute writes) because live events keep incrementing concurrently.
+    def recompute_counters!
+      tallies = Hash.new { |h, k| h[k] = { opens: 0, clickers: 0, urls: Hash.new(0) } }
+      current = Hash.new { |h, k| h[k] = { opens: 0, clickers: 0, urls: Hash.new(0) } }
+
+      scan_all_items do |item|
+        pk = item["pk"]
+        sk = item["sk"]
+        if sk == EmailEngagementDynamoStore::SUMMARY_SORT_KEY
+          current[pk][:opens] = item["open_count"].to_i
+          current[pk][:clickers] = item["click_count"].to_i
+        elsif sk.start_with?("OPEN#")
+          tallies[pk][:opens] += 1
+        elsif sk.start_with?("CLICKER#")
+          tallies[pk][:clickers] += 1
+        elsif sk.start_with?("CLICK#")
+          tallies[pk][:urls][item["click_url"]] += 1
+        elsif sk.start_with?("URL#")
+          current[pk][:urls][item["click_url"]] = item["click_count"].to_i
+        end
+      end
+
+      adjustments = 0
+      (tallies.keys | current.keys).each do |pk|
+        adjustments += apply_delta(pk, EmailEngagementDynamoStore::SUMMARY_SORT_KEY, "open_count", tallies[pk][:opens] - current[pk][:opens])
+        adjustments += apply_delta(pk, EmailEngagementDynamoStore::SUMMARY_SORT_KEY, "click_count", tallies[pk][:clickers] - current[pk][:clickers])
+        (tallies[pk][:urls].keys | current[pk][:urls].keys).each do |url|
+          adjustments += apply_delta(pk, store.url_sort_key(url), "click_count", tallies[pk][:urls][url] - current[pk][:urls][url], click_url: url)
+        end
+      end
+      puts "#{adjustments} counter adjustments applied; rerun until this reports 0."
+      adjustments
+    end
+
+    def verify!(sample_size: 1_000)
+      mismatches = []
+      CreatorEmailClickSummary.all.read(mode: :secondary_preferred).limit(sample_size).each do |summary|
+        pk = store.partition_key(summary.installment_id)
+        dynamo = store.client.get_item(
+          table_name: store.table_name,
+          key: { "pk" => pk, "sk" => EmailEngagementDynamoStore::SUMMARY_SORT_KEY }
+        ).item || {}
+        mongo_opens = CreatorEmailOpenEvent.where(installment_id: summary.installment_id).count
+        expected = { clicks: summary.total_unique_clicks.to_i, opens: mongo_opens }
+        actual = { clicks: dynamo["click_count"].to_i, opens: dynamo["open_count"].to_i }
+        mismatches << { installment_id: summary.installment_id, expected:, actual: } if expected != actual
+      end
+      puts mismatches.empty? ? "All #{sample_size} sampled installments match." : "#{mismatches.size} mismatches: #{mismatches.first(20).inspect}"
+      mismatches
+    end
+
+    private
+      def store
+        EmailEngagementDynamoStore
+      end
+
+      def each_mongo_batch(model, cursor_key)
+        last_id = $redis.get(cursor_key)
+        processed = 0
+        loop do
+          criteria = model.all.read(mode: :secondary_preferred).order(_id: :asc).limit(MONGO_BATCH_SIZE)
+          criteria = criteria.where(_id: { "$gt" => BSON::ObjectId.from_string(last_id) }) if last_id
+          docs = criteria.to_a
+          break if docs.empty?
+
+          yield docs
+          processed += docs.size
+          last_id = docs.last._id.to_s
+          $redis.set(cursor_key, last_id)
+          puts "#{model.name}: #{processed} docs this run, through #{last_id}" if (processed % 100_000).zero?
+        end
+        puts "#{model.name}: done, #{processed} docs this run."
+      end
+
+      def open_item(doc)
+        return if doc.installment_id.blank? || doc.mailer_method.blank?
+
+        first, last = timestamp_range(doc.open_timestamps, doc)
+        {
+          "pk" => store.partition_key(doc.installment_id),
+          "sk" => store.open_sort_key(mailer_method: doc.mailer_method, mailer_args: doc.mailer_args.to_s),
+          "mailer_method" => doc.mailer_method,
+          "mailer_args" => doc.mailer_args.to_s,
+          "open_count" => [doc.open_count.to_i, 1].max,
+          "first_open_at" => first,
+          "last_open_at" => last,
+        }
+      end
+
+      def click_items(doc)
+        return [] if doc.installment_id.blank? || doc.mailer_method.blank? || doc.click_url.blank?
+
+        pk = store.partition_key(doc.installment_id)
+        mailer_method = doc.mailer_method
+        mailer_args = doc.mailer_args.to_s
+        first, _last = timestamp_range(doc.click_timestamps, doc)
+        [
+          {
+            "pk" => pk,
+            "sk" => store.click_sort_key(mailer_method:, mailer_args:, click_url: doc.click_url),
+            "mailer_method" => mailer_method,
+            "mailer_args" => mailer_args,
+            "click_url" => doc.click_url,
+            "click_count" => [doc.click_count.to_i, 1].max,
+            "first_click_at" => first,
+          },
+          {
+            "pk" => pk,
+            "sk" => store.clicker_sort_key(mailer_method:, mailer_args:),
+            "mailer_method" => mailer_method,
+            "mailer_args" => mailer_args,
+            "first_click_at" => first,
+          },
+        ]
+      end
+
+      def timestamp_range(timestamps, doc)
+        times = Array(timestamps).compact
+        times = [doc._id.generation_time] if times.empty?
+        [times.min.utc.iso8601(3), times.max.utc.iso8601(3)]
+      end
+
+      # Docs are processed in _id (chronological) order, so keeping the first
+      # occurrence of a duplicate key (a re-clicked recipient's CLICKER#
+      # marker, or a race-created duplicate Mongo doc) preserves the earliest
+      # timestamps. BatchWriteItem rejects batches containing duplicate keys.
+      def write_items(items)
+        items.uniq { |item| [item["pk"], item["sk"]] }.each_slice(DYNAMO_BATCH_SIZE) do |slice|
+          requests = slice.map { |item| { put_request: { item: } } }
+          MAX_WRITE_ATTEMPTS.times do |attempt|
+            response = store.client.batch_write_item(request_items: { store.table_name => requests })
+            requests = response.unprocessed_items[store.table_name]
+            break if requests.blank?
+            raise "Unprocessed items remain after #{MAX_WRITE_ATTEMPTS} attempts" if attempt == MAX_WRITE_ATTEMPTS - 1
+            sleep(2**attempt * 0.1)
+          end
+        end
+      end
+
+      def scan_all_items(&block)
+        last_evaluated_key = nil
+        loop do
+          response = store.client.scan(
+            table_name: store.table_name,
+            limit: SCAN_PAGE_SIZE,
+            exclusive_start_key: last_evaluated_key
+          )
+          response.items.each(&block)
+          last_evaluated_key = response.last_evaluated_key
+          break if last_evaluated_key.blank?
+        end
+      end
+
+      def apply_delta(pk, sort_key, attribute, delta, click_url: nil)
+        return 0 if delta.zero?
+
+        update_expression = "ADD #counter :delta"
+        values = { ":delta" => delta }
+        if click_url
+          update_expression += " SET click_url = if_not_exists(click_url, :click_url)"
+          values[":click_url"] = click_url
+        end
+        store.client.update_item(
+          table_name: store.table_name,
+          key: { "pk" => pk, "sk" => sort_key },
+          update_expression:,
+          expression_attribute_names: { "#counter" => attribute },
+          expression_attribute_values: values
+        )
+        1
+      end
+  end
+end

--- a/spec/services/email_engagement_dynamo_store_spec.rb
+++ b/spec/services/email_engagement_dynamo_store_spec.rb
@@ -90,32 +90,30 @@ describe EmailEngagementDynamoStore do
       expect(requests).to be_empty
     end
 
-    it "records a first-ever click with the url total, the summary click count, and a compensating open" do
-      client.stub_responses(:query, { count: 0 })
-
+    it "records a first-ever click with the url total, the clicker marker, the summary click count, and a compensating open" do
       described_class.record_click(installment_id: 123, mailer_method:, mailer_args:, click_url:)
 
       expect(requests.map { _1[:operation_name] }).to eq(
-        [:query, :put_item, :update_item, :update_item, :put_item, :update_item]
+        [:put_item, :update_item, :put_item, :update_item, :put_item, :update_item]
       )
 
-      query = requests[0][:params]
-      expect(query[:key_condition_expression]).to eq("pk = :pk AND begins_with(sk, :sk_prefix)")
-      expect(plain_hash(query[:expression_attribute_values])).to eq(":pk" => "123", ":sk_prefix" => "CLICK##{recipient_digest}#")
-      expect(query[:select]).to eq("COUNT")
-      expect(query[:consistent_read]).to be(true)
-
-      click_put = requests[1][:params]
+      click_put = requests[0][:params]
       expect(plain(click_put[:item]["pk"])).to eq("123")
       expect(plain(click_put[:item]["sk"])).to eq("CLICK##{recipient_digest}##{url_digest}")
       expect(plain(click_put[:item]["click_url"])).to eq(click_url)
       expect(plain(click_put[:item]["click_count"])).to eq(1)
       expect(click_put[:condition_expression]).to eq("attribute_not_exists(pk)")
 
-      url_update = requests[2][:params]
+      url_update = requests[1][:params]
       expect(plain_hash(url_update[:key])).to eq("pk" => "123", "sk" => "URL##{url_digest}")
       expect(url_update[:update_expression]).to eq("ADD click_count :one SET click_url = :click_url")
       expect(plain(url_update[:expression_attribute_values][":click_url"])).to eq(click_url)
+
+      marker_put = requests[2][:params]
+      expect(plain(marker_put[:item]["pk"])).to eq("123")
+      expect(plain(marker_put[:item]["sk"])).to eq("CLICKER##{recipient_digest}")
+      expect(plain(marker_put[:item]["mailer_args"])).to eq(mailer_args)
+      expect(marker_put[:condition_expression]).to eq("attribute_not_exists(pk)")
 
       summary_click_update = requests[3][:params]
       expect(plain_hash(summary_click_update[:key])).to eq("pk" => "123", "sk" => "SUMMARY")
@@ -133,27 +131,26 @@ describe EmailEngagementDynamoStore do
     end
 
     it "does not increment the summary click count when the recipient has clicked another url before" do
-      client.stub_responses(:query, { count: 1 })
-      # The click item put succeeds; the compensating open put finds an existing open item.
-      client.stub_responses(:put_item, [{}, "ConditionalCheckFailedException"])
+      # The click item put succeeds; the clicker marker already exists, as does the open item.
+      client.stub_responses(:put_item, [{}, "ConditionalCheckFailedException", "ConditionalCheckFailedException"])
 
       described_class.record_click(installment_id: 123, mailer_method:, mailer_args:, click_url:)
 
-      expect(requests.map { _1[:operation_name] }).to eq([:query, :put_item, :update_item, :put_item])
-      expect(plain(requests[2][:params][:key]["sk"])).to eq("URL##{url_digest}")
+      expect(requests.map { _1[:operation_name] }).to eq([:put_item, :update_item, :put_item, :put_item])
+      expect(plain(requests[1][:params][:key]["sk"])).to eq("URL##{url_digest}")
+      expect(plain(requests[2][:params][:item]["sk"])).to eq("CLICKER##{recipient_digest}")
     end
 
     it "counts nothing on a repeat click of the same url by the same recipient" do
-      client.stub_responses(:query, { count: 1 })
       client.stub_responses(:put_item, "ConditionalCheckFailedException")
 
       described_class.record_click(installment_id: 123, mailer_method:, mailer_args:, click_url:)
 
-      expect(requests.map { _1[:operation_name] }).to eq([:query, :put_item])
+      expect(requests.map { _1[:operation_name] }).to eq([:put_item])
     end
 
     it "notifies instead of raising when DynamoDB fails" do
-      client.stub_responses(:query, "ProvisionedThroughputExceededException")
+      client.stub_responses(:put_item, "ProvisionedThroughputExceededException")
       expect(ErrorNotifier).to receive(:notify).with(kind_of(Aws::Errors::ServiceError))
 
       expect do

--- a/spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb
+++ b/spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+describe Onetime::BackfillEmailEngagementDynamoTable do
+  let(:client) { Aws::DynamoDB::Client.new(stub_responses: true) }
+  let(:mailer_method) { "CreatorContactingCustomersMailer.purchase_installment" }
+  let(:mailer_args) { "[123, 456]" }
+  let(:recipient_digest) { Digest::SHA256.hexdigest("#{mailer_method}\n#{mailer_args}") }
+  let(:click_url) { "https://example&#46;com/a" }
+  let(:url_digest) { Digest::SHA256.hexdigest(click_url) }
+
+  before do
+    EmailEngagementDynamoStore.client = client
+    $redis.del(described_class::OPENS_CURSOR_KEY, described_class::CLICKS_CURSOR_KEY)
+  end
+
+  after do
+    EmailEngagementDynamoStore.client = nil
+    $redis.del(described_class::OPENS_CURSOR_KEY, described_class::CLICKS_CURSOR_KEY)
+  end
+
+  def requests
+    client.api_requests
+  end
+
+  def written_items(request)
+    request[:params][:request_items]["email_engagement"].map do |r|
+      r[:put_request][:item].transform_values do |attribute_value|
+        type, value = attribute_value.first
+        type == :n ? Integer(value) : value
+      end
+    end
+  end
+
+  describe ".backfill_opens!" do
+    it "writes OPEN# items with counts and the timestamp range, skipping docs without an installment" do
+      opened_at = Time.utc(2026, 1, 5, 12)
+      CreatorEmailOpenEvent.create!(
+        installment_id: 123, mailer_method:, mailer_args:,
+        open_count: 3, open_timestamps: [opened_at + 1.hour, opened_at]
+      )
+      CreatorEmailOpenEvent.create!(installment_id: nil, mailer_method:, mailer_args: "[9, 9]", open_count: 1)
+
+      described_class.backfill_opens!
+
+      expect(requests.map { _1[:operation_name] }).to eq([:batch_write_item])
+      item = written_items(requests.first).sole
+      expect(item).to include(
+        "pk" => "123",
+        "sk" => "OPEN##{recipient_digest}",
+        "mailer_method" => mailer_method,
+        "mailer_args" => mailer_args,
+        "open_count" => 3,
+        "first_open_at" => opened_at.iso8601(3),
+        "last_open_at" => (opened_at + 1.hour).iso8601(3)
+      )
+    end
+
+    it "resumes from the Redis cursor" do
+      first = CreatorEmailOpenEvent.create!(installment_id: 1, mailer_method:, mailer_args: "[1, 1]", open_count: 1)
+      second = CreatorEmailOpenEvent.create!(installment_id: 2, mailer_method:, mailer_args: "[2, 2]", open_count: 1)
+      $redis.set(described_class::OPENS_CURSOR_KEY, first._id.to_s)
+
+      described_class.backfill_opens!
+
+      expect(written_items(requests.sole).sole["pk"]).to eq("2")
+      expect($redis.get(described_class::OPENS_CURSOR_KEY)).to eq(second._id.to_s)
+    end
+
+    it "retries unprocessed items before giving up" do
+      CreatorEmailOpenEvent.create!(installment_id: 123, mailer_method:, mailer_args:, open_count: 1)
+      allow(described_class).to receive(:sleep)
+      client.stub_responses(:batch_write_item, lambda { |context|
+        if requests.count { _1[:operation_name] == :batch_write_item } == 1
+          { unprocessed_items: { "email_engagement" => context.params[:request_items]["email_engagement"] } }
+        else
+          { unprocessed_items: {} }
+        end
+      })
+
+      described_class.backfill_opens!
+
+      expect(requests.count { _1[:operation_name] == :batch_write_item }).to eq(2)
+    end
+  end
+
+  describe ".backfill_clicks!" do
+    it "writes a CLICK# item and a CLICKER# marker per doc, deduping the marker across a recipient's urls" do
+      clicked_at = Time.utc(2026, 2, 1, 8)
+      CreatorEmailClickEvent.create!(
+        installment_id: 123, mailer_method:, mailer_args:, click_url:,
+        click_count: 1, click_timestamps: [clicked_at]
+      )
+      CreatorEmailClickEvent.create!(
+        installment_id: 123, mailer_method:, mailer_args:, click_url: "https://example&#46;com/b",
+        click_count: 1, click_timestamps: [clicked_at + 1.hour]
+      )
+
+      described_class.backfill_clicks!
+
+      items = written_items(requests.sole)
+      expect(items.map { _1["sk"] }).to contain_exactly(
+        "CLICK##{recipient_digest}##{url_digest}",
+        "CLICK##{recipient_digest}##{Digest::SHA256.hexdigest("https://example&#46;com/b")}",
+        "CLICKER##{recipient_digest}"
+      )
+      marker = items.find { _1["sk"] == "CLICKER##{recipient_digest}" }
+      expect(marker["first_click_at"]).to eq(clicked_at.iso8601(3))
+      click_item = items.find { _1["sk"] == "CLICK##{recipient_digest}##{url_digest}" }
+      expect(click_item).to include("click_url" => click_url, "click_count" => 1)
+    end
+  end
+
+  describe ".recompute_counters!" do
+    it "corrects SUMMARY and URL# counters by ADD deltas derived from item counts" do
+      scan_items = [
+        { "pk" => "123", "sk" => "OPEN#aaa" },
+        { "pk" => "123", "sk" => "OPEN#bbb" },
+        { "pk" => "123", "sk" => "CLICKER#aaa" },
+        { "pk" => "123", "sk" => "CLICK#aaa#u1", "click_url" => click_url },
+        { "pk" => "123", "sk" => "SUMMARY", "open_count" => 1, "click_count" => 1 },
+      ]
+      client.stub_responses(:scan, { items: scan_items, last_evaluated_key: nil })
+
+      adjustments = described_class.recompute_counters!
+
+      # open_count is off by one (2 items vs 1); click_count matches; URL# item is missing entirely.
+      expect(adjustments).to eq(2)
+      updates = requests.select { _1[:operation_name] == :update_item }.map { _1[:params] }
+      open_fix = updates.find { _1[:expression_attribute_names] == { "#counter" => "open_count" } }
+      expect(open_fix[:key]["sk"].values.first).to eq("SUMMARY")
+      expect(open_fix[:expression_attribute_values][":delta"]).to eq(n: "1")
+      url_fix = updates.find { _1[:key]["sk"].values.first == "URL##{url_digest}" }
+      expect(url_fix[:update_expression]).to include("if_not_exists(click_url, :click_url)")
+      expect(url_fix[:expression_attribute_values][":delta"]).to eq(n: "1")
+    end
+
+    it "applies nothing when counters already match item counts" do
+      scan_items = [
+        { "pk" => "123", "sk" => "OPEN#aaa" },
+        { "pk" => "123", "sk" => "CLICKER#aaa" },
+        { "pk" => "123", "sk" => "CLICK#aaa#u1", "click_url" => click_url },
+        { "pk" => "123", "sk" => "URL##{url_digest}", "click_url" => click_url, "click_count" => 1 },
+        { "pk" => "123", "sk" => "SUMMARY", "open_count" => 1, "click_count" => 1 },
+      ]
+      client.stub_responses(:scan, { items: scan_items, last_evaluated_key: nil })
+
+      expect(described_class.recompute_counters!).to eq(0)
+      expect(requests.map { _1[:operation_name] }).to eq([:scan])
+    end
+  end
+
+  describe ".verify!" do
+    it "reports installments whose DynamoDB counters disagree with Mongo" do
+      CreatorEmailClickSummary.create!(installment_id: 123, total_unique_clicks: 5, urls: {})
+      CreatorEmailOpenEvent.create!(installment_id: 123, mailer_method:, mailer_args:, open_count: 1)
+      client.stub_responses(:get_item, { item: { "pk" => "123", "sk" => "SUMMARY", "open_count" => 1, "click_count" => 4 } })
+
+      mismatches = described_class.verify!(sample_size: 10)
+
+      expect(mismatches.sole).to eq(
+        installment_id: 123,
+        expected: { clicks: 5, opens: 1 },
+        actual: { clicks: 4, opens: 1 }
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `Onetime::BackfillEmailEngagementDynamoTable`, the loader for gumroad-private#2158's backfill step, with four console-run phases:

1. `backfill_opens!` / `backfill_clicks!` — stream `CreatorEmailOpenEvent` and `CreatorEmailClickEvent` in ObjectId order (secondary-preferred reads), transform to `OPEN#` / `CLICK#` + `CLICKER#` items, and load via `BatchWriteItem` with unprocessed-item retries. The last processed ObjectId checkpoints in Redis, so a crash resumes instead of restarting.
2. `recompute_counters!` — one full table scan tallying items per installment, then corrects `SUMMARY` and `URL#` counters by **`ADD` deltas** rather than absolute writes, because live dual writes keep incrementing concurrently. Idempotent; rerun until it reports 0 adjustments.
3. `verify!` — samples installments and compares DynamoDB counters against Mongo (`CreatorEmailClickSummary.total_unique_clicks` and the open-event count) before any reads flip.

**Stacked on #7311** (uses `clicker_sort_key`); retargets to `main` when that merges.

## Why

The issue originally sketched `mongoexport` → S3 → DynamoDB Import, but the managed import only creates *new* tables and the live table is dual-written, Terraform-owned, and IAM-pinned by name. A Rails loader also reuses `EmailEngagementDynamoStore`'s own public key-derivation helpers (`partition_key`, digest and sort-key builders), so backfilled keys *cannot* disagree with the write path — reimplementing SHA256-of-mailer-args derivation in an external pipeline is exactly where a silent mismatch would be disastrous.

Correctness decisions worth reviewing:

- **Overwrite on collision** is safe by construction: the dual-write flag flips before the backfill starts, so every live item's recipient also has a Mongo doc containing at least the live item's events. First-occurrence-wins dedupe within a read batch keeps the earliest timestamps (docs stream in chronological ObjectId order), and `BatchWriteItem` rejects duplicate keys in one call anyway.
- **Counters are never summed across the boundary.** During the dual-write window DynamoDB counted "firsts" Mongo had already seen, so `recompute_counters!` derives every counter from item counts — the same self-deciding invariant the adapter maintains — and converges via delta application even while events flow.

## Before/After

No user-facing change and no behavior change at deploy time: this adds an operator-run script only; nothing invokes it. Walkthrough video: TODO before marking ready for review.

## QA steps

1. Locally against dynamodb-local with a few Mongo docs created in console: run the four phases in order and confirm items, counters, and a clean `verify!`.
2. Set the opens cursor to a mid-stream ObjectId and rerun `backfill_opens!` to confirm resume-from-checkpoint.
3. In production (post flag-flip): run during the provisioned-capacity window per the issue's plan; rerun `recompute_counters!` until 0 adjustments; gate the read flip on `verify!`.

## Test Results

- `bundle exec rspec spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb` — 7 examples, 0 failures (transform shapes, cursor resume, unprocessed-item retry, marker dedupe, delta corrections including the missing-`URL#` case, zero-adjustment no-op, verify mismatch reporting)
- `bundle exec rubocop` on both files — clean

---

AI disclosure: implemented with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)