### PR TITLE
Add a single-seller pilot to the DynamoDB engagement backfill

### DIFF
--- a/app/services/onetime/backfill_email_engagement_dynamo_table.rb
+++ b/app/services/onetime/backfill_email_engagement_dynamo_table.rb
@@ -8,6 +8,11 @@
 #   Onetime::BackfillEmailEngagementDynamoTable.recompute_counters!  # rerun until it reports 0 adjustments
 #   Onetime::BackfillEmailEngagementDynamoTable.verify!
 #
+# Or pilot a single seller first:
+#
+#   Onetime::BackfillEmailEngagementDynamoTable.backfill_seller!(seller_id)
+#   Onetime::BackfillEmailEngagementDynamoTable.verify_seller!(seller_id)
+#
 # The dual-write flag must be on before the first phase starts: Mongo then
 # strictly contains every live item, so overwriting on key collision is safe.
 # Item phases checkpoint the last Mongo ObjectId in Redis and resume from it.
@@ -38,36 +43,68 @@ class Onetime::BackfillEmailEngagementDynamoTable
     # corrects SUMMARY and URL# counters by the difference. Deltas (not
     # absolute writes) because live events keep incrementing concurrently.
     def recompute_counters!
-      tallies = Hash.new { |h, k| h[k] = { opens: 0, clickers: 0, urls: Hash.new(0) } }
-      current = Hash.new { |h, k| h[k] = { opens: 0, clickers: 0, urls: Hash.new(0) } }
+      tallies = Hash.new { |h, k| h[k] = new_tally }
+      current = Hash.new { |h, k| h[k] = new_tally }
+      scan_all_items { |item| classify_item(item, tallies[item["pk"]], current[item["pk"]]) }
 
-      scan_all_items do |item|
-        pk = item["pk"]
-        sk = item["sk"]
-        if sk == EmailEngagementDynamoStore::SUMMARY_SORT_KEY
-          current[pk][:opens] = item["open_count"].to_i
-          current[pk][:clickers] = item["click_count"].to_i
-        elsif sk.start_with?("OPEN#")
-          tallies[pk][:opens] += 1
-        elsif sk.start_with?("CLICKER#")
-          tallies[pk][:clickers] += 1
-        elsif sk.start_with?("CLICK#")
-          tallies[pk][:urls][item["click_url"]] += 1
-        elsif sk.start_with?("URL#")
-          current[pk][:urls][item["click_url"]] = item["click_count"].to_i
-        end
-      end
-
-      adjustments = 0
-      (tallies.keys | current.keys).each do |pk|
-        adjustments += apply_delta(pk, EmailEngagementDynamoStore::SUMMARY_SORT_KEY, "open_count", tallies[pk][:opens] - current[pk][:opens])
-        adjustments += apply_delta(pk, EmailEngagementDynamoStore::SUMMARY_SORT_KEY, "click_count", tallies[pk][:clickers] - current[pk][:clickers])
-        (tallies[pk][:urls].keys | current[pk][:urls].keys).each do |url|
-          adjustments += apply_delta(pk, store.url_sort_key(url), "click_count", tallies[pk][:urls][url] - current[pk][:urls][url], click_url: url)
-        end
-      end
+      adjustments = (tallies.keys | current.keys).sum { |pk| apply_deltas(pk, tallies[pk], current[pk]) }
       puts "#{adjustments} counter adjustments applied; rerun until this reports 0."
       adjustments
