### PR TITLE
Show restart-proof progress percentages in the global backfill phases

### DIFF
--- a/app/services/onetime/backfill_email_engagement_dynamo_table.rb
+++ b/app/services/onetime/backfill_email_engagement_dynamo_table.rb
@@ -22,6 +22,7 @@
 class Onetime::BackfillEmailEngagementDynamoTable
   MONGO_BATCH_SIZE = 1_000
   DYNAMO_BATCH_SIZE = 25 # BatchWriteItem hard limit
+  PROGRESS_INTERVAL = 100_000 # docs between progress lines
   SCAN_PAGE_SIZE = 1_000
   MAX_WRITE_ATTEMPTS = 8
   OPENS_CURSOR_KEY = "onetime_backfill_email_engagement_opens_last_id"
@@ -159,7 +160,17 @@ class Onetime::BackfillEmailEngagementDynamoTable
 
       def each_mongo_batch(model, cursor_key)
         last_id = $redis.get(cursor_key)
-        processed = 0
+        # The denominator is snapshotted once per backfill (NX) because live
+        # dual-writes keep growing the collection; the cumulative counter
+        # advances atomically with the cursor, so the percentage survives
+        # restarts with at most one re-processed batch of drift. Chasing docs
+        # written after the snapshot can push the final percentage slightly
+        # past 100 — that's the swept tail, not an error.
+        $redis.set("#{cursor_key}_total", model.collection.estimated_document_count, nx: true)
+        total = $redis.get("#{cursor_key}_total").to_i
+        run_started_at = Time.current
+        run_processed = 0
+
         loop do
           criteria = model.all.read(mode: :secondary_preferred).order(_id: :asc).limit(MONGO_BATCH_SIZE)
           criteria = criteria.where(_id: { "$gt" => BSON::ObjectId.from_string(last_id) }) if last_id
@@ -167,12 +178,23 @@ class Onetime::BackfillEmailEngagementDynamoTable
           break if docs.empty?
 
           yield docs
-          processed += docs.size
+          run_processed += docs.size
           last_id = docs.last._id.to_s
-          $redis.set(cursor_key, last_id)
-          puts "#{model.name}: #{processed} docs this run, through #{last_id}" if (processed % 100_000).zero?
+          _, cumulative = $redis.multi do |transaction|
+            transaction.set(cursor_key, last_id)
+            transaction.incrby("#{cursor_key}_processed", docs.size)
+          end
+          report_progress(model, cumulative.to_i, total, run_processed, run_started_at) if (run_processed % PROGRESS_INTERVAL).zero?
         end
-        puts "#{model.name}: done, #{processed} docs this run."
+        puts "#{model.name}: done, #{run_processed} docs this run."
+      end
+
+      def report_progress(model, cumulative, total, run_processed, run_started_at)
+        percent = total.zero? ? 100.0 : cumulative * 100.0 / total
+        elapsed = Time.current - run_started_at
+        rate = elapsed.positive? ? run_processed / elapsed : 0
+        remaining_hours = rate.positive? ? [(total - cumulative), 0].max / rate / 1.hour : 0
+        puts format("%s: %d/%d (%.1f%%) — %d docs/s, ~%.1fh remaining", model.name, cumulative, total, percent, rate, remaining_hours)
       end
 
       def open_item(doc)

--- a/spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb
+++ b/spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb
@@ -8,14 +8,20 @@ describe Onetime::BackfillEmailEngagementDynamoTable do
   let(:click_url) { "https://example&#46;com/a" }
   let(:url_digest) { Digest::SHA256.hexdigest(click_url) }
 
+  def progress_keys
+    [described_class::OPENS_CURSOR_KEY, described_class::CLICKS_CURSOR_KEY].flat_map do |key|
+      [key, "#{key}_total", "#{key}_processed"]
+    end
+  end
+
   before do
     EmailEngagementDynamoStore.client = client
-    $redis.del(described_class::OPENS_CURSOR_KEY, described_class::CLICKS_CURSOR_KEY)
+    $redis.del(*progress_keys)
   end
 
   after do
     EmailEngagementDynamoStore.client = nil
