### PR TITLE
Bootstrap gtag on seller-only analytics pages

### DIFF
--- a/app/javascript/data/google_analytics.test.ts
+++ b/app/javascript/data/google_analytics.test.ts
@@ -1,6 +1,27 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { sanitizedPageLocation, sanitizedPageReferrer } from "./google_analytics";
+vi.mock("$vendor/google_analytics_4", () => ({ default: vi.fn() }));
+
+import { sanitizedPageLocation, sanitizedPageReferrer, startTrackingForSeller } from "./google_analytics";
+
+function enableGa() {
+  document.head.innerHTML = '<meta property="gr:google_analytics:enabled" content="true">';
+}
+
+function stubGtag() {
+  const gtag = vi.fn();
+  vi.stubGlobal("gtag", gtag);
+  return gtag;
+}
+
+const sellerConfig = {
+  id: "seller-1",
+  googleAnalyticsId: "G-SELLERTEST1",
+  facebookPixelId: null,
+  tiktokPixelId: null,
+  trackFreeSales: false,
+};
 
 describe("sanitizedPageLocation", () => {
   it("strips reset_password_token so it never reaches analytics (gumroad-private#1260)", () => {
@@ -45,5 +66,50 @@ describe("sanitizedPageReferrer", () => {
 
   it("drops unparseable referrers rather than forwarding them unstripped", () => {
     expect(sanitizedPageReferrer("not a url")).toBe("");
+  });
+});
+
+describe("startTrackingForSeller", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("issues gtag js before the seller config so custom landing events transmit", () => {
+    enableGa();
+    const gtag = stubGtag();
+
+    startTrackingForSeller(sellerConfig);
+
+    expect(gtag).toHaveBeenNthCalledWith(1, "js", expect.any(Date));
+    expect(gtag).toHaveBeenNthCalledWith(
+      2,
+      "config",
+      "G-SELLERTEST1",
+      expect.objectContaining({ groups: "sellerseller-1", send_page_view: false }),
+    );
+    expect(gtag).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not bootstrap gtag when tracking is off", () => {
+    document.head.innerHTML = '<meta property="gr:google_analytics:enabled" content="false">';
+    const gtag = stubGtag();
+
+    startTrackingForSeller(sellerConfig);
+
+    expect(gtag).not.toHaveBeenCalled();
+  });
+
+  it("does not bootstrap gtag when the seller has no measurement id", () => {
+    enableGa();
+    const gtag = stubGtag();
+
+    startTrackingForSeller({ ...sellerConfig, googleAnalyticsId: null });
+
+    expect(gtag).not.toHaveBeenCalled();
   });
 });

--- a/app/javascript/data/google_analytics.test.ts
+++ b/app/javascript/data/google_analytics.test.ts
@@ -1,9 +1,12 @@
 // @vitest-environment happy-dom
+import loadGoogleAnalyticsScript from "$vendor/google_analytics_4";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sanitizedPageLocation, sanitizedPageReferrer, startTrackingForSeller } from "./google_analytics";
 
 vi.mock("$vendor/google_analytics_4", () => ({ default: vi.fn() }));
 
-import { sanitizedPageLocation, sanitizedPageReferrer, startTrackingForSeller } from "./google_analytics";
+const mockedLoadGoogleAnalyticsScript = vi.mocked(loadGoogleAnalyticsScript);
 
 function enableGa() {
   document.head.innerHTML = '<meta property="gr:google_analytics:enabled" content="true">';
@@ -73,17 +76,24 @@ describe("startTrackingForSeller", () => {
   beforeEach(() => {
     document.head.innerHTML = "";
     vi.unstubAllGlobals();
+    mockedLoadGoogleAnalyticsScript.mockReset();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    mockedLoadGoogleAnalyticsScript.mockReset();
   });
 
-  it("issues gtag js before the seller config so custom landing events transmit", () => {
+  it("loads gtag for seller-only pages, then issues js before seller config so custom landing events transmit", () => {
     enableGa();
-    const gtag = stubGtag();
+    const gtag = vi.fn();
+    mockedLoadGoogleAnalyticsScript.mockImplementation(() => {
+      vi.stubGlobal("gtag", gtag);
+    });
 
     startTrackingForSeller(sellerConfig);
+
+    expect(mockedLoadGoogleAnalyticsScript).toHaveBeenCalledOnce();
 
     expect(gtag).toHaveBeenNthCalledWith(1, "js", expect.any(Date));
     expect(gtag).toHaveBeenNthCalledWith(

--- a/app/javascript/data/google_analytics.ts
+++ b/app/javascript/data/google_analytics.ts
@@ -172,6 +172,9 @@ export function startTrackingForSeller(data: AnalyticsConfig) {
   if (!shouldTrack() || !data.googleAnalyticsId) return;
   if (typeof gtag === "undefined") loadGoogleAnalyticsScript();
 
+  // Custom landing / mobile tracking never call startTrackingForGumroad, so this
+  // path has to issue the gtag("js") bootstrap itself or seller events stay queued.
+  gtag("js", new Date());
   gtag("config", data.googleAnalyticsId, {
     groups: `seller${data.id}`,
     cookie_flags: "SameSite=None; Secure",


### PR DESCRIPTION
# Bootstrap gtag on seller-only analytics pages

## What

`startTrackingForSeller` now issues `gtag("js", new Date())` before the seller `config`, matching the bootstrap the default product page already gets from `startTrackingForGumroad`. Custom product/profile landing pages and mobile tracking only call the seller path, so they were loading gtag.js and pushing `page_view` / `view_item` into `dataLayer` without ever telling gtag to initialize its event queue.

## Why

Publishing a custom landing page made the seller's GA4 property stop receiving `page_view` and `view_item`. Auto `user_engagement` still arrived (config was live). Clearing the landing page restored tracking. The default product page hid the gap because it also runs `startTrackingForGumroad`.

## Before / after

- Before: seller-only surfaces called `gtag("config", …)` with no `gtag("js")`. Events sat in `dataLayer` and did not transmit.
- After: seller-only surfaces call `gtag("js", new Date())` then `gtag("config", …)`. Same event names as the standard product page.

Rejected alternative: also calling `startTrackingForGumroad()` from the custom-page entry point. That would send those views to Gumroad's own GA property as a side effect. The missing piece is the bootstrap, not a second measurement id.

## Checklist

- [x] Scope — seller-only gtag bootstrap; no Gumroad GA config, no event-name changes
- [x] Design — one line in `startTrackingForSeller` so custom landing + mobile tracking both get it
- [x] Build — `97aafd40bf` on `gumclaw/gp2257-custom-landing-ga4-js`
- [x] QA — vitest + mutation proof locally; live dataLayer probe on hosted preview at this head
- [ ] Shipped
- [ ] Market — n/a (bugfix, no launch)
- [ ] Sell — n/a

## Test Results

```text
npx prettier --write app/javascript/data/google_analytics.test.ts
  unchanged

npm run lint-fast -- --max-warnings 0 app/javascript/data/google_analytics.test.ts
  passed

npx vitest run app/javascript/data/google_analytics.test.ts
  at 97aafd40bf
  Test Files  1 passed (1)
  Tests  11 passed (11)

Mutation: delete `if (typeof gtag === "undefined") loadGoogleAnalyticsScript();` from startTrackingForSeller
  → 1 failed (the seller-only loader-path example)
  restored control: 11 passed
```

## QA

No rendered UI change — gtag command order is not visible on the page.

Local proof: vitest 11/11 plus the loader-removal mutant above.

Live probe 2026-08-22 14:04 UTC on hosted preview `gumclaw-gp2257-custom-landing-ga.apps.staging.gumroad.org` (`x-revision: 97aafd40bf9f` == head). Seeded `seller@gumroad.com` product `demo` with custom HTML + `G-TEST7352QA`. Playwright on `https://seller.gumclaw-gp2257-custom-landing-ga.apps.staging.gumroad.org/l/demo`:

- wrapper is the custom landing (`#gumroad-landing-frame` present)
- `gr:google_analytics:enabled=true`, `tracking_enabled=true`, seller GA id `G-TEST7352QA`
- `dataLayer` command order: `js` → `config G-TEST7352QA` → `event page_view` → `event view_item` (then gtm.dom / gtm.load)

That is the missing bootstrap plus the two events that were not transmitting.

Premerge review: clean @ 97aafd40bf9faa0fe0954851eb169f3d58e9ff17

---

## AI disclosure

Generated with **grok-4.6** (xAI), running as gumclaw. Prompts/instructions: GitHub issues webhook for a confirmed custom-landing GA4 transmission bug; standing autonomous-product-dev pipeline (draft PR early, no private incident specifics in the public repo).
