### PR TITLE
Preload the associations CustomerPresenter reads on every Sales row

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -166,13 +166,37 @@ class CustomersController < Sellers::BaseController
       sales.records
         .includes(
           :call,
-          :purchase_offer_code_discount,
+          :license,
+          :merchant_account,
+          :offer_code,
+          :preorder,
+          :price,
+          :purchaser,
+          # Lets Purchase#amount_refunded_cents take its in-memory Refund#effective?
+          # branch. Unpreloaded it runs a per-row SUM for cents_refundable.
+          :refunds,
+          :seller,
+          :shipment,
           :tip,
-          :upsell_purchase,
-          :variant_attributes,
           :url_redirect,
-          :link,
+          :variant_attributes,
+          affiliate: :affiliate_user,
+          commission_as_deposit: [:completion_purchase, { files_attachments: :blob }],
+          link: :alive_variants,
           product_review: [:response, { alive_videos: [:video_file] }],
+          purchase_custom_fields: { files_attachments: :blob },
+          purchase_offer_code_discount: :offer_code,
+          # original_product_review goes through Subscription#true_original_purchase (a different
+          # Purchase), so the top-level product_review preload never applies to memberships.
+          # :original_purchase is a separate cache; current_subscription_price_cents reads it.
+          subscription: [
+            :original_purchase,
+            {
+              last_payment_option: [:price, :installment_plan, :installment_plan_snapshot],
+              true_original_purchase: { product_review: [:response, { alive_videos: [:video_file] }] }
+            }
+          ],
+          upsell_purchase: :upsell,
           utm_link: [target_resource: [:seller, :user]]
         )
         .in_order_of(:id, sales.records.ids)

--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -233,6 +233,81 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
         expect(customer_ids[response].first(2)).to match_array([banana_purchase.external_id, apple_purchase.external_id])
       end
     end
