### PR TITLE
Sample 25 page images instead of rejecting large storefronts

### DIFF
--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -393,7 +393,29 @@ class ContentModeration::ModerateRecordService
       limit = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS
       return content if content.image_urls.size <= limit
 
-      content.class.new(text: content.text, image_urls: content.image_urls.sample(limit))
+      selected_urls = stable_page_image_sample(content.image_urls, limit)
+      if record.is_a?(Page) && record.persisted?
+        previous_urls = previous_page_image_urls
+        new_urls = content.image_urls - previous_urls
+        if new_urls.size < limit
+          selected_urls = new_urls + stable_page_image_sample(content.image_urls - new_urls, limit - new_urls.size)
+        end
+      end
+
+      content.class.new(text: content.text, image_urls: selected_urls)
+    end
+
+    def previous_page_image_urls
+      snapshot = record.dup
+      snapshot.custom_html = record.custom_html_was
+      snapshot.content = record.content_was if record.has_attribute?(:content)
+      ContentModeration::ContentExtractor.new.extract_from_page(snapshot).image_urls
+    end
+
+    def stable_page_image_sample(image_urls, limit)
+      # Stable per image set so retrying the same page cannot reshuffle coverage.
+      seed = Digest::SHA256.hexdigest(image_urls.join("\0")).to_i(16) % (2**31)
+      image_urls.sample(limit, random: Random.new(seed))
     end
 
     def run_ai_strategies(content)

--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -75,11 +75,6 @@ class ContentModeration::ModerateRecordService
     "directs buyers to message you on another platform to get it, which we don’t allow. Add the files, " \
     "videos, or written content buyers should get when they buy, then publish again."
 
-  # A page carrying more images than we will review is rejected rather than
-  # approved on a sample (see `check`), so the reason is about the page's size,
-  # not its content, and gets its own sentence saying what to change.
-  TOO_MANY_IMAGES_REASON_PREFIX = "too many images to review"
-
   # Turn raw moderation reasons (e.g. "OpenAI moderation flagged: violence
   # (score: 0.86, threshold: 0.9)" or "spam: repeated unrelated slogans") into
   # a friendly, de-duplicated phrase the seller can act on — without leaking
@@ -116,10 +111,6 @@ class ContentModeration::ModerateRecordService
       # on either way.
       "This #{noun} includes an image we can’t review, because the format is unsupported (such as an SVG data URL) " \
       "or the file is too large. Replace it with a smaller PNG, JPEG, GIF, or WebP and try again."
-    elsif rs.any? { |r| r.to_s.start_with?(TOO_MANY_IMAGES_REASON_PREFIX) }
-      "This #{noun} has more images than we can review, so we can’t publish it as is. " \
-      "Reduce it to at most #{ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS} images " \
-      "(or split it across several #{noun}s) and try again."
     elsif rs.any? { |r| off_platform_fulfillment_reason?(r) }
       message = format(OFF_PLATFORM_FULFILLMENT_MESSAGE, noun: noun)
       # A run can flag off-platform fulfillment alongside another violation
@@ -158,25 +149,7 @@ class ContentModeration::ModerateRecordService
     content = content.class.new(text: content.text, image_urls: []) if @skip_images
     return CheckResult.new(passed: true, reasons: []) if content.text.blank? && content.image_urls.empty?
 
-    if entity_type == :page && content.image_urls.size > ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS
-      previous_page_urls = previous_page_image_urls
-      if preexisting_over_budget_without_growth?(content, previous_page_urls)
-        # A live storefront catalog that already exceeds the cap must stay
-        # editable (1:1 cover swaps, copy tweaks) without raising the cap for
-        # new pages. Only newly introduced URLs are reviewed.
-        new_urls = content.image_urls - previous_page_urls
-        content = content.class.new(text: content.text, image_urls: new_urls)
-      else
-        # Approving a page approves what it DISPLAYS, so it is rejected rather than
-        # approved on a sample of its images.
-        reasons = ["#{TOO_MANY_IMAGES_REASON_PREFIX} (#{content.image_urls.size})"]
-        # `blocked: false`: the publish did stop, but the admin trail is read as
-        # abuse history, and a seller with a big gallery has not done anything
-        # wrong. The seller-facing message says what to change.
-        leave_admin_comment(reasons, blocked: false)
-        return CheckResult.new(passed: false, reasons: reasons)
-      end
-    end
+    content = sample_page_images(content) if entity_type == :page
 
     blocklist_result = ContentModeration::Strategies::BlocklistStrategy
                          .new(text: content.text, image_urls: content.image_urls)
@@ -416,18 +389,11 @@ class ContentModeration::ModerateRecordService
       end
     end
 
-    def previous_page_image_urls
-      return [] unless entity_type == :page && record.is_a?(Page) && record.persisted?
+    def sample_page_images(content)
+      limit = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS
+      return content if content.image_urls.size <= limit
 
