### PR TITLE
Disable license keys when a purchase is fully refunded

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2310,6 +2310,7 @@ class Purchase < ApplicationRecord
     end
 
     giftee_purchase.save!
+    giftee_purchase.disable_attached_license_if_fully_refunded! unless is_partially_refunded
   end
 
   def mark_product_purchases_as_refunded!(is_partially_refunded:)
@@ -2320,6 +2321,7 @@ class Purchase < ApplicationRecord
         product_purchase.update!(stripe_partially_refunded: true)
       else
         product_purchase.update!(stripe_refunded: true)
+        product_purchase.disable_attached_license_if_fully_refunded!
       end
     end
   end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2310,7 +2310,6 @@ class Purchase < ApplicationRecord
     end
 
     giftee_purchase.save!
-    giftee_purchase.disable_attached_license_if_fully_refunded! unless is_partially_refunded
   end
 
   def mark_product_purchases_as_refunded!(is_partially_refunded:)
@@ -2321,7 +2320,6 @@ class Purchase < ApplicationRecord
         product_purchase.update!(stripe_partially_refunded: true)
       else
         product_purchase.update!(stripe_refunded: true)
-        product_purchase.disable_attached_license_if_fully_refunded!
       end
     end
   end

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -538,19 +538,23 @@ class Purchase
 
   # /v2/licenses/verify rejects disabled keys but not stripe_refunded, so a
   # refunded purchase otherwise keeps a working key until the seller disables it.
+  # Look up the License row by purchase_id: Purchase#license_key is nil when the
+  # product is not currently flagged licensed, and Purchase#license remaps a
+  # renewal onto the original purchase's key.
   def disable_attached_license_if_fully_refunded!(for_fraud: false)
     return unless stripe_refunded?
 
-    license_to_disable = if is_recurring_subscription_charge
-      return unless for_fraud
-
-      subscription&.original_purchase&.license
+    targets = []
+    if is_recurring_subscription_charge
+      targets << subscription&.original_purchase&.license if for_fraud
     else
-      linked_license
+      targets << License.find_by(purchase_id: id)
+      if is_gift_sender_purchase && gift_given&.giftee_purchase_id
+        targets << License.find_by(purchase_id: gift_given.giftee_purchase_id)
+      end
     end
-    return if license_to_disable.blank? || license_to_disable.disabled?
 
-    license_to_disable.disable!
+    targets.compact.uniq.each { |license| license.disable! unless license.disabled? }
   end
 
   def buyer_presentment_refund_blocked?

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -339,7 +339,6 @@ class Purchase
       decrement_balance_for_refund_or_chargeback!(flow_of_funds, refund:) unless chargedback_not_reversed?
       mark_product_purchases_as_refunded!(is_partially_refunded: self.stripe_partially_refunded?)
       save!
-      disable_attached_license_if_fully_refunded!(for_fraud: is_for_fraud)
       reverse_the_transfer_made_for_dispute_win! if chargedback? && chargeback_reversed
       reverse_excess_amount_from_stripe_transfer(refund:) if stripe_partially_refunded && vat_already_refunded
       debit_processor_fee_from_merchant_account!(refund) unless is_refund_chargeback_fee_waived || chargedback_not_reversed?
@@ -369,6 +368,10 @@ class Purchase
       end
 
       true
+    end.tap do |refunded|
+      # After commit: ChargeProcessor.refund! has already moved the money.
+      # A failed license write must not roll back stripe_refunded.
+      disable_attached_license_if_fully_refunded!(for_fraud: is_for_fraud) if refunded
     end
   end
 
@@ -402,7 +405,6 @@ class Purchase
         refunds << refund
       end
       save!
-      disable_attached_license_if_fully_refunded!
       Credit.create_for_vat_exclusive_refund!(refund:) if paypal_order_id.present? || merchant_account&.is_a_stripe_connect_account?
       debit_processor_fee_from_merchant_account!(refund) unless is_refund_chargeback_fee_waived
       # refund can be nil here (build_partial_full_refund may return nothing). Pass the
@@ -411,6 +413,8 @@ class Purchase
       # is committed/visible and would miss it.
       CustomerMailer.partial_refund(email, link.id, id, gross_refund_amount_cents, formatted_refund_state, refund&.presentment_amount_cents, refund&.presentment_currency).deliver_later(queue: "critical")
       true
+    end.tap do |refunded|
+      disable_attached_license_if_fully_refunded! if refunded
     end
   end
 
@@ -531,7 +535,7 @@ class Purchase
     subscription.cancel_effective_immediately! if subscription.present? && !subscription.deactivated?
     ContactingCreatorMailer.purchase_refunded_for_fraud(id).deliver_later(queue: "default") unless seller.suspended?
     # Covers already-refunded retries: refund_and_save! is a no-op then, so the
-    # in-transaction hook above never ran.
+    # post-commit hook on refund_purchase! never ran.
     disable_attached_license_if_fully_refunded!(for_fraud: true)
     true
   end
@@ -541,20 +545,39 @@ class Purchase
   # Look up the License row by purchase_id: Purchase#license_key is nil when the
   # product is not currently flagged licensed, and Purchase#license remaps a
   # renewal onto the original purchase's key.
+  # Must run after the refund transaction commits — disable! is a separate
+  # write, and a failure here must not undo stripe_refunded after the processor
+  # has already returned the money.
   def disable_attached_license_if_fully_refunded!(for_fraud: false)
-    return unless stripe_refunded?
+    purchases = [self]
+    purchases.concat(product_purchases.to_a) if is_bundle_purchase?
 
-    targets = []
-    if is_recurring_subscription_charge
-      targets << subscription&.original_purchase&.license if for_fraud
-    else
-      targets << License.find_by(purchase_id: id)
-      if is_gift_sender_purchase && gift_given&.giftee_purchase_id
-        targets << License.find_by(purchase_id: gift_given.giftee_purchase_id)
+    purchases.each do |purchase|
+      next unless purchase.stripe_refunded?
+
+      targets = []
+      if purchase.is_recurring_subscription_charge
+        targets << purchase.subscription&.original_purchase&.license if for_fraud
+      else
+        targets << License.find_by(purchase_id: purchase.id)
+        if purchase.is_gift_sender_purchase && purchase.gift_given&.giftee_purchase_id
+          targets << License.find_by(purchase_id: purchase.gift_given.giftee_purchase_id)
+        end
       end
-    end
 
-    targets.compact.uniq.each { |license| license.disable! unless license.disabled? }
+      targets.compact.uniq.each { |license| license.disable! unless license.disabled? }
+    end
+  rescue StandardError => e
+    logger.error "Failed to disable license after refund for purchase #{id}: #{e.class}: #{e.message}"
+    ErrorNotifier.notify(
+      "Failed to disable license after refund",
+      context: {
+        purchase_id: id,
+        purchase_external_id: external_id,
+        error_class: e.class.name,
+        error: e.message,
+      }
+    )
   end
 
   def buyer_presentment_refund_blocked?

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -339,6 +339,7 @@ class Purchase
       decrement_balance_for_refund_or_chargeback!(flow_of_funds, refund:) unless chargedback_not_reversed?
       mark_product_purchases_as_refunded!(is_partially_refunded: self.stripe_partially_refunded?)
       save!
+      disable_attached_license_if_fully_refunded!(for_fraud: is_for_fraud)
       reverse_the_transfer_made_for_dispute_win! if chargedback? && chargeback_reversed
       reverse_excess_amount_from_stripe_transfer(refund:) if stripe_partially_refunded && vat_already_refunded
       debit_processor_fee_from_merchant_account!(refund) unless is_refund_chargeback_fee_waived || chargedback_not_reversed?
@@ -401,6 +402,7 @@ class Purchase
         refunds << refund
       end
       save!
+      disable_attached_license_if_fully_refunded!
       Credit.create_for_vat_exclusive_refund!(refund:) if paypal_order_id.present? || merchant_account&.is_a_stripe_connect_account?
       debit_processor_fee_from_merchant_account!(refund) unless is_refund_chargeback_fee_waived
       # refund can be nil here (build_partial_full_refund may return nothing). Pass the
@@ -528,7 +530,27 @@ class Purchase
 
     subscription.cancel_effective_immediately! if subscription.present? && !subscription.deactivated?
     ContactingCreatorMailer.purchase_refunded_for_fraud(id).deliver_later(queue: "default") unless seller.suspended?
+    # Covers already-refunded retries: refund_and_save! is a no-op then, so the
+    # in-transaction hook above never ran.
+    disable_attached_license_if_fully_refunded!(for_fraud: true)
     true
