### PR TITLE
Fix UTM auto-create race on paid-ad bursts (GUMROAD-1CA)

### DIFF
--- a/app/controllers/concerns/utm_link_tracking.rb
+++ b/app/controllers/concerns/utm_link_tracking.rb
@@ -30,17 +30,10 @@ module UtmLinkTracking
 
       utm_params = required_params.merge(optional_params).transform_values { _1.to_s.strip.downcase.gsub(/[^a-z0-9\-_]/u, "-").first(UtmLink::MAX_UTM_PARAM_LENGTH).presence }
 
-      # Look up existing links with the "alive" scope (not "active") so we also see links the
-      # seller has disabled. The model's uniqueness validation also checks against "alive"
-      # links, so if we only searched "active" here we could miss a disabled duplicate,
-      # try to create a new link, and have the save fail — which used to surface as a 422
-      # error on the buyer-facing page.
-      # Order by id so the lookup is deterministic when duplicate alive links exist.
-      # Duplicates happen when two simultaneous first visits both insert the same link:
-      # MySQL's unique index can't stop that when a nullable column (utm_term, utm_content,
-      # target_resource_id) is NULL, because NULLs never conflict in unique indexes. Without
-      # an explicit order, alternating visits could split between the duplicate rows;
-      # always picking the oldest row keeps all stats accumulating on one link.
+      # Match the model's alive-scope uniqueness check, including disabled links; otherwise
+      # this can miss a duplicate and turn a buyer-facing GET into a validation error.
+      # Deterministically pick the oldest alive duplicate because nullable unique-index
+      # columns can allow duplicate rows, and splitting visits would fragment stats.
       utm_link = UtmLink.alive
         .where(utm_params.merge(target_resource_type:, target_resource_id:))
         .order(:id)
@@ -54,12 +47,9 @@ module UtmLinkTracking
         begin
           auto_create_utm_link(utm_link, seller)
         rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
-          # We lost the auto-create race: a concurrent first visit with the same UTM
-          # parameters inserted the link between our lookup and our insert. The winner's
-          # insert committed on its own (auto_create_utm_link saves outside the visit
-          # transaction), so an uncached lookup now sees it. Converge onto the winner and
-          # record the visit there instead of raising. If no winner exists (a genuinely
-          # invalid link, not a race), re-raise so the rescue below reports and swallows.
+          # The auto-create insert is outside the visit transaction, so a race winner
+          # should now be committed and visible to an uncached lookup. Converge onto it;
+          # if no winner exists, this was not the race path and the outer rescue reports it.
           utm_link = UtmLink.uncached do
             UtmLink.alive
               .where(utm_params.merge(seller_id: seller.id, target_resource_type:, target_resource_id:))
@@ -76,22 +66,12 @@ module UtmLinkTracking
 
       track_visit(utm_link)
     rescue ActiveRecord::LockWaitTimeout, ActiveRecord::Deadlocked => e
-      # Row contention on the utm_links row the timestamp update writes — a concurrent
-      # visit to the same link, or Onetime::DedupDuplicateUtmLinks, may already hold it.
-      # This runs in a before_action on public GETs, so an uncaught timeout 500s the
-      # product page.
-      #
-      # Neither is retried. A LockWaitTimeout has already spent InnoDB's timeout (50s by
-      # default), so a retry queues behind the same lock; a deadlock victim could retry
-      # cheaply, but losing one visit is cheaper than a second retry path on a
-      # page-blocking write.
+      # Timestamp updates can contend with another visit or the dedupe job. Do not retry:
+      # lock timeouts already consumed the wait budget, and analytics must not block the page.
       ErrorNotifier.notify(e, utm_params: params.permit(:utm_source, :utm_medium, :utm_campaign, :utm_term, :utm_content).to_h)
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
-      # A uniqueness failure that is NOT the auto-create race (that one is recovered in the
-      # rescue above) — e.g. a visit write fails validation, or the auto-created link is
-      # genuinely invalid and no winner exists to converge onto. Retrying would not help.
-      # Report and swallow so the buyer-facing page still renders (analytics must never
-      # break the page).
+      # Non-race uniqueness/validation failures cannot converge or retry safely. Report and
+      # swallow so analytics never breaks the buyer-facing page.
       ErrorNotifier.notify(e, utm_params: params.permit(:utm_source, :utm_medium, :utm_campaign, :utm_term, :utm_content).to_h)
     end
 

