### PR TITLE
Ensure affiliate notification failures don't block sale pings

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2116,6 +2116,8 @@ class Purchase < ApplicationRecord
     after_commit do
       next if destroyed?
       AffiliateMailer.notify_affiliate_of_sale(id).deliver_later
+    rescue => e
+      Rails.logger.error("Failed to enqueue affiliate sale notification for purchase_id=#{id} affiliate_id=#{affiliate_id}: #{e.class}: #{e.message}")
     end
   end
 

--- a/spec/models/purchase/purchase_notification_spec.rb
+++ b/spec/models/purchase/purchase_notification_spec.rb
@@ -57,26 +57,6 @@ describe "Purchase Notifications", :vcr do
       expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(purchase.id, purchase.url_parameters)
     end
 
-    it "still schedules the sale ping when the affiliate notification enqueue fails" do
-      seller = create(:user, notification_endpoint: "http://notification.com")
-      product = create(:product, user: seller)
-      affiliate = create(:direct_affiliate, seller:)
-      purchase = create(:purchase, affiliate:, seller:, link: product, affiliate_credit_cents: 100)
-      mail_double = double
-      allow(mail_double).to receive(:deliver_later).and_raise(StandardError.new("mailer queue unavailable"))
-      allow(AffiliateMailer).to receive(:notify_affiliate_of_sale).and_return(mail_double)
-      allow(Rails.logger).to receive(:error)
-
-      expect do
-        Purchase.transaction do
-          purchase.notify_affiliate!
-          purchase.send_notification_webhook
-        end
-      end.to_not raise_error
-
-      expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(purchase.id, purchase.url_parameters)
-    end
-
     describe "with offer code" do
       before do
         @product = create(:product, price_cents: 600, user: create(:user, notification_endpoint: "http://notification.com"))

--- a/spec/models/purchase/purchase_notification_spec.rb
+++ b/spec/models/purchase/purchase_notification_spec.rb
@@ -57,6 +57,26 @@ describe "Purchase Notifications", :vcr do
       expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(purchase.id, purchase.url_parameters)
     end
 
+    it "still schedules the sale ping when the affiliate notification enqueue fails" do
+      seller = create(:user, notification_endpoint: "http://notification.com")
+      product = create(:product, user: seller)
+      affiliate = create(:direct_affiliate, seller:)
+      purchase = create(:purchase, affiliate:, seller:, link: product, affiliate_credit_cents: 100)
+      mail_double = double
+      allow(mail_double).to receive(:deliver_later).and_raise(StandardError.new("mailer queue unavailable"))
+      allow(AffiliateMailer).to receive(:notify_affiliate_of_sale).and_return(mail_double)
+      allow(Rails.logger).to receive(:error)
+
+      expect do
+        Purchase.transaction do
+          purchase.notify_affiliate!
+          purchase.send_notification_webhook
+        end
+      end.to_not raise_error
+
+      expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(purchase.id, purchase.url_parameters)
+    end
+
     describe "with offer code" do
       before do
         @product = create(:product, price_cents: 600, user: create(:user, notification_endpoint: "http://notification.com"))

--- a/spec/services/purchase/create_service_spec.rb
+++ b/spec/services/purchase/create_service_spec.rb
@@ -1595,6 +1595,25 @@ describe Purchase::CreateService, :vcr do
 
           Purchase::CreateService.new(product:, params:).perform
         end
+
+        it "still enqueues the sale ping when the affiliate notification enqueue fails" do
+          direct_affiliate = create(:direct_affiliate, seller: product.user)
+          params[:purchase][:affiliate_id] = direct_affiliate.id
+
+          mail_double = double
+          allow(mail_double).to receive(:deliver_later).and_raise(StandardError.new("mailer queue unavailable"))
+          allow(AffiliateMailer).to receive(:notify_affiliate_of_sale).and_return(mail_double)
+          allow(Rails.logger).to receive(:error)
+
+          purchase, error = nil
+          expect do
+            purchase, error = Purchase::CreateService.new(product:, params:).perform
+          end.to_not raise_error
+
+          expect(error).to be_nil
+          expect(purchase.purchase_state).to eq "successful"
+          expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(purchase.id, nil)
+        end
       end
 
       context "membership product" do

