### PR TITLE
Stop building the whole Payouts payload to render four dashboard numbers

### DIFF
--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -65,7 +65,7 @@ class CreatorHomePresenter
         "last_30" => analytics[:by_date][:totals][product.unique_permalink]&.sum || 0,
       }
     end.compact
-    balances = UserBalanceStatsService.new(user: seller).fetch[:overview]
+    balances = UserBalanceStatsService.new(user: seller).fetch_overview
 
     stripe_verification_message = nil
     if seller.stripe_account.present?

--- a/app/services/user_balance_stats_service.rb
+++ b/app/services/user_balance_stats_service.rb
@@ -19,6 +19,17 @@ class UserBalanceStatsService
     end
   end
 
+  # The dashboard needs only the four overview scalars. Building the rest of the payload,
+  # per-payment period aggregates especially, costs ~150 queries against purchases that nobody reads.
+  def fetch_overview
+    if should_use_cache?
+      UpdateUserBalanceStatsCacheWorker.perform_async(user.id)
+      cached = read_cache
+      return cached[:overview] if cached
+    end
+    overview_stats
+  end
+
   def write_cache
     data = generate
     $redis.setex(cache_key, 48.hours.to_i, data.to_json)
@@ -41,13 +52,7 @@ class UserBalanceStatsService
         generated_at: Time.current,
         next_payout_period_data:,
         processing_payout_periods_data: user.payments.processing.order("created_at DESC").map { payout_period_data(user, _1) },
-        overview: {
-          last_payout_period_data: payout_period_data(user, user.payments.completed.last),
-          balance: user.unpaid_balance_cents,
-          last_seven_days_sales_total: user.sales_cents_total(after: 7.days.ago),
-          last_28_days_sales_total: user.sales_cents_total(after: 28.days.ago),
-          sales_cents_total: user.sales_cents_total,
-        },
+        overview: overview_stats,
       }
 
       payments = user.payments.completed
@@ -67,6 +72,15 @@ class UserBalanceStatsService
       result[:payments] = payments
 
       result
+    end
+
+    def overview_stats
+      {
+        balance: user.unpaid_balance_cents,
+        last_seven_days_sales_total: user.sales_cents_total(after: 7.days.ago),
+        last_28_days_sales_total: user.sales_cents_total(after: 28.days.ago),
+        sales_cents_total: user.sales_cents_total,
+      }
     end
 
     def read_cache

--- a/spec/presenters/creator_home_presenter_spec.rb
+++ b/spec/presenters/creator_home_presenter_spec.rb
@@ -309,16 +309,43 @@ describe CreatorHomePresenter do
       end
     end
 
+    describe "dashboard query cost" do
+      # The dashboard reads four scalars out of :overview. Building the rest of the Payouts
+      # payload, per-payment period aggregates especially, is work nobody reads.
+      before do
+        create(:balance, user: seller, amount_cents: 5_000, date: 3.days.ago)
+        create(:balance, user: seller, amount_cents: 7_000, date: 2.days.ago)
+        3.times { |i| create(:payment_completed, user: seller, created_at: (i + 1).weeks.ago) }
+      end
+
+      it "does not build the per-payment payout period data the dashboard never reads" do
+        described_class.new(pundit_user).creator_home_props # warm caches
+
+        queries = []
+        callback = lambda do |_name, _start, _finish, _id, payload|
+          next if payload[:name] == "SCHEMA" || payload[:cached]
+          queries << payload[:sql] if payload[:sql].to_s.start_with?("SELECT")
+        end
+
+        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+          described_class.new(pundit_user).creator_home_props
+        end
+
+        purchase_queries = queries.grep(/FROM `purchases`/)
+        expect(purchase_queries.size).to be < 30,
+                                         "Expected the dashboard to stop building the Payouts payload, " \
+                                         "got #{purchase_queries.size} queries against purchases"
+      end
+    end
+
     describe "balances" do
       before do
