### PR TITLE
Cap Sales list pagination to Elasticsearch's result window (GUMROAD-1C1)

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -11,10 +11,7 @@ class CustomersController < Sellers::BaseController
   before_action :set_on_page_type
 
   CUSTOMERS_PER_PAGE = 20
-  # Elasticsearch's index.max_result_window caps `from + size` at 10_000, so a seller
-  # with more than 10k sales cannot page past (10_000 / CUSTOMERS_PER_PAGE) without the
-  # index rejecting the request. Cap both the requested offset and the advertised page
-  # count to keep the Sales list's last page reachable instead of a 500.
+  # Keep pagination within Elasticsearch's index.max_result_window.
   MAX_RESULT_WINDOW = 10_000
 
   layout "inertia", only: [:index, :show]
@@ -84,7 +81,7 @@ class CustomersController < Sellers::BaseController
     customers_presenter = CustomersPresenter.new(
       pundit_user:,
       customers: load_sales(sales),
-      pagination: { page: params[:page].to_i + 1, pages: total_pages(sales.results.total), next: nil },
+      pagination: { page: page_offset / CUSTOMERS_PER_PAGE + 1, pages: total_pages(sales.results.total), next: nil },
       count: sales.results.total
     )
 

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -118,7 +118,9 @@ class CustomersController < Sellers::BaseController
     end
   end
 
-  def handle_search_error
+  def handle_search_error(exception)
+    ErrorNotifier.notify(exception)
+
     if action_name == "paged"
       render json: { success: false, error: "search failed" }, status: :bad_request
     else

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -4,12 +4,18 @@ class CustomersController < Sellers::BaseController
   include CurrencyHelper
 
   rescue_from Faraday::TimeoutError, with: :handle_search_timeout
+  rescue_from Elasticsearch::Transport::Transport::Errors::BadRequest, with: :handle_search_error
 
 
   before_action :authorize
   before_action :set_on_page_type
 
   CUSTOMERS_PER_PAGE = 20
+  # Elasticsearch's index.max_result_window caps `from + size` at 10_000, so a seller
+  # with more than 10k sales cannot page past (10_000 / CUSTOMERS_PER_PAGE) without the
+  # index rejecting the request. Cap both the requested offset and the advertised page
+  # count to keep the Sales list's last page reachable instead of a 500.
+  MAX_RESULT_WINDOW = 10_000
 
   layout "inertia", only: [:index, :show]
 
@@ -20,7 +26,7 @@ class CustomersController < Sellers::BaseController
       pundit_user:,
       product:,
       customers: load_sales(sales),
-      pagination: { page: 1, pages: (sales.results.total / CUSTOMERS_PER_PAGE.to_f).ceil, next: nil },
+      pagination: { page: 1, pages: total_pages(sales.results.total), next: nil },
       count: sales.results.total
     )
     create_user_event("customers_view")
@@ -78,7 +84,7 @@ class CustomersController < Sellers::BaseController
     customers_presenter = CustomersPresenter.new(
       pundit_user:,
       customers: load_sales(sales),
-      pagination: { page: params[:page].to_i + 1, pages: (sales.results.total / CUSTOMERS_PER_PAGE.to_f).ceil, next: nil },
+      pagination: { page: params[:page].to_i + 1, pages: total_pages(sales.results.total), next: nil },
       count: sales.results.total
     )
 
@@ -115,7 +121,26 @@ class CustomersController < Sellers::BaseController
     end
   end
 
+  def handle_search_error
+    if action_name == "paged"
+      render json: { success: false, error: "search failed" }, status: :bad_request
+    else
+      redirect_back fallback_location: root_path, warning: "Request failed. Please try again.", status: :see_other
+    end
+  end
+
   private