-      snapshot = record.dup
-      snapshot.custom_html = record.custom_html_was
-      snapshot.content = record.content_was if record.has_attribute?(:content)
-      ContentModeration::ContentExtractor.new.extract_from_page(snapshot).image_urls
-    end
-
-    def preexisting_over_budget_without_growth?(content, previous_urls)
-      previous_urls.size > ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS &&
-        content.image_urls.size <= previous_urls.size
+      content.class.new(text: content.text, image_urls: content.image_urls.sample(limit))
     end
 
     def run_ai_strategies(content)
@@ -435,11 +401,9 @@ class ContentModeration::ModerateRecordService
         ContentModeration::Strategies::ClassifierStrategy.new(
           text: content.text,
           image_urls: content.image_urls,
-          # A page's images are arbitrary URLs the seller wrote into a public
-          # document, and the page is only allowed through if all of them were
-          # reviewed (`check` rejects a page over the budget), so every one gets a
-          # moderation attempt. Products and posts keep the default cap: their
-          # images come from our own uploads and their galleries are unbounded.
+          # Page image sets above the moderation budget are sampled before the
+          # strategies run. `:all` means every selected page image gets an attempt
+          # rather than being sliced again by the product/post default.
           max_images: entity_type == :page ? :all : ContentModeration::Strategies::ClassifierStrategy::MAX_IMAGES_TO_MODERATE,
         ),
         # `corroborate_judgment_flags` makes a spam, off-platform-fulfillment, or

--- a/spec/controllers/api/v2/links_controller_custom_html_spec.rb
+++ b/spec/controllers/api/v2/links_controller_custom_html_spec.rb
@@ -358,11 +358,10 @@ describe Api::V2::LinksController do
         )
       end
 
-      it "rejects new over-budget HTML when no page is live" do
+      it "previews new over-budget HTML by sampling the images" do
         post :preview_custom_html, params: { format: :json, access_token: @token.token, id: @product.external_id, custom_html: over_budget_html }
 
-        expect(response.parsed_body["success"]).to eq(false)
-        expect(response.parsed_body["message"]).to include("more images than we can review")
+        expect(response.parsed_body["success"]).to eq(true)
       end
 
       context "with a live over-budget root page" do
@@ -378,14 +377,13 @@ describe Api::V2::LinksController do
           expect(@product.custom_html).not_to include("swapped.png")
         end
 
-        it "still rejects adding an image to the live over-budget page" do
+        it "previews adding an image to the live over-budget page by sampling" do
           extra = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 2
           grown = over_budget_html + %(<img src="https://cdn.example.com/#{extra}.png">)
 
           post :preview_custom_html, params: { format: :json, access_token: @token.token, id: @product.external_id, custom_html: grown }
 
-          expect(response.parsed_body["success"]).to eq(false)
-          expect(response.parsed_body["message"]).to include("more images than we can review")
+          expect(response.parsed_body["success"]).to eq(true)
         end
       end
     end

--- a/spec/controllers/api/v2/users_controller_custom_html_spec.rb
+++ b/spec/controllers/api/v2/users_controller_custom_html_spec.rb
@@ -274,11 +274,10 @@ describe Api::V2::UsersController do
         )
       end
 
-      it "rejects new over-budget HTML when no page is live" do
+      it "previews new over-budget HTML by sampling the images" do
         post :preview_custom_html, params: { format: :json, access_token: @token.token, custom_html: over_budget_html }
 
-        expect(response.parsed_body["success"]).to eq(false)
-        expect(response.parsed_body["message"]).to include("more images than we can review")
+        expect(response.parsed_body["success"]).to eq(true)
       end
 
       context "with a live over-budget root page" do
@@ -294,14 +293,13 @@ describe Api::V2::UsersController do
           expect(@user.custom_html).not_to include("swapped.png")
         end
 
-        it "still rejects adding an image to the live over-budget page" do
+        it "previews adding an image to the live over-budget page by sampling" do
           extra = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 2
           grown = over_budget_html + %(<img src="https://cdn.example.com/#{extra}.png">)
 
           post :preview_custom_html, params: { format: :json, access_token: @token.token, custom_html: grown }
 
-          expect(response.parsed_body["success"]).to eq(false)
-          expect(response.parsed_body["message"]).to include("more images than we can review")
+          expect(response.parsed_body["success"]).to eq(true)
         end
       end
     end

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -210,6 +210,20 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
           expect(described_class.check(over_budget_page, :page).passed).to eq(true)
         end
 
