### PR TITLE
Require complete Fast/Slow matrices for suite reuse

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,9 @@ jobs:
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
-          sparse-checkout: bin/reuse-full-suite
+          sparse-checkout: |
+            bin/reuse-full-suite
+            .github/workflows/tests.yml
           sparse-checkout-cone-mode: false
       - id: reuse
         env:

--- a/bin/reuse-full-suite
+++ b/bin/reuse-full-suite
@@ -65,17 +65,25 @@ while idx < len(text):
     obj, end = dec.raw_decode(text, idx)
     jobs.extend(obj.get("jobs", []))
     idx = end
-def ok(prefix):
-    hits = [
-        j for j in jobs
-        if j.get("name", "").startswith(prefix)
-        and "noop" not in j.get("name", "").lower()
-    ]
-    return (
-        any(j.get("conclusion") == "success" for j in hits)
-        and not any(j.get("conclusion") == "failure" for j in hits)
-    )
-sys.exit(0 if ok("Test Fast") and ok("Test Slow") else 1)
+import re
+EXPECTED_SHARDS = {"Test Fast": 18, "Test Slow": 50}
+
+def ok(prefix, expected_count):
+    seen = {}
+    pattern = re.compile(rf"^{re.escape(prefix)} (\d+)(?:\b|$)")
+    for job in jobs:
+        name = job.get("name", "")
+        if "noop" in name.lower():
+            continue
+        match = pattern.match(name)
+        if not match:
+            continue
+        shard = int(match.group(1))
+        if shard < expected_count:
+            seen[shard] = job.get("conclusion")
+    return all(seen.get(shard) == "success" for shard in range(expected_count))
+
+sys.exit(0 if all(ok(prefix, count) for prefix, count in EXPECTED_SHARDS.items()) else 1)
 '
 }
 

--- a/bin/reuse-full-suite
+++ b/bin/reuse-full-suite
@@ -65,10 +65,26 @@ while idx < len(text):
     obj, end = dec.raw_decode(text, idx)
     jobs.extend(obj.get("jobs", []))
     idx = end
-import re
-EXPECTED_SHARDS = {"Test Fast": 18, "Test Slow": 50}
+import os, re
 
-def ok(prefix, expected_count):
+def expected_shards_from_workflow():
+    path = os.environ.get("TESTS_WORKFLOW_PATH", ".github/workflows/tests.yml")
+    text = open(path).read()
+    expected = {}
+    for job_key, prefix in (("test_fast", "Test Fast"), ("test_slow", "Test Slow")):
+        job = re.search(rf"(?ms)^  {job_key}:\n(?P<block>.*?)(?=^  [A-Za-z0-9_-]+:|\Z)", text)
+        if not job:
+            raise RuntimeError(f"missing {job_key} in {path}")
+        matrix = re.search(r"(?ms)^\s+ci_node_index:\s*(\[[^\]]*\])", job.group("block"))
+        if not matrix:
+            raise RuntimeError(f"missing {job_key} ci_node_index matrix in {path}")
+        shards = sorted({int(value) for value in re.findall(r"\d+", matrix.group(1))})
+        if shards != list(range(len(shards))):
+            raise RuntimeError(f"{job_key} matrix is not zero-based contiguous: {shards}")
+        expected[prefix] = set(shards)
+    return expected
+
+def ok(prefix, expected_shards):
     seen = {}
     pattern = re.compile(rf"^{re.escape(prefix)} (\d+)(?:\b|$)")
     for job in jobs:
@@ -79,12 +95,12 @@ def ok(prefix, expected_count):
         if not match:
             continue
         shard = int(match.group(1))
-        if shard >= expected_count:
-            return False
-        seen[shard] = job.get("conclusion")
-    return all(seen.get(shard) == "success" for shard in range(expected_count))
+        if shard in expected_shards:
+            seen[shard] = job.get("conclusion")
+    return all(seen.get(shard) == "success" for shard in expected_shards)
 