+    end
+
+    # Pilot: backfill a single seller's installments end-to-end (items plus a
+    # per-partition counter recompute), then compare with verify_seller!.
+    # Rerunnable at any time; the full backfill later re-puts identical items.
+    def backfill_seller!(seller_id)
+      installment_ids = Installment.where(seller_id:).ids
+      installment_ids.each do |installment_id|
+        CreatorEmailOpenEvent.where(installment_id:).read(mode: :secondary_preferred).each_slice(MONGO_BATCH_SIZE) do |docs|
+          write_items(docs.filter_map { open_item(_1) })
+        end
+        CreatorEmailClickEvent.where(installment_id:).read(mode: :secondary_preferred).each_slice(MONGO_BATCH_SIZE) do |docs|
+          write_items(docs.flat_map { click_items(_1) })
+        end
+        recompute_installment!(installment_id)
+      end
+      puts "Backfilled #{installment_ids.size} installments for seller #{seller_id}; compare with verify_seller!(#{seller_id})."
+      installment_ids.size
+    end
+
+    # Three-way comparison per installment. The invariant is DynamoDB ==
+    # counts derived from the Mongo documents; Mongo's stored click summary is
+    # reported alongside but is not the correctness bar — its cache-guarded
+    # counters have drifted historically.
+    def verify_seller!(seller_id)
+      mismatches = []
+      Installment.where(seller_id:).ids.each do |installment_id|
+        pk = store.partition_key(installment_id)
+        mongo_opens = CreatorEmailOpenEvent.where(installment_id:).count
+        click_rows = CreatorEmailClickEvent.where(installment_id:).pluck(:mailer_method, :mailer_args, :click_url).uniq
+        next if mongo_opens.zero? && click_rows.empty?
+
+        mongo_docs = {
+          opens: mongo_opens,
+          clicks: click_rows.map { |mailer_method, mailer_args, _| [mailer_method, mailer_args] }.uniq.size,
+          urls: click_rows.group_by { |_, _, url| url }.transform_values(&:size),
+        }
+        summary = store.client.get_item(
+          table_name: store.table_name,
+          key: { "pk" => pk, "sk" => EmailEngagementDynamoStore::SUMMARY_SORT_KEY },
+          consistent_read: true
+        ).item || {}
+        dynamo = { opens: summary["open_count"].to_i, clicks: summary["click_count"].to_i, urls: {} }
+        query_partition(pk, sk_prefix: "URL#") { |item| dynamo[:urls][item["click_url"]] = item["click_count"].to_i }
+
+        next if dynamo == mongo_docs
+        mismatches << {
+          installment_id:,
+          dynamo:,
+          mongo_docs:,
+          mongo_stored_clicks: CreatorEmailClickSummary.where(installment_id:).last&.total_unique_clicks.to_i,
+        }
+      end
+      puts mismatches.empty? ? "Seller #{seller_id}: every installment matches the Mongo documents." : "#{mismatches.size} mismatches: #{mismatches.first(20).inspect}"
+      mismatches
     end
 
     def verify!(sample_size: 1_000)
@@ -172,6 +209,65 @@ class Onetime::BackfillEmailEngagementDynamoTable
             raise "Unprocessed items remain after #{MAX_WRITE_ATTEMPTS} attempts" if attempt == MAX_WRITE_ATTEMPTS - 1
             sleep(2**attempt * 0.1)
           end
+        end
+      end
+
+      def new_tally
+        { opens: 0, clickers: 0, urls: Hash.new(0) }
+      end
+
+      def classify_item(item, tally, current)
+        sk = item["sk"]
+        if sk == EmailEngagementDynamoStore::SUMMARY_SORT_KEY
+          current[:opens] = item["open_count"].to_i
+          current[:clickers] = item["click_count"].to_i
+        elsif sk.start_with?("OPEN#")
+          tally[:opens] += 1
+        elsif sk.start_with?("CLICKER#")
+          tally[:clickers] += 1
+        elsif sk.start_with?("CLICK#")
+          tally[:urls][item["click_url"]] += 1
+        elsif sk.start_with?("URL#")
+          current[:urls][item["click_url"]] = item["click_count"].to_i
+        end
+      end
+
+      def apply_deltas(pk, tally, current)
+        adjustments = apply_delta(pk, EmailEngagementDynamoStore::SUMMARY_SORT_KEY, "open_count", tally[:opens] - current[:opens])
+        adjustments += apply_delta(pk, EmailEngagementDynamoStore::SUMMARY_SORT_KEY, "click_count", tally[:clickers] - current[:clickers])
+        (tally[:urls].keys | current[:urls].keys).each do |url|
+          adjustments += apply_delta(pk, store.url_sort_key(url), "click_count", tally[:urls][url] - current[:urls][url], click_url: url)
+        end
+        adjustments
+      end
+
+      def recompute_installment!(installment_id)
+        pk = store.partition_key(installment_id)
+        tally = new_tally
+        current = new_tally
+        query_partition(pk) { |item| classify_item(item, tally, current) }
+        apply_deltas(pk, tally, current)
+      end
+
+      def query_partition(pk, sk_prefix: nil)
+        key_condition = "pk = :pk"
+        values = { ":pk" => pk }
+        if sk_prefix
+          key_condition += " AND begins_with(sk, :sk_prefix)"
+          values[":sk_prefix"] = sk_prefix
+        end
+        last_evaluated_key = nil
+        loop do
+          response = store.client.query(
+            table_name: store.table_name,
+            key_condition_expression: key_condition,
+            expression_attribute_values: values,
+            exclusive_start_key: last_evaluated_key,
+            consistent_read: true
+          )
+          response.items.each { |item| yield item }
+          last_evaluated_key = response.last_evaluated_key
+          break if last_evaluated_key.blank?
         end
       end
 

