### PR TITLE
Synthesize a USD flow of funds for non-presentment, Gumroad-held purchases with nil flow_of_funds

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -4606,7 +4606,8 @@ class Purchase < ApplicationRecord
       # the existing nil path rather than being relabelled as dollars. If another processor
       # ever gains buyer-currency support, this line has to build the flow of funds from that
       # processor's own amounts instead of assuming dollars.
-      processor_charge.flow_of_funds ||= FlowOfFunds.build_simple_flow_of_funds(Currency::USD, self.total_transaction_cents) unless buyer_presentment?
+      flow_amount_cents = is_part_of_combined_charge? ? charge.amount_cents : self.total_transaction_cents
+      processor_charge.flow_of_funds ||= FlowOfFunds.build_simple_flow_of_funds(Currency::USD, flow_amount_cents) unless buyer_presentment?
       self.flow_of_funds = if is_part_of_combined_charge?
         build_flow_of_funds_from_combined_charge(processor_charge.flow_of_funds)
       else

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -4598,11 +4598,15 @@ class Purchase < ApplicationRecord
     def load_flow_of_funds(processor_charge)
       # Synthesising a US dollar flow of funds from the canonical total would be wrong for a
       # buyer-currency (presentment) charge, where the money actually moved in the buyer's
-      # currency. It is safe here because the guard restricts it to non-Stripe processors, and
-      # only Stripe charges can be presentment charges today. If another processor ever gains
-      # buyer-currency support, this line has to build the flow of funds from that processor's
-      # own amounts instead of assuming dollars.
-      processor_charge.flow_of_funds ||= FlowOfFunds.build_simple_flow_of_funds(Currency::USD, self.total_transaction_cents) if StripeChargeProcessor.charge_processor_id != charge_processor_id
+      # currency. Only Stripe charges can be presentment charges today, so the fallback was
+      # historically gated to non-Stripe processors; but a Stripe charge whose balance
+      # transaction isn't attached to its charge wrapper (see StripeCharge#build_flow_of_funds)
+      # can also arrive here with a nil flow of funds, and when it is not a presentment charge
+      # the money moved in USD, so the same simple fallback is safe. A presentment charge keeps
+      # the existing nil path rather than being relabelled as dollars. If another processor
+      # ever gains buyer-currency support, this line has to build the flow of funds from that
+      # processor's own amounts instead of assuming dollars.
+      processor_charge.flow_of_funds ||= FlowOfFunds.build_simple_flow_of_funds(Currency::USD, self.total_transaction_cents) unless buyer_presentment?
       self.flow_of_funds = if is_part_of_combined_charge?
         build_flow_of_funds_from_combined_charge(processor_charge.flow_of_funds)
       else

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -4141,6 +4141,11 @@ class Purchase < ApplicationRecord
   end
 
   def build_flow_of_funds_from_combined_charge(combined_flow_of_funds)
+    # Nothing to split until the processor has produced settlement data. Returning nil keeps a
+    # missing flow readable as "not settled yet" (Purchase::SyncStatusWithChargeProcessorService
+    # and #pending_buyer_presentment_settlement? both read it that way) instead of raising mid-split.
+    return if combined_flow_of_funds.nil?
+
     charge_purchases = charge.purchases.to_a.sort_by(&:id)
     purchase_index = charge_purchases.index { |purchase| purchase.id == id }
     raise ArgumentError, "Purchase #{id} is not part of charge #{charge&.id}" if purchase_index.nil?
@@ -4596,23 +4601,30 @@ class Purchase < ApplicationRecord
     end
 
     def load_flow_of_funds(processor_charge)
