### PR TITLE
Skip Fast/Slow on main when the same tree already passed them

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,38 +29,25 @@ jobs:
     # PR carrying the run-all-specs label. Push events have no PR payload,
     # so the label is looked up via the commit's PRs.
     #
-    # On main, reuse=true when a merged PR already ran Fast+Slow on the
-    # exact same git tree. Deploy then skips those shards.
+    # Fork PRs hit this job via pull_request_target (token is the base repo).
+    # No checkout here — only label lookup. Reuse of a prior Fast/Slow run
+    # lives in reuse_scope, which is main-push only.
     name: Run scope
     runs-on: ubicloud-standard-2
     needs: ci_gate
     if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
     permissions:
       pull-requests: read
-      actions: read
-      contents: read
     outputs:
       full: ${{ steps.scope.outputs.full }}
-      reuse: ${{ steps.scope.outputs.reuse }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-          persist-credentials: false
-          sparse-checkout: bin/reuse-full-suite
-          sparse-checkout-cone-mode: false
       - id: scope
         env:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
         run: |
-          echo "reuse=false" >> "$GITHUB_OUTPUT"
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
             echo "full=true" >> "$GITHUB_OUTPUT"
-            # Same git tree already passed Fast+Slow on the merged PR? Skip
-            # re-running ~68 shards before deploy. Tree mismatch (PR behind
-            # main) or a Relevant-only run does not reuse.
-            REPO="$GITHUB_REPOSITORY" bin/reuse-full-suite "$SHA" || true
             exit 0
           fi
           if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ]; then
@@ -73,6 +60,35 @@ jobs:
           else
             echo "full=false" >> "$GITHUB_OUTPUT"
           fi
+
+  reuse_scope:
+    # Main-only. Asks whether this exact git tree already passed Fast+Slow on
+    # a merged PR. Isolated from pull_request_target so a fork cannot put
+    # bin/reuse-full-suite in front of a token that can read Actions.
+    name: Reuse full suite
+    runs-on: ubicloud-standard-2
+    needs: ci_gate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      pull-requests: read
+      actions: read
+      contents: read
+    outputs:
+      reuse: ${{ steps.reuse.outputs.reuse }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout: bin/reuse-full-suite
+          sparse-checkout-cone-mode: false
+      - id: reuse
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.sha }}
+        run: |
+          echo "reuse=false" >> "$GITHUB_OUTPUT"
+          REPO="$GITHUB_REPOSITORY" bin/reuse-full-suite "$SHA" || true
 
   lint_js:
     name: Lint JS/TS
@@ -568,10 +584,18 @@ jobs:
     env:
       COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_fast_${{ matrix.ci_node_index }}
     runs-on: ubicloud-standard-4
-    needs: [build, run_scope]
+    needs: [build, run_scope, reuse_scope]
     # Full suite: main pushes (deploy gate) and PRs labeled run-all-specs,
     # unless this main commit is the same tree as a PR that already passed Fast+Slow.
-    if: needs.run_scope.outputs.full == 'true' && needs.run_scope.outputs.reuse != 'true'
+    # reuse_scope is skipped off main — always() so that skip does not cancel
+    # a run-all-specs PR. Empty reuse output is not 'true', so Fast still runs.
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.build.result == 'success' &&
+      needs.run_scope.result == 'success' &&
+      needs.run_scope.outputs.full == 'true' &&
+      needs.reuse_scope.outputs.reuse != 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -702,10 +726,18 @@ jobs:
       COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_slow_${{ matrix.ci_node_index }}
       WEB_REPO: antiwork/gumroad-web
     runs-on: ubicloud-standard-4
-    needs: [build, run_scope]
+    needs: [build, run_scope, reuse_scope]
     # Full suite: main pushes (deploy gate) and PRs labeled run-all-specs,
     # unless this main commit is the same tree as a PR that already passed Fast+Slow.
