### PR TITLE
Return the gift sender sale for Sales API license_key lookups

### DIFF
--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -211,8 +211,19 @@ class Api::V2::SalesController < Api::V2::BaseController
       sales = sales.where(link_id: product_id) if product_id.present?
       sales = sales.where(id: purchase_id) if purchase_id.present?
       sales = sales.where("full_name LIKE ?", "%#{Purchase.sanitize_sql_like(name)}%") if name.present?
-      sales = sales.where(id: License.where(serial: license_key.upcase).select(:purchase_id)) if license_key.present?
+      sales = sales.where(id: sale_ids_for_license_key(license_key)) if license_key.present?
       sales.order(created_at: :desc, id: :desc)
+    end
+
+    # Licenses for gifted products live on the giftee purchase, which
+    # for_sales_api then drops. Prefer the gift's payer leg so a license_key
+    # lookup returns the same sale the unfiltered Sales API already lists.
+    def sale_ids_for_license_key(license_key)
+      holder_ids = License.where(serial: license_key.upcase).select(:purchase_id)
+      Purchase.unscoped
+        .where(id: holder_ids)
+        .joins("LEFT JOIN gifts ON gifts.giftee_purchase_id = purchases.id")
+        .select("COALESCE(gifts.gifter_purchase_id, purchases.id)")
     end
 
     def export_filters

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -236,6 +236,47 @@ describe Api::V2::SalesController do
         }.as_json)
       end
 
+      it "returns the gift sender sale when license_key belongs to a gifted purchase" do
+        @product.update!(is_licensed: true)
+        sender = create(:purchase, :gift_sender, purchaser: @purchaser, link: @product)
+        giftee = create(:purchase, :gift_receiver, link: @product, seller: @seller, price_cents: 0)
+        create(:gift, link: @product, gifter_purchase: sender, giftee_purchase: giftee,
+                      gifter_email: sender.email, giftee_email: giftee.email)
+        giftee.create_license!
+
+        get :index, params: @params.merge(license_key: giftee.license.serial)
+
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(response.parsed_body["sales"].map { _1["id"] }).to eq([sender.external_id])
+        expect(response.parsed_body["sales"].first["license_key"]).to eq(giftee.license.serial)
+        expect(response.parsed_body["sales"].map { _1["id"] }).not_to include(giftee.external_id)
+      end
+
+      it "returns the gift sender sale for a gifted license_key on the deprecated page path" do
+        @product.update!(is_licensed: true)
+        sender = create(:purchase, :gift_sender, purchaser: @purchaser, link: @product)
+        giftee = create(:purchase, :gift_receiver, link: @product, seller: @seller, price_cents: 0)
+        create(:gift, link: @product, gifter_purchase: sender, giftee_purchase: giftee,
+                      gifter_email: sender.email, giftee_email: giftee.email)
+        giftee.create_license!
+
+        get :index, params: @params.merge(license_key: giftee.license.serial, page: 1)
+
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(response.parsed_body["sales"].map { _1["id"] }).to eq([sender.external_id])
+        expect(response.parsed_body["sales"].first["license_key"]).to eq(giftee.license.serial)
+      end
+
+      it "does not list gift-receiver purchases when license_key is absent" do
+        create(:purchase, :gift_receiver, link: @product, seller: @seller, price_cents: 0)
+
+        get :index, params: @params
+
+        expect(response.parsed_body["sales"].map { _1["id"] }).to match_array(
+          [@purchase, @free_trial_purchase].map(&:external_id)
+        )
+      end
+
       it "returns a 400 error when the page_key query times out" do
         allow(WithMaxExecutionTime).to receive(:timeout_queries).and_raise(WithMaxExecutionTime::QueryTimeoutError)
 


### PR DESCRIPTION
Premerge review: clean @ 71097e1fa8e42b9c8547251183a0de1a5c3ddf67
Return the gift sender sale for Sales API license_key lookups

> Ready for Ershad review: focused specs + mutation proof green, Greptile review clean, and CI/buildkite green at `71097e1fa8e4`.
> Premerge review: clean @ 71097e1fa8e42b9c8547251183a0de1a5c3ddf67

Addresses antiwork/gumroad-private#2287.

## What

`GET /v2/sales?license_key=` returns the gift sender sale when the matching license lives on a gift-receiver purchase. Unfiltered sales listing still excludes gift-receiver rows.

## Why

Licenses for gifted products are created on the giftee purchase (`Purchase#create_license!` skips the sender). The Sales API then loads through `for_sales_api` / `for_sales_api_ordered_by_date`, which drop `gift_receiver_purchase_successful`, so an explicit license-key lookup returned an empty array. Sellers cannot find a gifted licensed sale by the key their customer holds.

## Before / after

- Before: `GET /v2/sales?license_key=<giftee key>` → `sales: []`
- After: same request returns the gift sender sale, including `license_key` via the existing `linked_license` serializer path
- Unfiltered `/v2/sales` still omits gift-receiver rows

No rendered surface — backend API filter only. Preview screenshots do not apply.

## Checklist

- [x] Scope — license_key filter on Sales API index only; no change to general listing, licenses API, or gift creation
- [x] Design — remap giftee license holder to `gifts.gifter_purchase_id` when present; keep `for_sales_api` as-is
- [x] Build — controller helper + controller specs at `71097e1fa8`
- [x] QA — focused specs + revert-mutant proof below
- [ ] Shipped
- [ ] Market — n/a (API lookup fix)
- [ ] Sell — n/a

## Test Results

At `71097e1fa8`, `DISABLE_SPRING=1 bundle exec rspec spec/controllers/api/v2/sales_controller_spec.rb` (lines 224, 239, 255, 270):

- Green: 4 examples, 0 failures (non-gift license_key filter; gift license_key on page_key path; gift license_key on deprecated `page` path; unfiltered index still omits gift-receiver rows)
- Revert mutant (call `License.where(serial:)` instead of `sale_ids_for_license_key`): 2 failures, empty `sales` on both gift lookup examples; non-gift license_key and unfiltered listing still green
- Greptile review: clean at `71097e1fa8e4` (no P1/P2 findings; summary says no concrete changed-code failure remains)
- GitHub Tests: green at `71097e1fa8e4` after rerunning the runner-only `Migration versions` failure; `ci/green` success and Buildkite `buildkite/gumroad` success

## QA steps

1. Create a licensed product, gift it, confirm the license sits on the giftee purchase.
2. `GET /v2/sales?license_key=<that key>` as the seller — expect the paid sender sale, with `license_key` set.
3. `GET /v2/sales` with no license_key — expect the sender sale present and the giftee sale absent.
4. Repeat on the deprecated `page=1` path.

Non-coverage: a giftee license with no `gifts` row still resolves to the giftee purchase and is still dropped by `for_sales_api`. That is not the reported production shape.

---

## AI disclosure

Generated with **grok-4.6** (xAI), running as gumclaw.
Prompts/instructions: GitHub issues.opened webhook for antiwork/gumroad-private#2287; autonomous-product-dev plus gumroad-api-surface-changes. Build the license_key gift-lookup fix; do not change the unfiltered sales list.