--- a/app/services/onetime/backfill_email_engagement_dynamo_table.rb
+++ b/app/services/onetime/backfill_email_engagement_dynamo_table.rb
@@ -249,7 +249,7 @@ class Onetime::BackfillEmailEngagementDynamoTable
         apply_deltas(pk, tally, current)
       end
 
-      def query_partition(pk, sk_prefix: nil)
+      def query_partition(pk, sk_prefix: nil, &block)
         key_condition = "pk = :pk"
         values = { ":pk" => pk }
         if sk_prefix
@@ -265,7 +265,7 @@ class Onetime::BackfillEmailEngagementDynamoTable
             exclusive_start_key: last_evaluated_key,
             consistent_read: true
           )
-          response.items.each { |item| yield item }
+          response.items.each(&block)
           last_evaluated_key = response.last_evaluated_key
           break if last_evaluated_key.blank?
         end

--- a/spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb
+++ b/spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb
@@ -149,6 +149,55 @@ describe Onetime::BackfillEmailEngagementDynamoTable do
     end
   end
 
+  describe ".backfill_seller!" do
+    it "loads only the seller's installments and recomputes their counters from the partition" do
+      installment = create(:installment)
+      other_installment = create(:installment)
+      CreatorEmailOpenEvent.create!(installment_id: installment.id, mailer_method:, mailer_args:, open_count: 1)
+      CreatorEmailOpenEvent.create!(installment_id: other_installment.id, mailer_method:, mailer_args: "[7, 7]", open_count: 1)
+      pk = installment.id.to_s
+      # The partition query used by the per-installment recompute sees the open
+      # item but no SUMMARY, so open_count gets a +1 correction.
+      client.stub_responses(:query, { items: [{ "pk" => pk, "sk" => "OPEN##{recipient_digest}" }], last_evaluated_key: nil })
+
+      described_class.backfill_seller!(installment.seller_id)
+
+      written = requests.select { _1[:operation_name] == :batch_write_item }.flat_map { written_items(_1) }
+      expect(written.map { _1["pk"] }.uniq).to eq([pk])
+
+      summary_fix = requests.select { _1[:operation_name] == :update_item }.map { _1[:params] }.sole
+      expect(summary_fix[:key]["sk"].values.first).to eq("SUMMARY")
+      expect(summary_fix[:expression_attribute_names]).to eq("#counter" => "open_count")
+      expect(summary_fix[:expression_attribute_values][":delta"]).to eq(n: "1")
+    end
+  end
+
+  describe ".verify_seller!" do
+    it "reports nothing when DynamoDB matches the Mongo documents" do
+      installment = create(:installment)
+      CreatorEmailOpenEvent.create!(installment_id: installment.id, mailer_method:, mailer_args:, open_count: 2)
+      CreatorEmailClickEvent.create!(installment_id: installment.id, mailer_method:, mailer_args:, click_url:, click_count: 1)
+      client.stub_responses(:get_item, { item: { "pk" => installment.id.to_s, "sk" => "SUMMARY", "open_count" => 1, "click_count" => 1 } })
+      client.stub_responses(:query, { items: [{ "pk" => installment.id.to_s, "sk" => "URL##{url_digest}", "click_url" => click_url, "click_count" => 1 }], last_evaluated_key: nil })
+
+      expect(described_class.verify_seller!(installment.seller_id)).to eq([])
+    end
+
+    it "reports installments where DynamoDB disagrees with the document-derived counts" do
+      installment = create(:installment)
+      CreatorEmailClickSummary.create!(installment_id: installment.id, total_unique_clicks: 9, urls: {})
+      CreatorEmailOpenEvent.create!(installment_id: installment.id, mailer_method:, mailer_args:, open_count: 1)
+      CreatorEmailClickEvent.create!(installment_id: installment.id, mailer_method:, mailer_args:, click_url:, click_count: 1)
+      client.stub_responses(:get_item, { item: { "pk" => installment.id.to_s, "sk" => "SUMMARY", "open_count" => 1, "click_count" => 2 } })
+      client.stub_responses(:query, { items: [{ "pk" => installment.id.to_s, "sk" => "URL##{url_digest}", "click_url" => click_url, "click_count" => 1 }], last_evaluated_key: nil })
+
+      mismatch = described_class.verify_seller!(installment.seller_id).sole
+      expect(mismatch[:dynamo]).to eq(opens: 1, clicks: 2, urls: { click_url => 1 })
+      expect(mismatch[:mongo_docs]).to eq(opens: 1, clicks: 1, urls: { click_url => 1 })
+      expect(mismatch[:mongo_stored_clicks]).to eq(9)
+    end
+  end
+
   describe ".verify!" do
     it "reports installments whose DynamoDB counters disagree with Mongo" do
       CreatorEmailClickSummary.create!(installment_id: 123, total_unique_clicks: 5, urls: {})


