### PR TITLE
Allow 1:1 edits on storefront pages already over the 25-image cap

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -81,6 +81,28 @@ class Api::V2::BaseController < ApplicationController
       "custom_html is too long (maximum is #{Page::MAX_CUSTOM_HTML_LENGTH} characters)."
     end
 
+    # Validated candidate for the dry-run preview endpoints. When a root page is
+    # already live, the preview validates THAT page with the new HTML swapped in
+    # memory: moderation's over-budget exception keys on `persisted?` and
+    # `custom_html_was`, so an unsaved stand-in would preview-reject a 1:1 image
+    # swap the real write allows. Attributes are restored afterward so nothing
+    # is saved.
+    def validate_custom_html_preview_candidate(pageable, sanitized_html)
+      live = nil
+      live = pageable.page
+      return Page.new(pageable:, custom_html: sanitized_html, moderation_preview: true).tap(&:validate) if live.nil?
+
+      live.moderation_preview = true
+      live.custom_html = sanitized_html
+      live.validate
+      live
+    ensure
+      if live
+        live.restore_attributes
+        live.moderation_preview = nil
+      end
+    end
+
     def log_method_use
       return unless current_resource_owner.present?
       return unless doorkeeper_token.present?

--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -600,8 +600,7 @@ class Api::V2::LinksController < Api::V2::BaseController
 
     result = Ai::PageSanitizer.sanitize_with_report(custom_html)
     sanitized = result.html.presence
-    candidate_page = Page.new(pageable: @product, custom_html: sanitized, moderation_preview: true)
-    candidate_page.validate
+    candidate_page = validate_custom_html_preview_candidate(@product, sanitized)
     # :base as well as :custom_html: moderation reports on :base, and a preview
     # that ignored it would call a page publishable that the real write rejects.
     errors = candidate_page.errors.where(:custom_html) + candidate_page.errors.where(:base)

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -136,8 +136,7 @@ class Api::V2::UsersController < Api::V2::BaseController
 
     result = Ai::PageSanitizer.sanitize_with_report(custom_html)
     sanitized = result.html.presence
-    candidate_page = Page.new(pageable: current_resource_owner, custom_html: sanitized, moderation_preview: true)
-    candidate_page.validate
+    candidate_page = validate_custom_html_preview_candidate(current_resource_owner, sanitized)
     # :base as well as :custom_html: moderation reports on :base, and a preview
     # that ignored it would call a page publishable that the real write rejects.
     errors = candidate_page.errors.where(:custom_html) + candidate_page.errors.where(:base)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -14,9 +14,9 @@
 #   (a full-HTML takeover pushed by an agent or the CLI). Only users have
 #   slugged pages.
 class Page < ApplicationRecord
-  # Set on the unsaved candidate the dry-run preview endpoints validate, so
-  # moderation reports the verdict to the caller without recording an admin note
-  # about a page that was never published.
+  # Set on the candidate the dry-run preview endpoints validate (never saved),
+  # so moderation reports the verdict to the caller without recording an admin
+  # note about a page that was never published.
   attr_accessor :moderation_preview
 
   MAX_CUSTOM_HTML_LENGTH = 500_000

--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -158,15 +158,24 @@ class ContentModeration::ModerateRecordService
     content = content.class.new(text: content.text, image_urls: []) if @skip_images
     return CheckResult.new(passed: true, reasons: []) if content.text.blank? && content.image_urls.empty?
 
+    previous_page_urls = previous_page_image_urls
     if entity_type == :page && content.image_urls.size > ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS
-      # Approving a page approves what it DISPLAYS, so it is rejected rather than
-      # approved on a sample of its images.
-      reasons = ["#{TOO_MANY_IMAGES_REASON_PREFIX} (#{content.image_urls.size})"]
-      # `blocked: false`: the publish did stop, but the admin trail is read as
-      # abuse history, and a seller with a big gallery has not done anything
-      # wrong. The seller-facing message says what to change.
-      leave_admin_comment(reasons, blocked: false)
-      return CheckResult.new(passed: false, reasons: reasons)
+      if preexisting_over_budget_without_growth?(content, previous_page_urls)
+        # A live storefront catalog that already exceeds the cap must stay
+        # editable (1:1 cover swaps, copy tweaks) without raising the cap for
+        # new pages. Only newly introduced URLs are reviewed.
+        new_urls = content.image_urls - previous_page_urls
+        content = content.class.new(text: content.text, image_urls: new_urls)
+      else
+        # Approving a page approves what it DISPLAYS, so it is rejected rather than
+        # approved on a sample of its images.
+        reasons = ["#{TOO_MANY_IMAGES_REASON_PREFIX} (#{content.image_urls.size})"]
+        # `blocked: false`: the publish did stop, but the admin trail is read as
+        # abuse history, and a seller with a big gallery has not done anything
+        # wrong. The seller-facing message says what to change.
+        leave_admin_comment(reasons, blocked: false)
+        return CheckResult.new(passed: false, reasons: reasons)
+      end
     end
 
     blocklist_result = ContentModeration::Strategies::BlocklistStrategy
