### PR TITLE
Reject over-budget page image sets before moderation

### DIFF
--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -166,6 +166,9 @@ class ContentModeration::ModerateRecordService
         content = content.class.new(text: content.text, image_urls: new_urls)
       else
         reasons = ["#{TOO_MANY_IMAGES_REASON_PREFIX} (#{content.image_urls.size})"]
+        # `blocked: false`: the publish did stop, but the admin trail is read as
+        # abuse history, and a seller with a big gallery has not done anything
+        # wrong. The seller-facing message says what to change.
         leave_admin_comment(reasons, blocked: false)
         return CheckResult.new(passed: false, reasons: reasons)
       end

--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -75,6 +75,10 @@ class ContentModeration::ModerateRecordService
     "directs buyers to message you on another platform to get it, which we don’t allow. Add the files, " \
     "videos, or written content buyers should get when they buy, then publish again."
 
+  # A page carrying more images than we will review is rejected rather than
+  # approved on a sample. The reason is about the page's size, not its content.
+  TOO_MANY_IMAGES_REASON_PREFIX = "too many images to review"
+
   # Turn raw moderation reasons (e.g. "OpenAI moderation flagged: violence
   # (score: 0.86, threshold: 0.9)" or "spam: repeated unrelated slogans") into
   # a friendly, de-duplicated phrase the seller can act on — without leaking
@@ -111,6 +115,10 @@ class ContentModeration::ModerateRecordService
       # on either way.
       "This #{noun} includes an image we can’t review, because the format is unsupported (such as an SVG data URL) " \
       "or the file is too large. Replace it with a smaller PNG, JPEG, GIF, or WebP and try again."
+    elsif rs.any? { |r| r.to_s.start_with?(TOO_MANY_IMAGES_REASON_PREFIX) }
+      "This #{noun} has more images than we can review, so we can’t publish it as is. " \
+      "Reduce it to at most #{ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS} images " \
+      "(or split it across several #{noun}s) and try again."
     elsif rs.any? { |r| off_platform_fulfillment_reason?(r) }
       message = format(OFF_PLATFORM_FULFILLMENT_MESSAGE, noun: noun)
       # A run can flag off-platform fulfillment alongside another violation
@@ -149,7 +157,19 @@ class ContentModeration::ModerateRecordService
     content = content.class.new(text: content.text, image_urls: []) if @skip_images
     return CheckResult.new(passed: true, reasons: []) if content.text.blank? && content.image_urls.empty?
 
-    content = sample_page_images(content) if entity_type == :page
+    if entity_type == :page && content.image_urls.size > ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS
+      previous_page_urls = previous_page_image_urls
+      if preexisting_over_budget_without_growth?(content, previous_page_urls)
+        # A live storefront catalog that already exceeds the cap must stay
+        # editable without raising the cap for new pages.
+        new_urls = content.image_urls - previous_page_urls
+        content = content.class.new(text: content.text, image_urls: new_urls)
+      else
+        reasons = ["#{TOO_MANY_IMAGES_REASON_PREFIX} (#{content.image_urls.size})"]
+        leave_admin_comment(reasons, blocked: false)
+        return CheckResult.new(passed: false, reasons: reasons)
+      end
+    end
 
     blocklist_result = ContentModeration::Strategies::BlocklistStrategy
                          .new(text: content.text, image_urls: content.image_urls)
@@ -389,33 +409,18 @@ class ContentModeration::ModerateRecordService
       end
     end
 
-    def sample_page_images(content)
-      limit = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS
-      return content if content.image_urls.size <= limit
-
-      selected_urls = stable_page_image_sample(content.image_urls, limit)
-      if record.is_a?(Page) && record.persisted?
-        previous_urls = previous_page_image_urls
-        new_urls = content.image_urls - previous_urls
-        if new_urls.size < limit
-          selected_urls = new_urls + stable_page_image_sample(content.image_urls - new_urls, limit - new_urls.size)
-        end
-      end
-
-      content.class.new(text: content.text, image_urls: selected_urls)
-    end
-
     def previous_page_image_urls