-      # Synthesising a US dollar flow of funds from the canonical total would be wrong for a
-      # buyer-currency (presentment) charge, where the money actually moved in the buyer's
-      # currency. Only Stripe charges can be presentment charges today, so the fallback was
-      # historically gated to non-Stripe processors; but a Stripe charge whose balance
-      # transaction isn't attached to its charge wrapper (see StripeCharge#build_flow_of_funds)
-      # can also arrive here with a nil flow of funds, and when it is not a presentment charge
-      # the money moved in USD, so the same simple fallback is safe. A presentment charge keeps
-      # the existing nil path rather than being relabelled as dollars. If another processor
-      # ever gains buyer-currency support, this line has to build the flow of funds from that
-      # processor's own amounts instead of assuming dollars.
-      flow_amount_cents = is_part_of_combined_charge? ? charge.amount_cents : self.total_transaction_cents
-      processor_charge.flow_of_funds ||= FlowOfFunds.build_simple_flow_of_funds(Currency::USD, flow_amount_cents) unless buyer_presentment?
+      # Nil means two different things: on Gumroad-held money the canonical USD total is all
+      # there is to record, but on seller-held money Stripe settlement data simply has not
+      # arrived yet (StripeCharge#build_flow_of_funds), and dollars there become the holding
+      # amount of an account denominated in its own currency — a balance no payout picks up
+      # (gumroad-private#1471). Presentment stays nil for the same reason.
+      if funds_held_by_gumroad? && !buyer_presentment?
+        # Sized to the whole charge, because the combined-charge split below divides by it.
+        flow_amount_cents = is_part_of_combined_charge? ? charge.amount_cents : total_transaction_cents
+        processor_charge.flow_of_funds ||= FlowOfFunds.build_simple_flow_of_funds(Currency::USD, flow_amount_cents)
+      end
+
       self.flow_of_funds = if is_part_of_combined_charge?
         build_flow_of_funds_from_combined_charge(processor_charge.flow_of_funds)
       else
         processor_charge.flow_of_funds
       end
+    end
+
+    # Only Stripe routes charges into seller-owned accounts (destination and direct), so every
+    # other processor is Gumroad-held. Not charged_using_gumroad_merchant_account?, which is also
+    # true of a seller's own custom account, nor MerchantAccount#holder_of_funds, which answers
+    # the same question by dispatching through the charge-processor registry.
+    def funds_held_by_gumroad?
+      !(stripe_charge_processor? && merchant_account&.user_id.present?)
     end
 
     def additional_fields_for_creator_app_api

--- a/spec/models/purchase_flow_of_funds_spec.rb
+++ b/spec/models/purchase_flow_of_funds_spec.rb
@@ -5,12 +5,12 @@ require "spec_helper"
 describe Purchase do
   describe "#load_flow_of_funds" do
     # load_flow_of_funds is private; exercised directly to cover nil processor flows.
-    let(:purchase) { create(:purchase) } # defaults to Stripe charge processor
+    # Stripe, on Gumroad's own merchant account (no user => funds held by Gumroad).
+    let(:purchase) { create(:purchase, merchant_account: create(:merchant_account, user: nil)) }
+    let(:processor_charge) { OpenStruct.new(flow_of_funds: nil) }
 
-    context "when the processor charge has no flow of funds and the purchase is not buyer-presentment" do
+    context "when the processor charge has no flow of funds and the funds are Gumroad-held" do
       it "synthesises a simple USD flow of funds from the canonical total" do
-        processor_charge = OpenStruct.new(flow_of_funds: nil)
-
         purchase.send(:load_flow_of_funds, processor_charge)
 
         expect(purchase.flow_of_funds).to be_present
@@ -30,7 +30,6 @@ describe Purchase do
         charge.purchases << [purchase, sibling]
         purchase.update!(is_part_of_combined_charge: true)
         sibling.update!(is_part_of_combined_charge: true)
-        processor_charge = OpenStruct.new(flow_of_funds: nil)
 
         purchase.send(:load_flow_of_funds, processor_charge)
 
@@ -39,10 +38,51 @@ describe Purchase do
       end
     end
 