@@ -405,6 +414,20 @@ class ContentModeration::ModerateRecordService
       when :post then extractor.extract_from_post(record)
       when :page then extractor.extract_from_page(record)
       end
+    end
+
+    def previous_page_image_urls
+      return [] unless entity_type == :page && record.is_a?(Page) && record.persisted?
+
+      snapshot = record.dup
+      snapshot.custom_html = record.custom_html_was
+      snapshot.content = record.content_was if record.has_attribute?(:content)
+      ContentModeration::ContentExtractor.new.extract_from_page(snapshot).image_urls
+    end
+
+    def preexisting_over_budget_without_growth?(content, previous_urls)
+      previous_urls.size > ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS &&
+        content.image_urls.size <= previous_urls.size
     end
 
     def run_ai_strategies(content)

--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -158,8 +158,8 @@ class ContentModeration::ModerateRecordService
     content = content.class.new(text: content.text, image_urls: []) if @skip_images
     return CheckResult.new(passed: true, reasons: []) if content.text.blank? && content.image_urls.empty?
 
-    previous_page_urls = previous_page_image_urls
     if entity_type == :page && content.image_urls.size > ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS
+      previous_page_urls = previous_page_image_urls
       if preexisting_over_budget_without_growth?(content, previous_page_urls)
         # A live storefront catalog that already exceeds the cap must stay
         # editable (1:1 cover swaps, copy tweaks) without raising the cap for

--- a/spec/controllers/api/v2/links_controller_custom_html_spec.rb
+++ b/spec/controllers/api/v2/links_controller_custom_html_spec.rb
@@ -337,6 +337,58 @@ describe Api::V2::LinksController do
       expect(response.parsed_body["success"]).to eq(false)
       expect(response.parsed_body["message"]).to match(/content guidelines/i)
     end
+
+    context "when moderation reviews the page image budget" do
+      let(:strategy_result) { Struct.new(:status, :reasoning, keyword_init: true) }
+      let(:over_budget_html) do
+        count = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 1
+        (1..count).map { |n| %(<img src="https://cdn.example.com/#{n}.png">) }.join
+      end
+
+      before do
+        Feature.activate(:content_moderation)
+        allow(ContentModeration::Strategies::BlocklistStrategy).to receive(:new).and_return(
+          instance_double(ContentModeration::Strategies::BlocklistStrategy, perform: strategy_result.new(status: "compliant", reasoning: []))
+        )
+        allow(ContentModeration::Strategies::ClassifierStrategy).to receive(:new).and_return(
+          instance_double(ContentModeration::Strategies::ClassifierStrategy, perform: strategy_result.new(status: "compliant", reasoning: []))
+        )
+        allow(ContentModeration::Strategies::PromptStrategy).to receive(:new).and_return(
+          instance_double(ContentModeration::Strategies::PromptStrategy, perform: strategy_result.new(status: "compliant", reasoning: []))
+        )
+      end
+
+      it "rejects new over-budget HTML when no page is live" do
+        post :preview_custom_html, params: { format: :json, access_token: @token.token, id: @product.external_id, custom_html: over_budget_html }
+
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to include("more images than we can review")
+      end
+
+      context "with a live over-budget root page" do
+        before { Page.new(pageable: @product, custom_html: over_budget_html).save!(validate: false) }
+
+        it "previews a 1:1 image src swap as publishable, agreeing with the PUT, without writing" do
+          swapped = over_budget_html.sub("https://cdn.example.com/1.png", "https://cdn.example.com/swapped.png")
+
+          post :preview_custom_html, params: { format: :json, access_token: @token.token, id: @product.external_id, custom_html: swapped }
+
+          expect(response.parsed_body["success"]).to eq(true)
+          expect(@product.reload.custom_html).to include("https://cdn.example.com/1.png")
+          expect(@product.custom_html).not_to include("swapped.png")
+        end
+
+        it "still rejects adding an image to the live over-budget page" do
+          extra = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 2
+          grown = over_budget_html + %(<img src="https://cdn.example.com/#{extra}.png">)
+
+          post :preview_custom_html, params: { format: :json, access_token: @token.token, id: @product.external_id, custom_html: grown }
+
+          expect(response.parsed_body["success"]).to eq(false)
+          expect(response.parsed_body["message"]).to include("more images than we can review")
+        end
+      end
+    end
   end
 
   describe "when the custom_html_pages feature is disabled" do

--- a/spec/controllers/api/v2/users_controller_custom_html_spec.rb
+++ b/spec/controllers/api/v2/users_controller_custom_html_spec.rb
@@ -253,6 +253,58 @@ describe Api::V2::UsersController do
       post :preview_custom_html, params: { format: :json, custom_html: "<section>HTML</section>" }
       expect(response).to have_http_status(:unauthorized)
     end
