### PR TITLE
Stamp completed_at when a blast already finished sending

### DIFF
--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -39,7 +39,7 @@ class AlertOnStalledPostEmailBlastsJob
   AUTO_RESUME_WINDOW = 24.hours
 
   # Rows the run acted on (or would have) are the audit trail; message_for never truncates them.
-  AUDITED_ACTIONS = [:resumed, :would_resume, :skipped_reappeared].freeze
+  AUDITED_ACTIONS = [:resumed, :would_resume, :skipped_reappeared, :completed].freeze
 
   def perform
     scan = scan_for_stalled_blasts
@@ -90,6 +90,12 @@ class AlertOnStalledPostEmailBlastsJob
     def resolve_action(entry, live:)
       blast = entry[:blast]
       return nil unless entry[:disposition].in?([:dead, :unaccounted])
+      # Emails already left. Re-enqueueing restarts the audience load — the pass that
+      # keeps getting buried — and is the wrong tool once delivery covers the snapshot.
+      # Completing is not a send, so it is not gated on the resume flag or the 24h window.
+      if SendPostBlastEmailsJob.fully_delivered?(blast)
+        return SendPostBlastEmailsJob.complete_if_fully_delivered!(blast) ? :completed : nil
+      end
       # A DEAD entry proves its attempt chain ended; UNACCOUNTED can hide a live sender, and a
       # concurrent duplicate double-delivers a non-opener resend.
       return :held_non_opener if entry[:disposition] == :unaccounted && blast.to_non_openers?
@@ -189,6 +195,7 @@ class AlertOnStalledPostEmailBlastsJob
       action =
         case entry[:action]
         when :resumed then " → RESUMED"
+        when :completed then " → COMPLETED (already fully delivered)"
         when :would_resume then " → WOULD RESUME (dry run)"
         when :held_past_window then " → HELD (past #{AUTO_RESUME_WINDOW.inspect} resume window)"
         when :held_already_resumed then " → HELD (already auto-resumed once)"

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -18,9 +18,11 @@ class SendPostBlastEmailsJob
 
     if blast.to_non_openers?
       checkpoint_key = RedisKey.blast_non_opener_emails(blast.id)
+      sent_key = RedisKey.blast_sent_emails(blast.id)
       return false unless $redis.exists?(checkpoint_key)
+      return false if $redis.scard(sent_key) < $redis.scard(checkpoint_key)
 
-      $redis.scard(RedisKey.blast_sent_emails(blast.id)) >= $redis.scard(checkpoint_key)
+      $redis.sdiff(checkpoint_key, sent_key).empty?
     else
       snapshot_size = $redis.llen(RedisKey.blast_audience_snapshot(blast.id))
       snapshot_size.positive? && blast.delivery_count >= snapshot_size

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -9,6 +9,40 @@ class SendPostBlastEmailsJob
   # blast silently, which is what made the documented recovery a no-op (gumroad-private#1816).
   sidekiq_options retry: 10, queue: :default
 
+  # True when this blast has already handed every snapshotted recipient to an ESP.
+  # delivery_count only advances after a successful provider send, so a hard kill
+  # after the last slice leaves completed_at nil while this still returns true.
+  # Missing snapshot/checkpoint => unknown, not delivered — the caller resumes.
+  def self.fully_delivered?(blast)
+    return false if blast.completed_at.present?
+
+    if blast.to_non_openers?
+      checkpoint_key = RedisKey.blast_non_opener_emails(blast.id)
+      return false unless $redis.exists?(checkpoint_key)
+
+      $redis.scard(RedisKey.blast_sent_emails(blast.id)) >= $redis.scard(checkpoint_key)
+    else
+      snapshot_size = $redis.llen(RedisKey.blast_audience_snapshot(blast.id))
+      snapshot_size.positive? && blast.delivery_count >= snapshot_size
+    end
+  end
+
+  def self.mark_completed!(blast)
+    blast.update!(completed_at: Time.current) if blast.completed_at.nil?
+    snapshot_key = RedisKey.blast_audience_snapshot(blast.id)
+    checkpoint_key = RedisKey.blast_non_opener_emails(blast.id)
+    $redis.del(snapshot_key, "#{snapshot_key}:tmp", checkpoint_key, "#{checkpoint_key}:tmp")
+    blast
+  end
+
+  def self.complete_if_fully_delivered!(blast)
+    blast.reload
+    return false unless fully_delivered?(blast)
+
+    mark_completed!(blast)
+    true
+  end
+
   def perform(blast_id)
     @blast = PostEmailBlast.find(blast_id)
     @post = @blast.post