+  end
+
+  # /v2/licenses/verify rejects disabled keys but not stripe_refunded, so a
+  # refunded purchase otherwise keeps a working key until the seller disables it.
+  def disable_attached_license_if_fully_refunded!(for_fraud: false)
+    return unless stripe_refunded?
+
+    license_to_disable = if is_recurring_subscription_charge
+      return unless for_fraud
+
+      subscription&.original_purchase&.license
+    else
+      linked_license
+    end
+    return if license_to_disable.blank? || license_to_disable.disabled?
+
+    license_to_disable.disable!
   end
 
   def buyer_presentment_refund_blocked?

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -181,7 +181,11 @@ changed.merge(git("diff", "--name-only", "#{merge_base}..HEAD")) if merge_base
 changed.merge(git("diff", "--name-only", "HEAD"))
 changed.merge(git("ls-files", "--others", "--exclude-standard"))
 
+cassette_in_diff = changed.any? { |path| path.start_with?("spec/support/fixtures/vcr_cassettes/") }
 changed.reject! { |path| IGNORED_PATTERNS.any? { |re| re.match?(path) } }
+# Cassettes ride along with a mapped spec without forcing Slow. A cassette-only
+# diff has nothing left to attribute, so escalate rather than run zero specs.
+escalate!("cassette-only diff: map to the owning spec or add run-all-specs") if changed.empty? && cassette_in_diff
 
 unmappable = changed.select do |path|
   ESCALATE_PATTERNS.any? { |re| re.match?(path) } && !CONFIG_SPEC_MAP.key?(path)

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -119,6 +119,9 @@ IGNORED_PATTERNS = [
   %r{\.md\z},
   %r{\A\.agents/},
   %r{\A\.claude/},
+  # Recorded HTTP, not helpers. A cassette-only diff must not force Slow;
+  # the spec that plays the tape is already in the selection (or unchanged).
+  %r{\Aspec/support/fixtures/vcr_cassettes/},
 ].freeze
 
 # Above this many selected files the full suite's parallelism wins anyway.
@@ -328,6 +331,9 @@ changed.each do |path|
          File.exist?(path.sub(/\.(ts|tsx)\z/, '.test.\1')))
     # Covered by vitest, which lint_js runs on every PR (npm test). A
     # co-located .test file is that module's suite; neither needs rspec.
+    next
+  elsif path == "bin/branch-specs" || path == "spec/bin/branch_specs_test.rb"
+    # Standalone ruby test (ruby spec/bin/branch_specs_test.rb), not rspec.
     next
   elsif path.match?(%r{\A(lib|app)/.*\.rb\z}) &&
         (by_content = specs_mentioning(File.basename(path, ".rb"))).any?

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -472,6 +472,19 @@ check(
   expect_specs: %w[spec/models/widget_spec.rb],
 )
 
+# A tape-only change has no mapped spec left after ignore. Escalate so a
+# re-recorded or malformed cassette cannot merge with an empty Relevant run.
+check(
+  "VCR cassette-only diff escalates",
+  base_files: {
+    "spec/support/fixtures/vcr_cassettes/Widget/example.yml" => "old",
+  },
+  head_files: {
+    "spec/support/fixtures/vcr_cassettes/Widget/example.yml" => "new",
+  },
+  expect_escalate: true,
+)
+
 # Real helper changes under spec/support still need the full suite.
 check(
   "unmapped spec/support helper still escalates",

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -454,6 +454,32 @@ check_invalid_path_bytes_rejected(
   head_files: { "app/views/customer_mailer/_footer.html.erb" => "new" },
 )
 
+# VCR tapes are recordings, not helpers. Pairing one with a mapped spec
+# must not force the full suite (the escalate that put refund-only PRs
+# onto 50 Slow checkout shards).
+check(
+  "VCR cassette with a mapped spec does not escalate",
+  base_files: {
+    "app/models/widget.rb" => "old",
+    "spec/models/widget_spec.rb" => SPEC_STUB,
+    "spec/support/fixtures/vcr_cassettes/Widget/example.yml" => "old",
+  },
+  head_files: {
+    "app/models/widget.rb" => "new",
+    "spec/models/widget_spec.rb" => "#{SPEC_STUB}# changed\n",
+    "spec/support/fixtures/vcr_cassettes/Widget/example.yml" => "new",
+  },
+  expect_specs: %w[spec/models/widget_spec.rb],
+)
+
+# Real helper changes under spec/support still need the full suite.
+check(
+  "unmapped spec/support helper still escalates",
+  base_files: { "spec/support/mystery_helpers.rb" => "old" },
+  head_files: { "spec/support/mystery_helpers.rb" => "new" },
+  expect_escalate: true,
+)
+
 if $failures.empty?
   puts "#{$count} checks passed"
 else

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -1741,6 +1741,7 @@ describe "PurchaseRefunds", :vcr do
 
       context "when gifter purchase is fully refunded" do
         before do
+          create(:license, purchase: @giftee_purchase, link:)
           flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, @gifter_purchase.price_cents)
           @gifter_purchase.refund_purchase!(flow_of_funds, @gifter_purchase.link.user.id)
         end
@@ -1752,6 +1753,59 @@ describe "PurchaseRefunds", :vcr do
         it "sets the stripe_partially_refunded of giftee purchase to false" do
           expect(@giftee_purchase.reload.stripe_partially_refunded).to eq false
         end
+
+        it "disables the giftee license" do
+          expect(@giftee_purchase.reload.license).to be_disabled
+        end
+      end
+    end
+  end
+
+  describe "license disable on refund" do
+    def attach_license!(purchase)
+      create(:license, purchase:, link: purchase.link)
+    end
+
+    describe "ordinary refunds" do
+      before do
+        @initial_balance = 200
+        @user = create(:user)
+        @product = create(:product, user: @user)
+        @purchase = create(:purchase_in_progress, link: @product, chargeable: create(:chargeable))
+        @purchase.process!
+        @purchase.mark_successful!
+        create(:balance, user: @user, amount_cents: @initial_balance)
+      end
+
+      it "disables the license on a full refund" do
+        license = attach_license!(@purchase)
+        expect(ChargeProcessor).to receive(:refund!).and_call_original
+
+        @purchase.refund_and_save!(@user.id)
+
+        expect(license.reload).to be_disabled
+      end
+
+      it "does not disable the license on a partial refund" do
+        license = attach_license!(@purchase)
+        expect(ChargeProcessor).to receive(:refund!).and_call_original
+
+        @purchase.refund_and_save!(@user.id, amount_cents: @purchase.price_cents / 2)
+
+        expect(@purchase.reload.stripe_partially_refunded).to be(true)
+        expect(license.reload).not_to be_disabled
+      end
+
+      it "does not disable the original license when a renewal is refunded" do
+        original = create(:membership_purchase)
+        original_license = attach_license!(original)
+        renewal = create(:recurring_membership_purchase, subscription: original.subscription, link: original.link)
+        expect(ChargeProcessor).to receive(:refund!).and_call_original
+
+        renewal.refund_and_save!(original.seller.id)
+
+        expect(renewal.reload.stripe_refunded).to be(true)
+        expect(original_license.reload).not_to be_disabled
       end
     end
   end
@@ -1833,6 +1887,36 @@ describe "PurchaseRefunds", :vcr do
         expect(subscription.cancelled?).to eq true
         expect(subscription.deactivated?).to eq true
       end
+    end
+
+    it "disables the license" do
+      license = create(:license, purchase: @purchase, link: @purchase.link)
+      expect(ChargeProcessor).to receive(:refund!).and_call_original
+
+      @purchase.refund_for_fraud!(create(:admin_user).id)
+
+      expect(license.reload).to be_disabled
+    end
+
+    it "disables the license when retried on an already-refunded purchase" do
+      license = create(:license, purchase: @purchase, link: @purchase.link)
+      @purchase.update_columns(stripe_refunded: true)
+      allow(@purchase).to receive(:refund_and_save!).and_return(nil)
+
+      expect(@purchase.refund_for_fraud!(create(:admin_user).id)).to be(true)
+
+      expect(license.reload).to be_disabled
+    end
+
+    it "disables the original license when a renewal is refunded for fraud" do
+      original = create(:membership_purchase)
+      original_license = create(:license, purchase: original, link: original.link)
+      renewal = create(:recurring_membership_purchase, subscription: original.subscription, link: original.link)
+      expect(ChargeProcessor).to receive(:refund!).and_call_original
+
+      expect(renewal.refund_for_fraud!(create(:admin_user).id)).to be(true)
+
+      expect(original_license.reload).to be_disabled
     end
   end
 

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -1800,9 +1800,9 @@ describe "PurchaseRefunds", :vcr do
         original = create(:membership_purchase)
         original_license = attach_license!(original)
         renewal = create(:recurring_membership_purchase, subscription: original.subscription, link: original.link)
-        expect(ChargeProcessor).to receive(:refund!).and_call_original
+        flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, renewal.price_cents)
 
-        renewal.refund_and_save!(original.seller.id)
+        renewal.refund_purchase!(flow_of_funds, original.seller.id)
 
         expect(renewal.reload.stripe_refunded).to be(true)
         expect(original_license.reload).not_to be_disabled