-    $redis.del(described_class::OPENS_CURSOR_KEY, described_class::CLICKS_CURSOR_KEY)
+    $redis.del(*progress_keys)
   end
 
   def requests
@@ -64,6 +70,22 @@ describe Onetime::BackfillEmailEngagementDynamoTable do
 
       expect(written_items(requests.sole).sole["pk"]).to eq("2")
       expect($redis.get(described_class::OPENS_CURSOR_KEY)).to eq(second._id.to_s)
+    end
+
+    it "continues the progress percentage across a restart" do
+      first = CreatorEmailOpenEvent.create!(installment_id: 1, mailer_method:, mailer_args: "[1, 1]", open_count: 1)
+      CreatorEmailOpenEvent.create!(installment_id: 2, mailer_method:, mailer_args: "[2, 2]", open_count: 1)
+      # State left behind by an interrupted earlier run: 5 of 10 docs done.
+      $redis.set(described_class::OPENS_CURSOR_KEY, first._id.to_s)
+      $redis.set("#{described_class::OPENS_CURSOR_KEY}_total", 10)
+      $redis.set("#{described_class::OPENS_CURSOR_KEY}_processed", 5)
+      stub_const("#{described_class}::PROGRESS_INTERVAL", 1)
+
+      expect { described_class.backfill_opens! }
+        .to output(%r{CreatorEmailOpenEvent: 6/10 \(60\.0%\)}).to_stdout
+
+      expect($redis.get("#{described_class::OPENS_CURSOR_KEY}_processed")).to eq("6")
+      expect($redis.get("#{described_class::OPENS_CURSOR_KEY}_total")).to eq("10")
     end
 
     it "retries unprocessed items before giving up" do


### PR DESCRIPTION
## What

`each_mongo_batch` (used by `backfill_opens!` / `backfill_clicks!`) now reports real progress:

```
CreatorEmailOpenEvent: 124000000/899231554 (13.8%) — 3120 docs/s, ~69.0h remaining
```

Three mechanics behind it:

- **Denominator**: the collection's filter-less count (served from Mongo metadata, milliseconds at 899M docs) is snapshotted into Redis once per backfill with `NX`. Live dual-writes keep appending docs, so a stable snapshot keeps the percentage monotonic instead of creeping.
- **Numerator**: a cumulative processed counter in Redis, incremented **in the same `MULTI` as the cursor advance**, so the two can never diverge. A restart resumes cursor, counter, and total together — the percentage continues where it left off, with at most one re-processed batch (≤1,000 docs) of drift after a hard kill, and re-processed batches are counted once.
- **ETA**: docs/s measured over the current run, divided into the remainder — for a 1–2 day load this is the number an operator actually watches.

The reporting interval becomes a `PROGRESS_INTERVAL` constant (unchanged at 100k docs).

## Why

The global phases previously printed only a raw this-run doc count with no denominator, and the count reset to zero on every resume — useless for answering "how far along is the 899M-doc load and when does it finish?" during the multi-day backfill window (gumroad-private#2158), especially across the interruptions the loader is explicitly designed to survive. Counting docs `<= cursor` in Mongo as the numerator was rejected: it's an index range scan that gets slower the further the backfill progresses, which is exactly backwards for a progress check.

One honest caveat, documented in the code: the final percentage can end slightly above 100% because the loader chases the tail of docs written after the snapshot. That's the swept tail, not an error.

## Before/After

No user-facing change: operator-run console output only. Before: `CreatorEmailOpenEvent: 200000 docs this run, through <objectid>`. After: the percentage/rate/ETA line above, continuous across restarts. Walkthrough video: TODO before marking ready for review.

## QA steps

1. Locally: seed docs, run `backfill_opens!`, kill it mid-run, rerun — the percentage continues from where it stopped rather than restarting at zero.
2. Confirm `<cursor>_total` is written once and not overwritten by the rerun.

## Test Results

- `bundle exec rspec spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb` — 12 examples, 0 failures (adds the restart-continuation case: preset cursor/total/processed state, asserts the `6/10 (60.0%)` line and the persisted counters)
- `bundle exec rubocop` on both files — clean

---

AI disclosure: implemented with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)