-    if: needs.run_scope.outputs.full == 'true' && needs.run_scope.outputs.reuse != 'true'
+    # reuse_scope is skipped off main — always() so that skip does not cancel
+    # a run-all-specs PR. Empty reuse output is not 'true', so Slow still runs.
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.build.result == 'success' &&
+      needs.run_scope.result == 'success' &&
+      needs.run_scope.outputs.full == 'true' &&
+      needs.reuse_scope.outputs.reuse != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -1115,14 +1147,14 @@ jobs:
   unblock_deployment_from_buildkite:
     name: Unblock deployment from Buildkite
     runs-on: ubicloud-standard-2
-    needs: [run_scope, test_fast, test_slow, test_minitest]
+    needs: [run_scope, reuse_scope, test_fast, test_slow, test_minitest]
     # Skipped Fast/Slow (reuse) must not block deploy. success() is false when
     # a needed job is skipped, so check results explicitly.
     if: |
       github.event_name == 'push' && github.ref == 'refs/heads/main' &&
       needs.test_minitest.result == 'success' &&
       (
-        needs.run_scope.outputs.reuse == 'true' ||
+        needs.reuse_scope.outputs.reuse == 'true' ||
         (needs.test_fast.result == 'success' && needs.test_slow.result == 'success')
       )
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1148,11 +1148,15 @@ jobs:
     name: Unblock deployment from Buildkite
     runs-on: ubicloud-standard-2
     needs: [run_scope, reuse_scope, test_fast, test_slow, test_minitest]
-    # Skipped Fast/Slow (reuse) must not block deploy. success() is false when
-    # a needed job is skipped, so check results explicitly.
+    # Skipped Fast/Slow (reuse) must not block deploy. A needed job that is
+    # skipped fails the default success gate, so always() is required or
+    # this job never runs on the reuse path.
     if: |
+      always() &&
+      !cancelled() &&
       github.event_name == 'push' && github.ref == 'refs/heads/main' &&
       needs.test_minitest.result == 'success' &&
+      needs.reuse_scope.result == 'success' &&
       (
         needs.reuse_scope.outputs.reuse == 'true' ||
         (needs.test_fast.result == 'success' && needs.test_slow.result == 'success')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,22 +28,39 @@ jobs:
     # test_relevant job. Full suite: every push to main (deploy gate), or a
     # PR carrying the run-all-specs label. Push events have no PR payload,
     # so the label is looked up via the commit's PRs.
+    #
+    # On main, reuse=true when a merged PR already ran Fast+Slow on the
+    # exact same git tree. Deploy then skips those shards.
     name: Run scope
     runs-on: ubicloud-standard-2
     needs: ci_gate
     if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository }}
     permissions:
       pull-requests: read
+      actions: read
+      contents: read
     outputs:
       full: ${{ steps.scope.outputs.full }}
+      reuse: ${{ steps.scope.outputs.reuse }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          sparse-checkout: bin/reuse-full-suite
+          sparse-checkout-cone-mode: false
       - id: scope
         env:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
         run: |
+          echo "reuse=false" >> "$GITHUB_OUTPUT"
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
             echo "full=true" >> "$GITHUB_OUTPUT"
+            # Same git tree already passed Fast+Slow on the merged PR? Skip
+            # re-running ~68 shards before deploy. Tree mismatch (PR behind
+            # main) or a Relevant-only run does not reuse.
+            REPO="$GITHUB_REPOSITORY" bin/reuse-full-suite "$SHA" || true
             exit 0
           fi
           if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ]; then
@@ -552,9 +569,9 @@ jobs:
       COMPOSE_PROJECT_NAME: web_${{ github.run_id }}_${{ github.run_attempt }}_fast_${{ matrix.ci_node_index }}
     runs-on: ubicloud-standard-4
     needs: [build, run_scope]