@@ -1912,7 +1912,8 @@ describe "PurchaseRefunds", :vcr do
       original = create(:membership_purchase)
       original_license = create(:license, purchase: original, link: original.link)
       renewal = create(:recurring_membership_purchase, subscription: original.subscription, link: original.link)
-      expect(ChargeProcessor).to receive(:refund!).and_call_original
+      allow(renewal).to receive(:refund_and_save!).and_return(true)
+      renewal.update_columns(stripe_refunded: true)
 
       expect(renewal.refund_for_fraud!(create(:admin_user).id)).to be(true)
 

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -1807,6 +1807,21 @@ describe "PurchaseRefunds", :vcr do
         expect(renewal.reload.stripe_refunded).to be(true)
         expect(original_license.reload).not_to be_disabled
       end
+
+      it "keeps the refund recorded if license disable fails" do
+        license = attach_license!(@purchase)
+        allow_any_instance_of(License).to receive(:disable!).and_raise(ActiveRecord::RecordNotSaved.new("boom"))
+        allow(ErrorNotifier).to receive(:notify)
+        flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, @purchase.price_cents)
+
+        expect(@purchase.refund_purchase!(flow_of_funds, @user.id)).to be(true)
+        expect(@purchase.reload.stripe_refunded).to be(true)
+        expect(license.reload).not_to be_disabled
+        expect(ErrorNotifier).to have_received(:notify).with(
+          "Failed to disable license after refund",
+          hash_including(context: hash_including(purchase_id: @purchase.id))
+        )
+      end
     end
   end
 

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/_refund_for_fraud_/disables_the_license.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/_refund_for_fraud_/disables_the_license.yml
@@ -1,0 +1,1314 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_NBgosMJKhCvAS1","request_duration_ms":192}}'
+      Idempotency-Key:
+      - d9e7866b-d418-4c40-9846-064c4a26758a
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - d9e7866b-d418-4c40-9846-064c4a26758a
+      Original-Request:
+      - req_A7XP2tXyqttSPs
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_A7XP2tXyqttSPs
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6EdxIBOqvOFDrf0ZbN1oUg",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165721,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:21 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1U6EdxIBOqvOFDrf0ZbN1oUg
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_A7XP2tXyqttSPs","request_duration_ms":215}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:22 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_Tez8GPIils6FaQ
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6EdxIBOqvOFDrf0ZbN1oUg",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165721,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:22 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar2aaf8f9e11.app.test.gumroad.com%3A31340%2Fl%2Fh%21&metadata[purchase]=RM8rlTYFIacbAbJO20WhyQ%3D%3D&transfer_group=375521929&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1U6EdxIBOqvOFDrf0ZbN1oUg&statement_descriptor_suffix=edgar2aaf8f9e11
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Tez8GPIils6FaQ","request_duration_ms":185}}'
+      Idempotency-Key:
+      - 5e38ef8e-28fb-4fc9-bfd7-0d43573c4519
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:22 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1689'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - 5e38ef8e-28fb-4fc9-bfd7-0d43573c4519
+      Original-Request:
+      - req_x5edF7YDpYqXjs
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_x5edF7YDpYqXjs
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3U6EdyIBOqvOFDrf0PtLkKqk",
+          "object": "payment_intent",
+          "allowed_payment_method_types": null,
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3U6EdyIBOqvOFDrf0PtLkKqk_secret_E3ig4YXUWdsI50fpMIQ8f8ErO",
+          "confirmation_method": "automatic",
+          "created": 1787165722,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar2aaf8f9e11.app.test.gumroad.com:31340/l/h!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3U6EdyIBOqvOFDrf0LJtU41H",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "RM8rlTYFIacbAbJO20WhyQ=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1U6EdxIBOqvOFDrf0ZbN1oUg",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar2aaf8f9e11",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521929"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:22 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U6EdyIBOqvOFDrf0LJtU41H?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_x5edF7YDpYqXjs","request_duration_ms":813}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3774'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_p0tzBcK0Gh6iZM
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U6EdyIBOqvOFDrf0LJtU41H",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3U6EdyIBOqvOFDrf0QbPRBZB",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1787702400,
+            "balance_type": "payments",
+            "created": 1787165722,
+            "currency": "usd",
+            "description": "You bought http://edgar2aaf8f9e11.app.test.gumroad.com:31340/l/h!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3U6EdyIBOqvOFDrf0LJtU41H",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR2AAF8F9E1",
+          "captured": true,
+          "created": 1787165722,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar2aaf8f9e11.app.test.gumroad.com:31340/l/h!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "RM8rlTYFIacbAbJO20WhyQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 51,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U6EdyIBOqvOFDrf0PtLkKqk",
+          "payment_method": "pm_1U6EdxIBOqvOFDrf0ZbN1oUg",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "993375",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJv4l9QGMgY6eyASqbM6LBY3WQ618x28rcJf6dQNjzT3W8AWlybfeZIvkQiS16axOMDH9ZeW99C5ICyl",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar2aaf8f9e11",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521929"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:23 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U6EdyIBOqvOFDrf0LJtU41H
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_p0tzBcK0Gh6iZM","request_duration_ms":207}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3115'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_Nz3A8Z5yK7iFTd
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U6EdyIBOqvOFDrf0LJtU41H",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3U6EdyIBOqvOFDrf0QbPRBZB",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR2AAF8F9E1",
+          "captured": true,
+          "created": 1787165722,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar2aaf8f9e11.app.test.gumroad.com:31340/l/h!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "RM8rlTYFIacbAbJO20WhyQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 51,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U6EdyIBOqvOFDrf0PtLkKqk",
+          "payment_method": "pm_1U6EdxIBOqvOFDrf0ZbN1oUg",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "993375",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJv4l9QGMgYjqTKKWdk6LBa2ps8uL8dz_1AQFfbS-Yor07tIJyaegOIsNT_L0Xlu5VjIPfdEkFwG46uE",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar2aaf8f9e11",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521929"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:23 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/refunds
+    body:
+      encoding: UTF-8
+      string: charge=ch_3U6EdyIBOqvOFDrf0LJtU41H&reason=fraudulent
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Nz3A8Z5yK7iFTd","request_duration_ms":265}}'
+      Idempotency-Key:
+      - afd21423-1228-416d-b22f-5c4035a961fe
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '721'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - afd21423-1228-416d-b22f-5c4035a961fe
+      Original-Request:
+      - req_U4DJYmI8VTsOxa
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_U4DJYmI8VTsOxa
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3U6EdyIBOqvOFDrf0LXhfL1s",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_3U6EdyIBOqvOFDrf0SYAXWqv",
+          "charge": "ch_3U6EdyIBOqvOFDrf0LJtU41H",
+          "created": 1787165723,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3U6EdyIBOqvOFDrf0PtLkKqk",
+          "payment_method": "pm_1U6EdxIBOqvOFDrf0ZbN1oUg",
+          "reason": "fraudulent",
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:24 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/refunds/re_3U6EdyIBOqvOFDrf0LXhfL1s?expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_U4DJYmI8VTsOxa","request_duration_ms":865}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1225'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_QG8n4Jg2KhCKHn
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3U6EdyIBOqvOFDrf0LXhfL1s",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": {
+            "id": "txn_3U6EdyIBOqvOFDrf0SYAXWqv",
+            "object": "balance_transaction",
+            "amount": -100,
+            "available_on": 1787702400,
+            "balance_type": "payments",
+            "created": 1787165723,
+            "currency": "usd",
+            "description": "REFUND FOR CHARGE (You bought http://edgar2aaf8f9e11.app.test.gumroad.com:31340/l/h!)",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": -100,
+            "reporting_category": "refund",
+            "source": "re_3U6EdyIBOqvOFDrf0LXhfL1s",
+            "status": "pending",
+            "type": "refund"
+          },
+          "charge": "ch_3U6EdyIBOqvOFDrf0LJtU41H",
+          "created": 1787165723,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3U6EdyIBOqvOFDrf0PtLkKqk",
+          "payment_method": "pm_1U6EdxIBOqvOFDrf0ZbN1oUg",
+          "reason": "fraudulent",
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:24 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U6EdyIBOqvOFDrf0LJtU41H?expand%5B%5D=application_fee.refunds.data.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_QG8n4Jg2KhCKHn","request_duration_ms":286}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3810'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_QhSJeuNnNhlbR4
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U6EdyIBOqvOFDrf0LJtU41H",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 100,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3U6EdyIBOqvOFDrf0QbPRBZB",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1787702400,
+            "balance_type": "payments",
+            "created": 1787165722,
+            "currency": "usd",
+            "description": "You bought http://edgar2aaf8f9e11.app.test.gumroad.com:31340/l/h!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3U6EdyIBOqvOFDrf0LJtU41H",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR2AAF8F9E1",
+          "captured": true,
+          "created": 1787165722,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar2aaf8f9e11.app.test.gumroad.com:31340/l/h!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+            "user_report": "fraudulent"
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "RM8rlTYFIacbAbJO20WhyQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 51,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U6EdyIBOqvOFDrf0PtLkKqk",
+          "payment_method": "pm_1U6EdxIBOqvOFDrf0ZbN1oUg",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "993375",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJz4l9QGMgZoSNEbaZE6LBa_CSCBHwisudtF15KHoA5tSKeMi-rF7HXGo2y_Wg8WTCwAGwFWyV7fHUCZ",
+          "refunded": true,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar2aaf8f9e11",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521929"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:24 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/_refund_for_fraud_/disables_the_license_when_retried_on_an_already-refunded_purchase.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/_refund_for_fraud_/disables_the_license_when_retried_on_an_already-refunded_purchase.yml
@@ -1,0 +1,554 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_QhSJeuNnNhlbR4","request_duration_ms":270}}'
+      Idempotency-Key:
+      - 61608375-b048-4b25-86d3-fd5905113247
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - 61608375-b048-4b25-86d3-fd5905113247
+      Original-Request:
+      - req_tCGMPcDIq98IQ7
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_tCGMPcDIq98IQ7
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6Ee1IBOqvOFDrfDJCVgESv",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165725,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:25 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1U6Ee1IBOqvOFDrfDJCVgESv
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_tCGMPcDIq98IQ7","request_duration_ms":207}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_OcQnMlgZn9eedl
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6Ee1IBOqvOFDrfDJCVgESv",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165725,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:25 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar807c605214.app.test.gumroad.com%3A31340%2Fl%2Fu%21&metadata[purchase]=9mr6Dv1R4I6eCvpaZYXEow%3D%3D&transfer_group=375521930&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1U6Ee1IBOqvOFDrfDJCVgESv&statement_descriptor_suffix=edgar807c605214
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_OcQnMlgZn9eedl","request_duration_ms":192}}'
+      Idempotency-Key:
+      - 167ae11e-5694-450f-b718-0ca5a3f60f3b
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 402
+      message: Payment Required
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5537'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - 167ae11e-5694-450f-b718-0ca5a3f60f3b
+      Original-Request:
+      - req_t5DnkTSzUm8aRV
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_t5DnkTSzUm8aRV
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "charge": "ch_3U6Ee1IBOqvOFDrf0A1yVk6a",
+            "code": "card_declined",
+            "decline_code": "generic_decline",
+            "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+            "message": "Your card was declined.",
+            "payment_intent": {
+              "id": "pi_3U6Ee1IBOqvOFDrf0bk0EbPg",
+              "object": "payment_intent",
+              "allowed_payment_method_types": null,
+              "amount": 100,
+              "amount_capturable": 0,
+              "amount_details": {
+                "tip": {}
+              },
+              "amount_received": 0,
+              "application": null,
+              "application_fee_amount": null,
+              "automatic_payment_methods": null,
+              "canceled_at": null,
+              "cancellation_reason": null,
+              "capture_method": "automatic",
+              "client_secret": "pi_3U6Ee1IBOqvOFDrf0bk0EbPg_secret_9C2rRrbMppvdnWTAxFS3oM2rs",
+              "confirmation_method": "automatic",
+              "created": 1787165726,
+              "currency": "usd",
+              "customer": null,
+              "customer_account": null,
+              "description": "You bought http://edgar807c605214.app.test.gumroad.com:31340/l/u!",
+              "excluded_payment_method_types": null,
+              "invoice": null,
+              "last_payment_error": {
+                "charge": "ch_3U6Ee1IBOqvOFDrf0A1yVk6a",
+                "code": "card_declined",
+                "decline_code": "generic_decline",
+                "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+                "message": "Your card was declined.",
+                "payment_method": {
+                  "id": "pm_1U6Ee1IBOqvOFDrfDJCVgESv",
+                  "object": "payment_method",
+                  "allow_redisplay": "unspecified",
+                  "billing_details": {
+                    "address": {
+                      "city": null,
+                      "country": null,
+                      "line1": null,
+                      "line2": null,
+                      "postal_code": null,
+                      "state": null
+                    },
+                    "email": null,
+                    "name": null,
+                    "phone": null,
+                    "tax_id": null
+                  },
+                  "card": {
+                    "brand": "visa",
+                    "checks": {
+                      "address_line1_check": null,
+                      "address_postal_code_check": null,
+                      "cvc_check": "unavailable"
+                    },
+                    "country": "US",
+                    "display_brand": "visa",
+                    "exp_month": 8,
+                    "exp_year": 2027,
+                    "fingerprint": "hsksJCaNjbEGzjqP",
+                    "funding": "credit",
+                    "generated_from": null,
+                    "last4": "4242",
+                    "networks": {
+                      "available": [
+                        "visa"
+                      ],
+                      "preferred": null
+                    },
+                    "regulated_status": "unregulated",
+                    "three_d_secure_usage": {
+                      "supported": true
+                    },
+                    "wallet": null
+                  },
+                  "created": 1787165725,
+                  "customer": null,
+                  "customer_account": null,
+                  "livemode": false,
+                  "metadata": {},
+                  "shared_payment_granted_token": null,
+                  "type": "card"
+                },
+                "type": "card_error"
+              },
+              "latest_charge": "ch_3U6Ee1IBOqvOFDrf0A1yVk6a",
+              "livemode": false,
+              "managed_payments": {
+                "enabled": false
+              },
+              "metadata": {
+                "purchase": "9mr6Dv1R4I6eCvpaZYXEow=="
+              },
+              "next_action": null,
+              "on_behalf_of": null,
+              "payment_method": null,
+              "payment_method_configuration_details": null,
+              "payment_method_options": {
+                "card": {
+                  "installments": null,
+                  "mandate_options": null,
+                  "network": null,
+                  "request_three_d_secure": "automatic"
+                }
+              },
+              "payment_method_types": [
+                "card"
+              ],
+              "processing": null,
+              "receipt_email": null,
+              "review": null,
+              "setup_future_usage": null,
+              "shared_payment_granted_token": null,
+              "shipping": null,
+              "source": null,
+              "statement_descriptor": null,
+              "statement_descriptor_suffix": "edgar807c605214",
+              "status": "requires_payment_method",
+              "transfer_data": null,
+              "transfer_group": "375521930"
+            },
+            "payment_method": {
+              "id": "pm_1U6Ee1IBOqvOFDrfDJCVgESv",
+              "object": "payment_method",
+              "allow_redisplay": "unspecified",
+              "billing_details": {
+                "address": {
+                  "city": null,
+                  "country": null,
+                  "line1": null,
+                  "line2": null,
+                  "postal_code": null,
+                  "state": null
+                },
+                "email": null,
+                "name": null,
+                "phone": null,
+                "tax_id": null
+              },
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "unavailable"
+                },
+                "country": "US",
+                "display_brand": "visa",
+                "exp_month": 8,
+                "exp_year": 2027,
+                "fingerprint": "hsksJCaNjbEGzjqP",
+                "funding": "credit",
+                "generated_from": null,
+                "last4": "4242",
+                "networks": {
+                  "available": [
+                    "visa"
+                  ],
+                  "preferred": null
+                },
+                "regulated_status": "unregulated",
+                "three_d_secure_usage": {
+                  "supported": true
+                },
+                "wallet": null
+              },
+              "created": 1787165725,
+              "customer": null,
+              "customer_account": null,
+              "livemode": false,
+              "metadata": {},
+              "shared_payment_granted_token": null,
+              "type": "card"
+            },
+            "request_log_url": "https://dashboard.stripe.com/acct_1SNEgsIBOqvOFDrf/test/workbench/logs?object=req_t5DnkTSzUm8aRV",
+            "type": "card_error"
+          }
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:26 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/_refund_for_fraud_/disables_the_original_license_when_a_renewal_is_refunded_for_fraud.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/_refund_for_fraud_/disables_the_original_license_when_a_renewal_is_refunded_for_fraud.yml
@@ -1,0 +1,554 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_OcQnMlgZn9eedl","request_duration_ms":192}}'
+      Idempotency-Key:
+      - bc10cbae-ec27-45dd-8fb7-617a19be668f
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:27 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - bc10cbae-ec27-45dd-8fb7-617a19be668f
+      Original-Request:
+      - req_ZoAIl3GKCctA9x
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_ZoAIl3GKCctA9x
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6Ee3IBOqvOFDrflOCzmUl6",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165727,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:27 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1U6Ee3IBOqvOFDrflOCzmUl6
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_ZoAIl3GKCctA9x","request_duration_ms":202}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:27 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_PZbKoNDQwz88EX
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6Ee3IBOqvOFDrflOCzmUl6",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165727,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:27 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar98bb458317.app.test.gumroad.com%3A31340%2Fl%2Fq%21&metadata[purchase]=n6yuP53tcwjEuM2MmtwMTA%3D%3D&transfer_group=375521931&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1U6Ee3IBOqvOFDrflOCzmUl6&statement_descriptor_suffix=edgar98bb458317
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_PZbKoNDQwz88EX","request_duration_ms":174}}'
+      Idempotency-Key:
+      - 53e2e06c-56f8-42ca-b07f-6149513187c9
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 402
+      message: Payment Required
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:28 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5537'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - 53e2e06c-56f8-42ca-b07f-6149513187c9
+      Original-Request:
+      - req_VxKIgEdBKE86fA
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_VxKIgEdBKE86fA
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "charge": "ch_3U6Ee3IBOqvOFDrf1zifeyB1",
+            "code": "card_declined",
+            "decline_code": "generic_decline",
+            "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+            "message": "Your card was declined.",
+            "payment_intent": {
+              "id": "pi_3U6Ee3IBOqvOFDrf1xXPRJGa",
+              "object": "payment_intent",
+              "allowed_payment_method_types": null,
+              "amount": 100,
+              "amount_capturable": 0,
+              "amount_details": {
+                "tip": {}
+              },
+              "amount_received": 0,
+              "application": null,
+              "application_fee_amount": null,
+              "automatic_payment_methods": null,
+              "canceled_at": null,
+              "cancellation_reason": null,
+              "capture_method": "automatic",
+              "client_secret": "pi_3U6Ee3IBOqvOFDrf1xXPRJGa_secret_KlzRbYIXPGWI8IEfk8gtYLTFC",
+              "confirmation_method": "automatic",
+              "created": 1787165727,
+              "currency": "usd",
+              "customer": null,
+              "customer_account": null,
+              "description": "You bought http://edgar98bb458317.app.test.gumroad.com:31340/l/q!",
+              "excluded_payment_method_types": null,
+              "invoice": null,
+              "last_payment_error": {
+                "charge": "ch_3U6Ee3IBOqvOFDrf1zifeyB1",
+                "code": "card_declined",
+                "decline_code": "generic_decline",
+                "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+                "message": "Your card was declined.",
+                "payment_method": {
+                  "id": "pm_1U6Ee3IBOqvOFDrflOCzmUl6",
+                  "object": "payment_method",
+                  "allow_redisplay": "unspecified",
+                  "billing_details": {
+                    "address": {
+                      "city": null,
+                      "country": null,
+                      "line1": null,
+                      "line2": null,
+                      "postal_code": null,
+                      "state": null
+                    },
+                    "email": null,
+                    "name": null,
+                    "phone": null,
+                    "tax_id": null
+                  },
+                  "card": {
+                    "brand": "visa",
+                    "checks": {
+                      "address_line1_check": null,
+                      "address_postal_code_check": null,
+                      "cvc_check": "unavailable"
+                    },
+                    "country": "US",
+                    "display_brand": "visa",
+                    "exp_month": 8,
+                    "exp_year": 2027,
+                    "fingerprint": "hsksJCaNjbEGzjqP",
+                    "funding": "credit",
+                    "generated_from": null,
+                    "last4": "4242",
+                    "networks": {
+                      "available": [
+                        "visa"
+                      ],
+                      "preferred": null
+                    },
+                    "regulated_status": "unregulated",
+                    "three_d_secure_usage": {
+                      "supported": true
+                    },
+                    "wallet": null
+                  },
+                  "created": 1787165727,
+                  "customer": null,
+                  "customer_account": null,
+                  "livemode": false,
+                  "metadata": {},
+                  "shared_payment_granted_token": null,
+                  "type": "card"
+                },
+                "type": "card_error"
+              },
+              "latest_charge": "ch_3U6Ee3IBOqvOFDrf1zifeyB1",
+              "livemode": false,
+              "managed_payments": {
+                "enabled": false
+              },
+              "metadata": {
+                "purchase": "n6yuP53tcwjEuM2MmtwMTA=="
+              },
+              "next_action": null,
+              "on_behalf_of": null,
+              "payment_method": null,
+              "payment_method_configuration_details": null,
+              "payment_method_options": {
+                "card": {
+                  "installments": null,
+                  "mandate_options": null,
+                  "network": null,
+                  "request_three_d_secure": "automatic"
+                }
+              },
+              "payment_method_types": [
+                "card"
+              ],
+              "processing": null,
+              "receipt_email": null,
+              "review": null,
+              "setup_future_usage": null,
+              "shared_payment_granted_token": null,
+              "shipping": null,
+              "source": null,
+              "statement_descriptor": null,
+              "statement_descriptor_suffix": "edgar98bb458317",
+              "status": "requires_payment_method",
+              "transfer_data": null,
+              "transfer_group": "375521931"
+            },
+            "payment_method": {
+              "id": "pm_1U6Ee3IBOqvOFDrflOCzmUl6",
+              "object": "payment_method",
+              "allow_redisplay": "unspecified",
+              "billing_details": {
+                "address": {
+                  "city": null,
+                  "country": null,
+                  "line1": null,
+                  "line2": null,
+                  "postal_code": null,
+                  "state": null
+                },
+                "email": null,
+                "name": null,
+                "phone": null,
+                "tax_id": null
+              },
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "unavailable"
+                },
+                "country": "US",
+                "display_brand": "visa",
+                "exp_month": 8,
+                "exp_year": 2027,
+                "fingerprint": "hsksJCaNjbEGzjqP",
+                "funding": "credit",
+                "generated_from": null,
+                "last4": "4242",
+                "networks": {
+                  "available": [
+                    "visa"
+                  ],
+                  "preferred": null
+                },
+                "regulated_status": "unregulated",
+                "three_d_secure_usage": {
+                  "supported": true
+                },
+                "wallet": null
+              },
+              "created": 1787165727,
+              "customer": null,
+              "customer_account": null,
+              "livemode": false,
+              "metadata": {},
+              "shared_payment_granted_token": null,
+              "type": "card"
+            },
+            "request_log_url": "https://dashboard.stripe.com/acct_1SNEgsIBOqvOFDrf/test/workbench/logs?object=req_VxKIgEdBKE86fA",
+            "type": "card_error"
+          }
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:28 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/license_disable_on_refund/ordinary_refunds/disables_the_license_on_a_full_refund.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/license_disable_on_refund/ordinary_refunds/disables_the_license_on_a_full_refund.yml
@@ -1,0 +1,1310 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 5d41e909-eef1-4859-a160-534f8d6138cc
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=YkPp05_BT0VgAWF4XJZeRknZk4AK7h5aEGU2AOuHTaWbNAnEMfQoz744JuQmI0rbqcQwQG681-Lw9RjB;
+        report-to csp
+      Idempotency-Key:
+      - 5d41e909-eef1-4859-a160-534f8d6138cc
+      Original-Request:
+      - req_7WQNNkGMObF0DR
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=YkPp05_BT0VgAWF4XJZeRknZk4AK7h5aEGU2AOuHTaWbNAnEMfQoz744JuQmI0rbqcQwQG681-Lw9RjB&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=YkPp05_BT0VgAWF4XJZeRknZk4AK7h5aEGU2AOuHTaWbNAnEMfQoz744JuQmI0rbqcQwQG681-Lw9RjB&t=1"
+      Request-Id:
+      - req_7WQNNkGMObF0DR
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165711,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:11 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1U6EdnIBOqvOFDrfbXyFm1oH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_7WQNNkGMObF0DR","request_duration_ms":294}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_vpvsIUDDU3XbGX
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165711,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:11 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar975e6ec85.app.test.gumroad.com%3A31340%2Fl%2Fi%21&metadata[purchase]=ZNM2e4FTQB6AwwiAU0WbOQ%3D%3D&transfer_group=375521923&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1U6EdnIBOqvOFDrfbXyFm1oH&statement_descriptor_suffix=edgar975e6ec85
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_vpvsIUDDU3XbGX","request_duration_ms":176}}'
+      Idempotency-Key:
+      - 4c375324-7cc9-465a-87ac-6ae791a0c480
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1687'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - 4c375324-7cc9-465a-87ac-6ae791a0c480
+      Original-Request:
+      - req_FUGoB3dWCR6s2y
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_FUGoB3dWCR6s2y
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3U6EdnIBOqvOFDrf161OXFnO",
+          "object": "payment_intent",
+          "allowed_payment_method_types": null,
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3U6EdnIBOqvOFDrf161OXFnO_secret_bAWKJqko3zunTYVSUCLesPLUr",
+          "confirmation_method": "automatic",
+          "created": 1787165711,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "ZNM2e4FTQB6AwwiAU0WbOQ=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar975e6ec85",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521923"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:12 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U6EdnIBOqvOFDrf1ygJFBAd?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_FUGoB3dWCR6s2y","request_duration_ms":848}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3771'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_PgLkQhVSYIGz5y
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3U6EdnIBOqvOFDrf1ju02uwh",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1787702400,
+            "balance_type": "payments",
+            "created": 1787165712,
+            "currency": "usd",
+            "description": "You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR975E6EC85",
+          "captured": true,
+          "created": 1787165712,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "ZNM2e4FTQB6AwwiAU0WbOQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 48,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U6EdnIBOqvOFDrf161OXFnO",
+          "payment_method": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "129106",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJD4l9QGMgbhKqrs_zM6LBZsDaD_LysQ3saOflS4gM9VCFAgna4SP51kp8mGqa6PGzrFMDJKtnAUevSg",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar975e6ec85",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521923"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:12 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U6EdnIBOqvOFDrf1ygJFBAd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_PgLkQhVSYIGz5y","request_duration_ms":196}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3113'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_FONLC1fl1trNPi
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3U6EdnIBOqvOFDrf1ju02uwh",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR975E6EC85",
+          "captured": true,
+          "created": 1787165712,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "ZNM2e4FTQB6AwwiAU0WbOQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 48,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U6EdnIBOqvOFDrf161OXFnO",
+          "payment_method": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "129106",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJH4l9QGMgb3q1iIJro6LBbqyMhbdqqj96VUqjvAcr3vap5OAEqm_eSv-semcjcdXpi2syoK00J8jCMR",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar975e6ec85",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521923"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:13 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/refunds
+    body:
+      encoding: UTF-8
+      string: charge=ch_3U6EdnIBOqvOFDrf1ygJFBAd
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_FONLC1fl1trNPi","request_duration_ms":175}}'
+      Idempotency-Key:
+      - 482ad527-0149-4ebe-8e93-82fe1b1393c3
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '713'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - 482ad527-0149-4ebe-8e93-82fe1b1393c3
+      Original-Request:
+      - req_F6vlaJVKP2iu9f
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_F6vlaJVKP2iu9f
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3U6EdnIBOqvOFDrf17XXSg6A",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_3U6EdnIBOqvOFDrf1ucGbEkK",
+          "charge": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+          "created": 1787165713,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3U6EdnIBOqvOFDrf161OXFnO",
+          "payment_method": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:14 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/refunds/re_3U6EdnIBOqvOFDrf17XXSg6A?expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_F6vlaJVKP2iu9f","request_duration_ms":900}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1216'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_NOHp6FPCUzYvrs
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3U6EdnIBOqvOFDrf17XXSg6A",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": {
+            "id": "txn_3U6EdnIBOqvOFDrf1ucGbEkK",
+            "object": "balance_transaction",
+            "amount": -100,
+            "available_on": 1787702400,
+            "balance_type": "payments",
+            "created": 1787165713,
+            "currency": "usd",
+            "description": "REFUND FOR CHARGE (You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!)",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": -100,
+            "reporting_category": "refund",
+            "source": "re_3U6EdnIBOqvOFDrf17XXSg6A",
+            "status": "pending",
+            "type": "refund"
+          },
+          "charge": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+          "created": 1787165713,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3U6EdnIBOqvOFDrf161OXFnO",
+          "payment_method": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:14 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U6EdnIBOqvOFDrf1ygJFBAd?expand%5B%5D=application_fee.refunds.data.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_NOHp6FPCUzYvrs","request_duration_ms":290}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3772'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_CgFtaZlyYYy1fo
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 100,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3U6EdnIBOqvOFDrf1ju02uwh",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1787702400,
+            "balance_type": "payments",
+            "created": 1787165712,
+            "currency": "usd",
+            "description": "You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR975E6EC85",
+          "captured": true,
+          "created": 1787165712,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "ZNM2e4FTQB6AwwiAU0WbOQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 48,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U6EdnIBOqvOFDrf161OXFnO",
+          "payment_method": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "129106",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJL4l9QGMgZqWjh5PTA6LBZIbrcbCTt8aO_N9CuBMANAD8CQ0SWIEpdBRex6WBfqLlrsHjkOPY2kc8rn",
+          "refunded": true,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar975e6ec85",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521923"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:14 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/license_disable_on_refund/ordinary_refunds/does_not_disable_the_license_on_a_partial_refund.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/license_disable_on_refund/ordinary_refunds/does_not_disable_the_license_on_a_partial_refund.yml
@@ -1,0 +1,1312 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_CgFtaZlyYYy1fo","request_duration_ms":203}}'
+      Idempotency-Key:
+      - 957abb3e-1b6d-4ddd-b8aa-50220ca33304
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - 957abb3e-1b6d-4ddd-b8aa-50220ca33304
+      Original-Request:
+      - req_JwK5I7KCCIdkFf
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_JwK5I7KCCIdkFf
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6EdqIBOqvOFDrf1FmvD8f4",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165714,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:15 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1U6EdqIBOqvOFDrf1FmvD8f4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_JwK5I7KCCIdkFf","request_duration_ms":181}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_8F4cY4RHQqGXHh
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6EdqIBOqvOFDrf1FmvD8f4",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165714,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:15 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar99b3ab426.app.test.gumroad.com%3A31340%2Fl%2Fl%21&metadata[purchase]=xyBX6rp3-w9YE6fmA8WDMA%3D%3D&transfer_group=375521924&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1U6EdqIBOqvOFDrf1FmvD8f4&statement_descriptor_suffix=edgar99b3ab426
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_8F4cY4RHQqGXHh","request_duration_ms":218}}'
+      Idempotency-Key:
+      - 95cea5de-3091-4421-bd70-37ebd5c4c930
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1687'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - 95cea5de-3091-4421-bd70-37ebd5c4c930
+      Original-Request:
+      - req_qPKdSNi3sXZAsR
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_qPKdSNi3sXZAsR
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3U6EdrIBOqvOFDrf1AeRwAYN",
+          "object": "payment_intent",
+          "allowed_payment_method_types": null,
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3U6EdrIBOqvOFDrf1AeRwAYN_secret_uoqT8w1cQLngTzQ05FrvyJrPG",
+          "confirmation_method": "automatic",
+          "created": 1787165715,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar99b3ab426.app.test.gumroad.com:31340/l/l!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3U6EdrIBOqvOFDrf1pYVoA3e",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "xyBX6rp3-w9YE6fmA8WDMA=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1U6EdqIBOqvOFDrf1FmvD8f4",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar99b3ab426",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521924"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:16 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U6EdrIBOqvOFDrf1pYVoA3e?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_qPKdSNi3sXZAsR","request_duration_ms":1067}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3771'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_t2sk85e9HawNQm
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U6EdrIBOqvOFDrf1pYVoA3e",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3U6EdrIBOqvOFDrf16CQwqjl",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1787702400,
+            "balance_type": "payments",
+            "created": 1787165715,
+            "currency": "usd",
+            "description": "You bought http://edgar99b3ab426.app.test.gumroad.com:31340/l/l!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3U6EdrIBOqvOFDrf1pYVoA3e",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR99B3AB426",
+          "captured": true,
+          "created": 1787165715,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar99b3ab426.app.test.gumroad.com:31340/l/l!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "xyBX6rp3-w9YE6fmA8WDMA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 56,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U6EdrIBOqvOFDrf1AeRwAYN",
+          "payment_method": "pm_1U6EdqIBOqvOFDrf1FmvD8f4",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "646432",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJT4l9QGMgbAI9ADTLQ6LBbSgw07mEd91lPffBz7kwBGI27RgCos0yn9vZQqOIQrVUi8mnyyLtjEh5Xm",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar99b3ab426",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521924"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:16 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U6EdrIBOqvOFDrf1pYVoA3e
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_t2sk85e9HawNQm","request_duration_ms":317}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3113'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_B1wjOXmRjjqDKY
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U6EdrIBOqvOFDrf1pYVoA3e",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3U6EdrIBOqvOFDrf16CQwqjl",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR99B3AB426",
+          "captured": true,
+          "created": 1787165715,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar99b3ab426.app.test.gumroad.com:31340/l/l!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "xyBX6rp3-w9YE6fmA8WDMA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 56,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U6EdrIBOqvOFDrf1AeRwAYN",
+          "payment_method": "pm_1U6EdqIBOqvOFDrf1FmvD8f4",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "646432",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJX4l9QGMgb_u8eSODg6LBbfMT-HFkLIl56-ydgfVKHzCjNE-nhHGTjbLRK2KsZzBZMe1FWbvFNNWGB_",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar99b3ab426",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521924"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:17 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/refunds
+    body:
+      encoding: UTF-8
+      string: charge=ch_3U6EdrIBOqvOFDrf1pYVoA3e&amount=50
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_B1wjOXmRjjqDKY","request_duration_ms":222}}'
+      Idempotency-Key:
+      - 18703a73-82a2-4820-b475-7b1a13b6ea79
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '712'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - 18703a73-82a2-4820-b475-7b1a13b6ea79
+      Original-Request:
+      - req_b1r9AOs500ror6
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_b1r9AOs500ror6
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3U6EdrIBOqvOFDrf1W5u4aCp",
+          "object": "refund",
+          "amount": 50,
+          "balance_transaction": "txn_3U6EdrIBOqvOFDrf1GGP13rj",
+          "charge": "ch_3U6EdrIBOqvOFDrf1pYVoA3e",
+          "created": 1787165717,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3U6EdrIBOqvOFDrf1AeRwAYN",
+          "payment_method": "pm_1U6EdqIBOqvOFDrf1FmvD8f4",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:18 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/refunds/re_3U6EdrIBOqvOFDrf1W5u4aCp?expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_b1r9AOs500ror6","request_duration_ms":1044}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1213'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_OmjrXyDl4nx088
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3U6EdrIBOqvOFDrf1W5u4aCp",
+          "object": "refund",
+          "amount": 50,
+          "balance_transaction": {
+            "id": "txn_3U6EdrIBOqvOFDrf1GGP13rj",
+            "object": "balance_transaction",
+            "amount": -50,
+            "available_on": 1787702400,
+            "balance_type": "payments",
+            "created": 1787165717,
+            "currency": "usd",
+            "description": "REFUND FOR CHARGE (You bought http://edgar99b3ab426.app.test.gumroad.com:31340/l/l!)",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": -50,
+            "reporting_category": "refund",
+            "source": "re_3U6EdrIBOqvOFDrf1W5u4aCp",
+            "status": "pending",
+            "type": "refund"
+          },
+          "charge": "ch_3U6EdrIBOqvOFDrf1pYVoA3e",
+          "created": 1787165717,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3U6EdrIBOqvOFDrf1AeRwAYN",
+          "payment_method": "pm_1U6EdqIBOqvOFDrf1FmvD8f4",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:18 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U6EdrIBOqvOFDrf1pYVoA3e?expand%5B%5D=application_fee.refunds.data.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_OmjrXyDl4nx088","request_duration_ms":348}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3772'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_oVUqxLBoSKYWKp
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U6EdrIBOqvOFDrf1pYVoA3e",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 50,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3U6EdrIBOqvOFDrf16CQwqjl",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1787702400,
+            "balance_type": "payments",
+            "created": 1787165715,
+            "currency": "usd",
+            "description": "You bought http://edgar99b3ab426.app.test.gumroad.com:31340/l/l!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3U6EdrIBOqvOFDrf1pYVoA3e",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR99B3AB426",
+          "captured": true,
+          "created": 1787165715,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar99b3ab426.app.test.gumroad.com:31340/l/l!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "xyBX6rp3-w9YE6fmA8WDMA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 56,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U6EdrIBOqvOFDrf1AeRwAYN",
+          "payment_method": "pm_1U6EdqIBOqvOFDrf1FmvD8f4",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "646432",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJb4l9QGMgaR1374pFU6LBbckm00AXJ3IqGXoFsmk2NV2yvWJeAXYjWn70UNww-C1UHOWEdqJXCjb8Ti",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar99b3ab426",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521924"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:18 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/license_disable_on_refund/ordinary_refunds/does_not_disable_the_original_license_when_a_renewal_is_refunded.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/license_disable_on_refund/ordinary_refunds/does_not_disable_the_original_license_when_a_renewal_is_refunded.yml
@@ -1,0 +1,652 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_oVUqxLBoSKYWKp","request_duration_ms":227}}'
+      Idempotency-Key:
+      - 5dee63b6-a57d-439d-9446-c4065b7f6448
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - 5dee63b6-a57d-439d-9446-c4065b7f6448
+      Original-Request:
+      - req_FXpYbCBJ0SJdcv
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_FXpYbCBJ0SJdcv
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6EdvIBOqvOFDrfMf6w6Uip",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165719,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:19 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1U6EdvIBOqvOFDrfMf6w6Uip
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_FXpYbCBJ0SJdcv","request_duration_ms":184}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_RGVFk20B1VlFff
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6EdvIBOqvOFDrfMf6w6Uip",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165719,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:19 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgarcec5dd257.app.test.gumroad.com%3A31340%2Fl%2Fz%21&metadata[purchase]=Cy68aQ3f_awXvIzsr7NeuA%3D%3D&transfer_group=375521925&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1U6EdvIBOqvOFDrfMf6w6Uip&statement_descriptor_suffix=edgarcec5dd257
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_RGVFk20B1VlFff","request_duration_ms":171}}'
+      Idempotency-Key:
+      - d9b9859b-04f1-4d6d-816b-5f6a2488ceec
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1687'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - d9b9859b-04f1-4d6d-816b-5f6a2488ceec
+      Original-Request:
+      - req_doyBkJmXU92i6G
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_doyBkJmXU92i6G
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3U6EdvIBOqvOFDrf1NCZTFxK",
+          "object": "payment_intent",
+          "allowed_payment_method_types": null,
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3U6EdvIBOqvOFDrf1NCZTFxK_secret_xyagzpsGb7p9RtODpq3yNVRlw",
+          "confirmation_method": "automatic",
+          "created": 1787165719,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgarcec5dd257.app.test.gumroad.com:31340/l/z!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3U6EdvIBOqvOFDrf161EO150",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "Cy68aQ3f_awXvIzsr7NeuA=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1U6EdvIBOqvOFDrfMf6w6Uip",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarcec5dd257",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521925"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:20 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U6EdvIBOqvOFDrf161EO150?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_doyBkJmXU92i6G","request_duration_ms":875}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3771'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_NBgosMJKhCvAS1
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U6EdvIBOqvOFDrf161EO150",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3U6EdvIBOqvOFDrf1vHDnxTq",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1787702400,
+            "balance_type": "payments",
+            "created": 1787165719,
+            "currency": "usd",
+            "description": "You bought http://edgarcec5dd257.app.test.gumroad.com:31340/l/z!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3U6EdvIBOqvOFDrf161EO150",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGARCEC5DD257",
+          "captured": true,
+          "created": 1787165719,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgarcec5dd257.app.test.gumroad.com:31340/l/z!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "Cy68aQ3f_awXvIzsr7NeuA=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 17,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U6EdvIBOqvOFDrf1NCZTFxK",
+          "payment_method": "pm_1U6EdvIBOqvOFDrfMf6w6Uip",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "499702",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJj4l9QGMgYDI0R-nnc6LBYm82TylsxeGNK8iV-oKXUeWoiMP_5i4d7_D9VuxMV1hhn6XPnvqsBvdXWe",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgarcec5dd257",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521925"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:20 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/license_disable_on_refund/ordinary_refunds/keeps_the_refund_recorded_if_license_disable_fails.yml
+++ b/spec/support/fixtures/vcr_cassettes/PurchaseRefunds/license_disable_on_refund/ordinary_refunds/keeps_the_refund_recorded_if_license_disable_fails.yml
@@ -1,0 +1,1310 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - 5d41e909-eef1-4859-a160-534f8d6138cc
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=YkPp05_BT0VgAWF4XJZeRknZk4AK7h5aEGU2AOuHTaWbNAnEMfQoz744JuQmI0rbqcQwQG681-Lw9RjB;
+        report-to csp
+      Idempotency-Key:
+      - 5d41e909-eef1-4859-a160-534f8d6138cc
+      Original-Request:
+      - req_7WQNNkGMObF0DR
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=YkPp05_BT0VgAWF4XJZeRknZk4AK7h5aEGU2AOuHTaWbNAnEMfQoz744JuQmI0rbqcQwQG681-Lw9RjB&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=YkPp05_BT0VgAWF4XJZeRknZk4AK7h5aEGU2AOuHTaWbNAnEMfQoz744JuQmI0rbqcQwQG681-Lw9RjB&t=1"
+      Request-Id:
+      - req_7WQNNkGMObF0DR
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165711,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:11 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1U6EdnIBOqvOFDrfbXyFm1oH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_7WQNNkGMObF0DR","request_duration_ms":294}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_vpvsIUDDU3XbGX
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787165711,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:11 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=You+bought+http%3A%2F%2Fedgar975e6ec85.app.test.gumroad.com%3A31340%2Fl%2Fi%21&metadata[purchase]=ZNM2e4FTQB6AwwiAU0WbOQ%3D%3D&transfer_group=375521923&payment_method_types[0]=card&off_session=true&confirm=true&payment_method=pm_1U6EdnIBOqvOFDrfbXyFm1oH&statement_descriptor_suffix=edgar975e6ec85
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_vpvsIUDDU3XbGX","request_duration_ms":176}}'
+      Idempotency-Key:
+      - 4c375324-7cc9-465a-87ac-6ae791a0c480
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1687'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - 4c375324-7cc9-465a-87ac-6ae791a0c480
+      Original-Request:
+      - req_FUGoB3dWCR6s2y
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_FUGoB3dWCR6s2y
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3U6EdnIBOqvOFDrf161OXFnO",
+          "object": "payment_intent",
+          "allowed_payment_method_types": null,
+          "amount": 100,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 100,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3U6EdnIBOqvOFDrf161OXFnO_secret_bAWKJqko3zunTYVSUCLesPLUr",
+          "confirmation_method": "automatic",
+          "created": 1787165711,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "ZNM2e4FTQB6AwwiAU0WbOQ=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar975e6ec85",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521923"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:12 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U6EdnIBOqvOFDrf1ygJFBAd?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_FUGoB3dWCR6s2y","request_duration_ms":848}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3771'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_PgLkQhVSYIGz5y
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3U6EdnIBOqvOFDrf1ju02uwh",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1787702400,
+            "balance_type": "payments",
+            "created": 1787165712,
+            "currency": "usd",
+            "description": "You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR975E6EC85",
+          "captured": true,
+          "created": 1787165712,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "ZNM2e4FTQB6AwwiAU0WbOQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 48,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U6EdnIBOqvOFDrf161OXFnO",
+          "payment_method": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "129106",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJD4l9QGMgbhKqrs_zM6LBZsDaD_LysQ3saOflS4gM9VCFAgna4SP51kp8mGqa6PGzrFMDJKtnAUevSg",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar975e6ec85",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521923"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:12 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U6EdnIBOqvOFDrf1ygJFBAd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_PgLkQhVSYIGz5y","request_duration_ms":196}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3113'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_FONLC1fl1trNPi
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3U6EdnIBOqvOFDrf1ju02uwh",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR975E6EC85",
+          "captured": true,
+          "created": 1787165712,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "ZNM2e4FTQB6AwwiAU0WbOQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 48,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U6EdnIBOqvOFDrf161OXFnO",
+          "payment_method": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "129106",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJH4l9QGMgb3q1iIJro6LBbqyMhbdqqj96VUqjvAcr3vap5OAEqm_eSv-semcjcdXpi2syoK00J8jCMR",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar975e6ec85",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521923"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:13 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/refunds
+    body:
+      encoding: UTF-8
+      string: charge=ch_3U6EdnIBOqvOFDrf1ygJFBAd
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_FONLC1fl1trNPi","request_duration_ms":175}}'
+      Idempotency-Key:
+      - 482ad527-0149-4ebe-8e93-82fe1b1393c3
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '713'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Idempotency-Key:
+      - 482ad527-0149-4ebe-8e93-82fe1b1393c3
+      Original-Request:
+      - req_F6vlaJVKP2iu9f
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_F6vlaJVKP2iu9f
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3U6EdnIBOqvOFDrf17XXSg6A",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_3U6EdnIBOqvOFDrf1ucGbEkK",
+          "charge": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+          "created": 1787165713,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3U6EdnIBOqvOFDrf161OXFnO",
+          "payment_method": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:14 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/refunds/re_3U6EdnIBOqvOFDrf17XXSg6A?expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_F6vlaJVKP2iu9f","request_duration_ms":900}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1216'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_NOHp6FPCUzYvrs
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "re_3U6EdnIBOqvOFDrf17XXSg6A",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": {
+            "id": "txn_3U6EdnIBOqvOFDrf1ucGbEkK",
+            "object": "balance_transaction",
+            "amount": -100,
+            "available_on": 1787702400,
+            "balance_type": "payments",
+            "created": 1787165713,
+            "currency": "usd",
+            "description": "REFUND FOR CHARGE (You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!)",
+            "exchange_rate": null,
+            "fee": 0,
+            "fee_details": [],
+            "net": -100,
+            "reporting_category": "refund",
+            "source": "re_3U6EdnIBOqvOFDrf17XXSg6A",
+            "status": "pending",
+            "type": "refund"
+          },
+          "charge": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+          "created": 1787165713,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "destination_details": {
+            "card": {
+              "reference_status": "pending",
+              "reference_type": "acquirer_reference_number",
+              "type": "refund"
+            },
+            "type": "card"
+          },
+          "metadata": {},
+          "payment_intent": "pi_3U6EdnIBOqvOFDrf161OXFnO",
+          "payment_method": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:14 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U6EdnIBOqvOFDrf1ygJFBAd?expand%5B%5D=application_fee.refunds.data.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_NOHp6FPCUzYvrs","request_duration_ms":290}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 19 Aug 2026 18:55:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3772'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=sG__YXvZ0OFKhcaBhYXRbp38UyyMuQcw97PyDmQNNPB94arxFY8z4YbQZe1kCKjl8C3Eqi4uXPNERw_c&t=1"
+      Request-Id:
+      - req_CgFtaZlyYYy1fo
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 100,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3U6EdnIBOqvOFDrf1ju02uwh",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1787702400,
+            "balance_type": "payments",
+            "created": 1787165712,
+            "currency": "usd",
+            "description": "You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3U6EdnIBOqvOFDrf1ygJFBAd",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR975E6EC85",
+          "captured": true,
+          "created": 1787165712,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar975e6ec85.app.test.gumroad.com:31340/l/i!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "ZNM2e4FTQB6AwwiAU0WbOQ=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 48,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U6EdnIBOqvOFDrf161OXFnO",
+          "payment_method": "pm_1U6EdnIBOqvOFDrfbXyFm1oH",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 100,
+              "authorization_code": "129106",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 100,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKJL4l9QGMgZqWjh5PTA6LBZIbrcbCTt8aO_N9CuBMANAD8CQ0SWIEpdBRex6WBfqLlrsHjkOPY2kc8rn",
+          "refunded": true,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar975e6ec85",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375521923"
+        }
+  recorded_at: Wed, 19 Aug 2026 18:55:14 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
# Disable license keys when a purchase is fully refunded