+      return [] unless entity_type == :page && record.is_a?(Page) && record.persisted?
+
       snapshot = record.dup
       snapshot.custom_html = record.custom_html_was
       snapshot.content = record.content_was if record.has_attribute?(:content)
       ContentModeration::ContentExtractor.new.extract_from_page(snapshot).image_urls
     end
 
-    def stable_page_image_sample(image_urls, limit)
-      # Stable per image set so retrying the same page cannot reshuffle coverage.
-      seed = Digest::SHA256.hexdigest(image_urls.join("\0")).to_i(16) % (2**31)
-      image_urls.sample(limit, random: Random.new(seed))
+    def preexisting_over_budget_without_growth?(content, previous_urls)
+      previous_urls.size > ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS &&
+        content.image_urls.size <= previous_urls.size
     end
 
     def run_ai_strategies(content)
@@ -423,9 +428,8 @@ class ContentModeration::ModerateRecordService
         ContentModeration::Strategies::ClassifierStrategy.new(
           text: content.text,
           image_urls: content.image_urls,
-          # Page image sets above the moderation budget are sampled before the
-          # strategies run. `:all` means every selected page image gets an attempt
-          # rather than being sliced again by the product/post default.
+          # A page's images are arbitrary URLs the seller wrote into a public
+          # document, so every accepted one gets a moderation attempt.
           max_images: entity_type == :page ? :all : ContentModeration::Strategies::ClassifierStrategy::MAX_IMAGES_TO_MODERATE,
         ),
         # `corroborate_judgment_flags` makes a spam, off-platform-fulfillment, or

--- a/spec/controllers/api/v2/links_controller_custom_html_spec.rb
+++ b/spec/controllers/api/v2/links_controller_custom_html_spec.rb
@@ -358,10 +358,11 @@ describe Api::V2::LinksController do
         )
       end
 
-      it "previews new over-budget HTML by sampling the images" do
+      it "rejects new over-budget HTML when no page is live" do
         post :preview_custom_html, params: { format: :json, access_token: @token.token, id: @product.external_id, custom_html: over_budget_html }
 
-        expect(response.parsed_body["success"]).to eq(true)
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to include("more images than we can review")
       end
 
       context "with a live over-budget root page" do
@@ -377,13 +378,14 @@ describe Api::V2::LinksController do
           expect(@product.custom_html).not_to include("swapped.png")
         end
 
-        it "previews adding an image to the live over-budget page by sampling" do
+        it "still rejects adding an image to the live over-budget page" do
           extra = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 2
           grown = over_budget_html + %(<img src="https://cdn.example.com/#{extra}.png">)
 
           post :preview_custom_html, params: { format: :json, access_token: @token.token, id: @product.external_id, custom_html: grown }
 
-          expect(response.parsed_body["success"]).to eq(true)
+          expect(response.parsed_body["success"]).to eq(false)
+          expect(response.parsed_body["message"]).to include("more images than we can review")
         end
       end
     end

--- a/spec/controllers/api/v2/users_controller_custom_html_spec.rb
+++ b/spec/controllers/api/v2/users_controller_custom_html_spec.rb
@@ -274,10 +274,11 @@ describe Api::V2::UsersController do
         )
       end
 
-      it "previews new over-budget HTML by sampling the images" do
+      it "rejects new over-budget HTML when no page is live" do
         post :preview_custom_html, params: { format: :json, access_token: @token.token, custom_html: over_budget_html }
 
-        expect(response.parsed_body["success"]).to eq(true)
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to include("more images than we can review")
       end
 
       context "with a live over-budget root page" do
@@ -293,13 +294,14 @@ describe Api::V2::UsersController do
           expect(@user.custom_html).not_to include("swapped.png")
         end
 
-        it "previews adding an image to the live over-budget page by sampling" do
+        it "still rejects adding an image to the live over-budget page" do
           extra = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 2
           grown = over_budget_html + %(<img src="https://cdn.example.com/#{extra}.png">)
 
           post :preview_custom_html, params: { format: :json, access_token: @token.token, custom_html: grown }
 