+    context "when the processor charge has no flow of funds but the funds are seller-held" do
+      # A destination charge into the seller's own Stripe account: nil means Stripe has not
+      # produced the settlement data yet, and dollars here would become the holding amount of an
+      # account denominated in its own currency — a balance no payout picks up.
+      let(:merchant_account) { create(:merchant_account, currency: Currency::EUR) }
+
+      before { purchase.update!(merchant_account:) }
+
+      it "keeps the nil flow of funds instead of booking the seller's money as dollars" do
+        expect(merchant_account.holder_of_funds).to eq(HolderOfFunds::STRIPE)
+
+        purchase.send(:load_flow_of_funds, processor_charge)
+
+        expect(processor_charge.flow_of_funds).to be_nil
+        expect(purchase.flow_of_funds).to be_nil
+      end
+
+      it "keeps the nil flow of funds for a combined charge too" do
+        charge = create(:charge, seller: purchase.seller, merchant_account:,
+                                 amount_cents: purchase.total_transaction_cents)
+        charge.purchases << purchase
+        purchase.update!(is_part_of_combined_charge: true)
+
+        purchase.send(:load_flow_of_funds, processor_charge)
+
+        expect(processor_charge.flow_of_funds).to be_nil
+        expect(purchase.flow_of_funds).to be_nil
+      end
+    end
+
+    context "when the processor charge has no flow of funds and the processor is not Stripe" do
+      it "synthesises the USD flow the non-Stripe processors have always relied on" do
+        purchase.charge_processor_id = PaypalChargeProcessor.charge_processor_id
+        purchase.merchant_account = create(:merchant_account_paypal)
+
+        purchase.send(:load_flow_of_funds, processor_charge)
+
+        expect(purchase.flow_of_funds.issued_amount.currency).to eq(Currency::USD)
+        expect(purchase.flow_of_funds.issued_amount.cents).to eq(purchase.total_transaction_cents)
+      end
+    end
+
     context "when the processor charge has no flow of funds but the purchase IS buyer-presentment" do
       it "keeps the nil flow of funds instead of relabelling the buyer-currency charge as dollars" do
         create(:purchase_presentment, purchase:, charge_presentment: nil)
-        processor_charge = OpenStruct.new(flow_of_funds: nil)
 
         purchase.send(:load_flow_of_funds, processor_charge)
 
@@ -53,7 +93,7 @@ describe Purchase do
     context "when the processor charge already has a flow of funds" do
       it "uses the provided flow of funds and does not overwrite it" do
         provided = FlowOfFunds.build_simple_flow_of_funds(Currency::CAD, 7_00)
-        processor_charge = OpenStruct.new(flow_of_funds: provided)
+        processor_charge.flow_of_funds = provided
 
         purchase.send(:load_flow_of_funds, processor_charge)
 

--- a/spec/models/purchase_flow_of_funds_spec.rb
+++ b/spec/models/purchase_flow_of_funds_spec.rb
@@ -4,11 +4,7 @@ require "spec_helper"
 
 describe Purchase do
   describe "#load_flow_of_funds" do
-    # load_flow_of_funds is private; exercised directly. GUMROAD-1D9: a Stripe charge whose
-    # balance transaction isn't attached to its charge wrapper arrives with a nil flow of
-    # funds, and the historical fallback only covered non-Stripe processors, so the purchase
-    # raised NoMethodError during MarkSuccessfulService and the captured charge was left
-    # stranded. The fallback now also applies to non-presentment Stripe purchases.
+    # load_flow_of_funds is private; exercised directly to cover nil processor flows.
     let(:purchase) { create(:purchase) } # defaults to Stripe charge processor
 
     context "when the processor charge has no flow of funds and the purchase is not buyer-presentment" do
@@ -22,6 +18,24 @@ describe Purchase do
         expect(purchase.flow_of_funds.issued_amount.cents).to eq(purchase.total_transaction_cents)
         expect(purchase.flow_of_funds.settled_amount.cents).to eq(purchase.total_transaction_cents)
         expect(purchase.flow_of_funds.gumroad_amount.cents).to eq(purchase.total_transaction_cents)
