### PR TITLE
Track click pairs on SUMMARY so dashboard clicks keep their meaning

### DIFF
--- a/app/services/email_engagement_dynamo_store.rb
+++ b/app/services/email_engagement_dynamo_store.rb
@@ -4,7 +4,10 @@
 # CreatorEmailClickEvent / CreatorEmailClickSummary Mongo collections.
 #
 # Partition key `pk` (S, the stringified installment id), sort key `sk` (S), one of:
-#   SUMMARY                    — open_count / click_count counters for the installment
+#   SUMMARY                    — open_count / click_count / click_pair_count counters;
+#                                click_pair_count (unique recipient+url pairs) is what the
+#                                dashboard's "Clicks" has historically shown, click_count is
+#                                true unique clickers
 #   OPEN#<recipient>           — one item per recipient who opened
 #   CLICKER#<recipient>        — claims the recipient's first click; drives click_count
 #   CLICK#<recipient>#<url>    — one item per recipient + url first click
@@ -36,6 +39,7 @@ class EmailEngagementDynamoStore
         next unless put_click_item(installment_id:, mailer_method:, mailer_args:, click_url:, recipient:)
 
         increment_url_click_count(installment_id:, click_url:)
+        increment_summary(installment_id:, attribute: "click_pair_count")
         # The conditional marker put is both the "has this recipient clicked
         # anything?" check and the claim, so concurrent first clicks on
         # different urls can't double-increment the counter.

--- a/app/services/onetime/backfill_email_engagement_dynamo_table.rb
+++ b/app/services/onetime/backfill_email_engagement_dynamo_table.rb
@@ -114,6 +114,7 @@ class Onetime::BackfillEmailEngagementDynamoTable
         mongo_docs = {
           opens: mongo_opens,
           clicks: click_rows.map { |mailer_method, mailer_args, _| [mailer_method, mailer_args] }.uniq.size,
+          pairs: click_rows.size,
           urls: click_rows.group_by { |_, _, url| url }.transform_values(&:size),
         }
         summary = store.client.get_item(
@@ -121,7 +122,7 @@ class Onetime::BackfillEmailEngagementDynamoTable
           key: { "pk" => pk, "sk" => EmailEngagementDynamoStore::SUMMARY_SORT_KEY },
           consistent_read: true
         ).item || {}
-        dynamo = { opens: summary["open_count"].to_i, clicks: summary["click_count"].to_i, urls: {} }
+        dynamo = { opens: summary["open_count"].to_i, clicks: summary["click_count"].to_i, pairs: summary["click_pair_count"].to_i, urls: {} }
         query_partition(pk, sk_prefix: "URL#") { |item| dynamo[:urls][item["click_url"]] = item["click_count"].to_i }
 
         next if dynamo == mongo_docs
@@ -136,6 +137,11 @@ class Onetime::BackfillEmailEngagementDynamoTable
       mismatches
     end
 
+    # The gate compares DynamoDB against the Mongo documents (open docs and
+    # click-pair docs). Mongo's stored total_unique_clicks is reported on
+    # mismatch rows but never enforced: concurrent url-prefetch bursts have
+    # historically inflated it past the true clicker count, and it drifts a
+    # little from the pair-doc count for the same reason.
     def verify!(sample_size: 1_000)
       mismatches = []
       CreatorEmailClickSummary.all.read(mode: :secondary_preferred).limit(sample_size).each do |summary|
@@ -144,10 +150,13 @@ class Onetime::BackfillEmailEngagementDynamoTable
           table_name: store.table_name,
           key: { "pk" => pk, "sk" => EmailEngagementDynamoStore::SUMMARY_SORT_KEY }
         ).item || {}
