### PR TITLE
Make universal offer-code save reindex async instead of inline

### DIFF
--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -610,8 +610,14 @@ class OfferCode < ApplicationRecord
     end
 
     def reindex_associated_products(products_to_reindex: applicable_products + excluded_products)
-      products_to_reindex.each do |product|
-        product.enqueue_index_update_for(["offer_codes"])
+      # A universal code's applicable set is every alive product, so running the
+      # per-product index updates inline after_commit blows the request timeout
+      # for large catalogs. Enqueue them as background jobs after the row commits.
+      product_ids = products_to_reindex.map(&:id)
+      AfterCommitEverywhere.after_commit do
+        SendToElasticsearchWorker.perform_bulk(
+          product_ids.map { |product_id| [product_id, "update", ["offer_codes"]] }
+        )
       end
     end
 

--- a/spec/models/offer_code_spec.rb
+++ b/spec/models/offer_code_spec.rb
@@ -1394,20 +1394,21 @@ describe OfferCode do
       it "reindexes products when they are excluded from a universal offer code" do
         universal_offer_code = create(:universal_offer_code, user: creator)
 
-        expect(product1).to receive(:enqueue_index_update_for).with(["offer_codes"])
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product2.id, "update", ["offer_codes"])
         universal_offer_code.update!(excluded_products: [product1])
       end
 
       it "reindexes associated products when offer code is updated" do
-        expect(product1).to receive(:enqueue_index_update_for).with(["offer_codes"])
-        expect(product2).to receive(:enqueue_index_update_for).with(["offer_codes"])
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product2.id, "update", ["offer_codes"])
 
         offer_code.update(amount_cents: 500)
       end
 
       it "reindexes associated products when offer code code is changed" do
-        expect(product1).to receive(:enqueue_index_update_for).with(["offer_codes"])
-        expect(product2).to receive(:enqueue_index_update_for).with(["offer_codes"])
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product2.id, "update", ["offer_codes"])
 
         offer_code.update(code: "NEWYEAR2025")
       end
@@ -1421,8 +1422,8 @@ describe OfferCode do
       end
 
       it "reindexes associated products when offer code is destroyed" do
-        expect(product1).to receive(:enqueue_index_update_for).with(["offer_codes"])
-        expect(product2).to receive(:enqueue_index_update_for).with(["offer_codes"])
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product2.id, "update", ["offer_codes"])
 
         offer_code.destroy
       end
@@ -1436,8 +1437,8 @@ describe OfferCode do
       end
 
       it "only reindexes products that exist" do
-        expect(product1).to receive(:enqueue_index_update_for).with(["offer_codes"])
-        expect(product2).to receive(:enqueue_index_update_for).with(["offer_codes"])
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product2.id, "update", ["offer_codes"])
 
         offer_code.send(:reindex_associated_products)
       end


### PR DESCRIPTION
# Make universal offer-code save reindex async

## What

Saving a **universal** offer code on Checkout → Discounts 500s at the 120s Rack::Timeout ceiling (Sentry GUMROAD-YW, 18 events / 10 users, still firing 2026-08-21). `reindex_associated_products` previously ran a synchronous `ProductIndexingService.perform` per product inside `after_commit`; for a universal code the applicable set is every alive product, so a large catalog blew the request timeout. This PR enqueues the per-product `offer_codes` index updates as `SendToElasticsearchWorker` background jobs after the row commits instead.

## Why

Sellers with large catalogs cannot save a site-wide discount and get a hard 500 — and because the discount row often persists while the UI reports failure, retries amplify the full re-scan.

## Before / after

- Before: Save → after_commit → N synchronous ES updates in the request → 120s timeout for large catalogs; index often not written while the row persists.
- After: Save → row commits → `SendToElasticsearchWorker.perform_bulk([...])` enqueued → request returns promptly; background jobs update each product's `offer_codes` field to the same end state.

## Checklist

- [x] Scope — offer-code reindex path only (`reindex_associated_products` / `reindex_captured_products`); the general single-product `enqueue_index_update_for` path is untouched.
- [x] Design — reuse the existing `SendToElasticsearchWorker` + `AfterCommitEverywhere.after_commit` pattern (already used elsewhere in the app); rejects rescuing the timeout (would leave the index stale without a retry).
- [x] Build — branch `gumclaw/offer-code-async-reindex`, HEAD `601ec8a5c`.
- [x] QA — full `offer_code_spec.rb` 190 examples green + 5-assertion mutation proof (see Tests/QA).
- [ ] Shipped — CI green + Codex premerge clean at 601ec8a5c; checkout-adjacent so no auto-merge. Awaiting human review.
- [ ] Market — n/a (internal availability bug fix).
- [ ] Sell — n/a (no customer-facing change).

## Tests

```text
$ DISABLE_SPRING=1 bundle exec rspec spec/models/offer_code_spec.rb   (HEAD 601ec8a5c)
190 examples, 0 failures

$ DISABLE_SPRING=1 bundle exec rspec spec/models/offer_code_spec.rb:1387   (reindexing block)
6 examples, 0 failures

mutation proof: reverting reindex_associated_products to the old synchronous
enqueue_index_update_for loop -> all 5 enqueue assertions red
(expected to have enqueued a SendToElasticsearchWorker job)
```

## QA

Backend-only; no rendered surface, so no screenshot gate applies (no UI change). Mechanically exercised via the rewritten model specs: create/update/delete universal and non-universal offer codes, asserting a `SendToElasticsearchWorker` job is enqueued per affected product id after commit; mutation check confirmed the assertions fail against the pre-fix synchronous behavior. Post-deploy watch: GUMROAD-YW `lastSeen` should stop advancing once deployed.

---

AI disclosure: grok-4.6 (per `model.default`). Built with the autonomous product-dev skill workflow.


Premerge review: clean @ 601ec8a5c64d2b65f84391f53a0bf0f7ef644657