### PR DESCRIPTION
## What

Adds two methods to `Onetime::BackfillEmailEngagementDynamoTable` for piloting the backfill on one seller before the full ~27h load:

- `backfill_seller!(seller_id)` — resolves the seller's installment ids from MySQL, streams each installment's Mongo open/click docs (indexed lookups, batched, secondary-preferred) through the existing item transforms, then runs a per-partition counter recompute using the same `ADD`-delta logic as the global pass.
- `verify_seller!(seller_id)` — three-way comparison per installment: DynamoDB counters and `URL#` items vs counts derived from the Mongo *documents* vs Mongo's *stored* `CreatorEmailClickSummary`. The enforced invariant is DynamoDB == document-derived; the stored summary is reported alongside because its cache-guarded counters have drifted historically and are not the correctness bar.

The shared pieces (`classify_item`, `apply_deltas`, `query_partition`) are extracted from `recompute_counters!` so the global scan and the per-partition recompute use one implementation.

## Why

Before committing to the full 970M-item load, one seller proves the whole pipeline for pennies: the transforms, dual-write collision overwrites (pick a seller who blasted recently), the compensating-open path, and recompute convergence while live events arrive. Pilot partitions leave no cleanup debt — key derivation is deterministic, so the full backfill later re-puts identical items over them. The document-derived-vs-stored distinction in `verify_seller!` exists so a historical drift in Mongo's own click counters isn't misread as a backfill bug during the real reconciliation.

## Before/After

No user-facing change and no behavior change at deploy time: operator-run console methods only; nothing invokes them. Walkthrough video: TODO before marking ready for review.

## QA steps

1. Locally against dynamodb-local: create an installment with open/click docs, run `backfill_seller!` then `verify_seller!` — expect an empty mismatch list.
2. In production (dual-write flag is already on): pick a seller with a recent blast plus old posts, run `backfill_seller!(id)`, rerun once (idempotent), then `verify_seller!(id)` and eyeball any rows where DynamoDB differs from the document-derived counts.

## Test Results

- `bundle exec rspec spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb` — 10 examples, 0 failures (adds: seller scoping + per-partition delta correction; clean verify; mismatch reporting with the three-way breakdown)
- `bundle exec rubocop` on both files — clean

---

AI disclosure: implemented with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)