### PR TITLE
Retry sale pings on connect and read timeouts

### DIFF
--- a/app/sidekiq/post_to_individual_ping_endpoint_worker.rb
+++ b/app/sidekiq/post_to_individual_ping_endpoint_worker.rb
@@ -8,6 +8,25 @@ class PostToIndividualPingEndpointWorker
   BACKOFF_STRATEGY = [60, 180, 600, 3600].freeze
   REQUEST_TIMEOUT_SECONDS = 5
   MAX_REDIRECTS = 3
+  # Transient connect/read failures. Permanent URL verdicts (PrivateIP, InvalidUriScheme,
+  # InvalidURIError) stay in the INTERNET_EXCEPTIONS drop path below.
+  RETRYABLE_EXCEPTIONS = [
+    SsrfFilter::UnresolvedHostname,
+    Timeout::Error,
+    Net::OpenTimeout,
+    Net::ReadTimeout,
+    Errno::ECONNREFUSED,
+    Errno::ECONNRESET,
+    Errno::ENETUNREACH,
+    Errno::EHOSTUNREACH,
+    Errno::EADDRNOTAVAIL,
+    SocketError,
+    EOFError,
+    OpenSSL::SSL::SSLError,
+    Faraday::ConnectionFailed,
+    HTTP::ConnectionError,
+    HTTP::TimeoutError
+  ].freeze
 
   def perform(post_url, params, content_type = Mime[:url_encoded_form].to_s, user_id = nil)
     retry_count = params["retry_count"] || 0
@@ -52,21 +71,16 @@ class PostToIndividualPingEndpointWorker
     Rails.logger.info("PostToIndividualPingEndpointWorker response=#{response.code} content_type=#{content_type} user_id=#{user_id}")
 
     unless response.is_a?(Net::HTTPSuccess)
-      if ERROR_CODES_TO_RETRY.include?(response.code.to_i) && retry_count < (BACKOFF_STRATEGY.length - 1)
-        PostToIndividualPingEndpointWorker.perform_in(BACKOFF_STRATEGY[retry_count].seconds, post_url, params.merge("retry_count" => retry_count + 1), content_type, user_id)
-      end
+      enqueue_retry(post_url, params, content_type, user_id, retry_count) if ERROR_CODES_TO_RETRY.include?(response.code.to_i)
     end
 
-  # An empty lookup is usually a DNS blip, not a verdict on the URL (gp#2155), so retry it on the
-  # same backoff as a 5xx. Must precede the blanket rescue: SsrfFilter::Error is in
-  # INTERNET_EXCEPTIONS, which is also why PrivateIPAddress still falls through to a plain drop.
-  rescue SsrfFilter::UnresolvedHostname => e
+  # Must precede the blanket INTERNET_EXCEPTIONS rescue: SsrfFilter::Error is in that
+  # list, so UnresolvedHostname would otherwise drop, and PrivateIPAddress must keep
+  # falling through to a plain drop.
+  rescue *RETRYABLE_EXCEPTIONS => e
     Rails.logger.info("[#{e.class}] PostToIndividualPingEndpointWorker error content_type=#{content_type} user_id=#{user_id} retry_count=#{retry_count}")
-    if retry_count < (BACKOFF_STRATEGY.length - 1)
-      PostToIndividualPingEndpointWorker.perform_in(BACKOFF_STRATEGY[retry_count].seconds, post_url, params.merge("retry_count" => retry_count + 1), content_type, user_id)
-    end
-  # rescue clause to handle connection errors. Without this, the job
-  # would fail if the user inputted post_url is invalid.
+    enqueue_retry(post_url, params, content_type, user_id, retry_count)
+  # Permanent URL / connect verdicts (private IP, bad scheme, invalid URI).
   rescue *INTERNET_EXCEPTIONS => e
     Rails.logger.info("[#{e.class}] PostToIndividualPingEndpointWorker error content_type=#{content_type} user_id=#{user_id}")
   end
@@ -74,5 +88,17 @@ class PostToIndividualPingEndpointWorker
   private
     def encode_brackets(key)
       key.to_s.gsub(/[\[\]]/) { |char| URI.encode_www_form_component(char) }
+    end
+
+    def enqueue_retry(post_url, params, content_type, user_id, retry_count)
+      return unless retry_count < (BACKOFF_STRATEGY.length - 1)
+
+      PostToIndividualPingEndpointWorker.perform_in(
+        BACKOFF_STRATEGY[retry_count].seconds,
+        post_url,
+        params.merge("retry_count" => retry_count + 1),
+        content_type,
+        user_id
+      )
     end
 end

