### PR TITLE
Add progress output and single-installment mode to the seller backfill

### DIFF
--- a/app/services/onetime/backfill_email_engagement_dynamo_table.rb
+++ b/app/services/onetime/backfill_email_engagement_dynamo_table.rb
@@ -8,10 +8,11 @@
 #   Onetime::BackfillEmailEngagementDynamoTable.recompute_counters!  # rerun until it reports 0 adjustments
 #   Onetime::BackfillEmailEngagementDynamoTable.verify!
 #
-# Or pilot a single seller first:
+# Or pilot a single seller (or a single installment) first:
 #
 #   Onetime::BackfillEmailEngagementDynamoTable.backfill_seller!(seller_id)
 #   Onetime::BackfillEmailEngagementDynamoTable.verify_seller!(seller_id)
+#   Onetime::BackfillEmailEngagementDynamoTable.backfill_installment!(installment_id)
 #
 # The dual-write flag must be on before the first phase starts: Mongo then
 # strictly contains every live item, so overwriting on key collision is safe.
@@ -57,17 +58,44 @@ class Onetime::BackfillEmailEngagementDynamoTable
     # Rerunnable at any time; the full backfill later re-puts identical items.
     def backfill_seller!(seller_id)
       installment_ids = Installment.where(seller_id:).ids
-      installment_ids.each do |installment_id|
-        CreatorEmailOpenEvent.where(installment_id:).read(mode: :secondary_preferred).each_slice(MONGO_BATCH_SIZE) do |docs|
-          write_items(docs.filter_map { open_item(_1) })
-        end
-        CreatorEmailClickEvent.where(installment_id:).read(mode: :secondary_preferred).each_slice(MONGO_BATCH_SIZE) do |docs|
-          write_items(docs.flat_map { click_items(_1) })
-        end
-        recompute_installment!(installment_id)
+      doc_counts = installment_ids.index_with do |installment_id|
+        CreatorEmailOpenEvent.where(installment_id:).count + CreatorEmailClickEvent.where(installment_id:).count
+      end
+      total_docs = doc_counts.values.sum
+      processed_docs = 0
+
+      installment_ids.each_with_index do |installment_id, index|
+        backfill_installment!(installment_id, quiet: true)
+        processed_docs += doc_counts[installment_id]
+        percent = total_docs.zero? ? 100.0 : processed_docs * 100.0 / total_docs
+        puts format("[%d/%d] installment %d done (%d docs) — %.1f%% (%d/%d docs)",
+                    index + 1, installment_ids.size, installment_id, doc_counts[installment_id],
+                    percent, processed_docs, total_docs)
       end
       puts "Backfilled #{installment_ids.size} installments for seller #{seller_id}; compare with verify_seller!(#{seller_id})."
       installment_ids.size
+    end
+
+    # Backfill a single installment (items plus its counter recompute).
+    def backfill_installment!(installment_id, quiet: false)
+      docs = 0
+      progress = lambda do |batch|
+        crossed = docs / 100_000 > (docs - batch.size) / 100_000
+        puts "  installment #{installment_id}: #{docs} docs..." if crossed
+      end
+      CreatorEmailOpenEvent.where(installment_id:).read(mode: :secondary_preferred).each_slice(MONGO_BATCH_SIZE) do |batch|
+        write_items(batch.filter_map { open_item(_1) })
+        docs += batch.size
+        progress.call(batch)
+      end
+      CreatorEmailClickEvent.where(installment_id:).read(mode: :secondary_preferred).each_slice(MONGO_BATCH_SIZE) do |batch|
+        write_items(batch.flat_map { click_items(_1) })
+        docs += batch.size
+        progress.call(batch)
+      end
+      recompute_installment!(installment_id)
+      puts "Backfilled installment #{installment_id} (#{docs} docs); counters recomputed." unless quiet
+      docs
     end
 
     # Three-way comparison per installment. The invariant is DynamoDB ==

--- a/spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb
+++ b/spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb
@@ -160,7 +160,8 @@ describe Onetime::BackfillEmailEngagementDynamoTable do
       # item but no SUMMARY, so open_count gets a +1 correction.
       client.stub_responses(:query, { items: [{ "pk" => pk, "sk" => "OPEN##{recipient_digest}" }], last_evaluated_key: nil })
 