+
+    context "N+1 query prevention" do
+      # Purchase#linked_license short-circuits on link.is_licensed?, so without this override the
+      # inherited purchases' licenses are never read and the license assertion passes vacuously.
+      let(:product) { create(:product, user: seller, name: "Product 1", price_cents: 100, is_licensed: true) }
+      let(:physical_product) { create(:physical_product, user: seller, name: "Physical product") }
+      let(:membership_product) { create(:membership_product, user: seller, name: "Membership") }
+      let(:installment_plan_product) { create(:product, :with_installment_plan, user: seller, name: "Installment plan product") }
+
+      before do
+        # Rails renders a single-owner preload as `WHERE x = <id>`, the same shape as the per-row
+        # query asserted against below, so every association needs at least two owners on one page.
+        stub_const("CustomersController::CUSTOMERS_PER_PAGE", 20)
+
+        purchases.each { create(:purchase_custom_field, purchase: _1, name: "Company", value: "Acme") }
+
+        # The SKU is a regression guard: preloading through variant_attributes raises
+        # AssociationNotFoundError once a Sku is in the result set.
+        3.times do
+          physical_purchase = create(:physical_purchase, seller:, link: physical_product,
+                                                         variant_attributes: [create(:sku, link: physical_product)])
+          create(:shipment, purchase: physical_purchase)
+        end
+        3.times { create(:membership_purchase, seller:, link: membership_product) }
+        # Subscription#recurrence takes the installment-plan branch for these, reading the payment
+        # option's snapshot rather than its price.
+        3.times { create(:installment_plan_purchase, seller:, link: installment_plan_product) }
+        # cents_refundable reads amount_refunded_cents, which SUMs refunds per row unless preloaded.
+        purchases.first(2).each { create(:refund, purchase: _1, amount_cents: 50) }
+
+        index_model_records(Purchase)
+      end
+
+      it "does not issue per-row association queries for the data every Sales row renders" do
+        # Pre-warm feature flags, the policy's team membership lookup and AR column caches,
+        # none of which repeat per row.
+        get :paged, params: { page: 1 }
+        expect(response).to be_successful
+
+        queries = []
+        callback = lambda do |_name, _start, _finish, _id, payload|
+          sql = payload[:sql]
+          next if payload[:name] == "SCHEMA" || payload[:cached]
+          queries << sql if sql.present? && sql.start_with?("SELECT")
+        end
+
+        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+          get :paged, params: { page: 1 }
+        end
+
+        expect(response).to be_successful
+        # Guards every assertion below, which pass vacuously on a short page.
+        expect(response.parsed_body["customers"].size).to eq(15)
+
+        # A batched preload reads `... IN (...)`. A bare `= <id>` is the per-row shape
+        # CustomerPresenter#customer triggers for an association load_sales does not preload.
+        {
+          "purchase custom field" => /FROM `purchase_custom_fields`.*`purchase_custom_fields`\.`purchase_id` = \d+/m,
+          "license" => /FROM `licenses`.*`licenses`\.`purchase_id` = \d+/m,
+          "subscription" => /FROM `subscriptions`.*`subscriptions`\.`id` = \d+/m,
+          "shipment" => /FROM `shipments`.*`shipments`\.`purchase_id` = \d+/m,
+          "payment option" => /FROM `payment_options`.*`payment_options`\.`id` = \d+/m,
+          "installment plan snapshot" => /FROM `installment_plan_snapshots`.*`payment_option_id` = \d+/m,
+          "refund sum" => /SUM\(`refunds`\.`amount_cents`\).*`refunds`\.`purchase_id` = \d+/m,
+          # Scoped to the flags-filtered original_purchase shape on purpose. The COUNT from
+          # remaining_charges_count and the ORDER BY from pending_failure? are known residuals
+          # that no preload fixes, and they hit the same table.
+          "subscription original purchase" => /SELECT `purchases`\.\* FROM `purchases` WHERE `purchases`\.`subscription_id` = \d+ AND \(\(`purchases`\.`flags`/m,
+        }.each do |label, per_row_pattern|
+          per_row = queries.grep(per_row_pattern)
+          expect(per_row).to be_empty,
+                             "Expected no per-row #{label} queries, got #{per_row.size}:\n#{per_row.join("\n")}"
+        end
+      end
+    end
   end
 
   describe "GET paged with active_customers_only filter" do


### PR DESCRIPTION
# Preload the associations CustomerPresenter reads on every Sales row

> Import of AJ0070/gumroad#1. CI green + premerge clean at `51e86d89bd44`. Bounty eligibility is Jyo's call.

Premerge review: clean @ 51e86d89bd44b3c71486aab773cb6d1ca12db141

## What

`CustomersController#load_sales` now preloads the associations `CustomerPresenter` reads on every Sales row, instead of issuing single-owner lookups per sale.

## Why

`/customers` render time was dominated by serial per-row SELECTs. Same includes-list extension as #740 / #765.

Imported from https://github.com/AJ0070/gumroad/pull/1 by @AJ0070 (Jash Ambaliya).

## Before / after

Contributor-measured on a real `GET /customers/paged` (15 sales: licensed digital, physical+SKU, memberships, installment plans):

| | Before | After |
|---|---|---|
| Total SELECTs | 128 | 69 |
| Single-owner (`= <id>`) SELECTs | 115 | 44 |

Walkthrough video on the source PR (qa-media binaries were not imported): https://raw.githubusercontent.com/AJ0070/gumroad/perf/sales-page-n-plus-one/qa-media/pr-1-sales-page-n-plus-one-walkthrough.mp4

Deliberately left out: nested `variant_attributes: { variant_category: :link }` (500s once a Sku is in the set — Rails 7.1 STI), and `subscription: :purchases` (would hydrate every charge to save one indexed lookup).

## Checklist

- [x] Scope — additive preload + N+1 spec only. No presenter/behavior change. Bounty amount not decided here.
- [x] Design — extend the existing includes list; do not preload `subscription.purchases`.
- [x] Build — `51e86d89bd44b3c71486aab773cb6d1ca12db141` on `perf/sales-page-n-plus-one`
- [x] QA — failing-first proof + GET paged file slice captured below
- [ ] Shipped — ready for human merge (Sales / N+1 surface). Fable-5 still quota-blocked until 2026-09-01; not requesting review.
- [x] Market — n/a, internal performance
- [x] Sell — n/a

## Test Results

Failing-first at `51e86d89bd44b3c71486aab773cb6d1ca12db141` (controller reverted to `origin/main`, spec kept):

```
rspec spec/controllers/customers_controller_spec.rb -e "N+1 query prevention"
RED: 1 example, 1 failure
Failure/Error: expect(per_row).to be_empty
Expected no per-row purchase custom field queries, got 15:
SELECT `purchase_custom_fields`.* FROM `purchase_custom_fields` WHERE `purchase_custom_fields`.`purchase_id` = …
```

Restored controller:

```
rspec spec/controllers/customers_controller_spec.rb -e "N+1 query prevention"
1 example, 0 failures (3.27s)

rspec spec/controllers/customers_controller_spec.rb -e "GET paged"
9 examples, 0 failures (13.35s)
```

Full `customers_controller_spec.rb` was 35 examples, 7 failures. The new N+1 example passed in that run. The 7 reds are GET index/show `ViteRuby.instance.manifest.resolve_entries` (no `public/vite-test` in this worktree) and one `create(:merchant_account)` uniqueness collision — none are in the `GET paged` slice this change exercises.

## QA steps

1. Revert `app/controllers/customers_controller.rb` to `origin/main`, run the new N+1 example — fails on 15 per-row `purchase_custom_fields` lookups.
2. Restore the controller — same example is green; all 9 `GET paged` examples green.
3. Open `/customers` as a seller with licensed, physical, and membership sales. The page should look unchanged; query counts via rack-mini-profiler.

No preview-app screenshot is owed for an identical render. Visual evidence is the source-PR walkthrough linked above.

Bounty: unsolicited performance PR, not mapped to a named bounty in this import. Reviewer call.

---

## AI disclosure

Generated with **grok-4.6** (xAI), running as gumclaw. Prompts/instructions: webhook on antiwork/gumroad-private#2255 to review and import AJ0070/gumroad#1; follow import-contribution + oss-contribution-import-lessons (exclude qa-media binaries, attribute the contributor, do not promise merge or bounty).

