### PR TITLE
Refuse Stripe Radar value-list writes outside production

### DIFF
--- a/app/services/radar/value_list_sync_service.rb
+++ b/app/services/radar/value_list_sync_service.rb
@@ -17,8 +17,18 @@ class Radar::ValueListSyncService
     LIST_FOR_TYPE.key?(object_type)
   end
 
+  # Radar value lists are durable account-wide state, and every non-production environment
+  # (dev, CI, cassette recording, branch apps) shares one Stripe test account. A block-buyer
+  # flow leaking through here once blocked the 4242 test card's fingerprint for the whole
+  # account and every checkout spec declined until the item was deleted by hand.
+  def self.enabled?
+    Rails.env.production? || GlobalConfig.get("ENABLE_RADAR_VALUE_LIST_SYNC").present?
+  end
+
   # A stale removal keeps rejecting a legitimate buyer; adds can wait for the daily sync.
   def remove_block(platform_block)
+    return false unless self.class.enabled?
+
     list_config = LIST_FOR_TYPE[platform_block.object_type]
     return false if list_config.nil?
     return false if platform_block.reload.blocked_at.present?
@@ -45,6 +55,8 @@ class Radar::ValueListSyncService
   # Without this, only the removal recovered and a block added mid-removal stayed unenforced
   # until the daily sync.
   def add_block(platform_block)
+    return false unless self.class.enabled?
+
     list_config = LIST_FOR_TYPE[platform_block.object_type]
     return false if list_config.nil?
     return false if platform_block.reload.blocked_at.nil?
@@ -66,6 +78,8 @@ class Radar::ValueListSyncService
   end
 
   def sync_blocked_emails
+    return unless self.class.enabled?
+
     value_list = find_or_create_list(**LIST_FOR_TYPE[PlatformBlock::TYPES[:email]])
 
     blocked_emails = PlatformBlock.email.active.where("blocked_at >= ?", SYNC_WINDOW.ago)
@@ -86,6 +100,8 @@ class Radar::ValueListSyncService
   end
 
   def sync_blocked_cards
+    return unless self.class.enabled?
+
     value_list = find_or_create_list(**LIST_FOR_TYPE[PlatformBlock::TYPES[:charge_processor_fingerprint]])
 
     blocked_cards = PlatformBlock.charge_processor_fingerprint.active

--- a/spec/services/radar/value_list_sync_service_spec.rb
+++ b/spec/services/radar/value_list_sync_service_spec.rb
@@ -7,6 +7,68 @@ describe Radar::ValueListSyncService do
 
   let(:value_list) { double("ValueList", id: "rsl_123") }
 
+  before do
+    allow(described_class).to receive(:enabled?).and_return(true)
+  end
+
+  describe ".enabled?" do
+    before do
+      allow(described_class).to receive(:enabled?).and_call_original
+    end
+
+    it "is disabled outside production so the shared Stripe test account's lists are never written" do
+      expect(described_class.enabled?).to be(false)
+    end
+
+    it "is enabled in production" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+
+      expect(described_class.enabled?).to be(true)
+    end
+
+    it "can be forced on with ENABLE_RADAR_VALUE_LIST_SYNC" do
+      allow(GlobalConfig).to receive(:get).with("ENABLE_RADAR_VALUE_LIST_SYNC").and_return("1")
+
+      expect(described_class.enabled?).to be(true)
+    end
+  end
+
+  describe "when sync is disabled" do
+    before do
+      allow(described_class).to receive(:enabled?).and_return(false)
+    end
+
+    it "does not touch Stripe Radar from add_block" do
+      platform_block = PlatformBlock.add!(object_type: PlatformBlock::TYPES[:charge_processor_fingerprint], object_value: "testfingerprint1")
+
+      expect(Stripe::Radar::ValueList).not_to receive(:list)
+      expect(Stripe::Radar::ValueListItem).not_to receive(:create)
+
+      expect(service.add_block(platform_block)).to be(false)
+    end
+
+    it "does not touch Stripe Radar from remove_block" do
+      platform_block = PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "cleared@example.com")
+      platform_block.update_columns(blocked_at: nil, expires_at: nil)
+
+      expect(Stripe::Radar::ValueList).not_to receive(:list)
+      expect(Stripe::Radar::ValueListItem).not_to receive(:delete)
+
+      expect(service.remove_block(platform_block)).to be(false)
+    end
+
+    it "does not touch Stripe Radar from the daily syncs" do
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:email], object_value: "blocked@example.com")
+      PlatformBlock.add!(object_type: PlatformBlock::TYPES[:charge_processor_fingerprint], object_value: "testfingerprint2")
+
+      expect(Stripe::Radar::ValueList).not_to receive(:list)
+      expect(Stripe::Radar::ValueList).not_to receive(:create)
+
+      service.sync_blocked_emails
+      service.sync_blocked_cards
+    end
+  end
+
   describe "#sync_blocked_emails" do
     before do
       allow(Stripe::Radar::ValueList).to receive(:list)

