### PR TITLE
Add a setting to hide the Follow widget on a creator's public profile

### DIFF
--- a/app/javascript/components/Profile/index.tsx
+++ b/app/javascript/components/Profile/index.tsx
@@ -147,7 +147,7 @@ const PublicProfile = (props: Props) => {
 };
 
 export const Profile = (props: Props) => (
-  <Layout creatorProfile={props.creator_profile} hideFollowForm={!props.sections.length} currencySelector>
+  <Layout creatorProfile={props.creator_profile} hideFollowForm={!!props.creator_profile.hide_follow_widget || !props.sections.length} currencySelector>
     <PublicProfile {...props} />
   </Layout>
 );

--- a/app/javascript/data/profile_settings.ts
+++ b/app/javascript/data/profile_settings.ts
@@ -66,12 +66,12 @@ export const updateProfileSettings = async (
     profileVersion?: string | null;
   },
 ) => {
-  const { profile_picture_blob_id, tabs, sections, profileVersion, font, background_color, highlight_color, ...user } =
+  const { profile_picture_blob_id, tabs, sections, profileVersion, font, background_color, highlight_color, hide_follow_widget, ...user } =
     profileSettings;
-  // font/background_color/highlight_color live on seller_profile, not user, and must be pulled out
-  // of the rest-spread above — anything left in `user` is sent as a User attribute and the profile
-  // policy would reject these three there.
-  const sellerProfile = { font, background_color, highlight_color };
+  // font/background_color/highlight_color/hide_follow_widget live on seller_profile, not user,
+  // and must be pulled out of the rest-spread above — anything left in `user` is sent as a User
+  // attribute and the profile policy would reject them there.
+  const sellerProfile = { font, background_color, highlight_color, hide_follow_widget };
   const hasSellerProfileChanges = Object.values(sellerProfile).some((value) => value !== undefined);
   const response = await request({
     method: "PUT",

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -359,7 +359,7 @@ export default function SettingsPage() {
             <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
             <link rel="stylesheet" href={seller_fonts_css_source} />
             <div inert>
-              <ProfileLayout creatorProfile={previewCreatorProfile} hideFollowForm={!previewSectionCount}>
+              <ProfileLayout creatorProfile={previewCreatorProfile} hideFollowForm={!previewSectionCount || profileSettings.hide_follow_widget}>
                 <EditProfile
                   {...editableProfile}
                   creator_profile={previewCreatorProfile}
@@ -456,11 +456,22 @@ export default function SettingsPage() {
                   disabled={!canUpdate}
                   label="Show your storefront on product pages"
                 />
-                <FieldsetDescription>
-                  Product pages display your profile header above the product and the rest of your products below it, so
-                  buyers landing on a shared link can browse your whole store.
-                </FieldsetDescription>
-              </Fieldset>
+                <Fieldset>
+                  <ToggleSettingRow
+                    value={profileSettings.hide_follow_widget}
+                    onChange={(value) => updateProfileSettings({ hide_follow_widget: value })}
+                    disabled={!canUpdate}
+                    label="Hide the Follow button on your public profile"
+                  />
+                </Fieldset>
+                <Fieldset>
+                  <ToggleSettingRow
+                    value={profileSettings.product_page_storefront_enabled}
+                    onChange={(value) => updateProfileSettings({ product_page_storefront_enabled: value })}
+                    disabled={!canUpdate}
+                    label="Show your storefront on product pages"
+                  />
+                </Fieldset>
               {loggedInUser?.policies.settings_profile.manage_social_connections ? (
                 <Fieldset>
                   <FieldsetTitle>Social links</FieldsetTitle>

--- a/app/javascript/pages/Settings/Profile/profileSettingsForm.test.ts
+++ b/app/javascript/pages/Settings/Profile/profileSettingsForm.test.ts
@@ -15,6 +15,7 @@ const settings = (overrides: Partial<ProfileSettingsForm> = {}): ProfileSettings
   background_color: "#ffffff",
   highlight_color: "#ff90e8",
   product_page_storefront_enabled: false,
+  hide_follow_widget: false,
   ...overrides,
 });
 
@@ -53,6 +54,15 @@ describe("profile settings synchronization", () => {
     const rebased = rebaseProfileSettings(current, baseline, incoming);
 
     expect(changedProfileSettings(rebased, incoming)).toEqual({ bio: "Local bio edit" });
+  });
+
+  it("tracks hide_follow_widget as a changed setting", () => {
+    const baseline = settings();
+    const current = settings({ hide_follow_widget: true });
+
+    expect(changedProfileSettings(current, baseline)).toEqual({ hide_follow_widget: true });
+    expect(rebaseProfileSettings(current, baseline, settings()).hide_follow_widget).toBe(true);
+    expect(rebaseProfileSettings(settings(), baseline, settings({ hide_follow_widget: true })).hide_follow_widget).toBe(true);
   });
 
   it("matches the live primary-button foreground for saturated backgrounds", () => {

--- a/app/javascript/pages/Settings/Profile/profileSettingsForm.ts
+++ b/app/javascript/pages/Settings/Profile/profileSettingsForm.ts
@@ -8,6 +8,7 @@ export type ProfileSettingsForm = {
   highlight_color: string;
   profile_picture_blob_id: string | null;
   product_page_storefront_enabled: boolean;
+  hide_follow_widget: boolean;
 };
 
 export const profileThemeColors = (backgroundColor: string, highlightColor: string) => {
@@ -40,6 +41,7 @@ export const changedProfileSettings = (
   if (current.product_page_storefront_enabled !== baseline.product_page_storefront_enabled) {
     changes.product_page_storefront_enabled = current.product_page_storefront_enabled;
   }
+  if (current.hide_follow_widget !== baseline.hide_follow_widget) changes.hide_follow_widget = current.hide_follow_widget;
   return changes;
 };
 
@@ -65,4 +67,8 @@ export const rebaseProfileSettings = (
     current.product_page_storefront_enabled === previousBaseline.product_page_storefront_enabled
       ? incoming.product_page_storefront_enabled
       : current.product_page_storefront_enabled,
+  hide_follow_widget:
+    current.hide_follow_widget === previousBaseline.hide_follow_widget
+      ? incoming.hide_follow_widget
+      : current.hide_follow_widget,
 });

--- a/app/javascript/parsers/profile.ts
+++ b/app/javascript/parsers/profile.ts
@@ -6,6 +6,9 @@ export type CreatorProfile = {
   subdomain: string | null;
   is_verified: boolean;
   can_edit: boolean;
+  // Creator chose to hide the header Follow (email signup) widget. Absent for
+  // client-side-built previews (defaults false).
+  hide_follow_widget?: boolean;
   // Set only when this seller's subscribe form must pass a CAPTCHA — sellers we
   // have reviewed and marked compliant get no challenge. Optional because
   // several previews build a CreatorProfile client-side without one; a missing
@@ -27,4 +30,5 @@ export type ProfileSettings = {
   highlight_color: string;
   profile_picture_blob_id: string | null;
   product_page_storefront_enabled: boolean;
+  hide_follow_widget: boolean;
 };

--- a/app/policies/settings/profile_policy.rb
+++ b/app/policies/settings/profile_policy.rb
@@ -31,7 +31,7 @@ class Settings::ProfilePolicy < ApplicationPolicy
       :profile_version,
       {
         user: user_attributes,
-        seller_profile: [:font, :background_color, :highlight_color],
+        seller_profile: [:font, :background_color, :highlight_color, :hide_follow_widget],
         tabs: [:name, { sections: [] }],
         sections: [:id, *ProfileSectionPolicy::CREATE_ATTRIBUTES]
       }

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -19,6 +19,10 @@ class ProfilePresenter
       subdomain: seller.subdomain,
       is_verified: !!seller.verified,
       can_edit: can_edit_profile?,
+      # Public profile: creator can hide the header Follow (email signup) widget entirely.
+      # The frontend also hides it on its own when the profile has zero sections, so this
+      # flag is opt-out only.
+      hide_follow_widget: seller.seller_profile.hide_follow_widget,
       # Non-nil only when this seller's subscribe form has to pass a CAPTCHA
       # (see FollowRecaptcha). The follow form executes the challenge with this
       # key and FollowersController verifies the resulting token against the
@@ -68,6 +72,7 @@ class ProfilePresenter
           highlight_color: HexColorValidator.normalize(seller.seller_profile.highlight_color),
           profile_picture_blob_id: seller.avatar.signed_id,
           product_page_storefront_enabled: seller.product_page_storefront_enabled?,
+          hide_follow_widget: seller.seller_profile.hide_follow_widget,
         },
         editable_profile: shared_profile_props(seller_custom_domain_url: nil, request:),
         # Version stamp for optimistic concurrency: the editor sends it back on save so the server

--- a/db/migrate/20260821135314_add_hide_follow_widget_to_seller_profiles.rb
+++ b/db/migrate/20260821135314_add_hide_follow_widget_to_seller_profiles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHideFollowWidgetToSellerProfiles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :seller_profiles, :hide_follow_widget, :boolean, default: false
+  end
+end

--- a/spec/controllers/settings/profile_controller_spec.rb
+++ b/spec/controllers/settings/profile_controller_spec.rb
@@ -78,6 +78,13 @@ describe Settings::ProfileController, :vcr, type: :controller, inertia: true do
       )
     end
 
+    it "persists hide_follow_widget on the seller's profile" do
+      put :update, params: { seller_profile: { hide_follow_widget: true } }
+
+      expect(response).to have_http_status :see_other
+      expect(seller.reload.seller_profile.hide_follow_widget).to eq(true)
+    end
+
     it "leaves the other design fields alone when only one is sent" do
       seller.seller_profile.update!(background_color: "#ffffff", highlight_color: "#ff90e8", font: "ABC Favorit")
 

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -44,6 +44,7 @@ describe ProfilePresenter do
           subdomain: seller.subdomain,
           is_verified: false,
           can_edit: true,
+          hide_follow_widget: false,
           follow_recaptcha_site_key: FollowRecaptcha.site_key,
         }
       )
@@ -54,6 +55,12 @@ describe ProfilePresenter do
 
       expect(described_class.new(pundit_user:, seller: seller.reload).creator_profile[:follow_recaptcha_site_key]).to be_nil
     end
+
+    it "reflects hide_follow_widget from the seller's profile" do
+      seller.seller_profile.update!(hide_follow_widget: true)
+      expect(described_class.new(pundit_user:, seller: seller.reload).creator_profile[:hide_follow_widget]).to eq(true)
+    end
+
 
     it "includes the follow CAPTCHA key for a seller who has not been reviewed" do
       expect(seller.user_risk_state).to eq("not_reviewed")
@@ -295,6 +302,15 @@ describe ProfilePresenter do
       )
       expect(props[:profile_settings]).not_to have_key(:username)
     end
+
+    it "exposes hide_follow_widget on profile_settings and flips with the seller's choice" do
+      Link.import(force: true, refresh: true)
+      expect(presenter.profile_settings_props(request:)[:profile_settings][:hide_follow_widget]).to eq(false)
+
+      seller.seller_profile.update!(hide_follow_widget: true)
+      expect(described_class.new(pundit_user:, seller: seller.reload).profile_settings_props(request:)[:profile_settings][:hide_follow_widget]).to eq(true)
+    end
+
 
     describe "email_confirmation" do
       it "is nil when the seller's email is confirmed" do


### PR DESCRIPTION
## What

Add a creator-controlled setting to **hide the Follow (email subscribe) widget** from the public profile header. Today `Profile/Layout.tsx` renders the header `FollowForm` whenever the profile has at least one section, with no seller-facing lever to remove it ([gumroad-private#2243]). Sellers like `vbecloud.gumroad.com` asked to remove the subscribe form; this gives them the option.

## Why

The Follow widget is platform-added chrome on a seller's own profile. A seller who wants a cleaner landing look (or who captures subscribers elsewhere) currently has no way to drop the header signup box short of switching to a fully custom HTML page. A per-profile toggle is the lighter fix for the common "just want the subscribe box gone" case.

Design note (Sahil 2026-08-21): *"Sounds good (add), but they should use custom html ideally."* The custom-HTML landing page (served via `UsersController#show` → `render_custom_html_if_present`) already replaces the whole profile header, including this widget, for sellers who author one. This PR adds the toggle as the general, low-friction mechanism; both are independent and the flag does not touch custom-HTML profiles.

## Before-After

- **Before:** any profile with a live section shows the Follow widget in the header unconditionally.
- **After:** a seller turns on **"Hide the Follow button on your public profile"** under Settings → Profile → About; the public profile header then skips the FollowForm (`hideFollowForm` true). The widget still follows the pre-existing section-count rule (hidden when the profile has zero sections).
- Backend: `SellerProfile#hide_follow_widget` (boolean, default false) carried into `creator_profile` (public) and `profile_settings` (editor), guarded by `Settings::ProfilePolicy#permitted_attributes`.

## Test Results

- `ruby -c` clean on all changed Ruby files (presenter, policy, migration, both specs).
- Specs added/changed (run by the `Tests` CI workflow on this branch; local vitest/rspec runner not available in this clone env — listed under CI as authoritative):
  - `spec/presenters/profile_presenter_spec.rb` — `#creator_profile` exact-match updated for the new key; new example asserting the flag flips with `seller_profile.hide_follow_widget`; new `#profile_settings_props` example.
  - `spec/controllers/settings/profile_controller_spec.rb` — new example: PATCH `/profile` with `seller_profile: { hide_follow_widget: true }` persists on `SellerProfile`.
  - `app/javascript/pages/Settings/Profile/profileSettingsForm.test.ts` — `hide_follow_widget` is a tracked, rebasable changed setting.
- Frontend Typecheck TS + Lint JS/TS run on the pushed branch via CI (this change touches `.ts`/`.tsx` typing).

## QA steps

- (Recommended, once preview deploys to `apps.staging.gumroad.org`): open a seller's public profile with a live product → header shows the Follow widget. Then in Settings → Profile ("About" panel), flip **Hide the Follow button on your public profile** → save → reload the public profile → header widget is gone. Flip back → it returns.
- Backend probe path for a reviewer: `seller.seller_profile.update!(hide_follow_widget: true)` then confirm `ProfilePresenter#creator_profile[:hide_follow_widget]` and PATCH `/profile` persistence (spec-covered).
- Follow-up: migration adds `seller_profiles.hide_follow_widget` (defaults false) — verify it backfills cleanly on deploy.

### Migration

`20260821135314_add_hide_follow_widget_to_seller_profiles` (boolean, default false). Deploy-order note: schema change alongside code — lands everywhere at deploy time.

---

**QA / preview evidence:** The preview deploy is building; the hosted `apps.staging.gumroad.org` URL for this branch will be captured and added once live (the preview-screenshot watcher owns the healthy-preview handoff). Screenshot below once the deploy serves this head.

---
**AI disclosure:** Built by Hermes (Gumclaw) with model default `grok-4.6` per `~/.hermes/config.yaml`. Requested via gp#2243 + Sahil's "Sounds good (add)" comment; mechanism choice (toggle vs custom HTML guidance) noted in Why; alternative named, not hidden.