-sys.exit(0 if all(ok(prefix, count) for prefix, count in EXPECTED_SHARDS.items()) else 1)
+EXPECTED_SHARDS = expected_shards_from_workflow()
+sys.exit(0 if all(ok(prefix, shards) for prefix, shards in EXPECTED_SHARDS.items()) else 1)
 '
 }
 

--- a/bin/reuse-full-suite
+++ b/bin/reuse-full-suite
@@ -79,8 +79,9 @@ def ok(prefix, expected_count):
         if not match:
             continue
         shard = int(match.group(1))
-        if shard < expected_count:
-            seen[shard] = job.get("conclusion")
+        if shard >= expected_count:
+            return False
+        seen[shard] = job.get("conclusion")
     return all(seen.get(shard) == "success" for shard in range(expected_count))
 
 sys.exit(0 if all(ok(prefix, count) for prefix, count in EXPECTED_SHARDS.items()) else 1)

--- a/script/test-reuse-full-suite
+++ b/script/test-reuse-full-suite
@@ -56,70 +56,75 @@ EOF
 chmod +x "$FAKE/gh"
 
 mkdir -p "$FAKE/fix"
-printf '[{"number":1}]\n' > "$FAKE/fix/pulls.json"
-printf '{"workflow_runs":[{"name":"Tests","conclusion":"success","id":99}]}\n' > "$FAKE/fix/runs-green.json"
-python3 - "$FAKE/fix/jobs-full.json" <<'PY'
+write_workflow() {
+  python3 - "$FAKE/tests.yml" "$1" "$2" <<'PY'
+import sys
+path, fast_count, slow_count = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+def numbers(count):
+    return ", ".join(str(i) for i in range(count))
+open(path, "w").write(f"""name: Tests
+jobs:
+  test_fast:
+    name: Test Fast ${{{{ matrix.ci_node_index }}}}
+    strategy:
+      matrix:
+        ci_node_total: [{fast_count}]
+        ci_node_index: [{numbers(fast_count)}]
+  test_slow:
+    name: Test Slow ${{{{ matrix.ci_node_index }}}}
+    strategy:
+      matrix:
+        ci_node_total: [{slow_count}]
+        ci_node_index: [{numbers(slow_count)}]
+""")
+PY
+}
+write_jobs() {
+  python3 - "$3" "$1" "$2" <<'PY'
 import json, sys
+path, fast_count, slow_count = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
 jobs = [
     {"name": f"Test Fast {i}", "conclusion": "success"}
-    for i in range(18)
+    for i in range(fast_count)
 ] + [
     {"name": f"Test Slow {i}", "conclusion": "success"}
-    for i in range(50)
+    for i in range(slow_count)
 ]
-open(sys.argv[1], "w").write(json.dumps({"jobs": jobs}) + "\n")
+open(path, "w").write(json.dumps({"jobs": jobs}) + "\n")
 PY
+}
+write_workflow 18 50
+printf '[{"number":1}]\n' > "$FAKE/fix/pulls.json"
+printf '{"workflow_runs":[{"name":"Tests","conclusion":"success","id":99}]}\n' > "$FAKE/fix/runs-green.json"
+write_jobs 18 50 "$FAKE/fix/jobs-full.json"
 printf '{"jobs":[{"name":"Test Fast 0 (internal PR noop)","conclusion":"success"},{"name":"Test Relevant 0","conclusion":"success"}]}\n' > "$FAKE/fix/jobs-noop.json"
 
 run() {
-  REPO=antiwork/gumroad GH_FIXTURE_DIR="$FAKE/fix" GH="$FAKE/gh" "$SCRIPT" mainsha
+  TESTS_WORKFLOW_PATH="$FAKE/tests.yml" REPO=antiwork/gumroad GH_FIXTURE_DIR="$FAKE/fix" GH="$FAKE/gh" "$SCRIPT" mainsha
 }
 
 out=$(run)
 test "$out" = "reuse=true" || { echo "FAIL expected reuse=true got [$out]"; exit 1; }
 echo "ok same-tree full suite"
 