-        mongo_opens = CreatorEmailOpenEvent.where(installment_id: summary.installment_id).count
-        expected = { clicks: summary.total_unique_clicks.to_i, opens: mongo_opens }
-        actual = { clicks: dynamo["click_count"].to_i, opens: dynamo["open_count"].to_i }
-        mismatches << { installment_id: summary.installment_id, expected:, actual: } if expected != actual
+        expected = {
+          opens: CreatorEmailOpenEvent.where(installment_id: summary.installment_id).count,
+          pairs: CreatorEmailClickEvent.where(installment_id: summary.installment_id).count,
+        }
+        actual = { opens: dynamo["open_count"].to_i, pairs: dynamo["click_pair_count"].to_i }
+        next if expected == actual
+        mismatches << { installment_id: summary.installment_id, expected:, actual:, mongo_stored_clicks: summary.total_unique_clicks.to_i }
       end
       puts mismatches.empty? ? "All #{sample_size} sampled installments match." : "#{mismatches.size} mismatches: #{mismatches.first(20).inspect}"
       mismatches
@@ -263,7 +272,7 @@ class Onetime::BackfillEmailEngagementDynamoTable
       end
 
       def new_tally
-        { opens: 0, clickers: 0, urls: Hash.new(0) }
+        { opens: 0, clickers: 0, pairs: 0, urls: Hash.new(0) }
       end
 
       def classify_item(item, tally, current)
@@ -271,11 +280,13 @@ class Onetime::BackfillEmailEngagementDynamoTable
         if sk == EmailEngagementDynamoStore::SUMMARY_SORT_KEY
           current[:opens] = item["open_count"].to_i
           current[:clickers] = item["click_count"].to_i
+          current[:pairs] = item["click_pair_count"].to_i
         elsif sk.start_with?("OPEN#")
           tally[:opens] += 1
         elsif sk.start_with?("CLICKER#")
           tally[:clickers] += 1
         elsif sk.start_with?("CLICK#")
+          tally[:pairs] += 1
           tally[:urls][item["click_url"]] += 1
         elsif sk.start_with?("URL#")
           current[:urls][item["click_url"]] = item["click_count"].to_i
@@ -285,6 +296,7 @@ class Onetime::BackfillEmailEngagementDynamoTable
       def apply_deltas(pk, tally, current)
         adjustments = apply_delta(pk, EmailEngagementDynamoStore::SUMMARY_SORT_KEY, "open_count", tally[:opens] - current[:opens])
         adjustments += apply_delta(pk, EmailEngagementDynamoStore::SUMMARY_SORT_KEY, "click_count", tally[:clickers] - current[:clickers])
+        adjustments += apply_delta(pk, EmailEngagementDynamoStore::SUMMARY_SORT_KEY, "click_pair_count", tally[:pairs] - current[:pairs])
         (tally[:urls].keys | current[:urls].keys).each do |url|
           adjustments += apply_delta(pk, store.url_sort_key(url), "click_count", tally[:urls][url] - current[:urls][url], click_url: url)
         end

--- a/spec/services/email_engagement_dynamo_store_spec.rb
+++ b/spec/services/email_engagement_dynamo_store_spec.rb
@@ -90,11 +90,11 @@ describe EmailEngagementDynamoStore do
       expect(requests).to be_empty
     end
 
-    it "records a first-ever click with the url total, the clicker marker, the summary click count, and a compensating open" do
+    it "records a first-ever click with the url total, the pair count, the clicker marker, the summary click count, and a compensating open" do
       described_class.record_click(installment_id: 123, mailer_method:, mailer_args:, click_url:)
 
       expect(requests.map { _1[:operation_name] }).to eq(
-        [:put_item, :update_item, :put_item, :update_item, :put_item, :update_item]
+        [:put_item, :update_item, :update_item, :put_item, :update_item, :put_item, :update_item]
       )
 
       click_put = requests[0][:params]
@@ -109,36 +109,41 @@ describe EmailEngagementDynamoStore do
       expect(url_update[:update_expression]).to eq("ADD click_count :one SET click_url = :click_url")
       expect(plain(url_update[:expression_attribute_values][":click_url"])).to eq(click_url)
 
-      marker_put = requests[2][:params]
+      pair_update = requests[2][:params]
+      expect(plain_hash(pair_update[:key])).to eq("pk" => "123", "sk" => "SUMMARY")
+      expect(pair_update[:expression_attribute_names]).to eq("#counter" => "click_pair_count")
+
+      marker_put = requests[3][:params]
       expect(plain(marker_put[:item]["pk"])).to eq("123")
       expect(plain(marker_put[:item]["sk"])).to eq("CLICKER##{recipient_digest}")
       expect(plain(marker_put[:item]["mailer_args"])).to eq(mailer_args)
       expect(marker_put[:condition_expression]).to eq("attribute_not_exists(pk)")
 