@@ -359,14 +393,7 @@ class SendPostBlastEmailsJob
     end
 
     def mark_blast_as_completed
-      @blast.update!(completed_at: Time.current)
-      # The blast is done, so the retry-resume snapshot and the non-opener checkpoint
-      # have served their purpose. Also remove the temporary write-in-progress keys in
-      # case a previous attempt died mid-write (they carry a TTL, but no reason to keep
-      # them around).
-      snapshot_key = RedisKey.blast_audience_snapshot(@blast.id)
-      checkpoint_key = RedisKey.blast_non_opener_emails(@blast.id)
-      $redis.del(snapshot_key, "#{snapshot_key}:tmp", checkpoint_key, "#{checkpoint_key}:tmp")
+      self.class.mark_completed!(@blast)
     end
 
     # Stores email addresses in SentPostEmail, just before sending the emails.

--- a/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
+++ b/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
@@ -247,6 +247,46 @@ describe AlertOnStalledPostEmailBlastsJob do
       end
     end
 
+    it "stamps completed_at on a fully delivered DEAD blast instead of retrying it" do
+      blast = stalled_blast(requested_hours_ago: 6, delivery_count: 3)
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      stub_sidekiq(dead: [blast.id])
+
+      described_class.new.perform
+
+      expect(@dead_jobs.fetch(blast.id)).not_to have_received(:retry)
+      expect(SendPostBlastEmailsJob).not_to have_received(:perform_async)
+      expect(blast.reload.completed_at).to be_present
+      expect($redis.exists?(RedisKey.blast_audience_snapshot(blast.id))).to be(false)
+      expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+        expect(message).to match(/blast #{blast.id}.*DEAD → COMPLETED/)
+      end
+    end
+
+    it "completes a fully delivered blast past the resume window and when the resume flag is off" do
+      blast = stalled_blast(requested_hours_ago: 30, delivery_count: 3)
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      stub_sidekiq(dead: [blast.id])
+
+      described_class.new.perform
+
+      expect(@dead_jobs.fetch(blast.id)).not_to have_received(:retry)
+      expect(blast.reload.completed_at).to be_present
+    end
+
+    it "does not treat a partial send as fully delivered" do
+      blast = stalled_blast(requested_hours_ago: 6, delivery_count: 2)
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      stub_sidekiq(dead: [blast.id])
+
+      described_class.new.perform
+
+      expect(blast.reload.completed_at).to be_nil
+      expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
+        expect(message).not_to include("COMPLETED")
+      end
+    end
+
     context "when the flag is off" do
       it "never truncates action rows out of the report" do
         stub_const("#{described_class}::MAX_REPORTED", 1)

--- a/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
+++ b/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
@@ -249,7 +249,7 @@ describe AlertOnStalledPostEmailBlastsJob do
 
     it "stamps completed_at on a fully delivered DEAD blast instead of retrying it" do
       blast = stalled_blast(requested_hours_ago: 6, delivery_count: 3)
-      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), [1, 2, 3])
       stub_sidekiq(dead: [blast.id])
 
       described_class.new.perform
@@ -265,7 +265,7 @@ describe AlertOnStalledPostEmailBlastsJob do
 
     it "completes a fully delivered blast past the resume window and when the resume flag is off" do
       blast = stalled_blast(requested_hours_ago: 30, delivery_count: 3)
-      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), [1, 2, 3])
       stub_sidekiq(dead: [blast.id])
 
       described_class.new.perform
@@ -276,7 +276,7 @@ describe AlertOnStalledPostEmailBlastsJob do
 
     it "does not treat a partial send as fully delivered" do
       blast = stalled_blast(requested_hours_ago: 6, delivery_count: 2)
-      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), [1, 2, 3])
       stub_sidekiq(dead: [blast.id])
 
       described_class.new.perform

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -761,6 +761,16 @@ describe SendPostBlastEmailsJob, :freeze_time do
       $redis.sadd(sent, "b@example.com")
       expect(described_class.fully_delivered?(blast)).to be(true)
     end
