### PR TITLE
Move CI Docker images to the antiwork Docker Hub org

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -178,7 +178,7 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build and push base image
         env:
-          WEB_BASE_REPO: gumroadteam/web_base
+          WEB_BASE_REPO: antiwork/gumroad-web_base
         run: |
           set -e
           GREEN='\033[0;32m'
@@ -215,7 +215,7 @@ jobs:
       - name: Compute content-addressed test image tag
         id: test_image_tag
         env:
-          WEB_BASE_REPO: gumroadteam/web_base
+          WEB_BASE_REPO: antiwork/gumroad-web_base
         run: |
           set -e
           # Resolve the base test SHA (used as a hash input).
@@ -237,9 +237,9 @@ jobs:
             asset-precompile-
       - name: Build and push test image
         env:
-          WEB_BASE_REPO: gumroadteam/web_base
-          WEB_BASE_TEST_REPO: gumroadteam/web_base_test
-          WEB_REPO: gumroadteam/web
+          WEB_BASE_REPO: antiwork/gumroad-web_base
+          WEB_BASE_TEST_REPO: antiwork/gumroad-web_base_test
+          WEB_REPO: antiwork/gumroad-web
           TEST_IMAGE_TAG: ${{ steps.test_image_tag.outputs.tag }}
           ASSET_CACHE_HIT: ${{ steps.asset_cache.outputs.cache-hit }}
         run: |
@@ -410,9 +410,15 @@ jobs:
         ci_node_total: [2]
         ci_node_index: [0, 1]
 
+    # Service images are pulled before any step can `docker login`, so each
+    # service carries credentials — anonymous pulls share the runner IP's
+    # 10-pulls/hour budget.
     services:
       mysql:
         image: mysql:8.0.32
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: gumroad_test
@@ -425,15 +431,24 @@ jobs:
           --health-retries=10
       redis:
         image: redis:7
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
         ports:
           - 6379:6379
       stripe_mock:
         image: stripemock/stripe-mock:latest
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
         ports:
           - 12111:12111
           - 12112:12112
       mongo:
         image: mongo:4.4
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
         ports:
           - 27017:27017
       # Elasticsearch for the handful of ported tests that index records and query
@@ -443,6 +458,9 @@ jobs:
       # cluster via Thread.current[:minitest_real_es] (see RealElasticsearchBridge).
       elasticsearch:
         image: elasticsearch:7.9.3
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
         env:
           discovery.type: single-node
           ES_JAVA_OPTS: -Xms512m -Xmx512m
@@ -469,6 +487,19 @@ jobs:
 
       - name: Prepare test database
         run: bundle exec rake db:prepare
+
+      # The MinIO steps below `docker run` two Hub images; log in first so the
+      # pulls count against the paid org instead of the runner IP.
+      - name: Login to Docker Hub
+        uses: nick-fields/retry@v3
+        with:
+          timeout_seconds: 120
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Start MinIO (S3-compatible object storage)
         run: |
@@ -562,7 +593,7 @@ jobs:
             exit $((COMPOSE_EXIT + PULL_EXIT))
         env:
           COMPOSE_HTTP_TIMEOUT: "300"
-          WEB_REPO: gumroadteam/web
+          WEB_REPO: antiwork/gumroad-web
       - name: Wait for services and prepare test database
         uses: nick-fields/retry@v3
         with:
@@ -587,7 +618,7 @@ jobs:
             wait $ES_PID || exit 1
             wait $MINIO_PID || exit 1
         env:
-          WEB_REPO: gumroadteam/web
+          WEB_REPO: antiwork/gumroad-web
 
       - name: Run tests
         timeout-minutes: 15
@@ -631,7 +662,7 @@ jobs:
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           CI: true
           IN_DOCKER: true
-          WEB_REPO: gumroadteam/web
+          WEB_REPO: antiwork/gumroad-web
       - name: Archive flaky specs log
         if: always()
         uses: actions/upload-artifact@v4
