### PR TITLE
Fall back to computing the dashboard scalars when a cached blob has no overview

### DIFF
--- a/app/services/user_balance_stats_service.rb
+++ b/app/services/user_balance_stats_service.rb
@@ -21,11 +21,12 @@ class UserBalanceStatsService
 
   # The dashboard needs only the four overview scalars. Building the rest of the payload,
   # per-payment period aggregates especially, costs ~150 queries against purchases that nobody reads.
+  # A cached blob missing :overview falls through instead of returning nil.
   def fetch_overview
     if should_use_cache?
       UpdateUserBalanceStatsCacheWorker.perform_async(user.id)
-      cached = read_cache
-      return cached[:overview] if cached
+      cached_overview = read_cache&.dig(:overview)
+      return cached_overview if cached_overview
     end
     overview_stats
   end

--- a/spec/services/user_balance_stats_service_spec.rb
+++ b/spec/services/user_balance_stats_service_spec.rb
@@ -57,6 +57,18 @@ describe UserBalanceStatsService do
       end
     end
 
+    context "when the seller is cacheable and the cached payload has no overview" do
+      before do
+        allow(instance).to receive(:should_use_cache?).and_return(true)
+        $redis.setex(instance.send(:cache_key), 48.hours.to_i, { generated_at: now }.to_json)
+      end
+
+      it "computes the four scalars instead of returning nil" do
+        expect(instance).not_to receive(:generate)
+        expect(instance.fetch_overview).to eq(overview)
+      end
+    end
+
     context "when the seller is cacheable and the cache is warm" do
       let(:cached_payload) do
         {


### PR DESCRIPTION
## What

`UserBalanceStatsService#fetch_overview` returned `cached[:overview]` whenever a cached blob existed, so a blob that parses but has no `:overview` key returned `nil` — and `CreatorHomePresenter` then raised `NoMethodError` on `balances.fetch(:balance)`, taking down the page every seller lands on after login.

It now reads through with `&.dig(:overview)` and falls through to `overview_stats` on a miss.

```ruby
cached_overview = read_cache&.dig(:overview)
return cached_overview if cached_overview
```

## Why

No blob is in that state today — this is defence against shape drift across a deploy, which is a live risk rather than a theoretical one because the blob has a 48-hour TTL. Any change that moves, renames or restructures `:overview` leaves the previous shape readable by the new code for two days, and there is no reason for the dashboard to 500 in that window: recomputing the four scalars is four queries, which is what the uncached path already does for every ordinary seller.

It also covers a Redis value that parses but is missing the key for any other reason (hand-edited, written by a different branch in staging).

This is not a regression from #7358 — the code it replaced, `fetch[:overview]`, returned `nil` in exactly the same case. #7358 is just what made the fallback cheap enough to be obviously right, by extracting `overview_stats`.

## Before / After

No user-visible change on any path that works today; the difference is a rendered dashboard instead of a 500 on a blob without `:overview`.

**Walkthrough video is owed** — a clip of the dashboard's four Activity numbers loading on the cached and uncached paths. Holding this as a draft until it is attached.

## Test Results

- `bundle exec rspec spec/services/user_balance_stats_service_spec.rb -e "fetch_overview"` — 4 examples, 0 failures.
- `bundle exec rspec spec/services/user_balance_stats_service_spec.rb` — 20 examples, 5 failures. All 5 are pre-existing in my local environment, which has no `MerchantAccount.gumroad`, so the `balance` factory can't build; the same 5 fail on unmodified `main`.
- Mutation check: restoring `return cached[:overview] if cached` reddens the new example.
- `bundle exec rubocop` clean on both touched files.

New example: a cacheable seller whose cached blob has no `:overview` gets the four computed scalars instead of `nil`.

## QA steps

1. As a large (cacheable) seller, load the dashboard normally and confirm the four Activity numbers are unchanged.
2. In a console, overwrite that seller's `balance_stats_for_user_<id>` key with a JSON object that has no `overview` key, then reload the dashboard: before this change it 500s, after it renders the numbers.
3. Confirm the normal cached path still short-circuits — the refresh worker is still enqueued and `overview_stats` is not called when the blob has `:overview`.

Note: this touches `user_balance_stats_service.rb` next to the comment block edited by the Payouts payload PR, so whichever merges second needs a one-line rebase there.

---

AI Disclosure: Claude Opus 5.