-          expect(response.parsed_body["success"]).to eq(true)
+          expect(response.parsed_body["success"]).to eq(false)
+          expect(response.parsed_body["message"]).to include("more images than we can review")
         end
       end
     end

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -192,36 +192,33 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
         end
         let(:over_budget_page) { Page.new(pageable: seller, slug: "gallery", title: "Gallery", custom_html: over_budget_html) }
 
-        it "samples the page images instead of blocking on size" do
-          expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new) do |args|
-            expect(args[:max_images]).to eq(:all)
-            expect(args[:image_urls].size).to eq(ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS)
-            expect(args[:image_urls]).to all(match(%r{\Ahttps://cdn\.example\.com/\d+\.png\z}))
-            instance_double(ContentModeration::Strategies::ClassifierStrategy,
-                            perform: strategy_result.new(status: "compliant", reasoning: []))
-          end
+        it "blocks the page instead of approving it on a subset of its images" do
+          expect(ContentModeration::Strategies::ClassifierStrategy).not_to receive(:new)
 
-          expect(described_class.check(over_budget_page, :page).passed).to eq(true)
+          result = described_class.check(over_budget_page, :page)
+
+          expect(result.passed).to eq(false)
+          expect(result.reasons).to eq(
+            ["#{described_class::TOO_MANY_IMAGES_REASON_PREFIX} " \
+             "(#{ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 1})"]
+          )
         end
 
-        it "does not leave an admin size note for an over-budget sample" do
-          expect(ContentModerationAdminCommentJob).not_to receive(:perform_async)
+        it "tells the seller the limit rather than naming a content violation" do
+          message = described_class.seller_message(described_class.check(over_budget_page, :page).reasons, "page")
 
-          expect(described_class.check(over_budget_page, :page).passed).to eq(true)
+          expect(message).to include("more images than we can review")
+          expect(message).to include(ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS.to_s)
+          expect(message).not_to include("content guidelines")
         end
 
-        it "keeps the sample stable for identical page images" do
-          samples = []
-          allow(ContentModeration::Strategies::ClassifierStrategy).to receive(:new) do |args|
-            samples << args[:image_urls]
-            instance_double(ContentModeration::Strategies::ClassifierStrategy,
-                            perform: strategy_result.new(status: "compliant", reasoning: []))
-          end
+        it "records the block as a note rather than as abuse history" do
+          # A big gallery is a size problem, not a content violation, and the admin
+          # trail is read as abuse history.
+          expect(ContentModerationAdminCommentJob).to receive(:perform_async)
+            .with(seller.id, /flagged but did not block/)
 
-          2.times { expect(described_class.check(over_budget_page, :page).passed).to eq(true) }
-
-          expect(samples.size).to eq(2)
-          expect(samples.first).to eq(samples.second)
+          described_class.check(over_budget_page, :page)
         end
 
         it "lets the seller rename an already-live page that is over the limit" do
@@ -233,36 +230,29 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
           expect(over_budget_page.valid?).to eq(true)
         end
 
-        it "samples a live over-budget page after a 1:1 image src swap" do
+        it "lets a live over-budget page swap one image src without growing the set" do
           over_budget_page.save!(validate: false)
           swapped = over_budget_html.sub("https://cdn.example.com/1.png", "https://cdn.example.com/swapped.png")
           over_budget_page.custom_html = swapped
 
-          expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new) do |args|
-            expect(args[:image_urls].size).to eq(ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS)
-            expect(args[:image_urls]).to include("https://cdn.example.com/swapped.png")
-            expect(args[:image_urls]).to all(start_with("https://cdn.example.com/"))
-            instance_double(ContentModeration::Strategies::ClassifierStrategy,
-                            perform: strategy_result.new(status: "compliant", reasoning: []))
-          end
+          expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new)
+            .with(hash_including(image_urls: ["https://cdn.example.com/swapped.png"]))
+            .and_return(instance_double(ContentModeration::Strategies::ClassifierStrategy,
+                                        perform: strategy_result.new(status: "compliant", reasoning: [])))
 
           expect(described_class.check(over_budget_page, :page).passed).to eq(true)
         end
 
-        it "samples a live over-budget page after adding another image" do
+        it "still blocks adding another image to a live over-budget page" do
           over_budget_page.save!(validate: false)
           extra = ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS + 2
           over_budget_page.custom_html = over_budget_html + %(<img src="https://cdn.example.com/#{extra}.png">)
 
-          expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new) do |args|
-            expect(args[:image_urls].size).to eq(ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS)
-            expect(args[:image_urls]).to include("https://cdn.example.com/#{extra}.png")
-            expect(args[:image_urls]).to all(start_with("https://cdn.example.com/"))
-            instance_double(ContentModeration::Strategies::ClassifierStrategy,
-                            perform: strategy_result.new(status: "compliant", reasoning: []))
-          end
+          expect(ContentModeration::Strategies::ClassifierStrategy).not_to receive(:new)
 