-    # Full suite: main pushes (deploy gate) and PRs labeled run-all-specs.
-    # Everything else runs test_relevant instead.
-    if: needs.run_scope.outputs.full == 'true'
+    # Full suite: main pushes (deploy gate) and PRs labeled run-all-specs,
+    # unless this main commit is the same tree as a PR that already passed Fast+Slow.
+    if: needs.run_scope.outputs.full == 'true' && needs.run_scope.outputs.reuse != 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -686,9 +703,9 @@ jobs:
       WEB_REPO: antiwork/gumroad-web
     runs-on: ubicloud-standard-4
     needs: [build, run_scope]
-    # Full suite: main pushes (deploy gate) and PRs labeled run-all-specs.
-    # Everything else runs test_relevant instead.
-    if: needs.run_scope.outputs.full == 'true'
+    # Full suite: main pushes (deploy gate) and PRs labeled run-all-specs,
+    # unless this main commit is the same tree as a PR that already passed Fast+Slow.
+    if: needs.run_scope.outputs.full == 'true' && needs.run_scope.outputs.reuse != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -1098,8 +1115,16 @@ jobs:
   unblock_deployment_from_buildkite:
     name: Unblock deployment from Buildkite
     runs-on: ubicloud-standard-2
-    needs: [test_fast, test_slow, test_minitest]
-    if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [run_scope, test_fast, test_slow, test_minitest]
+    # Skipped Fast/Slow (reuse) must not block deploy. success() is false when
+    # a needed job is skipped, so check results explicitly.
+    if: |
+      github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+      needs.test_minitest.result == 'success' &&
+      (
+        needs.run_scope.outputs.reuse == 'true' ||
+        (needs.test_fast.result == 'success' && needs.test_slow.result == 'success')
+      )
     steps:
       - name: Unblock corresponding Buildkite build
         uses: nick-fields/retry@v3

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -6,8 +6,10 @@
 # for files whose behavior many end-to-end specs depend on.
 #
 # Branch CI runs exactly this list (see .github/workflows/tests.yml
-# test_relevant); main still runs everything before a deploy, and a PR can
-# opt into the full suite with the run-all-specs label.
+# test_relevant). Main still requires a green full suite before deploy, but
+# skips re-running Fast/Slow when the merge commit is the same git tree as a
+# PR that already passed them (bin/reuse-full-suite). A PR can opt into the
+# full suite with the run-all-specs label.
 #
 # Exits 3 (ESCALATE) when the diff cannot be mapped safely — dependency,
 # config, migration, factory, or unmapped-helper changes, or a selection so

--- a/bin/reuse-full-suite
+++ b/bin/reuse-full-suite
@@ -46,27 +46,56 @@ tree_of() {
   api "repos/$REPO/git/commits/$1" --jq .tree.sha
 }
 