+      end
+    end
+
+    context "when a combined-charge processor charge has no flow of funds" do
+      it "synthesises the shared charge flow from the whole charge before splitting the purchase share" do
+        sibling_product = create(:product, user: purchase.seller, price_cents: 20_00)
+        sibling = create(:purchase, link: sibling_product, seller: purchase.seller)
+        charge = create(:charge, seller: purchase.seller, merchant_account: purchase.merchant_account,
+                                 amount_cents: purchase.total_transaction_cents + sibling.total_transaction_cents)
+        charge.purchases << [purchase, sibling]
+        purchase.update!(is_part_of_combined_charge: true)
+        sibling.update!(is_part_of_combined_charge: true)
+        processor_charge = OpenStruct.new(flow_of_funds: nil)
+
+        purchase.send(:load_flow_of_funds, processor_charge)
+
+        expect(processor_charge.flow_of_funds.issued_amount.cents).to eq(charge.amount_cents)
+        expect(purchase.flow_of_funds.issued_amount.cents).to eq(purchase.total_transaction_cents)
       end
     end
 

--- a/spec/models/purchase_flow_of_funds_spec.rb
+++ b/spec/models/purchase_flow_of_funds_spec.rb
@@ -27,7 +27,7 @@ describe Purchase do
 
     context "when the processor charge has no flow of funds but the purchase IS buyer-presentment" do
       it "keeps the nil flow of funds instead of relabelling the buyer-currency charge as dollars" do
-        create(:purchase_presentment, purchase:)
+        create(:purchase_presentment, purchase:, charge_presentment: nil)
         processor_charge = OpenStruct.new(flow_of_funds: nil)
 
         purchase.send(:load_flow_of_funds, processor_charge)

--- a/spec/models/purchase_flow_of_funds_spec.rb
+++ b/spec/models/purchase_flow_of_funds_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Purchase do
+  describe "#load_flow_of_funds" do
+    # load_flow_of_funds is private; exercised directly. GUMROAD-1D9: a Stripe charge whose
+    # balance transaction isn't attached to its charge wrapper arrives with a nil flow of
+    # funds, and the historical fallback only covered non-Stripe processors, so the purchase
+    # raised NoMethodError during MarkSuccessfulService and the captured charge was left
+    # stranded. The fallback now also applies to non-presentment Stripe purchases.
+    let(:purchase) { create(:purchase) } # defaults to Stripe charge processor
+
+    context "when the processor charge has no flow of funds and the purchase is not buyer-presentment" do
+      it "synthesises a simple USD flow of funds from the canonical total" do
+        processor_charge = OpenStruct.new(flow_of_funds: nil)
+
+        purchase.send(:load_flow_of_funds, processor_charge)
+
+        expect(purchase.flow_of_funds).to be_present
+        expect(purchase.flow_of_funds.issued_amount.currency).to eq(Currency::USD)
+        expect(purchase.flow_of_funds.issued_amount.cents).to eq(purchase.total_transaction_cents)
+        expect(purchase.flow_of_funds.settled_amount.cents).to eq(purchase.total_transaction_cents)
+        expect(purchase.flow_of_funds.gumroad_amount.cents).to eq(purchase.total_transaction_cents)
+      end
+    end
+
+    context "when the processor charge has no flow of funds but the purchase IS buyer-presentment" do
+      it "keeps the nil flow of funds instead of relabelling the buyer-currency charge as dollars" do
+        create(:purchase_presentment, purchase:)
+        processor_charge = OpenStruct.new(flow_of_funds: nil)
+
+        purchase.send(:load_flow_of_funds, processor_charge)
+
+        expect(purchase.flow_of_funds).to be_nil
+      end
+    end
+
+    context "when the processor charge already has a flow of funds" do
+      it "uses the provided flow of funds and does not overwrite it" do
+        provided = FlowOfFunds.build_simple_flow_of_funds(Currency::CAD, 7_00)
+        processor_charge = OpenStruct.new(flow_of_funds: provided)
+
+        purchase.send(:load_flow_of_funds, processor_charge)
+
+        expect(purchase.flow_of_funds).to eq(provided)
+        expect(purchase.flow_of_funds.issued_amount.currency).to eq(Currency::CAD)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Synthesize a USD flow of funds for non-presentment, Gumroad-held purchases with nil `flow_of_funds`