> Draft, awaiting Ershad. Head `67f627a47`. Premerge (codex panel) clean; CI green (0 pending / 0 failing) at this SHA. Money-path: no automerge, staying draft. Cassette-only diffs now escalate instead of selecting zero specs.

Addresses antiwork/gumroad-private#2219

## What

A full refund (including a fraud refund) now disables the license key attached to that purchase. `/v2/licenses/verify` already rejects disabled keys, so the serial stops working without the seller having to disable it by hand.

Partial refunds leave the key enabled. A non-fraud refund of a membership renewal leaves the original purchase's key enabled. A fraud refund of a renewal disables the original key (the subscription is cancelled in that path anyway). Gift sender refunds disable the giftee key. Bundle child purchases get the same treatment when the bundle is fully refunded.

The hook looks up `License` by `purchase_id`. `Purchase#license_key` is nil unless the product is currently licensed, and `Purchase#license` remaps a renewal onto the original purchase.

## Why

Refunds already block downloads. License verify does not look at `stripe_refunded` — only at `disabled?` and `is_access_revoked?`. After a fraud refund the buyer still had a working serial until support disabled it.

## Before / after

- Before: full refund sets `stripe_refunded`; `/v2/licenses/verify` still returns `success: true` with `purchase.refunded: true`.
- After: full refund also sets `license.disabled_at`; verify returns `This license key has been disabled.`

