### PR TITLE
Default the DynamoDB endpoint instead of passing nil

### DIFF
--- a/app/services/email_engagement_dynamo_store.rb
+++ b/app/services/email_engagement_dynamo_store.rb
@@ -48,9 +48,12 @@ class EmailEngagementDynamoStore
     end
 
     def client
-      # An explicit endpoint is always passed because the global Aws.config
-      # endpoint override points at S3/MinIO in development and test.
-      @client ||= Aws::DynamoDB::Client.new(endpoint: ENV["DYNAMODB_ENDPOINT"].presence)
+      # An explicit endpoint is always passed: the global Aws.config endpoint
+      # points at MinIO in development and test, and the SDK raises at
+      # construction when the option is present but nil.
+      @client ||= Aws::DynamoDB::Client.new(
+        endpoint: GlobalConfig.get("DYNAMODB_ENDPOINT", "https://dynamodb.#{AWS_DEFAULT_REGION}.amazonaws.com")
+      )
     end
 
     def table_name

--- a/spec/services/email_engagement_dynamo_store_spec.rb
+++ b/spec/services/email_engagement_dynamo_store_spec.rb
@@ -159,6 +159,21 @@ describe EmailEngagementDynamoStore do
     end
   end
 
+  describe ".client" do
+    it "defaults to the regional DynamoDB endpoint when DYNAMODB_ENDPOINT is unset" do
+      described_class.client = nil
+      expect(described_class.client.config.endpoint.to_s).to eq("https://dynamodb.#{AWS_DEFAULT_REGION}.amazonaws.com")
+    end
+
+    it "honors DYNAMODB_ENDPOINT when set" do
+      described_class.client = nil
+      ENV["DYNAMODB_ENDPOINT"] = "http://localhost:8123"
+      expect(described_class.client.config.endpoint.to_s).to eq("http://localhost:8123")
+    ensure
+      ENV.delete("DYNAMODB_ENDPOINT")
+    end
+  end
+
   describe ".table_name" do
     it "prepends DYNAMODB_TABLE_PREFIX when set" do
       expect(described_class.table_name).to eq("email_engagement")


### PR DESCRIPTION
## What

`EmailEngagementDynamoStore.client` now resolves its endpoint via `GlobalConfig.get("DYNAMODB_ENDPOINT", "https://dynamodb.#{AWS_DEFAULT_REGION}.amazonaws.com")` instead of `ENV["DYNAMODB_ENDPOINT"].presence`, so the client is always constructed with a real endpoint. The env var still wins when set (dev lanes, dynamodb-local, branch apps).

## Why

When the `email_engagement_dynamodb_dual_write` flag was flipped in production today, every dual write failed instantly with `ArgumentError: missing required option ':endpoint'` (escalating in Bugsnag, ~470 events in 3 minutes; flag deactivated to stop it). Root cause: production has no `DYNAMODB_ENDPOINT` env var, so the client was built with an explicit `endpoint: nil` — and passing the option key with a nil value bypasses the SDK's regional default resolution and fails validation in Seahorse's `after_initialize`. The invalid state never appeared anywhere else because dev/test always had the env var or an injected stub client, so production was the first place the constructor ran without it.

The explicit endpoint stays (rather than omitting the option entirely) because the global `Aws.config` endpoint points at MinIO in development and test; defaulting through `GlobalConfig` keeps the option always-present and always-valid, and removes the need for any per-environment configuration.

## Before/After

No user-facing change; the flag is off. Before: flag on → 100% of dual writes raise at client construction (swallowed + reported), zero items written. After: client constructs against the regional endpoint. Note this alone does not make writes succeed — the app's IAM user also lacks DynamoDB permissions (companion PR in the infrastructure repo attaches the existing `<env>-dynamodb-app-access` policy to `_web-app-<env>`). Walkthrough video: TODO before marking ready for review.

## QA steps

1. In a production console after deploy: `EmailEngagementDynamoStore.client.config.endpoint.to_s` returns `https://dynamodb.us-east-1.amazonaws.com` (previously raised ArgumentError).
2. Locally with `DYNAMODB_ENDPOINT=http://localhost:8000`: the override still wins.

## Test Results

- `bundle exec rspec spec/services/email_engagement_dynamo_store_spec.rb` — 16 examples, 0 failures (adds `.client` default-endpoint and env-override cases)
- `bundle exec rubocop` on both files — clean

---

AI disclosure: implemented with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)