### PR TITLE
Verify the backfill against deduplicated pair counts

### DIFF
--- a/app/services/onetime/backfill_email_engagement_dynamo_table.rb
+++ b/app/services/onetime/backfill_email_engagement_dynamo_table.rb
@@ -152,7 +152,11 @@ class Onetime::BackfillEmailEngagementDynamoTable
         ).item || {}
         expected = {
           opens: CreatorEmailOpenEvent.where(installment_id: summary.installment_id).count,
-          pairs: CreatorEmailClickEvent.where(installment_id: summary.installment_id).count,
+          # Deduplicated: the unique click_index was never built in production,
+          # so the collection holds duplicate docs that DynamoDB's keyed items
+          # collapse by design (10-30% of docs on large blasts).
+          pairs: CreatorEmailClickEvent.where(installment_id: summary.installment_id)
+                                       .pluck(:mailer_method, :mailer_args, :click_url).uniq.size,
         }
         actual = { opens: dynamo["open_count"].to_i, pairs: dynamo["click_pair_count"].to_i }
         next if expected == actual

--- a/spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb
+++ b/spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb
@@ -271,5 +271,16 @@ describe Onetime::BackfillEmailEngagementDynamoTable do
 
       expect(described_class.verify!(sample_size: 10)).to eq([])
     end
+
+    it "expects the deduplicated pair count when Mongo holds duplicate click docs" do
+      CreatorEmailClickSummary.create!(installment_id: 123, total_unique_clicks: 2, urls: {})
+      CreatorEmailOpenEvent.create!(installment_id: 123, mailer_method:, mailer_args:, open_count: 1)
+      # Two docs for the same recipient+url pair: possible in production because
+      # the unique click_index was never built there.
+      2.times { CreatorEmailClickEvent.create!(installment_id: 123, mailer_method:, mailer_args:, click_url:, click_count: 1) }
+      client.stub_responses(:get_item, { item: { "pk" => "123", "sk" => "SUMMARY", "open_count" => 1, "click_pair_count" => 1 } })
+
+      expect(described_class.verify!(sample_size: 10)).to eq([])
+    end
   end
 end


### PR DESCRIPTION
## What

`verify!` (the global backfill's reconciliation gate for gumroad-private#2158) now compares `click_pair_count` against the count of **distinct** `(mailer_method, mailer_args, click_url)` triples instead of the raw click-document count, matching what `verify_seller!` already does.

## Why

The unique `click_index` declared on `CreatorEmailClickEvent` was never actually built in production (the live collection has only three non-unique indexes), so concurrent url-prefetch bursts inserted duplicate documents for the same recipient+url pair — verified directly: byte-identical triples written seconds apart, 20–30% of documents on large blasts, on both creator and Gumroad-account emails. DynamoDB's keyed items collapse those duplicates by design, which is correct per the option-B decision on the issue (unique link clicks). Left as-is, the raw-count gate would have flagged nearly every large installment as a mismatch during the full reconciliation, burying real problems in expected noise.

## Before/After

No user-facing change: operator-run verification only. Before: `verify!` would report a "mismatch" on any installment holding duplicate click docs. After: it enforces the invariant that actually holds — DynamoDB pairs == deduplicated Mongo pairs — and still reports Mongo's stored counter informationally on mismatch rows. Walkthrough video: TODO before marking ready for review.

## QA steps

1. Create two click docs for the same recipient+url (possible locally and in prod since the unique index doesn't exist), a DynamoDB `SUMMARY` with `click_pair_count: 1`, and run `verify!` — no mismatch reported.
2. A genuine divergence (pair count ≠ distinct triples) still reports.

## Test Results

- `bundle exec rspec spec/services/onetime/backfill_email_engagement_dynamo_table_spec.rb` — 14 examples, 0 failures (adds the duplicate-doc case)
- `bundle exec rubocop` on both files — clean

---

AI disclosure: implemented with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)