-      summary_click_update = requests[3][:params]
+      summary_click_update = requests[4][:params]
       expect(plain_hash(summary_click_update[:key])).to eq("pk" => "123", "sk" => "SUMMARY")
       expect(summary_click_update[:expression_attribute_names]).to eq("#counter" => "click_count")
 
-      open_put = requests[4][:params]
+      open_put = requests[5][:params]
       expect(plain(open_put[:item]["pk"])).to eq("123")
       expect(plain(open_put[:item]["sk"])).to eq("OPEN##{recipient_digest}")
       expect(plain(open_put[:item]["open_count"])).to eq(1)
       expect(open_put[:condition_expression]).to eq("attribute_not_exists(pk)")
 
-      summary_open_update = requests[5][:params]
+      summary_open_update = requests[6][:params]
       expect(plain_hash(summary_open_update[:key])).to eq("pk" => "123", "sk" => "SUMMARY")
       expect(summary_open_update[:expression_attribute_names]).to eq("#counter" => "open_count")
     end
 
-    it "does not increment the summary click count when the recipient has clicked another url before" do
+    it "counts the pair but not the summary click count when the recipient has clicked another url before" do
       # The click item put succeeds; the clicker marker already exists, as does the open item.
       client.stub_responses(:put_item, [{}, "ConditionalCheckFailedException", "ConditionalCheckFailedException"])
 
       described_class.record_click(installment_id: 123, mailer_method:, mailer_args:, click_url:)
 
-      expect(requests.map { _1[:operation_name] }).to eq([:put_item, :update_item, :put_item, :put_item])
+      expect(requests.map { _1[:operation_name] }).to eq([:put_item, :update_item, :update_item, :put_item, :put_item])
       expect(plain(requests[1][:params][:key]["sk"])).to eq("URL##{url_digest}")
-      expect(plain(requests[2][:params][:item]["sk"])).to eq("CLICKER##{recipient_digest}")
+      expect(requests[2][:params][:expression_attribute_names]).to eq("#counter" => "click_pair_count")
+      expect(plain(requests[3][:params][:item]["sk"])).to eq("CLICKER##{recipient_digest}")
     end
 
     it "counts nothing on a repeat click of the same url by the same recipient" do

--- a/spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb
+++ b/spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb
@@ -145,12 +145,15 @@ describe Onetime::BackfillEmailEngagementDynamoTable do
 
       adjustments = described_class.recompute_counters!
 
-      # open_count is off by one (2 items vs 1); click_count matches; URL# item is missing entirely.
-      expect(adjustments).to eq(2)
+      # open_count is off by one (2 items vs 1); click_count matches; the pair
+      # count and the URL# item are missing entirely.
+      expect(adjustments).to eq(3)
       updates = requests.select { _1[:operation_name] == :update_item }.map { _1[:params] }
       open_fix = updates.find { _1[:expression_attribute_names] == { "#counter" => "open_count" } }
       expect(open_fix[:key]["sk"].values.first).to eq("SUMMARY")
       expect(open_fix[:expression_attribute_values][":delta"]).to eq(n: "1")
+      pair_fix = updates.find { _1[:expression_attribute_names] == { "#counter" => "click_pair_count" } }
+      expect(pair_fix[:expression_attribute_values][":delta"]).to eq(n: "1")
       url_fix = updates.find { _1[:key]["sk"].values.first == "URL##{url_digest}" }
       expect(url_fix[:update_expression]).to include("if_not_exists(click_url, :click_url)")
       expect(url_fix[:expression_attribute_values][":delta"]).to eq(n: "1")
@@ -162,7 +165,7 @@ describe Onetime::BackfillEmailEngagementDynamoTable do
         { "pk" => "123", "sk" => "CLICKER#aaa" },
         { "pk" => "123", "sk" => "CLICK#aaa#u1", "click_url" => click_url },
         { "pk" => "123", "sk" => "URL##{url_digest}", "click_url" => click_url, "click_count" => 1 },