--- a/spec/sidekiq/post_to_individual_ping_endpoint_worker_spec.rb
+++ b/spec/sidekiq/post_to_individual_ping_endpoint_worker_spec.rb
@@ -59,15 +59,26 @@ describe PostToIndividualPingEndpointWorker do
     end
   end
 
-  it "does not raise when it encounters an internet error" do
+  it "does not raise when it encounters a retryable internet error" do
     allow(SsrfFilter).to receive(:post).and_raise(SocketError.new("socket error message"))
     messages = []
     allow(Rails.logger).to receive(:info) { |message| messages << message }
-    expect(SsrfFilter).to receive(:post).exactly(1).times
 
     PostToIndividualPingEndpointWorker.new.perform("http://example.com", { "q" => 47 })
 
-    expect(messages).to include("[SocketError] PostToIndividualPingEndpointWorker error content_type=#{Mime[:url_encoded_form]} user_id=")
+    expect(messages).to include("[SocketError] PostToIndividualPingEndpointWorker error content_type=#{Mime[:url_encoded_form]} user_id= retry_count=0")
+    expect(PostToIndividualPingEndpointWorker.jobs.size).to eq(1)
+  end
+
+  it "re-enqueues itself with backoff on a read timeout" do
+    allow(SsrfFilter).to receive(:post).and_raise(Net::ReadTimeout)
+
+    PostToIndividualPingEndpointWorker.new.perform("http://notification.com", { "q" => 47 })
+
+    expect(PostToIndividualPingEndpointWorker.jobs.size).to eq(1)
+    job = PostToIndividualPingEndpointWorker.jobs.first
+    expect(job["args"]).to eq(["http://notification.com", { "q" => 47, "retry_count" => 1 }, Mime[:url_encoded_form].to_s, nil])
+    expect(job["at"]).to be_within(5).of(PostToIndividualPingEndpointWorker::BACKOFF_STRATEGY.first.seconds.from_now.to_f)
   end
 
   it "re-raises a non-internet error" do


### PR DESCRIPTION
## What

Retry `PostToIndividualPingEndpointWorker` on transient connect/read failures (`Net::OpenTimeout`, `Net::ReadTimeout`, `SocketError`, `ECONNRESET`/`ECONNREFUSED`, `OpenSSL::SSL::SSLError`) using the same backoff already used for empty DNS and 5xx.

Permanent URL verdicts still drop with no retry: private IPs, invalid URI, invalid scheme.

## Why

[antiwork/gumroad#7248](https://github.com/antiwork/gumroad/pull/7248) stopped empty-DNS skips. The individual worker still swallowed every other `INTERNET_EXCEPTIONS` class after one 5s attempt. Prod logs `20260822T1828Z` on `production-logs-2` (Aug 19–22): **1958** `PostToIndividualPingEndpointWorker error` lines. Sample of 200: OpenTimeout 79, UnresolvedHostname 66 (already retried), ReadTimeout 36, ECONNREFUSED 12, InvalidUriScheme 4, SSLError 2, InvalidURIError 1.

That is the post-#7248 residual drop: the POST never happens, there is no Sidekiq retry, and a later manual re-ping succeeds.

Related: [antiwork/gumroad-private#2155](https://github.com/antiwork/gumroad-private/issues/2155)

## Before / After

| Failure | Before | After |
|---|---|---|
| `Net::OpenTimeout` / `Net::ReadTimeout` / `SocketError` / `ECONNRESET` / SSL | log + drop | same backoff as DNS/5xx (60s/180s/600s/3600s) |
| `SsrfFilter::UnresolvedHostname` | retry | unchanged |
| `SsrfFilter::PrivateIPAddress` / invalid URI / bad scheme | drop | unchanged |
| HTTP 5xx | retry | unchanged |

## Test Results

```
DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/post_to_individual_ping_endpoint_worker_spec.rb
18 examples, 0 failures
```

Mutation: the new ReadTimeout example reddens if that class stays on the drop path. PrivateIP example still asserts `jobs.size == 0`.

No schema change. No rendered surface.

## Status

- [x] Scope — retry transient connect/read errors only
- [x] Design — reuse existing backoff; keep private-IP / bad-URI drops
- [x] Build
- [ ] Ship — stays draft. Webhook delivery. Fable-5 blocked until 2026-09-01. Not requesting review.
- [ ] Market
- [ ] Sell

---

AI disclosure: Authored by gumclaw using Hermes Agent. Model: grok-4.6.

Premerge review: clean @ d4d057f74fa95826c98cc5121b90fbc4160f8726