-full_suite_green() {
-  local head="$1"
-  local run_id
-  run_id=$(api "repos/$REPO/actions/runs?head_sha=$head&status=completed&per_page=20" \
-    --jq '[.workflow_runs[] | select(.name == "Tests" and .conclusion == "success")][0].id // empty')
-  if [ -z "$run_id" ]; then
-    return 1
-  fi
-  # Require at least one completed-success Fast shard and one Slow shard.
-  # Skipped Fast/Slow means that run was test_relevant only — not reusable.
+run_has_full_suite() {
+  local run_id="$1"
   local jobs
-  jobs=$(api "repos/$REPO/actions/runs/$run_id/jobs?per_page=100" --paginate \
-    --jq '[.jobs[] | {name, conclusion}]')
+  # Raw pages: --paginate may emit more than one JSON object.
+  jobs=$(api "repos/$REPO/actions/runs/$run_id/jobs?per_page=100" --paginate)
   echo "$jobs" | python3 -c '
 import json, sys
-jobs = json.load(sys.stdin)
+text = sys.stdin.read()
+dec = json.JSONDecoder()
+jobs = []
+idx = 0
+while idx < len(text):
+    while idx < len(text) and text[idx].isspace():
+        idx += 1
+    if idx >= len(text):
+        break
+    obj, end = dec.raw_decode(text, idx)
+    jobs.extend(obj.get("jobs", []))
+    idx = end
 def ok(prefix):
-    hits = [j for j in jobs if j.get("name", "").startswith(prefix)]
-    return any(j.get("conclusion") == "success" for j in hits) and not any(j.get("conclusion") == "failure" for j in hits)
+    hits = [
+        j for j in jobs
+        if j.get("name", "").startswith(prefix)
+        and "noop" not in j.get("name", "").lower()
+    ]
+    return (
+        any(j.get("conclusion") == "success" for j in hits)
+        and not any(j.get("conclusion") == "failure" for j in hits)
+    )
 sys.exit(0 if ok("Test Fast") and ok("Test Slow") else 1)
 '
+}
+
+full_suite_green() {
+  local head="$1"
+  local run_ids
+  # Same SHA can have several successful Tests runs (push + pull_request_target
+  # noop). The newest is often the noop. Any run with green Fast+Slow counts.
+  run_ids=$(api "repos/$REPO/actions/runs?head_sha=$head&status=completed&per_page=20" --paginate \
+    --jq '.workflow_runs[] | select(.name == "Tests" and .conclusion == "success") | .id')
+  if [ -z "${run_ids:-}" ]; then
+    return 1
+  fi
+  local run_id
+  for run_id in $run_ids; do
+    if run_has_full_suite "$run_id"; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 MAIN_TREE=$(tree_of "$SHA" || true)

--- a/bin/reuse-full-suite
+++ b/bin/reuse-full-suite
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Decide whether this main commit can skip Fast/Slow because a PR already
+# ran the full suite on the exact same git tree.
+#
+# Prints reuse=true or reuse=false (and writes GITHUB_OUTPUT when set).
+# Never exits non-zero on a "no" — a lookup miss must re-run the suite.
+#
+# Usage:
+#   bin/reuse-full-suite <sha>
+#   REPO=antiwork/gumroad bin/reuse-full-suite <sha>
+set -euo pipefail
+
+SHA="${1:-}"
+REPO="${REPO:-${GITHUB_REPOSITORY:-antiwork/gumroad}}"
+GH="${GH:-gh}"
+
+emit() {
+  echo "reuse=$1"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "reuse=$1" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+if [ -z "$SHA" ]; then
+  echo "usage: bin/reuse-full-suite <sha>" >&2
+  emit false
+  exit 0
+fi
+
+api() {
+  "$GH" api "$@"
+}
+
+tree_of() {
+  api "repos/$REPO/git/commits/$1" --jq .tree.sha
+}
+
+full_suite_green() {
+  local head="$1"
+  local run_id
+  run_id=$(api "repos/$REPO/actions/runs?head_sha=$head&status=completed&per_page=20" \
+    --jq '[.workflow_runs[] | select(.name == "Tests" and .conclusion == "success")][0].id // empty')
+  if [ -z "$run_id" ]; then
+    return 1
+  fi
+  # Require at least one completed-success Fast shard and one Slow shard.
+  # Skipped Fast/Slow means that run was test_relevant only — not reusable.
+  local jobs
+  jobs=$(api "repos/$REPO/actions/runs/$run_id/jobs?per_page=100" --paginate \
+    --jq '[.jobs[] | {name, conclusion}]')
+  echo "$jobs" | python3 -c '
+import json, sys
+jobs = json.load(sys.stdin)
+def ok(prefix):
+    hits = [j for j in jobs if j.get("name", "").startswith(prefix)]
+    return any(j.get("conclusion") == "success" for j in hits) and not any(j.get("conclusion") == "failure" for j in hits)
+sys.exit(0 if ok("Test Fast") and ok("Test Slow") else 1)
+'
+}
+
+MAIN_TREE=$(tree_of "$SHA" || true)
+if [ -z "${MAIN_TREE:-}" ]; then
+  echo "reuse-full-suite: no tree for $SHA" >&2
+  emit false
+  exit 0
+fi
+
+PRS=$(api "repos/$REPO/commits/$SHA/pulls" --jq '.[].number' || true)
+if [ -z "${PRS:-}" ]; then
+  echo "reuse-full-suite: no associated PR for $SHA" >&2
+  emit false
+  exit 0
+fi
+
+for pr in $PRS; do
+  HEAD=$(api "repos/$REPO/pulls/$pr" --jq .head.sha)
+  PR_TREE=$(tree_of "$HEAD" || true)
+  if [ -z "${PR_TREE:-}" ]; then
+    continue
+  fi
+  if [ "$PR_TREE" != "$MAIN_TREE" ]; then
+    echo "reuse-full-suite: PR #$pr tree $PR_TREE != $MAIN_TREE" >&2
+    continue
+  fi
+  if full_suite_green "$HEAD"; then
+    echo "reuse-full-suite: reusing Tests from PR #$pr head $HEAD (tree $MAIN_TREE)" >&2
+    emit true
+    exit 0
+  fi
+  echo "reuse-full-suite: PR #$pr same tree but no green full suite on $HEAD" >&2
+done
+
+emit false
+exit 0

--- a/bin/reuse-full-suite
+++ b/bin/reuse-full-suite
@@ -113,7 +113,11 @@ if [ -z "${PRS:-}" ]; then
 fi
 
 for pr in $PRS; do
-  HEAD=$(api "repos/$REPO/pulls/$pr" --jq .head.sha)
+  HEAD=$(api "repos/$REPO/pulls/$pr" --jq .head.sha || true)
+  if [ -z "${HEAD:-}" ]; then
+    echo "reuse-full-suite: no head for PR #$pr" >&2
+    continue
+  fi
   PR_TREE=$(tree_of "$HEAD" || true)
   if [ -z "${PR_TREE:-}" ]; then
     continue

--- a/bin/reuse-full-suite
+++ b/bin/reuse-full-suite
@@ -27,6 +27,17 @@ if [ -z "$SHA" ]; then
   exit 0
 fi
 
+# Refuse to decide reuse unless this is a push to main. Fork PRs run Tests
+# via pull_request_target with a base-repo token — never skip the suite
+# from that path, even if a caller wires this script in by mistake.
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  if [ "${GITHUB_EVENT_NAME:-}" != "push" ] || [ "${GITHUB_REF:-}" != "refs/heads/main" ]; then
+    echo "reuse-full-suite: refuse off main ($GITHUB_EVENT_NAME $GITHUB_REF)" >&2
+    emit false
+    exit 0
+  fi
+fi
+
 api() {
   "$GH" api "$@"
 }

--- a/script/test-reuse-full-suite
+++ b/script/test-reuse-full-suite
@@ -100,4 +100,28 @@ out=$(GITHUB_ACTIONS=1 GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main REPO=an
 test "$out" = "reuse=true" || { echo "FAIL expected reuse=true on GHA main push got [$out]"; exit 1; }
 echo "ok allow GHA main push"
 
+# pulls/<n> 404 must emit reuse=false, not die with empty stdout.
+cat > "$FAKE/gh-fail-pull" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+jq_expr=""
+path=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--jq" ]; then jq_expr="$a"; fi
+  case "$a" in repos/*) path="$a" ;; esac
+  prev="$a"
+done
+apply() { if [ -n "$jq_expr" ]; then jq -r "$jq_expr"; else cat; fi; }
+if [[ "$path" == */git/commits/mainsha ]]; then echo '{"tree":{"sha":"TREE_MAIN"}}' | apply
+elif [[ "$path" == */commits/mainsha/pulls ]]; then echo '[{"number":1}]' | apply
+elif [[ "$path" == */pulls/1 ]]; then echo "boom" >&2; exit 1
+else echo "unexpected $path" >&2; exit 1
+fi
+EOF
+chmod +x "$FAKE/gh-fail-pull"
+out=$(REPO=antiwork/gumroad GH="$FAKE/gh-fail-pull" "$SCRIPT" mainsha || true)
+test "$out" = "reuse=false" || { echo "FAIL expected reuse=false on pulls 404 got [$out]"; exit 1; }
+echo "ok pulls 404 fail-closes"
+
 echo ALL_OK

--- a/script/test-reuse-full-suite
+++ b/script/test-reuse-full-suite
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Offline checks for bin/reuse-full-suite.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/bin/reuse-full-suite"
+FAKE="$(mktemp -d)"
+trap 'rm -rf "$FAKE"' EXIT
+
+cat > "$FAKE/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+jq_expr=""
+path=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--jq" ]; then
+    jq_expr="$a"
+  fi
+  case "$a" in
+    repos/*) path="$a" ;;
+  esac
+  prev="$a"
+done
+apply() {
+  if [ -n "$jq_expr" ]; then
+    jq -r "$jq_expr"
+  else
+    cat
+  fi
+}
+if [[ "$path" == */git/commits/mainsha ]]; then
+  echo '{"tree":{"sha":"TREE_MAIN"}}' | apply
+elif [[ "$path" == */git/commits/prhead ]]; then
+  echo '{"tree":{"sha":"TREE_MAIN"}}' | apply
+elif [[ "$path" == */git/commits/otherhead ]]; then
+  echo '{"tree":{"sha":"TREE_OTHER"}}' | apply
+elif [[ "$path" == */commits/mainsha/pulls ]]; then
+  cat "${GH_FIXTURE_DIR}/pulls.json" | apply
+elif [[ "$path" == */pulls/1 ]]; then
+  echo '{"head":{"sha":"prhead"}}' | apply
+elif [[ "$path" == */pulls/2 ]]; then
+  echo '{"head":{"sha":"otherhead"}}' | apply
+elif [[ "$path" == *actions/runs* && "$path" == *head_sha=prhead* ]]; then
+  cat "${GH_FIXTURE_DIR}/runs-green.json" | apply
+elif [[ "$path" == *actions/runs* && "$path" == *head_sha=* ]]; then
+  echo '{"workflow_runs":[]}' | apply
+elif [[ "$path" == */actions/runs/99/jobs* ]]; then
+  cat "${GH_FIXTURE_DIR}/jobs-full.json" | apply
+else
+  echo "unexpected gh api path=$path" >&2
+  exit 1
+fi
+EOF
+chmod +x "$FAKE/gh"
+
+mkdir -p "$FAKE/fix"
+printf '[{"number":1}]\n' > "$FAKE/fix/pulls.json"
+printf '{"workflow_runs":[{"name":"Tests","conclusion":"success","id":99}]}\n' > "$FAKE/fix/runs-green.json"
+printf '{"jobs":[{"name":"Test Fast 0","conclusion":"success"},{"name":"Test Slow 0","conclusion":"success"}]}\n' > "$FAKE/fix/jobs-full.json"
+
+run() {
+  REPO=antiwork/gumroad GH_FIXTURE_DIR="$FAKE/fix" GH="$FAKE/gh" "$SCRIPT" mainsha
+}
+
+out=$(run)
+test "$out" = "reuse=true" || { echo "FAIL expected reuse=true got [$out]"; exit 1; }
+echo "ok same-tree full suite"
+
+printf '[{"number":2}]\n' > "$FAKE/fix/pulls.json"
+out=$(run)
+test "$out" = "reuse=false" || { echo "FAIL expected reuse=false on tree mismatch got [$out]"; exit 1; }
+echo "ok different tree"
+
+printf '[]\n' > "$FAKE/fix/pulls.json"
+out=$(run)
+test "$out" = "reuse=false" || { echo "FAIL expected reuse=false with no PR got [$out]"; exit 1; }
+echo "ok no PR"
+
+printf '[{"number":1}]\n' > "$FAKE/fix/pulls.json"
+printf '{"jobs":[{"name":"Test Relevant 0","conclusion":"success"}]}\n' > "$FAKE/fix/jobs-full.json"
+out=$(run)
+test "$out" = "reuse=false" || { echo "FAIL expected reuse=false when only Relevant ran got [$out]"; exit 1; }
+echo "ok relevant-only is not reusable"
+
+echo ALL_OK