+        it "keeps the sample stable for identical page images" do
+          samples = []
+          allow(ContentModeration::Strategies::ClassifierStrategy).to receive(:new) do |args|
+            samples << args[:image_urls]
+            instance_double(ContentModeration::Strategies::ClassifierStrategy,
+                            perform: strategy_result.new(status: "compliant", reasoning: []))
+          end
+
+          2.times { expect(described_class.check(over_budget_page, :page).passed).to eq(true) }
+
+          expect(samples.size).to eq(2)
+          expect(samples.first).to eq(samples.second)
+        end
+
         it "lets the seller rename an already-live page that is over the limit" do
           over_budget_page.save!(validate: false)
           over_budget_page.title = "Renamed gallery"
@@ -226,6 +240,7 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
 
           expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new) do |args|
             expect(args[:image_urls].size).to eq(ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS)
+            expect(args[:image_urls]).to include("https://cdn.example.com/swapped.png")
             expect(args[:image_urls]).to all(start_with("https://cdn.example.com/"))
             instance_double(ContentModeration::Strategies::ClassifierStrategy,
                             perform: strategy_result.new(status: "compliant", reasoning: []))
@@ -241,6 +256,7 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
 
           expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new) do |args|
             expect(args[:image_urls].size).to eq(ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS)
+            expect(args[:image_urls]).to include("https://cdn.example.com/#{extra}.png")
             expect(args[:image_urls]).to all(start_with("https://cdn.example.com/"))
             instance_double(ContentModeration::Strategies::ClassifierStrategy,
                             perform: strategy_result.new(status: "compliant", reasoning: []))

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
         expect(described_class.check(product_page, :page).passed).to eq(true)
       end
 
-      it "asks the classifier to moderate every image, so no displayed image is approved unseen" do
+      it "asks the classifier to moderate every selected page image" do
         expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new)
           .with(hash_including(max_images: :all))
           .and_return(instance_double(ContentModeration::Strategies::ClassifierStrategy,
@@ -192,33 +192,22 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
         end
         let(:over_budget_page) { Page.new(pageable: seller, slug: "gallery", title: "Gallery", custom_html: over_budget_html) }
 
-        it "blocks the page instead of approving it on a subset of its images" do
-          expect(ContentModeration::Strategies::ClassifierStrategy).not_to receive(:new)
+        it "samples the page images instead of blocking on size" do
+          expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new) do |args|
+            expect(args[:max_images]).to eq(:all)
+            expect(args[:image_urls].size).to eq(ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS)
+            expect(args[:image_urls]).to all(match(%r{\Ahttps://cdn\.example\.com/\d+\.png\z}))
+            instance_double(ContentModeration::Strategies::ClassifierStrategy,
+                            perform: strategy_result.new(status: "compliant", reasoning: []))
+          end
 
-          result = described_class.check(over_budget_page, :page)
-
-          expect(result.passed).to eq(false)
-          expect(result.reasons).to eq(
-            ["#{described_class::TOO_MANY_IMAGES_REASON_PREFIX} " \
-             "(#{ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 1})"]
-          )
+          expect(described_class.check(over_budget_page, :page).passed).to eq(true)
         end
 
-        it "tells the seller the limit rather than naming a content violation" do
-          message = described_class.seller_message(described_class.check(over_budget_page, :page).reasons, "page")
+        it "does not leave an admin size note for an over-budget sample" do
+          expect(ContentModerationAdminCommentJob).not_to receive(:perform_async)
 
-          expect(message).to include("more images than we can review")
-          expect(message).to include(ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS.to_s)
-          expect(message).not_to include("content guidelines")
-        end
-
-        it "records the block as a note rather than as abuse history" do
-          # A big gallery is a size problem, not a content violation, and the admin
-          # trail is read as abuse history.
-          expect(ContentModerationAdminCommentJob).to receive(:perform_async)
-            .with(seller.id, /flagged but did not block/)
-
-          described_class.check(over_budget_page, :page)
+          expect(described_class.check(over_budget_page, :page).passed).to eq(true)
         end
 
         it "lets the seller rename an already-live page that is over the limit" do
@@ -230,29 +219,34 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
           expect(over_budget_page.valid?).to eq(true)
         end
 
-        it "lets a live over-budget page swap one image src without growing the set" do
+        it "samples a live over-budget page after a 1:1 image src swap" do
           over_budget_page.save!(validate: false)
           swapped = over_budget_html.sub("https://cdn.example.com/1.png", "https://cdn.example.com/swapped.png")
           over_budget_page.custom_html = swapped
 
-          expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new)
-            .with(hash_including(image_urls: ["https://cdn.example.com/swapped.png"]))
-            .and_return(instance_double(ContentModeration::Strategies::ClassifierStrategy,
-                                        perform: strategy_result.new(status: "compliant", reasoning: [])))
+          expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new) do |args|
+            expect(args[:image_urls].size).to eq(ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS)
+            expect(args[:image_urls]).to all(start_with("https://cdn.example.com/"))
+            instance_double(ContentModeration::Strategies::ClassifierStrategy,
+                            perform: strategy_result.new(status: "compliant", reasoning: []))
+          end
 
           expect(described_class.check(over_budget_page, :page).passed).to eq(true)
         end
 
-        it "still blocks adding another image to a live over-budget page" do
+        it "samples a live over-budget page after adding another image" do
           over_budget_page.save!(validate: false)
           extra = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 2
           over_budget_page.custom_html = over_budget_html + %(<img src="https://cdn.example.com/#{extra}.png">)
 
-          expect(ContentModeration::Strategies::ClassifierStrategy).not_to receive(:new)
+          expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new) do |args|
+            expect(args[:image_urls].size).to eq(ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS)
+            expect(args[:image_urls]).to all(start_with("https://cdn.example.com/"))
+            instance_double(ContentModeration::Strategies::ClassifierStrategy,
+                            perform: strategy_result.new(status: "compliant", reasoning: []))
+          end
 
-          result = described_class.check(over_budget_page, :page)
-          expect(result.passed).to eq(false)
-          expect(result.reasons.first).to start_with(described_class::TOO_MANY_IMAGES_REASON_PREFIX)
+          expect(described_class.check(over_budget_page, :page).passed).to eq(true)
         end
 
         it "counts images painted through nested CSS toward the budget" do
@@ -262,9 +256,14 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
           end.join("\n")
           nested_page = Page.new(pageable: seller, slug: "nested", title: "Nested", custom_html: "<style>#{nested_css}</style>")
 
-          expect(ContentModeration::Strategies::ClassifierStrategy).not_to receive(:new)
+          expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new) do |args|
+            expect(args[:image_urls].size).to eq(ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS)
+            expect(args[:image_urls]).to all(start_with("https://cdn.example.com/"))
+            instance_double(ContentModeration::Strategies::ClassifierStrategy,
+                            perform: strategy_result.new(status: "compliant", reasoning: []))
+          end
 