--- a/spec/support/fixtures/vcr_cassettes/Purchase_CreateService/for_a_preorder_purchase/affiliate_notification/digital_product/still_enqueues_the_sale_ping_when_the_affiliate_notification_enqueue_fails.yml
+++ b/spec/support/fixtures/vcr_cassettes/Purchase_CreateService/for_a_preorder_purchase/affiliate_notification/digital_product/still_enqueues_the_sale_ping_when_the_affiliate_notification_enqueue_fails.yml
@@ -1,0 +1,803 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_visa&billing_details[address][postal_code]=<STRONGBOX_GENERAL_PASSWORD>5
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_Aoh7gy2hopTb5o","request_duration_ms":0}}'
+      Idempotency-Key:
+      - b9493aab-dd4e-4c26-85d4-af4b583749a8
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 25 Aug 2026 03:37:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1132'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F;
+        report-to csp
+      Idempotency-Key:
+      - b9493aab-dd4e-4c26-85d4-af4b583749a8
+      Original-Request:
+      - req_WLMZg8kIjf54Hd
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F&t=1"
+      Request-Id:
+      - req_WLMZg8kIjf54Hd
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U8BApIBOqvOFDrfcDXRTVv1",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": "<STRONGBOX_GENERAL_PASSWORD>5",
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": "unchecked",
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787629039,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Tue, 25 Aug 2026 03:37:20 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_methods/pm_1U8BApIBOqvOFDrfcDXRTVv1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_WLMZg8kIjf54Hd","request_duration_ms":272}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 25 Aug 2026 03:37:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1132'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F&t=1"
+      Request-Id:
+      - req_FUmn8rNv4DNyK9
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1U8BApIBOqvOFDrfcDXRTVv1",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": "<STRONGBOX_GENERAL_PASSWORD>5",
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": "unchecked",
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 8,
+            "exp_year": 2027,
+            "fingerprint": "hsksJCaNjbEGzjqP",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1787629039,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Tue, 25 Aug 2026 03:37:20 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=600&currency=usd&description=You+bought+http%3A%2F%2Fedgar3452b7ad2.test.gumroad.com%3A31337%2Fl%2Fs%21&metadata[purchase]=_Lwn-dF3HHnSnNzCD6BDNw%3D%3D&transfer_group=375525722&payment_method_types[0]=card&payment_method=pm_1U8BApIBOqvOFDrfcDXRTVv1&statement_descriptor_suffix=edgar3452b7ad2
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_FUmn8rNv4DNyK9","request_duration_ms":177}}'
+      Idempotency-Key:
+      - 315c351b-8e50-44f6-bdd7-e7a8197eb2ef
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 25 Aug 2026 03:37:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1668'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F;
+        report-to csp
+      Idempotency-Key:
+      - 315c351b-8e50-44f6-bdd7-e7a8197eb2ef
+      Original-Request:
+      - req_MQsSFFAKLCTGkR
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F&t=1"
+      Request-Id:
+      - req_MQsSFFAKLCTGkR
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3U8BAqIBOqvOFDrf0NCCffAB",
+          "object": "payment_intent",
+          "allowed_payment_method_types": null,
+          "amount": 600,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3U8BAqIBOqvOFDrf0NCCffAB_secret_6INGYwGckHPguGNF75AgHQrMC",
+          "confirmation_method": "automatic",
+          "created": 1787629040,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar3452b7ad2.test.gumroad.com:31337/l/s!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": null,
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "_Lwn-dF3HHnSnNzCD6BDNw=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1U8BApIBOqvOFDrfcDXRTVv1",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar3452b7ad2",
+          "status": "requires_confirmation",
+          "transfer_data": null,
+          "transfer_group": "375525722"
+        }
+  recorded_at: Tue, 25 Aug 2026 03:37:20 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents/pi_3U8BAqIBOqvOFDrf0NCCffAB/confirm
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_MQsSFFAKLCTGkR","request_duration_ms":319}}'
+      Idempotency-Key:
+      - 7bf587ea-6707-4972-a30f-567930ee1399
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 25 Aug 2026 03:37:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1683'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F;
+        report-to csp
+      Idempotency-Key:
+      - 7bf587ea-6707-4972-a30f-567930ee1399
+      Original-Request:
+      - req_YZMPjxnttNoxvE
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F&t=1"
+      Request-Id:
+      - req_YZMPjxnttNoxvE
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3U8BAqIBOqvOFDrf0NCCffAB",
+          "object": "payment_intent",
+          "allowed_payment_method_types": null,
+          "amount": 600,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 600,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3U8BAqIBOqvOFDrf0NCCffAB_secret_6INGYwGckHPguGNF75AgHQrMC",
+          "confirmation_method": "automatic",
+          "created": 1787629040,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "You bought http://edgar3452b7ad2.test.gumroad.com:31337/l/s!",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3U8BAqIBOqvOFDrf0Oa6jWoZ",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "_Lwn-dF3HHnSnNzCD6BDNw=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1U8BApIBOqvOFDrfcDXRTVv1",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar3452b7ad2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375525722"
+        }
+  recorded_at: Tue, 25 Aug 2026 03:37:21 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3U8BAqIBOqvOFDrf0Oa6jWoZ?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_YZMPjxnttNoxvE","request_duration_ms":1115}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 25 Aug 2026 03:37:22 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3769'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=RqfAS4T22oLd8QHvLuWzd7cZFQtgrSaArMkAmAeOukbM41lR6dJhKpU6VVEpAn9_b5-Q9e5JRnDlZ4_F&t=1"
+      Request-Id:
+      - req_YLoK5A3yZnMGd2
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3U8BAqIBOqvOFDrf0Oa6jWoZ",
+          "object": "charge",
+          "amount": 600,
+          "amount_captured": 600,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3U8BAqIBOqvOFDrf0dmmXVQe",
+            "object": "balance_transaction",
+            "amount": 600,
+            "available_on": 1788220800,
+            "balance_type": "payments",
+            "created": 1787629041,
+            "currency": "usd",
+            "description": "You bought http://edgar3452b7ad2.test.gumroad.com:31337/l/s!",
+            "exchange_rate": null,
+            "fee": 47,
+            "fee_details": [
+              {
+                "amount": 47,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 553,
+            "reporting_category": "charge",
+            "source": "ch_3U8BAqIBOqvOFDrf0Oa6jWoZ",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": "<STRONGBOX_GENERAL_PASSWORD>5",
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR3452B7AD2",
+          "captured": true,
+          "created": 1787629041,
+          "currency": "usd",
+          "customer": null,
+          "description": "You bought http://edgar3452b7ad2.test.gumroad.com:31337/l/s!",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "_Lwn-dF3HHnSnNzCD6BDNw=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 47,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3U8BAqIBOqvOFDrf0NCCffAB",
+          "payment_method": "pm_1U8BApIBOqvOFDrfcDXRTVv1",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 600,
+              "authorization_code": "567498",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": "pass",
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 8,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 600,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKPKbtNQGMgayW_3NO4U6LBZnaMqA0DBO6sU82JgL-kG80L-jNcMSDYGEn0s7ALTiSHy1w2DJXueOtWLi",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar3452b7ad2",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "375525722"
+        }
+  recorded_at: Tue, 25 Aug 2026 03:37:22 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Status

- [x] Scope — post-#7354 silent sale-ping misses that never reach `PostToIndividualPingEndpointWorker`
- [x] Design — keep affiliate notification enqueue failures from aborting later sale-ping after-commit callbacks
- [x] Build — rescue and locally log affiliate sale-notification enqueue errors
- [x] QA — focused regression and adjacent API-notification checks passed locally
- [ ] Shipped
- [x] Market — existing Ping webhook contract preserved; no customer-facing launch needed
- [x] Sell — support/ops reliability fix; no sales collateral needed

## What

Affiliate sale-notification enqueue failures no longer block the sale Ping webhook from being enqueued.

The fix wraps the affiliate mailer enqueue inside its after-commit callback so that a mailer/queue failure is logged locally and later after-commit callbacks for the purchase can still run.

## Why

Refs antiwork/gumroad-private#2155.

The live audit on the reported residual misses found the remaining named misses are affiliate-attributed sales, and the local repro showed an affiliate notification enqueue exception aborts before the sale-ping enqueue runs. That produces the exact residual signature: the purchase is successful, manual re-ping works, but there is no `PostToIndividualPingEndpointWorker` attempt for the automatic sale ping.

## Before / After

Before:
- `notify_affiliate!` could raise inside its after-commit callback.
- That exception prevented the later `send_notification_webhook` after-commit callback from enqueueing `PostToPingEndpointsWorker`.

After:
- Affiliate notification enqueue errors are logged with purchase/affiliate ids.
- `PostToPingEndpointsWorker` still enqueues the sale ping for the purchase.

## Test Results

- RED first: `bundle exec rspec spec/services/purchase/create_service_spec.rb:3325` failed with `StandardError: mailer queue unavailable` at `app/models/purchase.rb:2118` before the fix.
- Review fix: moved the regression from direct callback invocation to `Purchase::CreateService`, so it now exercises the production purchase-success transition that registers `notify_affiliate!` before `send_notification_webhook`.
- GREEN focused: `DISABLE_SPRING=1 bundle exec rspec spec/services/purchase/create_service_spec.rb:1588 spec/services/purchase/create_service_spec.rb:1599 spec/models/purchase/purchase_notification_spec.rb:50` — 3 examples, 0 failures.
- Mutation proof: removing the rescue from `notify_affiliate!` makes `bundle exec rspec spec/services/purchase/create_service_spec.rb:1599` fail with `StandardError: mailer queue unavailable` before the sale ping assertion can pass.
- Syntax: `ruby -c app/models/purchase.rb && ruby -c spec/services/purchase/create_service_spec.rb && ruby -c spec/models/purchase/purchase_notification_spec.rb` — all OK.

## QA steps

No rendered surface. Backend-only — the spec mutation is the reviewable artifact.

1. Simulate `AffiliateMailer.notify_affiliate_of_sale(...).deliver_later` raising inside the purchase after-commit path.
2. Confirm the call does not raise to the purchase flow.
3. Confirm `PostToPingEndpointsWorker` still has the sale ping job for the purchase id and URL parameters.

---

AI disclosure: Implemented by Gumclaw using Hermes Agent model `grok-4.6`.

Premerge review: clean @ d4a4a5f5eb7605a8fa25e8f2d5ffc14cfe4198a6
