### PR TITLE
Keep the deploy readiness healthcheck free of Redis

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 class HealthcheckController < ApplicationController
+  # The blue/green deploy gates on this action: Consul polls it through nginx and the
+  # cluster only receives traffic once it answers 200 (the `web` check in
+  # gumroad-deployment's web_server_{blue,green}.nomad.erb). So it must answer whenever
+  # nginx and Puma are serving and depend on nothing else -- a 500 here reads as "not
+  # ready" and stalls the deploy.
+  #
+  # redirect_to_custom_subdomain breaks that: it reads Rails.cache and falls through to
+  # Redis on a miss, and the production cache is namespaced by REVISION, so every deploy
+  # starts cold and the first poll of every deploy makes that call. Skipped only for
+  # :index -- the monitoring actions below genuinely report on Redis.
+  skip_before_action :redirect_to_custom_subdomain, only: :index
+
   def index
     render plain: "healthcheck"
   end

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -10,6 +10,19 @@ describe HealthcheckController do
       expect(response.status).to eq(200)
       expect(response.body).to eq("healthcheck")
     end
+
+    # The blue/green deploy gates on this action, so anything it touches becomes something
+    # that can hold traffic off a healthy cluster. Adding a before_action to
+    # ApplicationController that reads Redis or the cache should fail here, not in a deploy.
+    it "answers without reading Redis or the cache" do
+      expect(SubdomainRedirectorService).not_to receive(:new)
+      expect($redis).not_to receive(:get)
+      expect(Rails.cache).not_to receive(:fetch)
+
+      get :index
+
+      expect(response.status).to eq(200)
+    end
   end
 
   SIDEKIQ_QUEUE_NAMES = [:critical, :default].freeze


### PR DESCRIPTION
## What

`GET /healthcheck` no longer reads Redis or the cache.

`HealthcheckController#index` is a bare `render plain: "healthcheck"`, but it inherits `ApplicationController`'s filter chain, and `redirect_to_custom_subdomain` calls `SubdomainRedirectorService#redirect_url_for` → `redirects` → `Rails.cache.fetch` → `$redis.get`. This skips that one filter for `:index` only, and adds a spec asserting the endpoint reaches neither Redis nor the cache.

## Why

The production blue/green deploy gates on this endpoint. Consul polls `GET /healthcheck` through nginx (the `web` service check in `gumroad-deployment`'s `web_server_{blue,green}.nomad.erb`) and `wait_for_healthy.sh` only routes Route53 traffic to a replaced web cluster once every new allocation answers 200. A 500 there reads as "this cluster is not ready" — so any dependency on the endpoint is a way to hold traffic off a cluster that is serving perfectly well.

Redis was such a dependency, and not an occasional one:

- `config.cache_store = :mem_cache_store, …, { namespace: ENV.fetch("REVISION") }` — the memcached namespace *is* the revision, so **every deploy starts with a cold cache** and the first readiness poll of every deploy misses.
- `SubdomainRedirectorService#redirects` has `return {} if config.blank?` *inside* the `Rails.cache.fetch` block. A `return` there returns from the method and skips the cache write, so while `subdomain_redirects_config` is blank — presumably the normal state — **every** request re-reads Redis.

Nothing rescues `Redis::CannotConnectError` on that path, so an unreachable Redis 500s the readiness check and fails the gate for a reason unrelated to serving traffic. Today that means a 180s stall per cluster and a fail-open; it becomes a hard abort once `WEB_READINESS_ENFORCE=1` is turned on, which is the documented intended end state of that gate.

Scoped to `:index` deliberately — the other actions in this controller (`sidekiq`, `payouts`, `paypal_balance`, …) are monitoring endpoints that report on Redis on purpose.

Alternatives considered:

- **Point the check at `/healthcheck.txt`** (answered by nginx directly). Rejected: that is the ALB liveness probe, and `docker/nginx/nginx.conf` says why the two are separate — it is answered by nginx so it cannot queue behind Puma. Gating the deploy on it would stop measuring the proxy hop and Rails at all, which is the entire reason the readiness check is an HTTP request rather than the TCP one.
- **Skip the whole filter chain for `:index`.** More robust in principle, but Rails has no clean idiom for it and the rest of the chain is verified not to touch Redis, the DB, or memcached for this request. The spec is the guard against future additions instead.

For the record, the rest of the request path was checked and is clean: `Rack::Attack`'s throttles all return falsy discriminators for a well-formed `GET /healthcheck` (no path matches, and the global `invalid_params` throttle returns `false`), so it makes no Redis call; `Rack::MiniProfiler` only reads its Redis store when a `__profilin` cookie is presented; and `set_is_user_custom_domain` → `CustomDomain.find_by_host` is short-circuited by `PublicSuffix.valid?` because the check's `Host` is the instance's IP, so it issues no query.

## Before/After

Not user-facing — no UI, route, or response change. `GET /healthcheck` returns the same `200 healthcheck` body; only what it touches on the way there changes.

⚠️ **Walkthrough video still to be attached.**

Behaviour, as the specs demonstrate:

| | `SubdomainRedirectorService.new` | Response |
|---|---|---|
| Before | called on every poll | `200 healthcheck` |
| After | not called | `200 healthcheck` |

## Test Results

```
bundle exec rspec spec/controllers/healthcheck_controller_spec.rb -e "GET 'index'"
# 2 examples, 0 failures

bundle exec rspec spec/controllers/application_controller_spec.rb spec/services/subdomain_redirector_service_spec.rb
# 62 examples, 1 failure

bundle exec rubocop app/controllers/healthcheck_controller.rb spec/controllers/healthcheck_controller_spec.rb
# 2 files inspected, no offenses detected
```

Reverting the `skip_before_action` fails the new spec, so it is a valid guard:

```
Failure/Error: redirect_url = SubdomainRedirectorService.new.redirect_url_for(request)
  (SubdomainRedirectorService (class)).new(no args)
      expected: 0 times with any arguments
      received: 1 time
```

Two notes on what I could not verify locally:

- The one failure above, and 3 in the `purchases` examples of the healthcheck spec file, are **pre-existing** — all are `create(:purchase)` raising `Validation failed: We couldn't charge your card`, and they fail identically on a clean `main` in my environment (no local Stripe test-account access). Unrelated to this diff.
- `bin/test-confidence` was not run — no `ANTHROPIC_API_KEY` in my environment.

---

🤖 AI disclosure: written with Claude Opus 5 (1M context) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