-python3 - "$FAKE/fix/jobs-full.json" <<'PY'
-import json, sys
-jobs = [
-    {"name": f"Test Fast {i}", "conclusion": "success"}
-    for i in range(18)
-] + [
-    {"name": f"Test Slow {i}", "conclusion": "success"}
-    for i in range(49)
-]
-open(sys.argv[1], "w").write(json.dumps({"jobs": jobs}) + "\n")
-PY
+write_jobs 18 49 "$FAKE/fix/jobs-full.json"
 out=$(run)
 test "$out" = "reuse=false" || { echo "FAIL expected reuse=false with an incomplete matrix got [$out]"; exit 1; }
 echo "ok incomplete matrix is not reusable"
 
-python3 - "$FAKE/fix/jobs-full.json" <<'PY'
-import json, sys
-jobs = [
-    {"name": f"Test Fast {i}", "conclusion": "success"}
-    for i in range(19)
-] + [
-    {"name": f"Test Slow {i}", "conclusion": "success"}
-    for i in range(50)
-]
-open(sys.argv[1], "w").write(json.dumps({"jobs": jobs}) + "\n")
-PY
+write_workflow 18 51
+write_jobs 18 50 "$FAKE/fix/jobs-full.json"
 out=$(run)
-test "$out" = "reuse=false" || { echo "FAIL expected reuse=false after a matrix expansion got [$out]"; exit 1; }
-echo "ok expanded matrix is not silently reused"
+test "$out" = "reuse=false" || { echo "FAIL expected reuse=false when workflow matrix grew got [$out]"; exit 1; }
+echo "ok workflow matrix drift fail-closes"
 
-python3 - "$FAKE/fix/jobs-full.json" <<'PY'
-import json, sys
-jobs = [
-    {"name": f"Test Fast {i}", "conclusion": "success"}
-    for i in range(18)
-] + [
-    {"name": f"Test Slow {i}", "conclusion": "success"}
-    for i in range(50)
-]
-open(sys.argv[1], "w").write(json.dumps({"jobs": jobs}) + "\n")
-PY
+write_jobs 18 51 "$FAKE/fix/jobs-full.json"
+out=$(run)
+test "$out" = "reuse=true" || { echo "FAIL expected reuse=true with expanded workflow matrix got [$out]"; exit 1; }
+echo "ok workflow matrix counts derive from workflow"
+
+write_workflow 18 50
+write_jobs 18 50 "$FAKE/fix/jobs-full.json"
 
 printf '[{"number":2}]\n' > "$FAKE/fix/pulls.json"
 out=$(run)