+
+    it "does not count stale sent-set emails toward a rebuilt non-opener checkpoint" do
+      blast.update!(recipient_filter: PostEmailBlast::RECIPIENT_FILTER_UNOPENED)
+      checkpoint = RedisKey.blast_non_opener_emails(blast.id)
+      sent = RedisKey.blast_sent_emails(blast.id)
+      $redis.sadd(checkpoint, "current-unsent@example.com", "current-sent@example.com")
+      $redis.sadd(sent, "current-sent@example.com", "previous-checkpoint@example.com")
+
+      expect(described_class.fully_delivered?(blast)).to be(false)
+    end
   end
 
   describe ".complete_if_fully_delivered!" do

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -718,6 +718,73 @@ describe SendPostBlastEmailsJob, :freeze_time do
     end
   end
 
+  describe ".fully_delivered?" do
+    let(:post) { create(:audience_post, :published, seller: @seller) }
+    let(:blast) { create(:blast, post:, completed_at: nil, delivery_count: 0) }
+
+    it "is false with no audience snapshot" do
+      blast.update!(delivery_count: 3)
+
+      expect(described_class.fully_delivered?(blast)).to be(false)
+    end
+
+    it "is false when delivery_count is short of the snapshot" do
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      blast.update!(delivery_count: 2)
+
+      expect(described_class.fully_delivered?(blast)).to be(false)
+    end
+
+    it "is true when delivery_count covers the snapshot" do
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      blast.update!(delivery_count: 3)
+
+      expect(described_class.fully_delivered?(blast)).to be(true)
+    end
+
+    it "is false once completed_at is already set" do
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      blast.update!(delivery_count: 3, completed_at: Time.current)
+
+      expect(described_class.fully_delivered?(blast)).to be(false)
+    end
+
+    it "uses the per-blast sent set for a non-opener resend" do
+      blast.update!(recipient_filter: PostEmailBlast::RECIPIENT_FILTER_UNOPENED)
+      checkpoint = RedisKey.blast_non_opener_emails(blast.id)
+      sent = RedisKey.blast_sent_emails(blast.id)
+      $redis.sadd(checkpoint, "a@example.com", "b@example.com")
+      $redis.sadd(sent, "a@example.com")
+
+      expect(described_class.fully_delivered?(blast)).to be(false)
+
+      $redis.sadd(sent, "b@example.com")
+      expect(described_class.fully_delivered?(blast)).to be(true)
+    end
+  end
+
+  describe ".complete_if_fully_delivered!" do
+    let(:post) { create(:audience_post, :published, seller: @seller) }
+    let(:blast) { create(:blast, post:, completed_at: nil, delivery_count: 3) }
+
+    it "stamps completed_at and drops the snapshot when delivery already covers it" do
+      snapshot = RedisKey.blast_audience_snapshot(blast.id)
+      $redis.rpush(snapshot, 1, 2, 3)
+
+      expect(described_class.complete_if_fully_delivered!(blast)).to be(true)
+      expect(blast.reload.completed_at).to eq(Time.current)
+      expect($redis.exists?(snapshot)).to be(false)
+    end
+
+    it "leaves an incomplete blast untouched" do
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      blast.update!(delivery_count: 2)
+
+      expect(described_class.complete_if_fully_delivered!(blast)).to be(false)
+      expect(blast.reload.completed_at).to be_nil
+    end
+  end
+
   def expect_sent_count(count)
     expect(PostSendgridApi.mails.size).to eq(count)
   end

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -729,21 +729,21 @@ describe SendPostBlastEmailsJob, :freeze_time do
     end
 
     it "is false when delivery_count is short of the snapshot" do
-      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), [1, 2, 3])
       blast.update!(delivery_count: 2)
 
       expect(described_class.fully_delivered?(blast)).to be(false)
     end
 
     it "is true when delivery_count covers the snapshot" do
-      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), [1, 2, 3])
       blast.update!(delivery_count: 3)
 
       expect(described_class.fully_delivered?(blast)).to be(true)
     end
 
     it "is false once completed_at is already set" do
-      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), [1, 2, 3])
       blast.update!(delivery_count: 3, completed_at: Time.current)
 
       expect(described_class.fully_delivered?(blast)).to be(false)
@@ -769,7 +769,7 @@ describe SendPostBlastEmailsJob, :freeze_time do
 
     it "stamps completed_at and drops the snapshot when delivery already covers it" do
       snapshot = RedisKey.blast_audience_snapshot(blast.id)