## What

`Purchase#load_flow_of_funds` synthesized a simple USD flow of funds from the canonical total only for non-Stripe processors (the guard `StripeChargeProcessor.charge_processor_id != charge_processor_id`). A Stripe charge can also arrive here with a nil `flow_of_funds` — `StripeCharge#build_flow_of_funds` leaves it nil when the charge's balance transaction isn't attached to the charge wrapper, and returns nil outright for a destination charge whose destination-payment balance transaction doesn't exist yet. Those purchases then died on the nil: `MarkSuccessfulService#perform` → `increment_sellers_balance!` → `flow_of_funds.issued_amount` raised `NoMethodError`, or, on a combined charge, `build_flow_of_funds_from_combined_charge` raised on the same nil one frame earlier. The charge stayed captured, the purchase was marked `failed`, and the seller was never credited (GUMROAD-1D9).

This PR:

- **Widens the fallback from "non-Stripe processors" to "Gumroad-held funds"** — money that settles into Gumroad's own account, where USD is the only denomination. That covers everything the old guard covered (non-Stripe processors are always Gumroad-held) plus Stripe charges on Gumroad's own account, which is where the crash was reachable.
- **Sizes a combined charge's synthesized flow from the whole charge** (`charge.amount_cents`) so the per-purchase share split in `build_flow_of_funds_from_combined_charge` is correct. This matches what `Purchase::SyncStatusWithChargeProcessorService` already does on its own nil-flow path.
- **Returns nil from `build_flow_of_funds_from_combined_charge` when there is nothing to split**, so a missing flow of funds behaves the same on a combined charge as on a standalone one — blank, readable by callers as "not settled yet" — instead of raising mid-split.
- **Leaves buyer-presentment and seller-held charges on the existing nil path.**

## Why

Real money-path incident: a buyer was charged, Stripe captured, the purchase was then marked `failed` rather than `successful`, the seller was never credited, and no refund was issued because the failure transition correctly assumes "failed == declined == no money moved." The root cause is a nil `flow_of_funds` on a non-presentment Stripe charge.

The fallback is deliberately scoped to Gumroad-held funds, because a nil `flow_of_funds` means two different things:

- **Gumroad-held money**: nothing else was recorded and the canonical USD total is the whole truth, so synthesizing it is exact.
- **Seller-held money** (a destination or direct charge into the seller's own Stripe account): nil means Stripe has not produced the settlement data *yet*. This is a bounded wait — `StripeCharge::DESTINATION_PAYMENT_SETTLEMENT_GRACE` exists precisely for it. Synthesizing dollars there leaves `merchant_account_gross_amount` nil, so `BalanceTransaction::Amount.create_holding_amount_for_seller` falls through to its USD branch and writes a balance whose `holding_currency` is USD on an account denominated in its own currency. `StripePayoutProcessor.is_balance_payable` drops exactly that row, so the seller is silently short-paid instead of loudly failed — see the comment on `Balance#holding_currency` and gumroad-private#1471. A `NoMethodError` is a bad outcome; an unpayable balance nobody is alerted about is a worse one.
- **Buyer-presentment charges** stay nil for the same reason the original guard excluded them: the money moved in the buyer's currency and must not be relabelled as dollars.

The predicate is `stripe_charge_processor? && merchant_account&.user_id.present?` rather than `MerchantAccount#holder_of_funds`, which answers the same question by dispatching through the charge-processor registry from inside the charge path (and is stubbed as a strict `instance_double` by the existing charge-service specs). It is deliberately *not* `charged_using_gumroad_merchant_account?`, which is also true of a seller's own custom account.

## Before / after

| Condition | Before | After |
|---|---|---|
| Non-presentment purchase, Gumroad-held funds, `processor_charge.flow_of_funds` nil | `NoMethodError: undefined method 'issued_amount' for nil` → purchase marked failed, seller unpaid, capture stranded | `flow_of_funds` = simple USD flow for `total_transaction_cents` → seller credited |
| Combined charge, Gumroad-held funds, nil flow | same `NoMethodError`, raised inside `build_flow_of_funds_from_combined_charge` | simple USD flow for `charge.amount_cents`, then split to this purchase's share |
| Non-Stripe processor (PayPal, Braintree), nil flow | simple USD flow for `total_transaction_cents` | unchanged — always Gumroad-held (combined charges now sized from the whole charge) |
| Seller-held Stripe charge (destination or direct), nil flow | `NoMethodError` | `flow_of_funds` stays nil — no USD relabelling of an account's own currency. Still fails downstream; see follow-up |
| Buyer-presentment purchase, nil flow | `flow_of_funds` stays nil | unchanged — stays nil |
| Any purchase with `flow_of_funds` already present | uses provided flow | unchanged |

## Test Results

```
$ bundle exec rspec spec/models/purchase_flow_of_funds_spec.rb
7 examples, 0 failures
```

Mutation proofs, each guard reverted on its own:

- Widen the guard back to `unless buyer_presentment?` → the two seller-held examples fail (a USD flow gets written for seller-held money); the rest stay green.
- Drop `return if combined_flow_of_funds.nil?` from the combined splitter → the seller-held combined-charge example fails (`NoMethodError` mid-split instead of a blank flow).

Adjacent suites run against a pre-change baseline on the same checkout, with identical failure sets before and after (the residual failures are a local seed gap — `MerchantAccount.gumroad` is absent locally — not regressions):

- `spec/services/order/charge_service_spec.rb`
- `spec/models/charge_spec.rb`
- `spec/services/purchase/sync_status_with_charge_processor_service_spec.rb`
- `spec/services/purchase/mark_successful_service_spec.rb`
- `spec/services/purchase/finalize_confirmed_charge_service_spec.rb`
- `spec/services/purchase/unstick_stuck_in_progress_service_spec.rb`
- `spec/services/purchase/presentment_refund_spec.rb`

`bundle exec rubocop` clean on both changed files. No schema change.

`autoreview` (codex/gpt-5.6-sol) at `0e41ec7f`: clean, no P0 defects — that run predates the narrowing commit. (The claude/fable-5 panel leg could not run — that engine was at its API usage limit.)

There is no rendered surface here — this is a backend money-path change — so the evidence is the specs and mutation proofs above rather than before/after media. No walkthrough video was recorded.

## Follow-up (deliberately not in this PR)

Seller-held Stripe charges with missing settlement data still fail. The correct fix is to defer them the way buyer-presentment already does — pass `allow_missing_flow_of_funds` from `Purchase#charge!` and `Order::ChargeService`, and drop the presentment-only gates in `FinalizeBuyerPresentmentPurchaseJob` and `FinalizeBuyerPresentmentChargeJob` — so the purchase stays `in_progress` and `SyncStatusWithChargeProcessorService` books real amounts once Stripe settles. That changes what checkout returns for a not-yet-successful purchase, so it needs its own PR, review and QA.

The irreversible half of the underlying incident (refunding the buyer, post-fix reconciliation) is likewise not in this PR and is tracked on gumroad-private#2241; it has since been executed by hand.

## QA steps

1. Read the diff in `app/models/purchase.rb` (`load_flow_of_funds`, `funds_held_by_gumroad?`, `build_flow_of_funds_from_combined_charge`) and `spec/models/purchase_flow_of_funds_spec.rb`.
2. Run `bundle exec rspec spec/models/purchase_flow_of_funds_spec.rb` (7 examples).
3. In a console: a non-presentment Stripe `Purchase` on a Gumroad-held merchant account with `processor_charge.flow_of_funds == nil` gets a USD simple flow for `total_transaction_cents` after `load_flow_of_funds` (or `charge.amount_cents`, split, for a combined charge). The same purchase on a merchant account belonging to a seller keeps a nil flow, as does a presentment purchase.

---

**This is an autonomous-agent PR with a human review commit on top.** Models: `grok-4.6` for the original implementation (instruction set: autonomous-product-dev / pr-evidence-media skills), Claude Opus 5 for the narrowing commit (`ae49ff2`) and its specs.