--- a/spec/sidekiq/radar/add_value_list_item_job_spec.rb
+++ b/spec/sidekiq/radar/add_value_list_item_job_spec.rb
@@ -6,6 +6,7 @@ describe Radar::AddValueListItemJob do
   let(:value_list) { double("ValueList", id: "rsl_123") }
 
   before do
+    allow(Radar::ValueListSyncService).to receive(:enabled?).and_return(true)
     allow(Stripe::Radar::ValueList).to receive(:list).and_return(double(data: [value_list]))
     allow(Stripe::Radar::ValueListItem).to receive(:list).and_return(double(data: []))
   end

--- a/spec/sidekiq/radar/remove_value_list_item_job_spec.rb
+++ b/spec/sidekiq/radar/remove_value_list_item_job_spec.rb
@@ -6,6 +6,7 @@ describe Radar::RemoveValueListItemJob do
   let(:value_list) { double("ValueList", id: "rsl_123") }
 
   before do
+    allow(Radar::ValueListSyncService).to receive(:enabled?).and_return(true)
     allow(Stripe::Radar::ValueList).to receive(:list).and_return(double(data: [value_list]))
   end
 


### PR DESCRIPTION
## What

Gates every write path of `Radar::ValueListSyncService` (`add_block`, `remove_block`, `sync_blocked_emails`, `sync_blocked_cards`) behind a new `.enabled?` check: enabled in production, disabled everywhere else, with an `ENABLE_RADAR_VALUE_LIST_SYNC` env override for a run that genuinely needs to write. Existing service/job specs opt in by stubbing `enabled?`; new specs pin down that a disabled service never touches `Stripe::Radar`.

## Why

Radar value lists are durable, account-wide state on the Stripe account — and every non-production environment (local dev, CI, VCR cassette recording, branch apps) shares one Stripe **test** account. Charges are ephemeral per-run noise; a value-list write outlives the run and applies to everyone.

That's not hypothetical: on 2026-08-19 at 18:55 UTC, a refund-for-fraud flow running against the shared test account executed `Radar::AddValueListItemJob` for real (`js: true` specs run with VCR off and WebMock open, and `:sidekiq_inline` executes the job in-process) and pushed the `4242 4242 4242 4242` test card's fingerprint onto the shared account's card block list. From that moment, every checkout spec in the full suite failed with "Your card was declined." (Radar outcome: `blocklist`) — all ~50 Slow shards red on every main build until the Radar item was found and deleted by hand.

The guard lives in the service (the single choke point in front of every `Stripe::Radar` call) rather than in spec config, because the same leak is reachable from a local dev server with Sidekiq running — any environment pointing at the shared account, not just RSpec. Enqueueing is left untouched; the job simply no-ops at execution, so no callback behavior changes. The onetime backfill's direct `find_or_create_list`/`add_item_to_list` calls are intentionally unguarded — it's prod-console tooling.

## Before/After

No user-facing surface — this changes when a background sync is allowed to call Stripe, nothing rendered anywhere. Before: any non-production run that created a card/email `PlatformBlock` could silently write to the shared test account's Radar lists (and once broke CI org-wide). After: those writes are refused outside production unless explicitly opted in; production behavior is unchanged.

## Test Results

- `bundle exec rspec spec/services/radar/value_list_sync_service_spec.rb spec/sidekiq/radar/` — 51 examples, 0 failures
- `bundle exec rspec spec/models/platform_block_spec.rb spec/services/onetime/backfill_radar_value_lists_spec.rb` — 31 examples, 0 failures
- Reverting the guard with the new specs in place fails all three "when sync is disabled" examples, so the coverage is real.
- `bundle exec rubocop` on all touched files — no offenses

---

AI disclosure: written with Claude Fable 5.