-      described_class.backfill_seller!(installment.seller_id)
+      expect { described_class.backfill_seller!(installment.seller_id) }
+        .to output(%r{\[1/1\] installment #{installment.id} done \(1 docs\) — 100\.0% \(1/1 docs\)}).to_stdout
 
       written = requests.select { _1[:operation_name] == :batch_write_item }.flat_map { written_items(_1) }
       expect(written.map { _1["pk"] }.uniq).to eq([pk])
@@ -169,6 +170,28 @@ describe Onetime::BackfillEmailEngagementDynamoTable do
       expect(summary_fix[:key]["sk"].values.first).to eq("SUMMARY")
       expect(summary_fix[:expression_attribute_names]).to eq("#counter" => "open_count")
       expect(summary_fix[:expression_attribute_values][":delta"]).to eq(n: "1")
+    end
+  end
+
+  describe ".backfill_installment!" do
+    it "loads a single installment's docs and recomputes its counters, leaving siblings alone" do
+      installment = create(:installment)
+      sibling = create(:installment)
+      CreatorEmailOpenEvent.create!(installment_id: installment.id, mailer_method:, mailer_args:, open_count: 1)
+      CreatorEmailClickEvent.create!(installment_id: installment.id, mailer_method:, mailer_args:, click_url:, click_count: 1)
+      CreatorEmailOpenEvent.create!(installment_id: sibling.id, mailer_method:, mailer_args: "[7, 7]", open_count: 1)
+      client.stub_responses(:query, { items: [], last_evaluated_key: nil })
+
+      docs = described_class.backfill_installment!(installment.id)
+
+      expect(docs).to eq(2)
+      written = requests.select { _1[:operation_name] == :batch_write_item }.flat_map { written_items(_1) }
+      expect(written.map { _1["pk"] }.uniq).to eq([installment.id.to_s])
+      expect(written.map { _1["sk"] }).to contain_exactly(
+        "OPEN##{recipient_digest}",
+        "CLICK##{recipient_digest}##{url_digest}",
+        "CLICKER##{recipient_digest}"
+      )
     end
   end
 


### PR DESCRIPTION
## What

Two additions to `Onetime::BackfillEmailEngagementDynamoTable`:

- **Progress percentages for `backfill_seller!`**: it precomputes each installment's Mongo doc count (cheap indexed counts), then prints a running line after each installment — `[3/57] installment 12345 done (450 docs) — 12.3% (1,234/10,000 docs)` — plus an intra-installment `... 100000 docs...` line every 100k docs so a six-figure blast doesn't look hung.
- **`backfill_installment!(installment_id)`**: the per-installment work (item load + counter recompute) extracted into a public method, so a single installment can be imported alone or re-repaired without touching the seller's other installments. `backfill_seller!` now loops over it.

## Why

The first large-seller pilot run sat silent from invocation until the final summary — for a seller with hundreds of thousands of docs that's tens of minutes with no way to distinguish "working" from "hung," and no way to redo one installment without redoing all of them. Doc counts are computed upfront (rather than discovered while streaming) so the percentage is against a known denominator; the counts are indexed `installment_id` lookups, so the precompute adds seconds even for large sellers.

## Before/After

No user-facing change: operator-run console methods only. Before: no output until the final line. After: numbered per-installment progress with a running percentage. Walkthrough video: TODO before marking ready for review.

## QA steps

1. Locally with a couple of installments and Mongo docs: `backfill_seller!(seller_id)` prints `[1/2] … 50.0% …`, `[2/2] … 100.0% …`, then the summary.
2. `backfill_installment!(installment_id)` loads only that installment's items and prints its doc count; a sibling installment's docs are untouched.
3. Rerunning either is idempotent (keyed overwrites + delta recompute), same as before.

## Test Results

- `bundle exec rspec spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb` — 11 examples, 0 failures (adds the progress-output assertion and the single-installment scoping case)
- `bundle exec rubocop` on both files — clean

---

AI disclosure: implemented with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)