-      $redis.rpush(snapshot, 1, 2, 3)
+      $redis.rpush(snapshot, [1, 2, 3])
 
       expect(described_class.complete_if_fully_delivered!(blast)).to be(true)
       expect(blast.reload.completed_at).to eq(Time.current)
@@ -777,7 +777,7 @@ describe SendPostBlastEmailsJob, :freeze_time do
     end
 
     it "leaves an incomplete blast untouched" do
-      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), 1, 2, 3)
+      $redis.rpush(RedisKey.blast_audience_snapshot(blast.id), [1, 2, 3])
       blast.update!(delivery_count: 2)
 
       expect(described_class.complete_if_fully_delivered!(blast)).to be(false)


### PR DESCRIPTION
> Draft: Greptile P1 fix, focused specs, and mutation proof are in; CI and pre-merge QA audit still owed.

## What

When a post-email blast has already handed every snapshotted recipient to the ESP but the send worker was hard-killed before `mark_blast_as_completed`, `AlertOnStalledPostEmailBlastsJob` now stamps `completed_at` instead of retrying the send job.

## Why

A fully delivered blast currently sits on the emails dashboard as in-progress forever (antiwork/gumroad-private#2250). Re-enqueueing restarts the audience load — the same pass that keeps getting buried — and is the wrong tool once `delivery_count` already covers the snapshot.

## Before / after

- Before: blast 457486 delivered 85,499/85,499, `completed_at` nil, dead-set burial after the last slice; dashboard stuck.
- After: a DEAD/UNACCOUNTED blast whose `delivery_count` covers the Redis audience snapshot (non-opener: every current checkpoint email is present in the sent set) gets `completed_at` stamped and the snapshot dropped. Partial sends still resume as before.

## Checklist

- [x] Scope — completion stamp only; does not stop the mid-run Sidekiq burial itself
- [x] Design — snapshot/`delivery_count` compare; not gated on the resume flag or 24h window because this is not a send
- [x] Build — `230de2cf` on `gp2250-blast-completion-marker`
- [x] QA — focused completion specs green + Greptile P1 mutation proof at `230de2cf` (see Test Results)
- [ ] Shipped
- [ ] Market — n/a (backend completion stamp, no rendered surface)
- [ ] Sell — n/a

## Test Results

At `230de2cf`:

```
ruby -c app/sidekiq/send_post_blast_emails_job.rb
Syntax OK

DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/send_post_blast_emails_job_spec.rb:721
6 examples, 0 failures
```

Greptile P1 mutation proof:

- Mutant: replace the non-opener checkpoint subset check with `true` after the cardinality guard.
- Result: `spec/sidekiq/send_post_blast_emails_job_spec.rb:765` failed with `Expected true to equal false`.
- Restored the fix and reran the `.fully_delivered?` focused group: 6 examples, 0 failures.

Previous build evidence at `a3363195e` before the Greptile fix:

```
bundle exec rspec spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb \
  spec/sidekiq/send_post_blast_emails_job_spec.rb:721 \
  spec/sidekiq/send_post_blast_emails_job_spec.rb:766
27 examples, 0 failures
```

Original mutation proof at `a3363195e` (both mutants reddened their own example):

- drop `fully_delivered?` complete-instead-of-resume → red: stamps completed_at on a fully delivered DEAD blast instead of retrying it
- treat missing snapshot as fully delivered → red: fully_delivered? is false with no audience snapshot

A full-file send-job + alert-job run at `230de2cf` hit the same local Vite manifest blocker (`entrypoints/email.ts` missing because this worktree has no node_modules). The alert-job examples completed green before the command failed; CI is the full-file authority for the Vite-dependent send-job examples.

## QA steps

1. Ran the `.fully_delivered?` focused examples above at the current head.
2. Ran the Greptile P1 mutation proof above, restored the production code, and reran the focused group green.
3. After deploy: blast 457486 should get `completed_at` on the next `AlertOnStalledPostEmailBlastsJob` tick if its audience snapshot is still in Redis; otherwise `SendPostBlastEmailsJob.mark_completed!(blast)` is the ops stamp (no re-enqueue).

No rendered surface — backend-only completion stamp.

---

## AI disclosure

Generated with **grok-4.6** (xAI), running as Gumclaw.
Prompts/instructions given: handle the gumroad-private#2250 opened webhook; build the completion-marker gap so a fully delivered blast is not left in-progress after dead-set burial.