+
+    context "when moderation reviews the page image budget" do
+      let(:strategy_result) { Struct.new(:status, :reasoning, keyword_init: true) }
+      let(:over_budget_html) do
+        count = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 1
+        (1..count).map { |n| %(<img src="https://cdn.example.com/#{n}.png">) }.join
+      end
+
+      before do
+        Feature.activate(:content_moderation)
+        allow(ContentModeration::Strategies::BlocklistStrategy).to receive(:new).and_return(
+          instance_double(ContentModeration::Strategies::BlocklistStrategy, perform: strategy_result.new(status: "compliant", reasoning: []))
+        )
+        allow(ContentModeration::Strategies::ClassifierStrategy).to receive(:new).and_return(
+          instance_double(ContentModeration::Strategies::ClassifierStrategy, perform: strategy_result.new(status: "compliant", reasoning: []))
+        )
+        allow(ContentModeration::Strategies::PromptStrategy).to receive(:new).and_return(
+          instance_double(ContentModeration::Strategies::PromptStrategy, perform: strategy_result.new(status: "compliant", reasoning: []))
+        )
+      end
+
+      it "rejects new over-budget HTML when no page is live" do
+        post :preview_custom_html, params: { format: :json, access_token: @token.token, custom_html: over_budget_html }
+
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to include("more images than we can review")
+      end
+
+      context "with a live over-budget root page" do
+        before { Page.new(pageable: @user, custom_html: over_budget_html).save!(validate: false) }
+
+        it "previews a 1:1 image src swap as publishable, agreeing with the PUT, without writing" do
+          swapped = over_budget_html.sub("https://cdn.example.com/1.png", "https://cdn.example.com/swapped.png")
+
+          post :preview_custom_html, params: { format: :json, access_token: @token.token, custom_html: swapped }
+
+          expect(response.parsed_body["success"]).to eq(true)
+          expect(@user.reload.custom_html).to include("https://cdn.example.com/1.png")
+          expect(@user.custom_html).not_to include("swapped.png")
+        end
+
+        it "still rejects adding an image to the live over-budget page" do
+          extra = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 2
+          grown = over_budget_html + %(<img src="https://cdn.example.com/#{extra}.png">)
+
+          post :preview_custom_html, params: { format: :json, access_token: @token.token, custom_html: grown }
+
+          expect(response.parsed_body["success"]).to eq(false)
+          expect(response.parsed_body["message"]).to include("more images than we can review")
+        end
+      end
+    end
   end
 
   describe "when the custom_html_pages feature is disabled" do

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -230,6 +230,31 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
           expect(over_budget_page.valid?).to eq(true)
         end
 
+        it "lets a live over-budget page swap one image src without growing the set" do
+          over_budget_page.save!(validate: false)
+          swapped = over_budget_html.sub("https://cdn.example.com/1.png", "https://cdn.example.com/swapped.png")
+          over_budget_page.custom_html = swapped
+
+          expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new)
+            .with(hash_including(image_urls: ["https://cdn.example.com/swapped.png"]))
+            .and_return(instance_double(ContentModeration::Strategies::ClassifierStrategy,
+                                        perform: strategy_result.new(status: "compliant", reasoning: [])))
+
+          expect(described_class.check(over_budget_page, :page).passed).to eq(true)
+        end
+
+        it "still blocks adding another image to a live over-budget page" do
+          over_budget_page.save!(validate: false)
+          extra = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 2
+          over_budget_page.custom_html = over_budget_html + %(<img src="https://cdn.example.com/#{extra}.png">)
+
+          expect(ContentModeration::Strategies::ClassifierStrategy).not_to receive(:new)
+
+          result = described_class.check(over_budget_page, :page)
+          expect(result.passed).to eq(false)
+          expect(result.reasons.first).to start_with(described_class::TOO_MANY_IMAGES_REASON_PREFIX)
+        end
+
         it "counts images painted through nested CSS toward the budget" do
           count = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 1
           nested_css = (1..count).map do |n|


### PR DESCRIPTION
Ref antiwork/gumroad-private#2245

## Status

- [x] Scope — option (c) only: do not raise the 25-image cap
- [x] Design — persisted over-budget pages may save when image count does not increase; only new URLs are reviewed
- [x] Build
- [x] QA — backend-only; no UI screenshot gate
- [ ] Shipped

Does **not** decide whether large storefront catalogs should get a higher cap. Sahil still owns that product call.

## What

A live custom storefront page with more than 25 images can be saved again if the edit does not add images. A 1:1 `<img src>` swap (shawalebooks cover change) is the motivating case. New pages and edits that grow the image set are still rejected at 26+.

## Why

`#6718` rejects any `Page#save!` once `image_urls.size > 25`, including a one-src swap of a 47-image catalog. Title-only saves already skipped the image phase; HTML edits did not.

## Test Results

`DISABLE_SPRING=1 bundle exec rspec spec/services/content_moderation/moderate_record_service_spec.rb -e "more images than we will review"` — 8 examples, 0 failures (including new 1:1 swap + growth-still-blocked cases).

`bundle exec rubocop --force-exclusion -A app/services/content_moderation/moderate_record_service.rb spec/services/content_moderation/moderate_record_service_spec.rb` — no offenses.

---

AI disclosure: grok-4.6. Prompt/instructions: pr-and-issue-advancer cron on gp#2245 (stuck confirmed→PR); Sahil standing order to take confirmed work as far as possible. Conservative option (c) only.
Premerge review: clean @ 33754f650c76f7dcaa59c278902e35bcfff5c098


