### PR TITLE
Send TikTok InitiateCheckout when the buyer reaches checkout

### DIFF
--- a/app/javascript/components/Checkout/initialCheckout.test.ts
+++ b/app/javascript/components/Checkout/initialCheckout.test.ts
@@ -65,6 +65,27 @@ describe("computeInitialCheckout", () => {
     expect(result.beginCheckoutEvents.map((e) => e.action)).toEqual(["begin_checkout", "begin_checkout"]);
   });
 
+  it("reports per-unit product prices and a quantity-adjusted checkout total", () => {
+    const products = [
+      { ...makeProductToAdd({ permalink: "a", creatorId: "seller-1", price: 500 }), quantity: 3 },
+      { ...makeProductToAdd({ permalink: "b", creatorId: "seller-1", price: 250 }), quantity: 1 },
+    ];
+
+    const result = computeInitialCheckout(makeArgs(products));
+
+    expect(result.beginCheckoutEvents).toEqual([
+      {
+        action: "begin_checkout",
+        seller_id: "seller-1",
+        price: 17.5,
+        products: [
+          { permalink: "a", name: baseProduct.name, quantity: 3, price: 5 },
+          { permalink: "b", name: baseProduct.name, quantity: 1, price: 2.5 },
+        ],
+      },
+    ]);
+  });
+
   it("is pure: repeated invocations on a shared multi-product array produce identical results (the render-loop regression + no input mutation)", () => {
     // Multi-element + a stable reference: if the function mutated the caller's
     // array (e.g. an in-place reverse), successive calls would diverge. A

--- a/app/javascript/components/Checkout/initialCheckout.ts
+++ b/app/javascript/components/Checkout/initialCheckout.ts
@@ -128,12 +128,15 @@ export const computeInitialCheckout = ({
     }
 
     for (const [creatorId, creatorCart] of creatorCarts) {
-      const products = creatorCart.map((item) => ({
-        permalink: item.product.permalink,
-        name: item.product.name,
-        quantity: item.quantity,
-        price: convertToUSD(item, getDiscountedPrice(initialCart, item).price) / 100.0,
-      }));
+      const products = creatorCart.map((item) => {
+        const linePriceUsd = convertToUSD(item, getDiscountedPrice(initialCart, item).price) / 100.0;
+        return {
+          permalink: item.product.permalink,
+          name: item.product.name,
+          quantity: item.quantity,
+          price: linePriceUsd / item.quantity,
+        };
+      });
       beginCheckoutEvents.push({
         action: "begin_checkout",
         seller_id: creatorId,

--- a/app/javascript/data/tiktok_pixel.test.ts
+++ b/app/javascript/data/tiktok_pixel.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$vendor/tiktok_pixel", () => ({ default: vi.fn() }));
+vi.mock("$vendor/facebook_pixel", () => ({ default: vi.fn() }));
+vi.mock("$vendor/google_analytics_4", () => ({ default: vi.fn() }));
+
+import { trackProductEvent } from "$app/data/tiktok_pixel";
+import type { AnalyticsConfig } from "$app/utils/user_analytics";
+
+const PIXEL_ID = "CTESTPIXELID1234567";
+
+const config: AnalyticsConfig = {
+  id: "seller-1",
+  facebookPixelId: null,
+  googleAnalyticsId: null,
+  tiktokPixelId: PIXEL_ID,
+  trackFreeSales: false,
+};
+
+function enablePixel() {
+  document.head.innerHTML = '<meta property="gr:tiktok_pixel:enabled" content="true">';
+}
+
+function stubTtq() {
+  const track = vi.fn();
+  const page = vi.fn();
+  const instance = vi.fn(() => ({ track, page }));
+  vi.stubGlobal("ttq", { load: vi.fn(), page: vi.fn(), track: vi.fn(), instance });
+  return { track, instance };
+}
+
+describe("TikTok trackProductEvent", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("maps begin_checkout to InitiateCheckout with cart contents", () => {
+    enablePixel();
+    const { track, instance } = stubTtq();
+
+    trackProductEvent(config, {
+      action: "begin_checkout",
+      seller_id: "seller-1",
+      price: 12.5,
+      products: [
+        { permalink: "demo", name: "Demo", quantity: 2, price: 5 },
+        { permalink: "pack", name: "Pack", quantity: 1, price: 2.5 },
+      ],
+    });
+
+    expect(instance).toHaveBeenCalledWith(PIXEL_ID);
+    expect(track).toHaveBeenCalledWith("InitiateCheckout", {
+      contents: [
+        { content_id: "demo", content_type: "product", quantity: 2, price: 5 },
+        { content_id: "pack", content_type: "product", quantity: 1, price: 2.5 },
+      ],
+      value: 12.5,
+      currency: "USD",
+      content_type: "product",
+    });
+  });
+
+  it("does not fire InitiateCheckout for a free checkout unless trackFreeSales", () => {
+    enablePixel();
+    const { track } = stubTtq();
+
+    trackProductEvent(config, {
+      action: "begin_checkout",
+      seller_id: "seller-1",
+      price: 0,
+      products: [{ permalink: "free", name: "Free", quantity: 1, price: 0 }],
+    });
+    expect(track).not.toHaveBeenCalled();
+
+    trackProductEvent(
+      { ...config, trackFreeSales: true },
+      {
+        action: "begin_checkout",
+        seller_id: "seller-1",
+        price: 0,
+        products: [{ permalink: "free", name: "Free", quantity: 1, price: 0 }],
+      },
+    );
+    expect(track).toHaveBeenCalledWith("InitiateCheckout", expect.objectContaining({ value: 0 }));
+  });
+
+  it("still maps iwantthis to AddToCart", () => {
+    enablePixel();
+    const { track } = stubTtq();
+
+    trackProductEvent(config, { action: "iwantthis", permalink: "demo", product_name: "Demo" });
+
+    expect(track).toHaveBeenCalledWith("AddToCart", { content_id: "demo", content_type: "product" });
+  });
+
+  it("does not track when the pixel meta tag is off", () => {
+    document.head.innerHTML = '<meta property="gr:tiktok_pixel:enabled" content="false">';
+    const { track } = stubTtq();
+
+    trackProductEvent(config, {
+      action: "begin_checkout",
+      seller_id: "seller-1",
+      price: 10,
+      products: [{ permalink: "demo", name: "Demo", quantity: 1, price: 10 }],
+    });
+
+    expect(track).not.toHaveBeenCalled();
+  });
+});

--- a/app/javascript/data/tiktok_pixel.ts
+++ b/app/javascript/data/tiktok_pixel.ts
@@ -2,7 +2,6 @@ import loadTikTokPixelScript from "$vendor/tiktok_pixel";
 
 import {
   AnalyticsConfig,
-  BeginCheckoutEvent,
   BuyerCurrencyDisplayViewedEvent,
   GumroadEvents,
   ProductAnalyticsEvent,
@@ -10,11 +9,12 @@ import {
 
 export type TikTokPixelConfig = { tiktokPixelId: string | null };
 
-type TikTokProductAnalyticsEvent = Exclude<ProductAnalyticsEvent, BeginCheckoutEvent | BuyerCurrencyDisplayViewedEvent>;
+type TikTokProductAnalyticsEvent = Exclude<ProductAnalyticsEvent, BuyerCurrencyDisplayViewedEvent>;
 
-const TikTokEvents: Record<Exclude<GumroadEvents, "begin_checkout" | "buyer_currency_display_viewed">, string> = {
+const TikTokEvents: Record<Exclude<GumroadEvents, "buyer_currency_display_viewed">, string> = {
   viewed: "ViewContent",
   iwantthis: "AddToCart",
+  begin_checkout: "InitiateCheckout",
   purchased: "CompletePayment",
 };
 
@@ -36,6 +36,19 @@ export function trackProductEvent(config: AnalyticsConfig, data: TikTokProductAn
         currency: data.currency,
       });
     }
+  } else if (data.action === "begin_checkout") {
+    if (!config.trackFreeSales && data.price === 0) return;
+    ttq.instance(config.tiktokPixelId).track(TikTokEvents[data.action], {
+      contents: data.products.map((product) => ({
+        content_id: product.permalink,
+        content_type: "product",
+        quantity: product.quantity,
+        price: product.price,
+      })),
+      value: data.price,
+      currency: "USD",
+      content_type: "product",
+    });
   } else {
     ttq.instance(config.tiktokPixelId).track(TikTokEvents[data.action], {
       content_id: data.permalink,

--- a/app/javascript/utils/user_analytics.test.ts
+++ b/app/javascript/utils/user_analytics.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$vendor/tiktok_pixel", () => ({ default: vi.fn() }));
+vi.mock("$vendor/facebook_pixel", () => ({ default: vi.fn() }));
+vi.mock("$vendor/google_analytics_4", () => ({ default: vi.fn() }));
+
+const facebookTrack = vi.fn();
+const tiktokTrack = vi.fn();
+const googleTrack = vi.fn();
+
+vi.mock("$app/data/facebook_pixel", () => ({
+  trackProductEvent: (...args: unknown[]) => {
+    facebookTrack(...args);
+  },
+  startTrackingForSeller: vi.fn(),
+  trackProfilePageView: vi.fn(),
+}));
+vi.mock("$app/data/tiktok_pixel", () => ({
+  trackProductEvent: (...args: unknown[]) => {
+    tiktokTrack(...args);
+  },
+  startTrackingForSeller: vi.fn(),
+}));
+vi.mock("$app/data/google_analytics", () => ({
+  trackProductEvent: (...args: unknown[]) => {
+    googleTrack(...args);
+  },
+  startTrackingForSeller: vi.fn(),
+  trackProfilePageView: vi.fn(),
+}));
+
+import { startTrackingForSeller, trackProductEvent } from "$app/utils/user_analytics";
+
+const analytics = {
+  google_analytics_id: "G-TEST",
+  facebook_pixel_id: "1234567890",
+  tiktok_pixel_id: "CTESTPIXELID1234567",
+  free_sales: false,
+};
+
+const beginCheckout = {
+  action: "begin_checkout" as const,
+  seller_id: "seller-1",
+  price: 9,
+  products: [{ permalink: "demo", name: "Demo", quantity: 1, price: 9 }],
+};
+
+describe("trackProductEvent begin_checkout routing", () => {
+  beforeEach(() => {
+    facebookTrack.mockReset();
+    tiktokTrack.mockReset();
+    googleTrack.mockReset();
+    startTrackingForSeller("seller-1", analytics);
+  });
+
+  it("forwards begin_checkout to TikTok and Google, not Facebook", () => {
+    trackProductEvent("seller-1", beginCheckout);
+
+    expect(googleTrack).toHaveBeenCalledWith(expect.anything(), beginCheckout);
+    expect(tiktokTrack).toHaveBeenCalledWith(expect.anything(), beginCheckout);
+    expect(facebookTrack).not.toHaveBeenCalled();
+  });
+
+  it("still forwards iwantthis to Facebook and TikTok", () => {
+    const event = { action: "iwantthis" as const, permalink: "demo", product_name: "Demo" };
+    trackProductEvent("seller-1", event);
+
+    expect(facebookTrack).toHaveBeenCalledWith(expect.anything(), event);
+    expect(tiktokTrack).toHaveBeenCalledWith(expect.anything(), event);
+  });
+});

--- a/app/javascript/utils/user_analytics.ts
+++ b/app/javascript/utils/user_analytics.ts
@@ -102,7 +102,7 @@ export function trackProductEvent(id: string | undefined, data: ProductAnalytics
 
   GoogleAnalytics.trackProductEvent(config, data);
   if (data.action !== "begin_checkout") FacebookPixel.trackProductEvent(config, data);
-  if (data.action !== "begin_checkout") TikTokPixel.trackProductEvent(config, data);
+  TikTokPixel.trackProductEvent(config, data);
 }
 
 export type SellerPurchaseEvent = {


### PR DESCRIPTION
# Send TikTok InitiateCheckout when the buyer reaches checkout

> Tests CI green on `21c00587e` (ci/green + Buildkite 21604). Test Relevant 0–3 had timed out at 25m on `2cc44deff` with 0 assertion failures; `run-all-specs` retriggered this head.

Premerge review: clean @ 21c00587ed54b9722cb1b82f78505e741efa8051

## What

When a buyer lands on Gumroad checkout, the existing `begin_checkout` analytics event is now forwarded to the seller's TikTok pixel as `InitiateCheckout` (with cart contents, USD value). Facebook is unchanged: it already fires `InitiateCheckout` on `iwantthis`.

## Why

Sellers using TikTok ads only received `PageView` / `AddToCart` / `CompletePayment`. Direct checkout links (`?wanted=true`) skip the product page, so `AddToCart` never fires either. Google Analytics already gets `begin_checkout`; TikTok did not.

Ref: antiwork/gumroad-private#2237

## Before / after

- Before: `user_analytics.ts` skipped TikTok (and Facebook) on `begin_checkout`. TikTok mapped `viewed` → `ViewContent`, `iwantthis` → `AddToCart`, `purchased` → `CompletePayment`. Multi-quantity carts also multiplied an already quantity-adjusted line price by quantity again.
- After: TikTok maps `begin_checkout` → `InitiateCheckout`. Facebook still skips `begin_checkout`. Product rows carry per-unit USD; event value is sum(price * quantity). Free checkouts follow the same `trackFreeSales` gate as `CompletePayment`.

No rendered UI change. The pixel call is not visible on the checkout page. No qa-media stills — there is nothing to screenshot; the reviewable artifact is the pixel mapping + vitest.

## Checklist

- [x] Scope — TikTok only; Facebook and CSP / Event Builder left alone
- [x] Design — reuse the existing checkout `begin_checkout` event instead of a new client path
- [x] Build — `2cc44deff67c10b02ea1c104f6968dfd2dfd453d`
- [x] QA — vitest 13/13; three mapping mutants killed; Greptile quantity P1 fixed; autoreview clean at this head; no visual surface
- [ ] Shipped
- [ ] Market — n/a (seller pixel event, no launch)
- [ ] Sell — n/a

## Test Results

Captured at `2cc44deff67c10b02ea1c104f6968dfd2dfd453d`:

```
node_modules/.bin/vitest run app/javascript/data/tiktok_pixel.test.ts app/javascript/utils/user_analytics.test.ts app/javascript/components/Checkout/initialCheckout.test.ts
Test Files  3 passed (3)
Tests  13 passed (13)
Duration  6.94s
```

Mutation at the mapping commit (all three red, then sources restored):

- restore the `begin_checkout` TikTok skip → routing spec fails
- map `begin_checkout` to `AddToCart` → InitiateCheckout spec fails
- drop the `begin_checkout` payload branch → InitiateCheckout spec fails

Autoreview `--mode branch --base origin/main --engine codex --max-priority P1` at this SHA: clean, exit 0.

Greptile P1 (inflated multi-quantity value): accepted and fixed in `2cc44deff`. `getDiscountedPrice().price` is a line total; rows now store per-unit USD.

## QA

1. Ran the three vitest files at this SHA: 13 passed.
2. Confirmed no rendered surface: checkout markup is unchanged; the new behavior is `ttq.instance(...).track("InitiateCheckout", ...)`.
3. Code/spec/comment audit: Facebook skip kept on purpose; quantity double-count fixed at the event builder.

---

AI disclosure: grok-4.6. Prompt/instructions: autonomous-product-dev webhook on antiwork/gumroad-private#2237; map begin_checkout to TikTok InitiateCheckout; leave Facebook excluded. Quantity fix landed by a sibling gumclaw session after Greptile.