--- a/script/test-reuse-full-suite
+++ b/script/test-reuse-full-suite
@@ -82,4 +82,13 @@ out=$(run)
 test "$out" = "reuse=false" || { echo "FAIL expected reuse=false when only Relevant ran got [$out]"; exit 1; }
 echo "ok relevant-only is not reusable"
 
+printf '{"jobs":[{"name":"Test Fast 0","conclusion":"success"},{"name":"Test Slow 0","conclusion":"success"}]}\n' > "$FAKE/fix/jobs-full.json"
+out=$(GITHUB_ACTIONS=1 GITHUB_EVENT_NAME=pull_request_target GITHUB_REF=refs/heads/main REPO=antiwork/gumroad GH_FIXTURE_DIR="$FAKE/fix" GH="$FAKE/gh" "$SCRIPT" mainsha)
+test "$out" = "reuse=false" || { echo "FAIL expected reuse=false off main event got [$out]"; exit 1; }
+echo "ok refuse pull_request_target"
+
+out=$(GITHUB_ACTIONS=1 GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main REPO=antiwork/gumroad GH_FIXTURE_DIR="$FAKE/fix" GH="$FAKE/gh" "$SCRIPT" mainsha)
+test "$out" = "reuse=true" || { echo "FAIL expected reuse=true on GHA main push got [$out]"; exit 1; }
+echo "ok allow GHA main push"
+
 echo ALL_OK

