### PR TITLE
Speed up daily instant payouts cohort lookup

### DIFF
--- a/app/business/payments/payouts/payouts.rb
+++ b/app/business/payments/payouts/payouts.rb
@@ -445,7 +445,15 @@ class Payouts
   end
 
   def self.create_instant_payouts_for_balances_up_to_date(date)
-    users = User.holding_balance.where("json_data->'$.payout_frequency' = 'daily'")
+    # Daily is a few hundred sellers. User.holding_balance groups the whole unpaid
+    # balances table (~hours) to find them — start from the daily ids instead.
+    daily_user_ids = User.where("json_data->'$.payout_frequency' = ?", User::PayoutSchedule::DAILY).ids
+    holding_ids = if daily_user_ids.empty?
+      []
+    else
+      Balance.unpaid.where(user_id: daily_user_ids).group(:user_id).having("SUM(amount_cents) > 0").pluck(:user_id)
+    end
+    users = User.where(id: holding_ids)
     self.create_instant_payouts_for_balances_up_to_date_for_users(date, users, perform_async: true, add_comment: true)
   end
 

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -678,13 +678,14 @@ describe Payouts do
       expect(described_class).to receive(:create_instant_payouts_for_balances_up_to_date_for_users).with(payout_date, [u4], perform_async: true, add_comment: true)
 
       queries = []
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      callback = lambda { |*, payload|
         sql = payload[:sql]
         next unless sql.start_with?("SELECT")
         queries << sql
+      }
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        described_class.create_instant_payouts_for_balances_up_to_date(payout_date)
       end
-      described_class.create_instant_payouts_for_balances_up_to_date(payout_date)
-      ActiveSupport::Notifications.unsubscribe(subscriber)
 
       grouped = queries.grep(/SUM\(amount_cents\)/)
       expect(grouped.join).to match(/`user_id` IN \(/)

--- a/spec/business/payments/payouts/payouts_spec.rb
+++ b/spec/business/payments/payouts/payouts_spec.rb
@@ -670,14 +670,26 @@ describe Payouts do
     let(:payout_date) { Date.yesterday }
 
     it "calls create_instant_payouts_for_balances_up_to_date_for_users with all users holding balance with a payout frequency of daily" do
+      weekly_holder = create(:user, unpaid_balance_cents: 100, payout_frequency: User::PayoutSchedule::WEEKLY)
       create(:user, unpaid_balance_cents: 0, payout_frequency: User::PayoutSchedule::WEEKLY)
-      create(:user, unpaid_balance_cents: 100, payout_frequency: User::PayoutSchedule::WEEKLY)
       create(:user, unpaid_balance_cents: 0, payout_frequency: User::PayoutSchedule::DAILY)
       u4 = create(:user, unpaid_balance_cents: 100, payout_frequency: User::PayoutSchedule::DAILY)
 
       expect(described_class).to receive(:create_instant_payouts_for_balances_up_to_date_for_users).with(payout_date, [u4], perform_async: true, add_comment: true)
 
+      queries = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        sql = payload[:sql]
+        next unless sql.start_with?("SELECT")
+        queries << sql
+      end
       described_class.create_instant_payouts_for_balances_up_to_date(payout_date)
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+
+      grouped = queries.grep(/SUM\(amount_cents\)/)
+      expect(grouped.join).to match(/`user_id` IN \(/)
+      expect(grouped.join).to include(u4.id.to_s)
+      expect(grouped.join).not_to include(weekly_holder.id.to_s)
     end
   end
 


### PR DESCRIPTION
## What

Daily instant payouts now find the daily-frequency sellers first, then sum unpaid balances only for those ids.

## Why

`PerformDailyInstantPayoutsWorker` was holding deploys for ~60 minutes at 08:00 UTC. The job was still using `User.holding_balance` (a GROUP BY over every unpaid balance row) to find a tiny daily cohort.

Live today: **261** sellers have `payout_frequency = daily`, **135** of them have an unpaid balance. The weekly batch already stopped using that unscoped GROUP BY after it blew the 5-minute statement cap.

This does not change who gets paid or how `PayoutUsersService` creates payments.

## Before / After

Non-user-facing. Walkthrough of the existing daily-payouts path is in the spec run below.

## Test Results

- Sabotage: restore the old `User.holding_balance.where(json…)` one-liner → the new `user_id IN` assertion fails.
- `bundle exec rspec spec/business/payments/payouts/payouts_spec.rb:672 spec/sidekiq/perform_daily_instant_payouts_worker_spec.rb` → 2 examples, 0 failures.
- Full `payouts_spec.rb` → 103 examples, 1 failure: `create(:merchant_account)` "already connected" factory collision, unrelated to this diff.
- Greptile P2: SQL listener now uses `ActiveSupport::Notifications.subscribed` so it is torn down if the method raises (`c242208c96`). `ruby -c` on the spec file: Syntax OK.

## QA steps

No rendered surface. Cohort query only; payment creation is unchanged.

- [x] Scope — daily instant-payout cohort lookup only
- [x] Design — daily ids first, then unpaid SUM for those ids
- [x] Build — `c242208c96`
- [x] QA — sabotage + focused rspec at `18c8116`; spec isolation follow-up syntax-checked
- [ ] Shipped
- [ ] Market
- [ ] Sell

---

AI disclosure: Grok 4.6 (xAI). Prompt: speed up the daily instant payouts job; there cannot be that many creators with it on.

Premerge review: clean @ 18c81161796670acb6dd716ba77692477ad8c93f (follow-up c242208c96 is spec isolation only)