## Checklist

- [x] Scope — full refund + fraud refund + gift/bundle children. Not chargebacks, not a verify-API change, not a backfill of already-refunded keys.
- [x] Design — disable the existing License row (the flag verify already honors) instead of teaching verify to read `stripe_refunded`.
- [x] Build — `gp2219-disable-license-on-refund` @ 67f627a47
- [x] QA — no rendered surface; Relevant CI green at 67f627a47 (0 pending, 0 failing)
- [ ] Shipped
- [ ] Market — n/a, backend license validity
- [ ] Sell — n/a

## Test Results

`ruby spec/bin/branch_specs_test.rb` at 67f627a47: 27 checks, 0 failures (cassette-with-mapped-spec stays selected; cassette-only now escalates). Selector against origin/main at c3a2b992fe: 18 refund-path specs, no Slow. `bundle exec rspec spec/models/purchase/purchase_refunds_spec.rb -e "keeps the refund recorded if license disable fails"` at 715e85d865: 1 example, 0 failures.

CI at `67f627a47`: green, 0 pending / 0 failing. Prior head `c3a2b992fe` (run 32322401324) Compute relevant specs SUCCESS — 18 files, no Slow.

## QA

No rendered surface. After deploy: refund a licensed purchase, then POST /v2/licenses/verify with that serial and expect the disabled-key error. A partial refund of another licensed purchase should still verify.

## Ownership

Handed to `ershad` with `awaiting-human` for the money-path merge decision (refunds disable license keys). Staying draft; no automerge; review request deferred until ready-flip. Expected of Ershad: decide whether this refund→disable hook is the right merge.

---

AI disclosure: grok-4.6.

Premerge review: clean @ 67f627a47d8d96a729e13a0cec0e791c3d232b6f