-          expect(described_class.check(nested_page, :page).passed).to eq(false)
+          expect(described_class.check(nested_page, :page).passed).to eq(true)
         end
 
         it "moderates a page that sits exactly at the limit" do


### PR DESCRIPTION
Ref antiwork/gumroad-private#2245

Premerge review: P1 @ 7c137eae4a8f9b81a736057ec583b57d874c6277

## Status

- [x] Scope — implement Sahil's product call: sample 25 page images instead of rejecting large pages
- [x] Design — oversized page image sets are sampled to the existing 25-image moderation budget; identical image sets get a stable sample so retrying cannot reshuffle coverage; already-live pages always include newly added URLs when fewer than 25 are added
- [x] Build
- [x] Ship — Sahil accepted the sampled-moderation tradeoff and merged this on 2026-08-22; future improvements can tighten coverage without blocking this product change.
- [ ] Market
- [ ] Sell

## What

Custom storefront pages with more than 25 images no longer fail moderation just because the page is large. The moderation service samples 25 page images and sends every selected image through the existing page moderation path.

## Why

Sahil resolved the open product-direction question on gp#2245: “Can just pick 25 random instead of have a cap.” This replaces the size rejection that made legitimate catalog/storefront pages uneditable once they exceeded the image budget.

## Before-After

Before: any page with 26+ extracted images returned the “more images than we can review” error before content moderation strategies ran.

After: the page can save; moderation reviews text plus a 25-image sample, and existing preview endpoints agree with the write path for new and already-live over-budget pages.

## Test Results

Syntax OK on moderate_record_service.rb, moderate_record_service_spec.rb, users_controller_custom_html_spec.rb, and links_controller_custom_html_spec.rb. RuboCop reported no offenses on those four files. RSpec: 8 examples for “more images than we will review”, 3 examples each for the two controller “moderation reviews the page image budget” filters, and 161 examples across the three spec files — 0 failures. pnpm format was not run; this repo is configured to use npm.

Autoreview at 015ff94e4c reported P1: sampled page approval can publish unmoderated prohibited images. I changed the sample to be stable per image set and to prioritize newly added URLs for already-live pages, then reran autoreview at 7c137eae4a; it still reports P1 because new over-budget pages can still contain unreviewed images outside the sample.

## QA

Backend-only/API change; no rendered UI surface. Controller preview specs confirm new over-budget custom HTML and live over-budget page edits return success: true instead of the size error.



## Sol QA audit (this head)

VERDICT: P1 @ 7c137eae4a8f9b81a736057ec583b57d874c6277

- P1: over-budget pages are sampled before moderation, but the full `custom_html` is still saved and rendered. A new page with 26+ images can publish prohibited images outside the selected 25. Stable sampling stops reshuffle-on-retry; it does not close the bypass.
- P2: live-page new-URL specs are not mutation-strong.
- P2: comments in `content_extractor.rb` / `classifier_strategy.rb` still say over-budget pages are rejected.