@@ -652,7 +683,7 @@ jobs:
     name: Test Slow ${{ matrix.ci_node_index }}${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
     env:
       COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_slow_${{ matrix.ci_node_index }}
-      WEB_REPO: gumroadteam/web
+      WEB_REPO: antiwork/gumroad-web
     runs-on: ubicloud-standard-4
     needs: [build, run_scope]
     # Full suite: main pushes (deploy gate) and PRs labeled run-all-specs.
@@ -748,7 +779,7 @@ jobs:
             exit $((COMPOSE_EXIT + PULL_EXIT))
         env:
           COMPOSE_HTTP_TIMEOUT: "300"
-          WEB_REPO: gumroadteam/web
+          WEB_REPO: antiwork/gumroad-web
       - name: Wait for services and prepare test database
         uses: nick-fields/retry@v3
         with:
@@ -773,7 +804,7 @@ jobs:
             wait $ES_PID || exit 1
             wait $MINIO_PID || exit 1
         env:
-          WEB_REPO: gumroadteam/web
+          WEB_REPO: antiwork/gumroad-web
 
       - name: Run tests
         timeout-minutes: 25
@@ -818,7 +849,7 @@ jobs:
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           CI: true
           IN_DOCKER: true
-          WEB_REPO: gumroadteam/web
+          WEB_REPO: antiwork/gumroad-web
       - name: Archive capybara artifacts
         if: failure()
         uses: actions/upload-artifact@v4
@@ -907,7 +938,7 @@ jobs:
     name: Test Relevant ${{ matrix.ci_node_index }}${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
     env:
       COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_relevant_${{ matrix.ci_node_index }}
-      WEB_REPO: gumroadteam/web
+      WEB_REPO: antiwork/gumroad-web
     runs-on: ubicloud-standard-4
     needs: [build, run_scope, relevant_specs]
     # Branch/PR counterpart of test_fast/test_slow: the same docker setup and


### PR DESCRIPTION
## What

Moves the images `tests.yml` builds and pulls from the `gumroadteam` Docker Hub user namespace to the `antiwork` organization:

- `gumroadteam/web_base` → `antiwork/gumroad-web_base`
- `gumroadteam/web_base_test` → `antiwork/gumroad-web_base_test`
- `gumroadteam/web` → `antiwork/gumroad-web`

It also authenticates the pulls that were still anonymous in `test_minitest`, which had no Docker Hub login at all:

- each service container (`mysql`, `redis`, `stripe_mock`, `mongo`, `elasticsearch`) now carries a `credentials:` block — service images are pulled by the runner before any step can run `docker login`, so a login step can't cover them
- a login step now precedes the MinIO steps, which `docker run` two more Hub images (`minio/minio`, `minio/mc`)

## Why

CI images should live under the shared `antiwork` org (paid plan) rather than a standalone user account. Rate limits follow the authenticated account: paid-plan pulls are unlimited, while anonymous pulls share a 10-pulls/hour budget per runner IPv4 — and hosted runners share egress IPs, so the anonymous service-container pulls in `test_minitest` were the likeliest way to hit the limit.

Buildkite intentionally needs no change here: its images are pushed to and pulled from ECR, and its `docker-login` plugin already authenticates Docker Hub pulls (rate-limit relief only) with the same credentials this workflow uses. The `DOCKERHUB_USERNAME`/`DOCKERHUB_PASSWORD` secrets are unchanged — those credentials were verified to have read and write access on all three new repos.

The new repos were pre-seeded with the current content-addressed tags (server-side manifest copy via `docker buildx imagetools create`), so this branch's first build gets `manifest inspect` hits instead of a from-scratch base rebuild. The old `gumroadteam/*` repos stay up until open branches are rebased past this change, since push-event CI uses the workflow file from the branch.

## Before/After

CI-only change with nothing user-visible to record; the CI run on this PR exercises the change end to end:

- the `build` job resolves the pre-seeded `antiwork/gumroad-web_base` / `antiwork/gumroad-web_base_test` tags and pushes the test image to `antiwork/gumroad-web`
- the test jobs pull `antiwork/gumroad-web:test-*`
- `test_minitest` pulls every Hub image authenticated

QA: on this PR's Tests run, check the `build` job logs reference only `antiwork/*` repos, and the `test_minitest` setup pulls services without rate-limit warnings.

## Test Results

- Read + write verified on `antiwork/gumroad-web`, `antiwork/gumroad-web_base`, and `antiwork/gumroad-web_base_test` with the CI credentials (tags pushed via `imagetools`, manifests pulled back)
- Rate-limit probe with the CI credentials returns no `ratelimit-limit`/`ratelimit-remaining` headers, i.e. unlimited pulls
- `.github/workflows/tests.yml` parses as valid YAML
- CI on this PR runs the switched workflow itself

---

AI disclosure: written with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)