--- a/app/controllers/concerns/utm_link_tracking.rb
+++ b/app/controllers/concerns/utm_link_tracking.rb
@@ -5,11 +5,6 @@ module UtmLinkTracking
 
   private
     def track_utm_link_visit
-      # Used by the duplicate-link rescue below, which re-runs this method once via
-      # `retry`. `||=` (not plain assignment) so the flag survives the retry re-running
-      # the method body — a plain assignment would reset it and loop forever.
-      retried_after_duplicate_insert ||= false
-
       return unless request.get?
 
       required_params = {
@@ -35,31 +30,73 @@ module UtmLinkTracking
 
       utm_params = required_params.merge(optional_params).transform_values { _1.to_s.strip.downcase.gsub(/[^a-z0-9\-_]/u, "-").first(UtmLink::MAX_UTM_PARAM_LENGTH).presence }
 
+      # Look up existing links with the "alive" scope (not "active") so we also see links the
+      # seller has disabled. The model's uniqueness validation also checks against "alive"
+      # links, so if we only searched "active" here we could miss a disabled duplicate,
+      # try to create a new link, and have the save fail — which used to surface as a 422
+      # error on the buyer-facing page.
+      # Order by id so the lookup is deterministic when duplicate alive links exist.
+      # Duplicates happen when two simultaneous first visits both insert the same link:
+      # MySQL's unique index can't stop that when a nullable column (utm_term, utm_content,
+      # target_resource_id) is NULL, because NULLs never conflict in unique indexes. Without
+      # an explicit order, alternating visits could split between the duplicate rows;
+      # always picking the oldest row keeps all stats accumulating on one link.
+      utm_link = UtmLink.alive
+        .where(utm_params.merge(target_resource_type:, target_resource_id:))
+        .order(:id)
+        .first_or_initialize
+
+      # A disabled link means the seller intentionally paused tracking for these UTM
+      # parameters — respect that and don't record the visit.
+      return if utm_link.persisted? && !utm_link.enabled?
+
+      if utm_link.new_record?
+        begin
+          auto_create_utm_link(utm_link, seller)
+        rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+          # We lost the auto-create race: a concurrent first visit with the same UTM
+          # parameters inserted the link between our lookup and our insert. The winner's
+          # insert committed on its own (auto_create_utm_link saves outside the visit
+          # transaction), so an uncached lookup now sees it. Converge onto the winner and
+          # record the visit there instead of raising. If no winner exists (a genuinely
+          # invalid link, not a race), re-raise so the rescue below reports and swallows.
+          utm_link = UtmLink.uncached do
+            UtmLink.alive
+              .where(utm_params.merge(seller_id: seller.id, target_resource_type:, target_resource_id:))
+              .order(:id)
+              .first
+          end
+          raise if utm_link.blank?
+        end
+      end
+      return unless utm_link.persisted?
+      # The converged winner could have been disabled by the seller while we handled the
+      # race — respect that the same way the lookup above does, and don't record the visit.
+      return if !utm_link.enabled?
+
+      track_visit(utm_link)
+    rescue ActiveRecord::LockWaitTimeout, ActiveRecord::Deadlocked => e
+      # Row contention on the utm_links row the timestamp update writes — a concurrent
+      # visit to the same link, or Onetime::DedupDuplicateUtmLinks, may already hold it.
+      # This runs in a before_action on public GETs, so an uncaught timeout 500s the
+      # product page.
+      #
+      # Neither is retried. A LockWaitTimeout has already spent InnoDB's timeout (50s by
+      # default), so a retry queues behind the same lock; a deadlock victim could retry
+      # cheaply, but losing one visit is cheaper than a second retry path on a
+      # page-blocking write.
+      ErrorNotifier.notify(e, utm_params: params.permit(:utm_source, :utm_medium, :utm_campaign, :utm_term, :utm_content).to_h)
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+      # A uniqueness failure that is NOT the auto-create race (that one is recovered in the
+      # rescue above) — e.g. a visit write fails validation, or the auto-created link is
+      # genuinely invalid and no winner exists to converge onto. Retrying would not help.
+      # Report and swallow so the buyer-facing page still renders (analytics must never
+      # break the page).
+      ErrorNotifier.notify(e, utm_params: params.permit(:utm_source, :utm_medium, :utm_campaign, :utm_term, :utm_content).to_h)
+    end
+
+    def track_visit(utm_link)
       ActiveRecord::Base.transaction do
-        # Look up existing links with the "alive" scope (not "active") so we see links the
-        # seller has disabled. The model's uniqueness validation also checks against "alive"
-        # links, so if we only searched "active" links here we could miss a disabled duplicate,
-        # try to create a new link, and have the save fail — which used to surface as a 422
-        # error on the buyer-facing page.
-        #
-        # Order by id so the lookup is deterministic when duplicate alive links exist.
-        # Duplicates happen when two simultaneous first visits both insert the same link:
-        # MySQL's unique index can't stop that when a nullable column (utm_term, utm_content,
-        # target_resource_id) is NULL, because NULLs never conflict in unique indexes. Without
-        # an explicit order, alternating visits could split between the duplicate rows;
-        # always picking the oldest row keeps all stats accumulating on one link.
-        utm_link = UtmLink.alive
-          .where(utm_params.merge(target_resource_type:, target_resource_id:))
-          .order(:id)
-          .first_or_initialize
-
-        # A disabled link means the seller intentionally paused tracking for these UTM
-        # parameters — respect that and don't record the visit.
-        return if utm_link.persisted? && !utm_link.enabled?
-
-        auto_create_utm_link(utm_link, seller) if utm_link.new_record?
-        return unless utm_link.persisted?
-
         utm_link.utm_link_visits.create!(
           user: current_user,
           referrer: request.referrer,
@@ -75,53 +112,6 @@ module UtmLinkTracking
 
         UpdateUtmLinkStatsJob.perform_async(utm_link.id)
       end
-    rescue ActiveRecord::LockWaitTimeout, ActiveRecord::Deadlocked => e
-      # Row contention on the utm_links row the timestamp update above writes — a concurrent
-      # visit to the same link, or Onetime::DedupDuplicateUtmLinks, may already hold it. This
-      # runs in a before_action on public GETs, so an uncaught timeout 500s the product page.
-      #
-      # Neither is retried, unlike the uniqueness races below. A LockWaitTimeout has already
-      # waited out InnoDB's timeout (50s by default), so a retry queues behind the same lock;
-      # a deadlock victim could retry cheaply, but losing one visit is cheaper than a second
-      # retry path on a page-blocking write.
-      ErrorNotifier.notify(e, utm_params: params.permit(:utm_source, :utm_medium, :utm_campaign, :utm_term, :utm_content).to_h)
-    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
-      # Two simultaneous first visits with the same UTM parameters can both find no existing
-      # link and both try to auto-create it. The request that loses the race fails in one of
-      # two ways, depending on when the winner commits relative to the loser's save:
-      #
-      #   - ActiveRecord::RecordNotUnique — the winner commits after the loser's uniqueness
-      #     validation query ran, so the loser passes validation and then hits the database's
-      #     unique index on insert.
-      #   - ActiveRecord::RecordInvalid — the winner commits before the loser's uniqueness
-      #     validation query runs, so the loser's UtmLink#utm_fields_are_unique_per_target_resource
-      #     validation sees the winner's row and fails with "A link with similar UTM parameters
-      #     already exists".
-      #
-      # There is a third outcome: MySQL unique indexes treat NULL values as non-conflicting,
-      # and this index includes nullable columns (utm_term, utm_content, target_resource_id),
-      # so two racers can BOTH insert successfully and leave duplicate alive rows. Visits keep
-      # working for such links — the lookup above deterministically picks the oldest duplicate,
-      # and the model only re-validates uniqueness when identifying fields change (not on
-      # click-timestamp updates). Merging the duplicate rows themselves is handled by the
-      # Onetime::DedupDuplicateUtmLinks task; see https://github.com/antiwork/gumroad/issues/5989.
-      #
-      # In both recoverable cases the winning request has committed the link by the time we get here, so
-      # retrying once lets this request find that link and still record the visit. For
-      # RecordInvalid we only retry when the failing record is the auto-created UtmLink itself
-      # (a new record) — validation failures on other records in this block aren't races and
-      # retrying wouldn't help. If any failure repeats after the retry, something else is
-      # wrong — report and swallow so the buyer-facing page still renders (analytics must
-      # never break the page).
-      race_recoverable = e.is_a?(ActiveRecord::RecordNotUnique) ||
-        (e.record.is_a?(UtmLink) && e.record.new_record?)
-
-      if race_recoverable && !retried_after_duplicate_insert
-        retried_after_duplicate_insert = true
-        retry
-      end
-
-      ErrorNotifier.notify(e, utm_params: params.permit(:utm_source, :utm_medium, :utm_campaign, :utm_term, :utm_content).to_h)
     end
 
     def auto_create_utm_link(utm_link, seller)

--- a/spec/controllers/concerns/utm_link_tracking_spec.rb
+++ b/spec/controllers/concerns/utm_link_tracking_spec.rb
@@ -233,16 +233,21 @@ describe UtmLinkTracking, type: :controller do
       request.path = "/"
     end
 
-    it "retries once, recovers, and records the visit without reporting an error", :sidekiq_inline do
-      # Simulate losing the race: the first attempt to insert the auto-created link raises
-      # RecordNotUnique (in production this happens when a concurrent request inserted the
-      # same link between our find_or_initialize_by and our insert). The retry re-runs the
-      # lookup and must succeed without surfacing an error.
+    it "converges onto the racer that committed first and records the visit without reporting an error", :sidekiq_inline do
+      # The loser's auto-create raises RecordNotUnique because a concurrent request already
+      # inserted the same link (the winner committed between our lookup and our insert). We
+      # must not re-run the whole method (that lost against an uncommitted winner in a paid-ad
+      # burst); instead re-read the winner uncached in one shot and record the visit on it.
       original_save = UtmLink.instance_method(:save!)
       raised_once = false
       allow_any_instance_of(UtmLink).to receive(:save!) do |instance, *args|
         if instance.new_record? && !raised_once
           raised_once = true
+          # Simulate the winner committing concurrently. Only the loser's auto-create raises;
+          # the nested `create!` below commits the winner via original_save.
+          create(:utm_link, seller:, utm_source: "facebook", utm_medium: "social", utm_campaign: "summer_sale",
+                            utm_term: nil, utm_content: nil,
+                            target_resource_type: UtmLink.target_resource_types[:profile_page], target_resource_id: nil)
           raise ActiveRecord::RecordNotUnique
         end
         original_save.bind_call(instance, *args)
@@ -251,22 +256,23 @@ describe UtmLinkTracking, type: :controller do
       expect(ErrorNotifier).not_to receive(:notify)
 
       expect do
-        get :action, params: utm_params
+        get :action, params: { utm_source: "facebook", utm_medium: "social", utm_campaign: "summer_sale" }
       end.to change(UtmLinkVisit, :count).by(1)
 
       expect(response).to be_successful
+      expect(UtmLink.alive.count).to eq(1)
       utm_link = UtmLink.alive.find_by!(utm_source: "facebook", utm_medium: "social", utm_campaign: "summer_sale")
       expect(utm_link.total_clicks).to eq(1)
       expect(utm_link.utm_link_visits.count).to eq(1)
     end
 
-    it "retries once and recovers when the loser fails on the uniqueness validation instead of the database index", :sidekiq_inline do
+    it "converges onto the racer that won via the uniqueness validation and records the visit without reporting an error", :sidekiq_inline do
       # The other timing of the same race: the winning request commits BEFORE the losing
       # request's uniqueness validation query runs, so the loser fails model validation
       # (RecordInvalid) rather than the database's unique index (RecordNotUnique). This is
       # the "A link with similar UTM parameters already exists" error seen in production.
-      # The retry re-runs the lookup, finds the winner's link, and must record the visit
-      # without surfacing an error.
+      # The convergence re-reads the winner uncached and must record the visit without
+      # surfacing an error.
       original_save = UtmLink.instance_method(:save!)
       raised_once = false
       allow_any_instance_of(UtmLink).to receive(:save!) do |instance, *args|
@@ -286,20 +292,20 @@ describe UtmLinkTracking, type: :controller do
       expect(ErrorNotifier).not_to receive(:notify)
 
       expect do
-        get :action, params: utm_params
+        get :action, params: { utm_source: "facebook", utm_medium: "social", utm_campaign: "summer_sale" }
       end.to change(UtmLinkVisit, :count).by(1)
 
       expect(response).to be_successful
+      expect(UtmLink.alive.count).to eq(1)
       utm_link = UtmLink.alive.find_by!(utm_source: "facebook", utm_medium: "social", utm_campaign: "summer_sale")
       expect(utm_link.total_clicks).to eq(1)
       expect(utm_link.utm_link_visits.count).to eq(1)
     end
 
-    it "reports the error after a single retry when the auto-created link stays invalid" do
-      # If the validation failure isn't a transient race (it repeats on the retry), we must
-      # not loop — report once and let the page render. Counting save attempts is what makes
-      # this spec fail if the retry is removed (old code: 1 attempt) or unbounded (hang): the
-      # fixed code makes exactly 2 attempts — the original save plus one retry.
+    it "reports the error once (no retry) when the auto-create fails with no winner to converge onto" do
+      # If the auto-create validation failure isn't a race (no concurrent winner exists), we
+      # must not loop or re-try — report once and let the page render. Counting save attempts
+      # pins that: exactly ONE auto-create save, then convergence finds nothing and we report.
       save_attempts = 0
       allow_any_instance_of(UtmLink).to receive(:save!) do |instance, *args|
         save_attempts += 1
@@ -309,10 +315,10 @@ describe UtmLinkTracking, type: :controller do
       expect(ErrorNotifier).to receive(:notify).once.with(instance_of(ActiveRecord::RecordInvalid), anything)
 
       expect do
-        get :action, params: utm_params
+        get :action, params: { utm_source: "facebook", utm_medium: "social", utm_campaign: "summer_sale" }
       end.not_to change(UtmLinkVisit, :count)
 
-      expect(save_attempts).to eq(2)
+      expect(save_attempts).to eq(1)
       expect(response).to be_successful
     end
   end


### PR DESCRIPTION
## Status

Ready. Low-risk UTM race fix. Automerge armed. `working` removed. Premerge clean at `6ba1fa8f`.

- [x] Scope
- [x] Design
- [x] Build
- [x] QA
- [x] Shipped — automerge armed 2026-08-25
- [ ] Market
- [ ] Sell

## What

Stops UTM visit tracking from dropping visits (and flooding Sentry) during paid-ad bursts on a single product page. `GUMROAD-1CA` (`ActiveRecord::RecordNotUnique` on the utm_links unique index) jumped from 3 ev/day to **407 ev / 65 users / 24h**, all production, all `LinksController#show`, all the same Meta/IG campaign.

## Why

`UtmLinkTracking#track_utm_link_visit` ran `auto_create_utm_link`'s unique-key insert **inside the same `ActiveRecord::Base.transaction`** as the visit write + `first_click_at`/`last_click_at` + `UpdateUtmLinkStatsJob`. InnoDB holds the unique-key lock until that whole transaction commits. A paid burst is N racers against an **uncommitted** winner: each loser's `retry` re-ran the lookup, still couldn't `SELECT` the uncommitted row, inserted again, failed a second time, and `ErrorNotifier.notify`'d. Retry-once only worked for two racers with a committed winner — the assumption `#5983`/`#5986` were built on.

## Before → After

**Before (per loser):**
1. auto-create insert (unique-key lock held)
2. visit create + timestamps + enqueue — same transaction
3. loser hits `RecordNotUnique` → `retry` re-runs full method → still can't see uncommitted winner → fails again → `notify` → visit dropped

**After (per loser):**
1. `auto_create_utm_link` saves **outside** the visit transaction → winner's row commits on its own → lock released immediately
2. on `RecordNotUnique`/race `RecordInvalid`, converge: re-read the winner **uncached**, scoped by `seller_id` (matching the model's uniqueness validation, which the live lookup was missing) → record the visit on it
3. notify **only** when no winner exists (genuinely invalid link, not a race)

## Tests

- `DISABLE_SPRING=1 bundle exec rspec spec/controllers/concerns/utm_link_tracking_spec.rb` → **21 examples, 0 failures**
- `DISABLE_SPRING=1 bundle exec rspec spec/controllers/utm_links_controller_spec.rb spec/models/utm_link_visit_spec.rb spec/sidekiq/update_utm_link_stats_job_spec.rb` → **44 examples, 0 failures**
- `ruby -c` clean on both changed files
- `ruby -c app/controllers/concerns/utm_link_tracking.rb` after comment-only review follow-up @ `6ba1fa8f0b91` → **Syntax OK**
- Rewrote the three race specs that pinned the old retry mechanism to pin the new convergence behavior: loser converges onto a concurrently-committed winner with no `ErrorNotifier.notify` and exactly 1 alive link (both `RecordNotUnique` and `RecordInvalid` timings); a genuine non-race failure notifies exactly once with no retry.

## QA

Executed local spec runs (above) covering: normal visit on an existing link, disabled link skipped, soft-deleted link auto-recreates, auto-create on product/post/profile/subscribe pages, UTM truncation, cookies-disabled skip, LockWaitTimeout/deadlock notify-once with page rendering, and the three race cases.

Backend change with no rendered surface — the proof is the passing race specs plus the (still unchanged) rescue that guarantees the product page never 500s.

---

AI disclosure: written and tested by Hermes Agent (model `grok-4.6` per config).

Premerge review: clean @ 6ba1fa8f0b91a002fd1f7c60c686f0fffd0f76d7