-        { "pk" => "123", "sk" => "SUMMARY", "open_count" => 1, "click_count" => 1 },
+        { "pk" => "123", "sk" => "SUMMARY", "open_count" => 1, "click_count" => 1, "click_pair_count" => 1 },
       ]
       client.stub_responses(:scan, { items: scan_items, last_evaluated_key: nil })
 
@@ -222,7 +225,7 @@ describe Onetime::BackfillEmailEngagementDynamoTable do
       installment = create(:installment)
       CreatorEmailOpenEvent.create!(installment_id: installment.id, mailer_method:, mailer_args:, open_count: 2)
       CreatorEmailClickEvent.create!(installment_id: installment.id, mailer_method:, mailer_args:, click_url:, click_count: 1)
-      client.stub_responses(:get_item, { item: { "pk" => installment.id.to_s, "sk" => "SUMMARY", "open_count" => 1, "click_count" => 1 } })
+      client.stub_responses(:get_item, { item: { "pk" => installment.id.to_s, "sk" => "SUMMARY", "open_count" => 1, "click_count" => 1, "click_pair_count" => 1 } })
       client.stub_responses(:query, { items: [{ "pk" => installment.id.to_s, "sk" => "URL##{url_digest}", "click_url" => click_url, "click_count" => 1 }], last_evaluated_key: nil })
 
       expect(described_class.verify_seller!(installment.seller_id)).to eq([])
@@ -233,29 +236,40 @@ describe Onetime::BackfillEmailEngagementDynamoTable do
       CreatorEmailClickSummary.create!(installment_id: installment.id, total_unique_clicks: 9, urls: {})
       CreatorEmailOpenEvent.create!(installment_id: installment.id, mailer_method:, mailer_args:, open_count: 1)
       CreatorEmailClickEvent.create!(installment_id: installment.id, mailer_method:, mailer_args:, click_url:, click_count: 1)
-      client.stub_responses(:get_item, { item: { "pk" => installment.id.to_s, "sk" => "SUMMARY", "open_count" => 1, "click_count" => 2 } })
+      client.stub_responses(:get_item, { item: { "pk" => installment.id.to_s, "sk" => "SUMMARY", "open_count" => 1, "click_count" => 2, "click_pair_count" => 1 } })
       client.stub_responses(:query, { items: [{ "pk" => installment.id.to_s, "sk" => "URL##{url_digest}", "click_url" => click_url, "click_count" => 1 }], last_evaluated_key: nil })
 
       mismatch = described_class.verify_seller!(installment.seller_id).sole
-      expect(mismatch[:dynamo]).to eq(opens: 1, clicks: 2, urls: { click_url => 1 })
-      expect(mismatch[:mongo_docs]).to eq(opens: 1, clicks: 1, urls: { click_url => 1 })
+      expect(mismatch[:dynamo]).to eq(opens: 1, clicks: 2, pairs: 1, urls: { click_url => 1 })
+      expect(mismatch[:mongo_docs]).to eq(opens: 1, clicks: 1, pairs: 1, urls: { click_url => 1 })
       expect(mismatch[:mongo_stored_clicks]).to eq(9)
     end
   end
 
   describe ".verify!" do
-    it "reports installments whose DynamoDB counters disagree with Mongo" do
+    it "reports installments whose DynamoDB counters disagree with the Mongo documents" do
       CreatorEmailClickSummary.create!(installment_id: 123, total_unique_clicks: 5, urls: {})
       CreatorEmailOpenEvent.create!(installment_id: 123, mailer_method:, mailer_args:, open_count: 1)
-      client.stub_responses(:get_item, { item: { "pk" => "123", "sk" => "SUMMARY", "open_count" => 1, "click_count" => 4 } })
+      CreatorEmailClickEvent.create!(installment_id: 123, mailer_method:, mailer_args:, click_url:, click_count: 1)
+      client.stub_responses(:get_item, { item: { "pk" => "123", "sk" => "SUMMARY", "open_count" => 1, "click_pair_count" => 3 } })
 
       mismatches = described_class.verify!(sample_size: 10)
 
       expect(mismatches.sole).to eq(
         installment_id: 123,
-        expected: { clicks: 5, opens: 1 },
-        actual: { clicks: 4, opens: 1 }
+        expected: { opens: 1, pairs: 1 },
+        actual: { opens: 1, pairs: 3 },
+        mongo_stored_clicks: 5
       )
