### PR TITLE
Retry contended sales-related-products upserts instead of dying

### DIFF
--- a/app/models/sales_related_products_info.rb
+++ b/app/models/sales_related_products_info.rb
@@ -23,6 +23,13 @@ class SalesRelatedProductsInfo < ApplicationRecord
   # many products the buyer owns.
   SALES_COUNT_UPSERT_BATCH_SIZE = 100
 
+  # Concurrent upserts deadlock against each other often enough to matter (a multi-item
+  # cart fires one job per purchase, all landing here at once). Retrying is the remedy
+  # rather than avoidance: under REPEATABLE READ the losing statement is InnoDB's chosen
+  # victim, not a symptom of bad SQL. Keep the ceiling low — this sleeps a Sidekiq thread.
+  UPSERT_CONTENTION_RETRIES = 3
+  UPSERT_CONTENTION_BASE_BACKOFF = 0.05
+
   # Applies +1 (or -1) to the pairwise sales counter between `product_id` and each of
   # `related_product_ids`, creating the pair row if it does not exist yet.
   #
@@ -64,9 +71,14 @@ class SalesRelatedProductsInfo < ApplicationRecord
     # than going negative.
     new_sales_count = increment ? 1 : 0
 
-    pair_product_ids.each_slice(SALES_COUNT_UPSERT_BATCH_SIZE) do |slice|
-      values_sql = slice.map do |related_product_id|
-        smaller_id, larger_id = [product_id, related_product_id].sort
+    # Sorted so that two overlapping statements — the norm for a multi-item cart, whose jobs
+    # derive near-identical pair sets — take their row locks in the same order. This does not
+    # address the insert-intention conflict at the tail of the clustered index, which is what
+    # the retry below is for; it removes the separate lock-ordering deadlock on top of it.
+    pairs = pair_product_ids.map { [product_id, _1].minmax }.sort
+
+    pairs.each_slice(SALES_COUNT_UPSERT_BATCH_SIZE) do |slice|
+      values_sql = slice.map do |smaller_id, larger_id|
         "(#{[smaller_id, larger_id, new_sales_count, now_string, now_string].join(', ')})"
       end.join(", ")
 