--- a/script/test-reuse-full-suite
+++ b/script/test-reuse-full-suite
@@ -44,6 +44,8 @@ elif [[ "$path" == *actions/runs* && "$path" == *head_sha=prhead* ]]; then
   cat "${GH_FIXTURE_DIR}/runs-green.json" | apply
 elif [[ "$path" == *actions/runs* && "$path" == *head_sha=* ]]; then
   echo '{"workflow_runs":[]}' | apply
+elif [[ "$path" == */actions/runs/88/jobs* ]]; then
+  cat "${GH_FIXTURE_DIR}/jobs-noop.json" | apply
 elif [[ "$path" == */actions/runs/99/jobs* ]]; then
   cat "${GH_FIXTURE_DIR}/jobs-full.json" | apply
 else
@@ -57,6 +59,7 @@ mkdir -p "$FAKE/fix"
 printf '[{"number":1}]\n' > "$FAKE/fix/pulls.json"
 printf '{"workflow_runs":[{"name":"Tests","conclusion":"success","id":99}]}\n' > "$FAKE/fix/runs-green.json"
 printf '{"jobs":[{"name":"Test Fast 0","conclusion":"success"},{"name":"Test Slow 0","conclusion":"success"}]}\n' > "$FAKE/fix/jobs-full.json"