-          expect(described_class.check(over_budget_page, :page).passed).to eq(true)
+          result = described_class.check(over_budget_page, :page)
+          expect(result.passed).to eq(false)
+          expect(result.reasons.first).to start_with(described_class::TOO_MANY_IMAGES_REASON_PREFIX)
         end
 
         it "counts images painted through nested CSS toward the budget" do
@@ -272,14 +262,9 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
           end.join("\n")
           nested_page = Page.new(pageable: seller, slug: "nested", title: "Nested", custom_html: "<style>#{nested_css}</style>")
 
-          expect(ContentModeration::Strategies::ClassifierStrategy).to receive(:new) do |args|
-            expect(args[:image_urls].size).to eq(ContentModeration::ContentExtractor::MAX_PAGE_IMAGE_URLS)
-            expect(args[:image_urls]).to all(start_with("https://cdn.example.com/"))
-            instance_double(ContentModeration::Strategies::ClassifierStrategy,
-                            perform: strategy_result.new(status: "compliant", reasoning: []))
-          end
+          expect(ContentModeration::Strategies::ClassifierStrategy).not_to receive(:new)
 
-          expect(described_class.check(nested_page, :page).passed).to eq(true)
+          expect(described_class.check(nested_page, :page).passed).to eq(false)
         end
 
         it "moderates a page that sits exactly at the limit" do


### PR DESCRIPTION
This fixes a moderation bypass from the recent page image sampling change.

A seller could put more images on a public custom page than the moderation budget covers, and only a stable subset would be checked. Any violating image outside that subset could still be published and shown to buyers.

The fix restores the fail-closed behavior for new or grown over-budget page image sets. Existing over-budget pages can still make edits that do not grow the image set, and one-for-one image swaps keep reviewing the newly introduced image.

I verified this with:

`bundle exec rspec spec/services/content_moderation/moderate_record_service_spec.rb spec/controllers/api/v2/links_controller_custom_html_spec.rb spec/controllers/api/v2/users_controller_custom_html_spec.rb`

The run passed with 161 examples and no failures.

Premerge: Codex P1 at `52f6bef869db627d421d90addfd73a0d82671705` was clean. No rendered surface (API/service reject). Not money-path; not arming automerge. Assigned to Gianfranco for human review of the fail-closed publish gate.

AI-assisted by Gumclaw using grok-4.6 (xAI).

Premerge review: clean @ 52f6bef869db627d421d90addfd73a0d82671705

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Restored to @gianfrancopiana + `awaiting-human`. The 17:19Z steal was a false red: `ci/green` is SUCCESS at `52f6bef869`; CI Gate / Run scope / Reuse full suite CANCELLED/SKIPPED are the pull_request_target twin, not a failed suite. Auditor now keys CI on `ci/green` and ignores CANCELLED/SKIPPED twins.
<!-- gumclaw-ownership-sweep -->