@@ -78,7 +90,24 @@ class SalesRelatedProductsInfo < ApplicationRecord
         VALUES #{values_sql}
         ON DUPLICATE KEY UPDATE sales_count = sales_count + (#{sales_count_change}), updated_at = #{now_string};
       SQL
+      execute_upsert_with_contention_retry(query)
+    end
+  end
+
+  # Retries are per statement, so slices that already committed are never replayed. Safe
+  # because a deadlocked (or lock-wait-timed-out) statement rolls back whole and this runs
+  # outside any wrapping transaction: nothing was counted, so nothing can double-count.
+  def self.execute_upsert_with_contention_retry(query)
+    attempts = 0
+    begin
       ApplicationRecord.connection.execute(query)
+    rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout
+      attempts += 1
+      raise if attempts > UPSERT_CONTENTION_RETRIES
+
+      # Jittered so two statements retrying against each other don't line up again.
+      sleep(UPSERT_CONTENTION_BASE_BACKOFF * (2**(attempts - 1)) * (0.5 + Kernel.rand))
+      retry
     end
   end
 

--- a/spec/models/sales_related_products_info_spec.rb
+++ b/spec/models/sales_related_products_info_spec.rb
@@ -3,6 +3,40 @@
 require "spec_helper"
 
 describe SalesRelatedProductsInfo do
+  def upsert?(sql)
+    sql.to_s.include?("INSERT INTO #{described_class.table_name}")
+  end
+
+  def capture_upsert_statements
+    statements = []
+    allow(ApplicationRecord.connection).to receive(:execute).and_wrap_original do |original, sql, *args|
+      statements << sql if upsert?(sql)
+      original.call(sql, *args)
+    end
+    yield
+    statements
+  end
+
+  # Fails the first `times` upsert attempts, then lets them through. Tracks the attempt
+  # count in @upsert_attempts.
+  def fail_upserts(times:, with:)
+    @upsert_attempts = 0
+    allow(ApplicationRecord.connection).to receive(:execute).and_wrap_original do |original, sql, *args|
+      if upsert?(sql)
+        @upsert_attempts += 1
+        raise with, "Deadlock found when trying to get lock" if @upsert_attempts <= times
+      end
+      original.call(sql, *args)
+    end
+  end
+
+  def pair_for(product1, product2)
+    described_class.find_by(
+      smaller_product_id: [product1.id, product2.id].min,
+      larger_product_id: [product1.id, product2.id].max
+    )
+  end
+
   describe ".find_or_create_info" do
     let(:sales_related_products_info) { create(:sales_related_products_info) }
 
@@ -114,6 +148,96 @@ describe SalesRelatedProductsInfo do
         described_class.update_sales_counts(product_id: product.id, related_product_ids: [], increment: true)
         described_class.update_sales_counts(product_id: product.id, related_product_ids: [product.id], increment: true)
       end.not_to change(described_class, :count)
+    end
+
+    context "when concurrent upserts contend for the same rows" do
+      before { allow(described_class).to receive(:sleep) }
+
+      # Every statement lists its pairs in the same order, so two overlapping upserts cannot
+      # take the same row locks in opposite orders.
+      it "emits each statement's pairs in ascending pair order" do
+        product = create(:product)
+        related = create_list(:product, 5)
+        stub_const("#{described_class}::SALES_COUNT_UPSERT_BATCH_SIZE", 2)
+
+        statements = capture_upsert_statements do
+          described_class.update_sales_counts(
+            product_id: product.id,
+            related_product_ids: related.map(&:id).shuffle,
+            increment: true
+          )
+        end
+
+        pairs = statements.flat_map { _1.scan(/\((\d+), (\d+), \d+, /).map { |s, l| [s.to_i, l.to_i] } }
+        expect(pairs.size).to eq(5)
+        expect(pairs).to eq(pairs.sort)
+      end
+
+      it "retries a deadlocked statement and applies the increment" do
+        product = create(:product)
+        other = create(:product)
+        fail_upserts(times: 1, with: ActiveRecord::Deadlocked)
+
+        described_class.update_sales_counts(product_id: product.id, related_product_ids: [other.id], increment: true)
+
+        expect(@upsert_attempts).to eq(2)
+        expect(pair_for(product, other).sales_count).to eq(1)
+      end
+
+      it "retries a lock wait timeout as well" do
+        product = create(:product)
+        other = create(:product)
+        fail_upserts(times: 1, with: ActiveRecord::LockWaitTimeout)
+
+        described_class.update_sales_counts(product_id: product.id, related_product_ids: [other.id], increment: true)
+
+        expect(@upsert_attempts).to eq(2)
+        expect(pair_for(product, other).sales_count).to eq(1)
+      end
+
+      it "counts a retried pair exactly once" do
+        product = create(:product)
+        other = create(:product)
+        create(:sales_related_products_info, smaller_product_id: [product.id, other.id].min, larger_product_id: [product.id, other.id].max, sales_count: 4)
+        fail_upserts(times: 2, with: ActiveRecord::Deadlocked)
+
+        described_class.update_sales_counts(product_id: product.id, related_product_ids: [other.id], increment: true)
+
+        expect(pair_for(product, other).sales_count).to eq(5)
+      end
+
+      it "raises once the retry ceiling is exhausted so persistent contention still surfaces" do
+        product = create(:product)
+        other = create(:product)
+        fail_upserts(times: described_class::UPSERT_CONTENTION_RETRIES + 1, with: ActiveRecord::Deadlocked)
+
+        expect do
+          described_class.update_sales_counts(product_id: product.id, related_product_ids: [other.id], increment: true)
+        end.to raise_error(ActiveRecord::Deadlocked)
+
+        expect(@upsert_attempts).to eq(described_class::UPSERT_CONTENTION_RETRIES + 1)
+      end
+
+      it "does not replay a slice that already committed" do
+        product = create(:product)
+        related = create_list(:product, 4)
+        stub_const("#{described_class}::SALES_COUNT_UPSERT_BATCH_SIZE", 1)
+        # Fail only the third statement, after two slices have already committed.
+        @upsert_attempts = 0
+        allow(ApplicationRecord.connection).to receive(:execute).and_wrap_original do |original, sql, *args|
+          if upsert?(sql)
+            @upsert_attempts += 1
+            raise ActiveRecord::Deadlocked, "Deadlock found when trying to get lock" if @upsert_attempts == 3
+          end
+          original.call(sql, *args)
+        end
+
+        described_class.update_sales_counts(product_id: product.id, related_product_ids: related.map(&:id), increment: true)
+
+        # 4 slices, one of them attempted twice.
+        expect(@upsert_attempts).to eq(5)
+        expect(related.map { pair_for(product, _1).sales_count }).to all(eq(1))
+      end
     end
   end
 


### PR DESCRIPTION
## What

`UpdateSalesRelatedProductsInfosJob` exhausts its Sidekiq retries on `ActiveRecord::Deadlocked` and dies, which silently drops the pairwise sales counts for the affected purchases — those products just stop contributing to "customers also bought" data.

Two changes in `SalesRelatedProductsInfo.update_sales_counts`:

- Retry a deadlocked (or lock-wait-timed-out) upsert statement, with jittered backoff and a low ceiling.
- Emit each statement's pairs in a consistent `(smaller_product_id, larger_product_id)` order.

## Why

The write here is a multi-row `INSERT ... ON DUPLICATE KEY UPDATE`. Under `REPEATABLE READ` it takes next-key (gap) locks on the rows it updates, and any genuinely-new pairs in the same statement insert at the tail of the auto-increment clustered index. So each concurrent statement ends up **holding a gap lock on the last page's `supremum` record while also needing an insert-intention lock on that same gap.** Gap locks are mutually compatible; gap locks and insert-intention locks are not. Two such statements deadlock, and InnoDB picks one arbitrarily to roll back.

I confirmed this against the primary's `LATEST DETECTED DEADLOCK` section: both transactions hold `lock_mode X` on `supremum` in `index PRIMARY` and both wait for `lock_mode X insert intention` on the same record. It is not a row-ordering problem on the unique index, which is where I first looked.

A multi-item cart makes this routine rather than rare. `Purchase#enqueue_update_sales_related_products_infos_job` fires one job per purchase, so an N-item cart enqueues N of these simultaneously for the same buyer, each deriving a near-identical pair set from the same purchase history.

**Why retry rather than avoid.** The losing statement is InnoDB's arbitrary victim, not a symptom of bad SQL, and retrying is provably safe here: a deadlocked statement rolls back whole, and this code runs outside any wrapping transaction, so nothing was counted and nothing can double-count. Retries are per statement, so slices that already committed are never replayed. The ceiling is deliberately low because the backoff sleeps a Sidekiq thread.

Alternatives considered and rejected:

- **Serialize per buyer** (one job per cart, or a per-email lock). This only reduces the *rate*. The contended gap is at the tail of the clustered index and is global to the table, so two unrelated buyers inserting new pairs concurrently deadlock the same way. It adds coordination machinery without closing the hole.
- **`READ COMMITTED` for this transaction.** This genuinely eliminates the class, since RC takes no gap locks, and it remains the right follow-up if retries prove insufficient. Left out here because it needs the primary's `binlog_format` confirmed first and is a much larger behavioural claim to make in the same PR as the bug fix.
- **One statement per pair.** Shrinks the lock window, but reverses the statement consolidation done deliberately for the replica-lag work in #1353.

The ordering change is secondary and does not touch the insert-intention conflict. It is here because overlapping statements — the multi-item cart case again — would otherwise take their shared *row* locks in opposite orders, which is a second, independent deadlock stacked on the first.

## Before / After

⚠️ **Video still owed on this PR — I could not record one here.** This is a background-job/database-locking change with no user-visible surface, so there is no before/after UI to capture, but per the contributing guide a non-user-facing PR still needs a short walkthrough clip and this does not have one yet. Flagging rather than quietly skipping it.

Behavioural before/after, for review in the meantime:

| | Before | After |
|---|---|---|
| Statement deadlocks | Propagates, burns a Sidekiq retry, job eventually dies and the counts are lost | Retried in-process with jittered backoff; the increment lands |
| Persistent contention | Same as above | Still raises after the ceiling, so it stays visible rather than being swallowed |
| Pair order within a statement | Purchase-recency order, differs between concurrent jobs | Ascending pair order, identical between concurrent jobs |
| Already-committed slices | n/a | Never replayed on a later slice's retry |

## Test Results

Six new examples in `spec/models/sales_related_products_info_spec.rb`, all of which fail with the fix reverted (verified by reverting both hunks and re-running — 6 examples, 6 failures):

- retries a deadlocked statement and applies the increment
- retries a lock wait timeout as well
- counts a retried pair exactly once
- raises once the retry ceiling is exhausted so persistent contention still surfaces
- does not replay a slice that already committed
- emits each statement's pairs in ascending pair order

```
bundle exec rspec spec/models/sales_related_products_info_spec.rb   # 21 examples, 0 failures
bundle exec rubocop app/models/sales_related_products_info.rb spec/models/sales_related_products_info_spec.rb   # no offenses
npm run typecheck   # clean
bin/check-migration-versions   # OK, no collision
```

`spec/sidekiq/update_sales_related_products_infos_job_spec.rb` fails on my machine at the `create(:purchase, ...)` factory with "We couldn't charge your card" — that reproduces identically on a clean `main` checkout, so it is local environment breakage rather than this change. Leaving it to CI.

## QA steps

1. Deploy to a preview app.
2. Buy two or more products in a single cart as the same buyer, where the buyer already owns other products.
3. Confirm both `UpdateSalesRelatedProductsInfosJob` jobs complete rather than landing in the retry or dead set.
4. Confirm the `sales_related_products_infos` rows for every pair incremented exactly once — no pair double-counted, none missed.
5. Refund one of the purchases and confirm the matching decrement applies exactly once.

## Follow-ups

- The jobs that already died on this need a **throttled re-drive** once this is deployed. Bulk-retrying them from the dead set is actively counterproductive: they all contend on the same table, so releasing them at once is itself a deadlock storm, and `Sidekiq::SortedEntry#retry` preserves the exhausted `retry_count`, meaning each job gets one attempt rather than three. A re-drive wants fresh `perform_async` calls in small spaced batches.
- The comment above `update_sales_counts` asserts `binlog_format = MIXED`. The worker replica reports `ROW`. Worth confirming on the primary and correcting the comment, since the replica-lag reasoning in that comment rests on it.

---

AI disclosure: written with Claude Fable 5.