@@ -144,11 +149,11 @@ test "$out" = "reuse=true" || { echo "FAIL expected reuse=true when a later run 
 echo "ok noop does not shadow a green full suite"
 
 printf '{"workflow_runs":[{"name":"Tests","conclusion":"success","id":99}]}\n' > "$FAKE/fix/runs-green.json"
-out=$(GITHUB_ACTIONS=1 GITHUB_EVENT_NAME=pull_request_target GITHUB_REF=refs/heads/main REPO=antiwork/gumroad GH_FIXTURE_DIR="$FAKE/fix" GH="$FAKE/gh" "$SCRIPT" mainsha)
+out=$(GITHUB_ACTIONS=1 GITHUB_EVENT_NAME=pull_request_target GITHUB_REF=refs/heads/main TESTS_WORKFLOW_PATH="$FAKE/tests.yml" REPO=antiwork/gumroad GH_FIXTURE_DIR="$FAKE/fix" GH="$FAKE/gh" "$SCRIPT" mainsha)
 test "$out" = "reuse=false" || { echo "FAIL expected reuse=false off main event got [$out]"; exit 1; }
 echo "ok refuse pull_request_target"
 
-out=$(GITHUB_ACTIONS=1 GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main REPO=antiwork/gumroad GH_FIXTURE_DIR="$FAKE/fix" GH="$FAKE/gh" "$SCRIPT" mainsha)
+out=$(GITHUB_ACTIONS=1 GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main TESTS_WORKFLOW_PATH="$FAKE/tests.yml" REPO=antiwork/gumroad GH_FIXTURE_DIR="$FAKE/fix" GH="$FAKE/gh" "$SCRIPT" mainsha)
 test "$out" = "reuse=true" || { echo "FAIL expected reuse=true on GHA main push got [$out]"; exit 1; }
 echo "ok allow GHA main push"
 
@@ -172,7 +177,7 @@ else echo "unexpected $path" >&2; exit 1
 fi
 EOF
 chmod +x "$FAKE/gh-fail-pull"
-out=$(REPO=antiwork/gumroad GH="$FAKE/gh-fail-pull" "$SCRIPT" mainsha || true)
+out=$(TESTS_WORKFLOW_PATH="$FAKE/tests.yml" REPO=antiwork/gumroad GH="$FAKE/gh-fail-pull" "$SCRIPT" mainsha || true)
 test "$out" = "reuse=false" || { echo "FAIL expected reuse=false on pulls 404 got [$out]"; exit 1; }
 echo "ok pulls 404 fail-closes"
 

--- a/script/test-reuse-full-suite
+++ b/script/test-reuse-full-suite
@@ -98,6 +98,21 @@ python3 - "$FAKE/fix/jobs-full.json" <<'PY'
 import json, sys
 jobs = [
     {"name": f"Test Fast {i}", "conclusion": "success"}
+    for i in range(19)
+] + [
+    {"name": f"Test Slow {i}", "conclusion": "success"}
+    for i in range(50)
+]
+open(sys.argv[1], "w").write(json.dumps({"jobs": jobs}) + "\n")
+PY
+out=$(run)
+test "$out" = "reuse=false" || { echo "FAIL expected reuse=false after a matrix expansion got [$out]"; exit 1; }
+echo "ok expanded matrix is not silently reused"
+
+python3 - "$FAKE/fix/jobs-full.json" <<'PY'
+import json, sys
+jobs = [
+    {"name": f"Test Fast {i}", "conclusion": "success"}
     for i in range(18)
 ] + [
     {"name": f"Test Slow {i}", "conclusion": "success"}

--- a/script/test-reuse-full-suite
+++ b/script/test-reuse-full-suite
@@ -58,7 +58,17 @@ chmod +x "$FAKE/gh"
 mkdir -p "$FAKE/fix"
 printf '[{"number":1}]\n' > "$FAKE/fix/pulls.json"
 printf '{"workflow_runs":[{"name":"Tests","conclusion":"success","id":99}]}\n' > "$FAKE/fix/runs-green.json"
-printf '{"jobs":[{"name":"Test Fast 0","conclusion":"success"},{"name":"Test Slow 0","conclusion":"success"}]}\n' > "$FAKE/fix/jobs-full.json"
+python3 - "$FAKE/fix/jobs-full.json" <<'PY'
+import json, sys
+jobs = [
+    {"name": f"Test Fast {i}", "conclusion": "success"}
+    for i in range(18)
+] + [
+    {"name": f"Test Slow {i}", "conclusion": "success"}
+    for i in range(50)
+]
+open(sys.argv[1], "w").write(json.dumps({"jobs": jobs}) + "\n")
+PY
 printf '{"jobs":[{"name":"Test Fast 0 (internal PR noop)","conclusion":"success"},{"name":"Test Relevant 0","conclusion":"success"}]}\n' > "$FAKE/fix/jobs-noop.json"
 
 run() {
@@ -68,6 +78,33 @@ run() {
 out=$(run)
 test "$out" = "reuse=true" || { echo "FAIL expected reuse=true got [$out]"; exit 1; }
 echo "ok same-tree full suite"
+
+python3 - "$FAKE/fix/jobs-full.json" <<'PY'
+import json, sys
+jobs = [
+    {"name": f"Test Fast {i}", "conclusion": "success"}
+    for i in range(18)
+] + [
+    {"name": f"Test Slow {i}", "conclusion": "success"}
+    for i in range(49)
+]
+open(sys.argv[1], "w").write(json.dumps({"jobs": jobs}) + "\n")
+PY
+out=$(run)
+test "$out" = "reuse=false" || { echo "FAIL expected reuse=false with an incomplete matrix got [$out]"; exit 1; }
+echo "ok incomplete matrix is not reusable"
+
+python3 - "$FAKE/fix/jobs-full.json" <<'PY'
+import json, sys
+jobs = [
+    {"name": f"Test Fast {i}", "conclusion": "success"}
+    for i in range(18)
+] + [
+    {"name": f"Test Slow {i}", "conclusion": "success"}
+    for i in range(50)
+]
+open(sys.argv[1], "w").write(json.dumps({"jobs": jobs}) + "\n")
+PY
 
 printf '[{"number":2}]\n' > "$FAKE/fix/pulls.json"
 out=$(run)


### PR DESCRIPTION
## What

Require `bin/reuse-full-suite` to derive the expected Fast/Slow shard sets from `.github/workflows/tests.yml` before it reuses a prior Tests run for a main push.

## Why

Greptile's post-merge review on #7356 was right: the merged helper accepted a run with only one green Fast job and one green Slow job, so an incomplete matrix could have skipped the missing shards on main. Greptile then caught the follow-up drift hazard here: duplicating the 18/50 matrix counts in the helper means a future workflow expansion could be silently ignored.

## Before / after

- Before: any prior successful Tests run with at least one green Fast job and one green Slow job could set `reuse=true`; the first fix still duplicated the workflow's Fast/Slow shard counts inside the helper.
- After: `reuse=true` requires every Fast/Slow shard index from the current workflow file to be present and successful; missing shards, skipped shards, noops, incomplete matrices, or future matrix expansions fail closed to `reuse=false` until the matching expanded run is complete.

## Test Results

```text
bash -n bin/reuse-full-suite script/test-reuse-full-suite
bash script/test-reuse-full-suite
ok same-tree full suite
ok incomplete matrix is not reusable
ok workflow matrix drift fail-closes
ok workflow matrix counts derive from workflow
ok different tree
ok no PR
ok relevant-only is not reusable
ok noop does not shadow a green full suite
ok refuse pull_request_target
ok allow GHA main push
ok pulls 404 fail-closes
ALL_OK
```

Mutation proof:

```text
mutated bin/reuse-full-suite back to the one-green-per-suite predicate
bash script/test-reuse-full-suite
MUTANT_KILLED
FAIL expected reuse=false with an incomplete matrix got [reuse=true]

mutated bin/reuse-full-suite to hard-code Fast=18 and Slow=50 instead of reading the workflow
bash script/test-reuse-full-suite
MUTANT_KILLED
FAIL expected reuse=false when workflow matrix grew got [reuse=true]
```

## QA steps

No rendered surface. This is a CI helper predicate; the QA evidence is the offline fixture run and mutation proof above.

## Status

- [x] Scope — post-merge Greptile P2 on #7356 plus follow-up drift P2 on this PR
- [x] Design — derive expected shard indexes from the workflow matrix and fail closed
- [x] Build
- [x] QA — shell syntax, offline fixtures, mutation proof
- [ ] Shipped — waiting on PR CI and review
- [x] Market — not applicable; internal CI reliability fix
- [x] Sell — not applicable; internal CI reliability fix

---

AI assistance: grok-4.6 helped implement and verify this change.

Premerge review: clean @ 9c8a349abc97ff039341f91a084aecb6f64a40ab