+printf '{"jobs":[{"name":"Test Fast 0 (internal PR noop)","conclusion":"success"},{"name":"Test Relevant 0","conclusion":"success"}]}\n' > "$FAKE/fix/jobs-noop.json"
 
 run() {
   REPO=antiwork/gumroad GH_FIXTURE_DIR="$FAKE/fix" GH="$FAKE/gh" "$SCRIPT" mainsha
@@ -77,12 +80,18 @@ test "$out" = "reuse=false" || { echo "FAIL expected reuse=false with no PR got 
 echo "ok no PR"
 
 printf '[{"number":1}]\n' > "$FAKE/fix/pulls.json"
-printf '{"jobs":[{"name":"Test Relevant 0","conclusion":"success"}]}\n' > "$FAKE/fix/jobs-full.json"
+printf '{"workflow_runs":[{"name":"Tests","conclusion":"success","id":88}]}\n' > "$FAKE/fix/runs-green.json"
 out=$(run)
-test "$out" = "reuse=false" || { echo "FAIL expected reuse=false when only Relevant ran got [$out]"; exit 1; }
+test "$out" = "reuse=false" || { echo "FAIL expected reuse=false when only Relevant/noop ran got [$out]"; exit 1; }
 echo "ok relevant-only is not reusable"
 
-printf '{"jobs":[{"name":"Test Fast 0","conclusion":"success"},{"name":"Test Slow 0","conclusion":"success"}]}\n' > "$FAKE/fix/jobs-full.json"
+# Newest Tests run is the pull_request_target noop; older run has Fast+Slow.
+printf '{"workflow_runs":[{"name":"Tests","conclusion":"success","id":88},{"name":"Tests","conclusion":"success","id":99}]}\n' > "$FAKE/fix/runs-green.json"
+out=$(run)
+test "$out" = "reuse=true" || { echo "FAIL expected reuse=true when a later run has Fast+Slow got [$out]"; exit 1; }
+echo "ok noop does not shadow a green full suite"
+
+printf '{"workflow_runs":[{"name":"Tests","conclusion":"success","id":99}]}\n' > "$FAKE/fix/runs-green.json"
 out=$(GITHUB_ACTIONS=1 GITHUB_EVENT_NAME=pull_request_target GITHUB_REF=refs/heads/main REPO=antiwork/gumroad GH_FIXTURE_DIR="$FAKE/fix" GH="$FAKE/gh" "$SCRIPT" mainsha)
 test "$out" = "reuse=false" || { echo "FAIL expected reuse=false off main event got [$out]"; exit 1; }
 echo "ok refuse pull_request_target"


### PR DESCRIPTION
Skip Fast/Slow on main when that exact tree already passed them

## What

If this main commit is the same git tree as a merged PR that already ran Test Fast and Test Slow green, skip those ~68 shards and unblock deploy from Minitest + that earlier run.

## Why

A `run-all-specs` PR already paid for the full suite. Squash/rebase onto an up-to-date main is the same code. Re-running Fast/Slow before deploy is waste. A PR that was behind main has a different tree after squash, so the suite still runs.

## Security (OSS / `pull_request_target`)

Fork PRs run Tests via `pull_request_target` with a **base-repo** token. The first draft checked out the head SHA (including forks) in that job. That is the same class as the old `bin/branch-specs` Greptile P1.

Now:

- `run_scope` (fork + branch): **no checkout**. `pull-requests: read` only. Label lookup only.
- `reuse_scope`: **push to main only**. Checkout `github.sha` with `persist-credentials: false`, then run `bin/reuse-full-suite`.
- The helper refuses `reuse=true` unless `GITHUB_EVENT_NAME=push` and `GITHUB_REF=refs/heads/main`.
- Fast/Slow use `always()` so a skipped `reuse_scope` on a `run-all-specs` PR still runs the suite.

## Before / after

- Before: every push to main always runs Fast (18) + Slow (50), then unblocks Buildkite.
- After: same, unless `bin/reuse-full-suite` finds a merged PR whose head tree equals this commit and whose Tests run had successful Fast and Slow shards. Relevant-only greens do not count.

## Test Results

```text
bash script/test-reuse-full-suite
ok same-tree full suite
ok different tree
ok no PR
ok relevant-only is not reusable
ok refuse pull_request_target
ok allow GHA main push
ALL_OK
```

## Sol

First pass (old head) P1: skipped Fast/Slow skipped the deploy unblock. Fixed with `always()` on that job.

P2: newest successful Tests run can be the `pull_request_target` noop. Now scan every successful Tests run.

## Checklist

- [x] Scope
- [x] Design — tree equality + Fast/Slow success; fork path isolated
- [x] Build
- [ ] QA
- [ ] Shipped

AI disclosure: Grok 4.6. Prompt: skip full specs before deploy when the same commit already ran them; keep it secure on a public repo.
