### PR TITLE
Fix POST /v2/upsells 500 when cross_sell is omitted

### DIFF
--- a/app/models/upsell.rb
+++ b/app/models/upsell.rb
@@ -11,6 +11,10 @@ class Upsell < ApplicationRecord
             :flag_query_mode => :bit_operator,
             check_for_column: false
 
+  # `cross_sell` is a non-null column with no DB default; default it here so the
+  # public API can omit the key on create instead of raising NotNullViolation.
+  attribute :cross_sell, :boolean, default: false
+
   belongs_to :seller, class_name: "User"
   # For a cross-sell, this is the product that will be added to the cart if the buyer accepts the offer.
   # For an upsell, this is the product on which the buyer is offered a version change.

--- a/spec/controllers/api/v2/upsells_controller_spec.rb
+++ b/spec/controllers/api/v2/upsells_controller_spec.rb
@@ -219,6 +219,18 @@ describe Api::V2::UpsellsController do
         expect(response.parsed_body["message"]).to be_present
       end
 
+      it "creates an upsell without cross_sell instead of a server error" do
+        params = @params.except(:cross_sell)
+
+        expect do
+          post @action, params:, as: :json
+        end.to change { @user.upsells.count }.by(1)
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(@user.upsells.last.cross_sell).to eq(false)
+      end
+
       it "returns an error when a call is offered as an upsell" do
         call = create(:call_product, user: @user)
         expect do

--- a/spec/services/save_upsell_service_spec.rb
+++ b/spec/services/save_upsell_service_spec.rb
@@ -19,7 +19,6 @@ describe SaveUpsellService do
           name: "Upgrade",
           text: "Upgrade now",
           description: "Better tier",
-          cross_sell: false,
           product_id: product.external_id,
           upsell_variants: [{ selected_variant_id: product.alive_variants.first.external_id, offered_variant_id: product.alive_variants.second.external_id }],
         )
@@ -27,12 +26,23 @@ describe SaveUpsellService do
 
       expect(upsell).to be_persisted
       expect(upsell.name).to eq("Upgrade")
-      expect(upsell.cross_sell).to be(false)
+      expect(upsell.text).to eq("Upgrade now")
+      expect(upsell.description).to eq("Better tier")
       expect(upsell.product).to eq(product)
       expect(upsell.variant).to be_nil
       expect(upsell.upsell_variants.length).to eq(1)
       expect(upsell.upsell_variants.first.selected_variant).to eq(product.alive_variants.first)
       expect(upsell.upsell_variants.first.offered_variant).to eq(product.alive_variants.second)
+    end
+
+    it "defaults cross_sell to false when the key is omitted on create" do
+      upsell = described_class.new(
+        seller:,
+        params: params(name: "Upsell", product_id: product.external_id)
+      ).perform
+
+      expect(upsell).to be_persisted
+      expect(upsell.cross_sell).to be(false)
     end
 
     it "creates a cross-sell with a discounted offer code and selected products" do


### PR DESCRIPTION
## What

`POST /v2/upsells` 500s with `ActiveRecord::NotNullViolation: Column 'cross_sell' cannot be null` when the client omits `cross_sell` on create.

Root cause: `upsells.cross_sell` is `null: false` with no database default. `SaveUpsellService` permits `:cross_sell` and assigns whatever is present; on create an omitted key leaves it `nil`, and `save` hits the NOT NULL constraint before validations run.

## Why

The in-app editor always sends the flag; the public v2 API path does not default it. The factory default is `false`. Fixing by defaulting on new records matches that established behavior without relaxing `null: false`.

## Before-After

- **Before:** create without `cross_sell` → uncaught MySQL 500 (Sentry, 2 events / 2 users, production 2026-08-24).
- **After:** omitted `cross_sell` on create persists `false` (same as the factory/UI default); explicit `true` still honored.

## Test Results

Ran locally (`DISABLE_SPRING=1 bundle exec rspec`):
- `spec/services/save_upsell_service_spec.rb` — 10 examples, 0 failures (incl. new "defaults cross_sell to false when the key is omitted on create").
- `spec/controllers/api/v2/upsells_controller_spec.rb` — 43 examples, 0 failures (incl. new "creates an upsell without cross_sell instead of a server error"); with `spec/models/upsell_spec.rb`, 59 examples, 0 failures.
- Mutation check: removing `attribute :cross_sell, :boolean, default: false` makes the new service spec fail (1 failure), confirming it has teeth.

## QA steps

Create an upsell via `SaveUpsellService` (and via `POST /v2/upsells`) with no `cross_sell` key; assert the record persists with `cross_sell == false` and the response is a 200 `success: true`, not a 500. Covered by the two new specs above.

Backend-only — no rendered surface; the spec mutation is the reviewable artifact. Docs-only/screenshot gate does not apply.

## Notes

The same v2 payloads also send `offer_code_id` and `upsell_product_id`, which are not in `SaveUpsellService::PERMITTED_PARAMS` — a separate contract gap (those clients won't get the cross-sell they intended), out of scope for this crash fix.

- [x] **Scope** — `POST /v2/upsells` create path (`Api::V2::UpsellsController#create` → `SaveUpsellService#perform`)
- [x] **Design** — default `cross_sell` to `false` on new records via `attribute :cross_sell, :boolean, default: false`; matches factory/UI default, keeps `null: false`
- [x] **Build** — model attribute default + 2 specs (service + controller regression)
- [x] **QA** — service + controller + model specs green (69 examples, 0 failures incl. both new); mutation check proves the new service spec bites
- [ ] **Shipped** — pending CI + deploy
- [ ] **Market / Sell** — n/a (API crash fix)

---
AI disclosure: authored with Hermes Agent (grok-4.6).

Premerge review: clean @ 1a3b74b649c980fca496789783d35e61b067471e

