### PR TITLE
Remove retired mLab alert

### DIFF
--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -28,9 +28,8 @@ Here are the things to look for immediately in Sentry:
 ## What To Do
 
 1. There is a replica lag. Go into the [AWS Console](https://<AWS_ACCOUNT_ID>.signin.aws.amazon.com/console) --> RDS --> Instances and show monitoring on the Production Replica. If the lag is very high, follow this [commit](https://github.com/gumroad/web/commit/14a50ecde5ee557be12fc14906d6b443cce9d352) to remove the replica and use master directly. Make sure to revert/undo this once the lag is gone and push the commits to master --> deploy --> staging.
-2. This is usually a sign that [mLab](https://status.mlab.com/) is having some issue and you can check the status of it [here](https://status.compose.io/).
-3. The worker is in a bad state so we want to stop and start it. In most cases, a reboot will work, but a start and stop will always work and is the safer route to take. Go into the [AWS Console](https://<AWS_ACCOUNT_ID>.signin.aws.amazon.com/console) --> EC2 --> Instances, find the worker in the list, go to actions and stop it. Once it is stopped, start it, and watch Sidekiq to see it is back working and not hung on jobs. It takes 2-3 minutes for a machine to start up again.
-4. This is a lot more complicated. First, go to [New Relic](https://rpm.newrelic.com/accounts/85918/servers) and see which workers have a high disk usage. Go into the [AWS Console](https://<AWS_ACCOUNT_ID>.signin.aws.amazon.com/console) --> EC2 --> Instances and stop & start those workers. This is usually a good way to go. Once the machines have stopped and started, check New Relic again and see that the disk usage has gone down. If not, `ssh` into the worker and run `sudo rm -rf /tmp/*`. You may get errors saying "Operation not permitted", nothing to do about that. Then follow these steps:
+2. The worker is in a bad state so we want to stop and start it. In most cases, a reboot will work, but a start and stop will always work and is the safer route to take. Go into the [AWS Console](https://<AWS_ACCOUNT_ID>.signin.aws.amazon.com/console) --> EC2 --> Instances, find the worker in the list, go to actions and stop it. Once it is stopped, start it, and watch Sidekiq to see it is back working and not hung on jobs. It takes 2-3 minutes for a machine to start up again.
+3. This is a lot more complicated. First, go to [New Relic](https://rpm.newrelic.com/accounts/85918/servers) and see which workers have a high disk usage. Go into the [AWS Console](https://<AWS_ACCOUNT_ID>.signin.aws.amazon.com/console) --> EC2 --> Instances and stop & start those workers. This is usually a good way to go. Once the machines have stopped and started, check New Relic again and see that the disk usage has gone down. If not, `ssh` into the worker and run `sudo rm -rf /tmp/*`. You may get errors saying "Operation not permitted", nothing to do about that. Then follow these steps:
 
 ```
 grd
@@ -47,7 +46,7 @@ ls -l
 
 You want to remove all the past deploys using `rm -rf [name]` where the name is NOT the one `current` links to. If the size of the directory `current` links to is huge, then you have no choice but to make some change to the code, deploy to production, and remove that directory which is now old as `current` will link to the new deploy.
 
-5. If containers are not receiving any traffic, try restart on EC2 for the green/blue servers. Containers might not have allocated properly on deploy.
+4. If containers are not receiving any traffic, try restart on EC2 for the green/blue servers. Containers might not have allocated properly on deploy.
 
 ## Server Disks Full
 


### PR DESCRIPTION
## What

Remove the retired mLab and Compose status instruction from the alerts runbook.

## Why

Both referenced domains no longer resolve, so the troubleshooting step cannot be followed.

## Before/After

Documentation-only change; the diff is the reviewable artifact.

## Test Results

- Verified both retired URLs fail DNS resolution.
- Verified the final diff removes only the retired instruction and keeps the list numbered consecutively.

---

Based on https://github.com/denzasikora-lab/gumroad/pull/1 by @denzasikora-lab.

AI Disclosure: Claude Opus 4.6 was used to review the original PR and import the changes.

Premerge review: clean @ b25b2836d2173d4d99f7d682baadc9a971382d76