-        allow_any_instance_of(UserBalanceStatsService).to receive(:fetch).and_return(
+        allow_any_instance_of(UserBalanceStatsService).to receive(:fetch_overview).and_return(
           {
-            overview: {
-              balance: 10_000,
-              last_seven_days_sales_total: 5_000,
-              last_28_days_sales_total: 15_000,
-              sales_cents_total: 50_000
-            },
+            balance: 10_000,
+            last_seven_days_sales_total: 5_000,
+            last_28_days_sales_total: 15_000,
+            sales_cents_total: 50_000
           }
         )
       end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -13,21 +13,12 @@ describe "Dashboard", js: true, type: :system do
   describe "dashboard stats" do
     before do
       create(:product, user: seller)
-      allow_any_instance_of(UserBalanceStatsService).to receive(:fetch).and_return(
+      allow_any_instance_of(UserBalanceStatsService).to receive(:fetch_overview).and_return(
         {
-          overview: {
-            balance: 10_000,
-            last_seven_days_sales_total: 5_000,
-            last_28_days_sales_total: 15_000,
-            sales_cents_total: 50_000
-          },
-          next_payout_period_data: {
-            should_be_shown_currencies_always: false,
-            minimum_payout_amount_cents: 10_000,
-            is_user_payable: false,
-            status: :not_payable
-          },
-          processing_payout_periods_data: []
+          balance: 10_000,
+          last_seven_days_sales_total: 5_000,
+          last_28_days_sales_total: 15_000,
+          sales_cents_total: 50_000
         }
       )
     end

--- a/spec/services/user_balance_stats_service_spec.rb
+++ b/spec/services/user_balance_stats_service_spec.rb
@@ -19,6 +19,74 @@ describe UserBalanceStatsService do
     end
   end
 
+  describe "#fetch_overview" do
+    let(:now) { Time.zone.local(2024, 6, 15, 12, 0, 0) }
+    let(:overview) do
+      {
+        balance: 12_34,
+        last_seven_days_sales_total: 10_00,
+        last_28_days_sales_total: 40_00,
+        sales_cents_total: 90_00,
+      }
+    end
+
+    before do
+      travel_to(now)
+      allow(user).to receive(:unpaid_balance_cents).and_return(overview[:balance])
+      allow(user).to receive(:sales_cents_total).with(no_args).and_return(overview[:sales_cents_total])
+      allow(user).to receive(:sales_cents_total).with(after: 7.days.ago).and_return(overview[:last_seven_days_sales_total])
+      allow(user).to receive(:sales_cents_total).with(after: 28.days.ago).and_return(overview[:last_28_days_sales_total])
+    end
+
+    context "when the seller is not cacheable" do
+      before { allow(instance).to receive(:should_use_cache?).and_return(false) }
+
+      it "returns the four overview scalars without building the payouts payload" do
+        expect(instance).not_to receive(:generate)
+        expect(instance.fetch_overview).to eq(overview)
+      end
+    end
+
+    context "when the seller is cacheable and the cache is cold" do
+      before { allow(instance).to receive(:should_use_cache?).and_return(true) }
+
+      it "computes the four scalars and enqueues a cache refresh" do
+        expect(instance).not_to receive(:generate)
+        expect(instance.fetch_overview).to eq(overview)
+        expect(UpdateUserBalanceStatsCacheWorker).to have_enqueued_sidekiq_job(user.id)
+      end
+    end
+
+    context "when the seller is cacheable and the cache is warm" do
+      let(:cached_payload) do
+        {
+          generated_at: now,
+          next_payout_period_data: { status: "payable" },
+          processing_payout_periods_data: [],
+          overview:,
+          payout_period_data: { 1 => { amount: 99 } },
+          payments: [],
+          is_paginating: false,
+        }
+      end
+
+      before do
+        allow(instance).to receive(:should_use_cache?).and_return(true)
+        $redis.setex(instance.send(:cache_key), 48.hours.to_i, cached_payload.to_json)
+      end
+
+      it "returns only the nested overview hash" do
+        expect(instance).not_to receive(:generate)
+        expect(instance).not_to receive(:overview_stats)
+        result = instance.fetch_overview
+        expect(result).to eq(overview)
+        expect(result.keys).to match_array(overview.keys)
+        expect(result).not_to have_key(:payout_period_data)
+        expect(UpdateUserBalanceStatsCacheWorker).to have_enqueued_sidekiq_job(user.id)
+      end
+    end
+  end
+
   describe "#fetch" do
     let(:fetched) { instance.fetch }
 


### PR DESCRIPTION
Sahil marked this ready. CI is green at `9052c9200b`. Greptile 5/5 on that head. fable-5 is API-capped until 2026-09-01; Sol (gpt-5.6-sol) reviewed this head instead. Sol P1 to keep `last_payout_period_data` is declined: `git grep` on origin/main finds only the producer, and `PayoutsPresenter` never reads it. No automerge (dashboard balance scalars).

## What

`CreatorHomePresenter` called `UserBalanceStatsService#fetch`, which builds the entire Payouts-page payload including a `payout_period_data` aggregate for every completed payment, then read four scalars out of `:overview` and discarded the rest.

One of the five keys it computed, `last_payout_period_data`, was read nowhere in the repo, so this removes it rather than moving it.

`fetch_overview` returns just the four values the dashboard renders.

## Why

This is the page every seller lands on after login, and it is not cached for ordinary sellers.

Follow-up to #7351, which removed the per-row lookups on the Sales page.

## Before / After

- Before: dashboard `creator_home_props` called `fetch` and paid for every completed payment's period aggregate.
- After: dashboard calls `fetch_overview` (four scalars). `PayoutsPresenter` still calls `fetch`.

Autoreview P1 at `4689cefda4`: presenter specs stubbed `fetch_overview`, so swapping the 7-day and 28-day windows or returning the whole cached payload stayed green. Service examples at `9052c9200b` pin both.

Mutation table (3 new examples, all killed):

- swap 7-day and 28-day sales windows → red: uncached + cold-cache examples
- return whole cached payload instead of `cached[:overview]` → red: warm-cache example
- fall through to `generate` instead of `overview_stats` → red: uncached + cold-cache examples

Sol P1 at `9052c9200b` (restore `last_payout_period_data` on `fetch`): declined. The symbol exists only as a producer on origin/main; payouts reads `next_payout_period_data` and `processing_payout_periods_data`.

## Test Results

- `bundle exec rspec spec/services/user_balance_stats_service_spec.rb:44 :53 :78` at `9052c9200b` — 3 examples, 0 failures.
- Mutation check: all 3 mutants reddened their own examples.
- Push Tests `32610072593` at `9052c9200b`: success (ci/green + buildkite/gumroad).
- Greptile Review on `9052c9200b`: 5/5, 0 inline comments.
- Sol review on `9052c9200b`: 1 P1 declined as above.

## QA steps

1. Open the dashboard as a seller with unpaid balance and sales in the last 7 and 28 days.
2. Confirm Balance, Last 7 days, Last 28 days, and Total match the previous `fetch` overview values.
3. Open Payouts and confirm the page still loads (`PayoutsPresenter` still calls `fetch`).

Preview (x-revision should be 9052c9200b): https://import-dashboard-balance-overvie.apps.staging.gumroad.org

Visual walkthrough lives on the source PR (qa-media was not imported so binaries stay out of this repo):
https://github.com/AJ0070/gumroad/pull/2

- [x] Scope — dashboard reads four scalars; Payouts path unchanged
- [x] Design — `fetch_overview` unwraps `cached[:overview]` and otherwise calls `overview_stats`
- [x] Build — import + spec pin at `9052c9200b`
- [ ] QA — walkthrough on source PR; logged-in preview walk of the four scalars still owed
- [ ] Shipped
- [ ] Market
- [ ] Sell

Premerge review: clean @ 9052c9200b5b0e511ec0fb879163c134cb1f10f7

---

Based on https://github.com/AJ0070/gumroad/pull/2 by @AJ0070.

AI Disclosure: Grok 4.6 was used to review the original PR, import the changes, and add the fetch_overview service specs. Sol (gpt-5.6-sol) ran the premerge review because fable-5 is usage-capped until 2026-09-01.