+    # `from` is 0-indexed; page 500 (1-indexed) is the last legal ES window (9980). Clamp
+    # requests past it to that window so a deep page renders the last page rather than
+    # an ES "Result window is too large" rejection.
+    def page_offset
+      params[:page].to_i.clamp(0, MAX_RESULT_WINDOW / CUSTOMERS_PER_PAGE - 1) * CUSTOMERS_PER_PAGE
+    end
+
+    def total_pages(total)
+      [(total / CUSTOMERS_PER_PAGE.to_f).ceil, MAX_RESULT_WINDOW / CUSTOMERS_PER_PAGE].min
+    end
+
     def fetch_sales(query: nil, sort: nil, products: nil, variants: nil, excluded_products: nil, excluded_variants: nil, minimum_amount_cents: nil, maximum_amount_cents: nil, created_after: nil, created_before: nil, country: nil, active_customers_only: false, minimum_license_uses: nil)
       search_options = {
         seller: current_seller,
@@ -128,7 +153,7 @@ class CustomersController < Sellers::BaseController
         exclude_giftees: true,
         exclude_bundle_product_purchases: true,
         exclude_commission_completion_purchases: true,
-        from: params[:page].to_i * CUSTOMERS_PER_PAGE,
+        from: page_offset,
         size: CUSTOMERS_PER_PAGE,
         sort: [{ created_at: { order: :desc } }, { id: { order: :desc } }],
         track_total_hits: true,

--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -368,6 +368,7 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
       body = response.parsed_body.deep_symbolize_keys
       # 30k sales at 20/page would be 1500 pages, but the ES window is only 10k hits.
       expect(body[:pagination][:pages]).to eq(500)
+      expect(body[:pagination][:page]).to eq(500)
       # Page 501 (0-indexed 500) is clamped to the last legal offset, not from+size = 14700.
       expect(requested_from).to eq(9_980)
     end

--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -352,6 +352,36 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
     end
   end
 
+  describe "GET paged with more than 10k customers" do
+    let(:product) { create(:product, user: seller) }
+
+    it "caps the advertised page count and clamps the ES `from` to the last legal window" do
+      requested_from = nil
+      allow(PurchaseSearchService).to receive(:search) do |options|
+        requested_from = options[:from]
+        double("sales", results: double("results", total: 30_000), records: Purchase.none)
+      end
+
+      get :paged, params: { page: 501 }
+
+      expect(response).to be_successful
+      body = response.parsed_body.deep_symbolize_keys
+      # 30k sales at 20/page would be 1500 pages, but the ES window is only 10k hits.
+      expect(body[:pagination][:pages]).to eq(500)
+      # Page 501 (0-indexed 500) is clamped to the last legal offset, not from+size = 14700.
+      expect(requested_from).to eq(9_980)
+    end
+
+    it "renders a 400 (not a 500) if ES still rejects an over-window query" do
+      allow(PurchaseSearchService).to receive(:search).and_raise(Elasticsearch::Transport::Transport::Errors::BadRequest)
+
+      get :paged, params: { page: 501 }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to eq("success" => false, "error" => "search failed")
+    end
+  end
+
   describe "GET charges" do
     before do
       @product = create(:product, user: seller)

--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -375,6 +375,7 @@ describe CustomersController, :vcr, type: :controller, inertia: true do
 
     it "renders a 400 (not a 500) if ES still rejects an over-window query" do
       allow(PurchaseSearchService).to receive(:search).and_raise(Elasticsearch::Transport::Transport::Errors::BadRequest)
+      expect(ErrorNotifier).to receive(:notify).with(instance_of(Elasticsearch::Transport::Transport::Errors::BadRequest))
 
       get :paged, params: { page: 501 }
 


### PR DESCRIPTION
## Stages
- [x] Scope
- [x] Design
- [x] Build
- [x] Ship
- [ ] Market
- [ ] Sell

## What

The Sales/customers page 500s for sellers with more than 10,000 successful sales once they page past Elasticsearch's `index.max_result_window` (10,000 hits). `CustomersController#paged` sends `from: (page-1)*20` with no cap, and ES rejects `from + size > 10000` with an uncaught `Elasticsearch::Transport::Transport::Errors::BadRequest`. The paginator also still advertised `ceil(total/20)` pages, so a catalog over 10k sales offered a last-page button that could never succeed.

Sentry [GUMROAD-1C1](https://gumroad-to.sentry.io/issues/7672656767/): 489 events / 10 users, 100% production, 100% `CustomersController#paged`. Latest request `GET /customers/paged?page=735` → `from+size=14700`. Sampled offsets in a 17s burst walk 10080 → 14760 (pages 504–738).

## Why

This is a reachability bug, not a data problem: `.max_result_window` is a cluster-scoped scan tax and must not be raised. The fix caps the request to the last legal window and stops the paginator from offering an unreachable page.

## Before / After

Before: `GET /customers/paged?page=501` → ES 400 → uncaught → HTTP 500, page renders broken.
After: the `from` offset is clamped to the last legal window (9,980) so a deep page returns the last page of data, the response reports the clamped current page (500), and the paginator's `pages` value is capped at 500 so no last-page button points past the window. Any remaining ES `BadRequest` on a search renders `{ success: false, error: "search failed" }` (HTTP 400) instead of 500.

## Test Results

Ran `spec/controllers/customers_controller_spec.rb` locally (controller spec, boots Rails and exits). All `paged` examples pass (30 passes; the 7 failures in the file are the pre-existing Vite-test-build environmental failure in the inertia-rendered `index`/`show`/`customer_emails` examples — confirmed identical on unmodified baseline via `git stash`).

New regression examples (both green):
1. `GET paged with more than 10k customers ... caps the advertised page count and clamps the ES from to the last legal window` — asserts `pagination[:pages] == 500`, `pagination[:page] == 500` for a `page=501` request, and that the `from` sent to `PurchaseSearchService` is clamped to 9980 (not 14700).
2. `... renders a 400 (not a 500) if ES still rejects an over-window query` — asserts HTTP 400 + `{success: false}` on a rescued ES `BadRequest`.

Mutation proof (each fix is load-bearing; ran each against the spec and confirmed red, restored):
- Removed the page-count cap → spec fails (`Expected 1500 to eq 500`).
- Removed the `from` clamp → spec fails (`Expected 10000 to eq 9980`).
- Removed the `BadRequest` rescue → spec fails (raises instead of rendering 400).

Greptile follow-up at `6c6eba9df9`:
- `ruby -c app/controllers/customers_controller.rb` and `ruby -c spec/controllers/customers_controller_spec.rb` — syntax OK.
- `bundle exec rubocop --force-exclusion -a app/controllers/customers_controller.rb spec/controllers/customers_controller_spec.rb` — 2 files inspected, no offenses.
- `DISABLE_SPRING=1 bundle exec rspec spec/controllers/customers_controller_spec.rb:355` — 2 examples, 0 failures.
- Mutation proof for the metadata fix: reverting the response page to `params[:page].to_i + 1` makes the new assertion fail (`Expected 501 to eq 500`), then restored and re-ran green.
- Attempted `pnpm format ...` per parent CLAUDE.md; the repo is configured for npm. Attempted `npm run format ...`; no `format` script exists, so RuboCop was the applicable formatter/check.

## QA

Hosted preview `https://customers-window-fix.apps.staging.gumroad.org` at `x-revision: 6c6eba9df967` (matches head). Logged in as `seller@gumroad.com`.

- `GET /customers` → HTTP 200.
- `GET /customers/paged?page=1` → HTTP 200, `pagination.page=1`.
- `GET /customers/paged?page=501` → HTTP 200 (not 500), `pagination.page=500`.
- `GET /customers/paged?page=735` → HTTP 200 (not 500), `pagination.page=500`.

The seed seller has no sales (`pages=0`), so the last-page button is not rendered, but the production 500 does not need 10k rows: ES rejects `from+size > 10000` even on an empty index. The deep-page requests are the same shape as Sentry GUMROAD-1C1 (`page=735` → `from+size=14700`) and now clamp instead of 500ing.

## QA steps (for a >10k catalog after merge)

1. As a seller with >10k sales, open Sales.
2. Open the last page in the paginator (now max page 500).
3. Assert the page renders HTTP 200, and the paginator no longer offers page 501.

## AI disclosure

Developed by Gumclaw, Gumroad's AI agent (model: grok-4.6), reviewed per the autonomous-product-dev QA audit against the live diff and regression specs.

---

Closes antiwork/gumroad-private#2266 (GUMROAD-1C1).

Premerge review: clean @ 6c6eba9df967ffb80573d98e557b5abd881ea9c0