+    end
+
+    it "does not enforce Mongo's stored click counter when the documents match" do
+      CreatorEmailClickSummary.create!(installment_id: 123, total_unique_clicks: 5, urls: {})
+      CreatorEmailOpenEvent.create!(installment_id: 123, mailer_method:, mailer_args:, open_count: 1)
+      CreatorEmailClickEvent.create!(installment_id: 123, mailer_method:, mailer_args:, click_url:, click_count: 1)
+      client.stub_responses(:get_item, { item: { "pk" => "123", "sk" => "SUMMARY", "open_count" => 1, "click_pair_count" => 1 } })
+
+      expect(described_class.verify!(sample_size: 10)).to eq([])
     end
   end
 end


### PR DESCRIPTION
## What

Adds a `click_pair_count` counter to the `SUMMARY` item — unique recipient+url pairs, i.e. the number the dashboard's "Clicks" column has historically shown — maintained in three places:

- `EmailEngagementDynamoStore.record_click`: one `ADD` on every successful `CLICK#` item put (a conditional put succeeding *is* a new pair, so the counter can't race).
- The backfill loader's recompute (`recompute_counters!` / per-installment): derived as the count of `CLICK#` items, corrected via the same `ADD`-delta convergence as the other counters.
- `verify!` / `verify_seller!`: the reconciliation gate now enforces `click_pair_count` == Mongo click-document count (documents are unique per pair via the `click_index`), and reports Mongo's stored `total_unique_clicks` on mismatch rows without enforcing it.

`click_count` (true unique clickers, driven by the `CLICKER#` marker) stays maintained alongside.

## Why

Backfilling eight large posts for a high-volume seller and comparing against the dashboard showed Mongo's stored `total_unique_clicks` is 2–4× the true unique-clicker count (e.g. 28,480 vs 7,513; 33,558 vs 9,376) — and on every post it lands within ~1% of the click-*document* count. The mechanism: mail clients and link-scanning bots hit all of an email's urls nearly simultaneously, concurrent workers all pass the "has this recipient clicked before?" check before any document exists, and each increments the counter. At blast scale that race is the dominant path, so the counter has de facto always meant unique recipient+url pairs.

Decision: the dashboard's numbers should not change when reads flip to DynamoDB, so the read flip will serve `click_pair_count`. Keeping it as a `SUMMARY` attribute (rather than summing `URL#` items at read time) preserves the workflow presenter's single `BatchGetItem` for per-installment counts. The true-clicker count remains available for a future, deliberately-communicated metric correction.

Sequencing: already-backfilled partitions (the pilot seller and the eight-post run) gain the counter on their next recompute — no reload needed. The full backfill hasn't run, so this must merge before it does.

## Before/After

No user-facing change: the dual-write flag path gains one write per new pair (~20k/day), and reads still come from Mongo. This is precisely so that the *later* read flip is also not a user-facing change. Walkthrough video: TODO before marking ready for review.

## QA steps

1. Against dynamodb-local with the flag active: click two urls as one recipient and one url as another — `SUMMARY` shows `click_pair_count: 3`, `click_count: 2` (verified end-to-end; the run is in the test results).
2. Run `recompute_counters!` against a partition backfilled before this change — it adds the missing `click_pair_count` as a delta and reports the adjustment.

## Test Results

- `bundle exec rspec spec/services/email_engagement_dynamo_store_spec.rb spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb` — 29 examples, 0 failures (click op sequences with the pair increment; recompute delta for a missing pair counter; verify gates on pair docs; stored counter explicitly not enforced)
- End-to-end against `amazon/dynamodb-local` with the Terraform-shaped table: `click_pair_count: 3` / `click_count: 2` / per-url totals correct
- `bundle exec rubocop` on all four files — clean

---

AI disclosure: implemented with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)