### PR TITLE
Register a fixed-interval e-mandate on membership reauth (gp#1410)

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -4016,7 +4016,10 @@ class Purchase < ApplicationRecord
     # Ref: Stripe::SetupIntentsController#create
     return if is_multi_buy?
 
-    recurrence = subscription_duration if is_original_subscription_purchase? || is_upgrade_purchase?
+    # Reauth / card-update purchases enter this method via setup_future_charges, not
+    # the original/upgrade flags. Passing nil recurrence here registers a sporadic
+    # mandate, which RBI issuers then refuse for the same monthly membership.
+    recurrence = subscription_duration if is_original_subscription_purchase? || is_upgrade_purchase? || setup_future_charges
     interval, interval_count = StripeChargeProcessor.indian_card_mandate_interval(recurrence)
 
     mandate_options = {

--- a/test/models/purchase_test.rb
+++ b/test/models/purchase_test.rb
@@ -6158,6 +6158,29 @@ class PurchaseTest < ActiveSupport::TestCase
     assert_equal 525, mandate_options[:payment_method_options][:card][:mandate_options][:amount]
   end
 
+  test "#mandate_options_for_stripe maps the fixed recurrence interval for a restart purchase (not sporadic)" do
+    product = create_membership_product
+    subscription = create_subscription(link: product)
+    create_purchase(charge_processor_id: StripeChargeProcessor.charge_processor_id, link: product, purchase_state: "successful",
+                    card_country: "IN", subscription:, is_original_subscription_purchase: true,
+                    price_cents: 100, total_transaction_cents: 105, displayed_price_cents: 100)
+    # Card-update reauth is not the original purchase and not an upgrade. It reaches
+    # mandate creation through setup_future_charges (Subscription::UpdaterService).
+    restart_purchase = create_purchase(charge_processor_id: StripeChargeProcessor.charge_processor_id, link: product, purchase_state: "in_progress",
+                                       card_country: "IN", subscription:, is_original_subscription_purchase: false,
+                                       price_cents: 100, total_transaction_cents: 105, displayed_price_cents: 100)
+    restart_purchase.setup_future_charges = true
+    chargeable = mock("chargeable")
+    chargeable.stubs(:requires_mandate?).returns(true)
+    restart_purchase.stubs(:chargeable).returns(chargeable)
+    restart_purchase.stubs(:subscription_duration).returns("monthly")
+
+    mandate_options = restart_purchase.mandate_options_for_stripe
+
+    assert_equal "month", mandate_options[:payment_method_options][:card][:mandate_options][:interval]
+    assert_equal 1, mandate_options[:payment_method_options][:card][:mandate_options][:interval_count]
+  end
+
   # ---- #is_an_async_off_session_charge_in_india? ----------------------------
 
   test "#is_an_async_off_session_charge_in_india? when card country is not India returns false if it is a regular purchase" do


### PR DESCRIPTION
## What

`Purchase#mandate_options_for_stripe` now looks up the membership recurrence for card-update / reauth purchases, not only original and upgrade purchases.

Those reauth charges already enter this method through `setup_future_charges` (`Subscription::UpdaterService`). The interval lookup still required `is_original_subscription_purchase?` or `is_upgrade_purchase?`, so a restart registered a sporadic mandate.

## Why

gumroad-private#1410: restart registers a sporadic mandate. A monthly India-card membership reauth then asks the issuer for a sporadic mandate, which is the wrong RBI shape for that recurrence.

This is independent of https://github.com/antiwork/gumroad/pull/7337 (selector still has to offer INR before those 218 buyers can complete reauth). This PR only fixes the mandate interval if/when they do.

Part of https://github.com/antiwork/gumroad-private/issues/1410 — mandate-interval slice only. The fail-fast / error-code persistence items on that issue are unchanged.

## Before / After

Before: a `setup_future_charges` reauth purchase with `subscription_duration=monthly` sent `interval=sporadic`.

After: the same purchase sends `interval=month`, `interval_count=1`.

Backend money-path. No rendered surface. Stays draft; do not automerge.

## Test Results

- Added `#mandate_options_for_stripe maps the fixed recurrence interval for a restart purchase (not sporadic)` in `test/models/purchase_test.rb`.
- Mutation: drop `|| setup_future_charges` from the recurrence guard — that example expects `month` and gets `sporadic`.
- CI at `31b4cc305cc8ba87e222a211e0028092fbcb2036`: full `run-all-specs` green — Test Fast 0–17, Test Slow 0–49, Test Minitest 0–1, Lint Ruby / Lint JS/TS / Typecheck TS / Build images / ci/green, Buildkite #21711.

## QA steps

1. Read the one-line change in `Purchase#mandate_options_for_stripe` and the new test.
2. Confirm a monthly membership card-update with `setup_future_charges` now builds `interval=month`.
3. Do not re-email seller 9460701's 218 buyers from this PR.

## Status

- [x] Scope — restart/reauth mandate interval only.
- [x] Build — recurrence lookup includes `setup_future_charges`.
- [x] CI — full Fast/Slow + Minitest green at this head (Buildkite #21711).
- [x] Premerge — Codex (gpt-5.6-sol) clean; Fable-5 400 until 2026-09-01.
- [ ] Ship — stays draft. Money-path; no automerge.

Ownership: draft stays unassigned with `working`. Merge waits on the fable-5 panel (400 until 2026-09-01). Sibling path `Stripe::SetupIntentsController#create` still hardcodes `interval: sporadic` unless `india_card_mandate_reliability` is on — out of this PR's UpdaterService/`setup_future_charges` slice.

Premerge review: clean @ 0bf8b2dba2ea96aac9e7a6616d7b175c8edd9778

Related: antiwork/gumroad-private#1410

---

AI disclosure: Authored by gumclaw using Hermes Agent. Model: grok-4.6.


