### PR TITLE
Drop serializer-only ProductFile.as_json keys in SaveFilesService so a v2 files PUT with that shape does not 500

### DIFF
--- a/app/services/save_files_service.rb
+++ b/app/services/save_files_service.rb
@@ -1,16 +1,9 @@
 # frozen_string_literal: true
 
 class SaveFilesService
-  # ProductFile.as_json exposes these derived keys, but they are not ProductFile
-  # columns and are not valid write targets on the save path. A v2 client that
-  # GETs a product and PUTs the files back echoes them verbatim (file_size is
-  # the top-level file's `file_size: size` alias; the rest are computed or
-  # serialization metadata), and update! would raise UnknownAttributeError on
-  # the first one — 500ing the whole product update. Drop them here so the
-  # round-trip echo is a no-op. Deliberately NOT included: writable flag-backed
-  # attributes ProductFile.as_json also exposes (stream_only, pdf_stamp_enabled,
-  # hide_kindle_and_read_buttons) and genuine columns (display_name,
-  # description, pagelength, duration, width, height, url, isbn).
+  # ProductFile.as_json exposes these derived keys to v2 clients, but
+  # ProductFile cannot write them back. Keep writable flag-backed as_json
+  # attributes out of this list.
   UNWRITABLE_SERIALIZED_FILE_KEYS = %i[
     file_size extension is_pdf is_streamable is_transcoding_in_progress attached_product_name status
   ].freeze
@@ -133,10 +126,6 @@ class SaveFilesService
           file_params[:display_name] ||= file_params[:file_name]
           file_params.delete(:file_name)
         end
-
-        # Serializer-only keys echoed by a v2 GET->PUT round-trip (see
-        # UNWRITABLE_SERIALIZED_FILE_KEYS). update! has no such columns/writers,
-        # so leaving them would raise and 500 the whole product update.
         file_params.except!(*UNWRITABLE_SERIALIZED_FILE_KEYS)
       end
     end

--- a/app/services/save_files_service.rb
+++ b/app/services/save_files_service.rb
@@ -126,7 +126,12 @@ class SaveFilesService
           file_params[:display_name] ||= file_params[:file_name]
           file_params.delete(:file_name)
         end
-        file_params.except!(*UNWRITABLE_SERIALIZED_FILE_KEYS)
+        # Hash#except! is missing on ActionController::Parameters (editor PUT),
+        # and v2 JSON uses string keys. delete works for Hash, HWIA, and Parameters.
+        UNWRITABLE_SERIALIZED_FILE_KEYS.each do |key|
+          file_params.delete(key)
+          file_params.delete(key.to_s)
+        end
       end
     end
 end

--- a/app/services/save_files_service.rb
+++ b/app/services/save_files_service.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class SaveFilesService
-  # ProductFile.as_json exposes these derived keys to v2 clients, but
-  # ProductFile cannot write them back. Keep writable flag-backed as_json
-  # attributes out of this list.
+  # ProductFile.as_json (editor/internal serialization — not the smaller v2
+  # GET shape) includes these derived keys, but ProductFile cannot write them
+  # back. Keep writable flag-backed as_json attributes out of this list.
   UNWRITABLE_SERIALIZED_FILE_KEYS = %i[
     file_size extension is_pdf is_streamable is_transcoding_in_progress attached_product_name status
   ].freeze

--- a/app/services/save_files_service.rb
+++ b/app/services/save_files_service.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 
 class SaveFilesService
+  # ProductFile.as_json exposes these derived keys, but they are not ProductFile
+  # columns and are not valid write targets on the save path. A v2 client that
+  # GETs a product and PUTs the files back echoes them verbatim (file_size is
+  # the top-level file's `file_size: size` alias; the rest are computed or
+  # serialization metadata), and update! would raise UnknownAttributeError on
+  # the first one — 500ing the whole product update. Drop them here so the
+  # round-trip echo is a no-op. Deliberately NOT included: writable flag-backed
+  # attributes ProductFile.as_json also exposes (stream_only, pdf_stamp_enabled,
+  # hide_kindle_and_read_buttons) and genuine columns (display_name,
+  # description, pagelength, duration, width, height, url, isbn).
+  UNWRITABLE_SERIALIZED_FILE_KEYS = %i[
+    file_size extension is_pdf is_streamable is_transcoding_in_progress attached_product_name status
+  ].freeze
+
   delegate :product_files, to: :owner
   attr_reader :owner, :params, :rich_content_params, :contract
 
@@ -119,6 +133,11 @@ class SaveFilesService
           file_params[:display_name] ||= file_params[:file_name]
           file_params.delete(:file_name)
         end
+
+        # Serializer-only keys echoed by a v2 GET->PUT round-trip (see
+        # UNWRITABLE_SERIALIZED_FILE_KEYS). update! has no such columns/writers,
+        # so leaving them would raise and 500 the whole product update.
+        file_params.except!(*UNWRITABLE_SERIALIZED_FILE_KEYS)
       end
     end
 end

--- a/spec/services/save_files_service_spec.rb
+++ b/spec/services/save_files_service_spec.rb
@@ -173,6 +173,45 @@ describe SaveFilesService do
       expect(file.reload.display_name).to eq("renamed file")
     end
 
+    it "is a no-op for serializer-only keys a v2 GET->PUT round-trip echoes (file_size etc.)" do
+      file = create(:product_file, link: @product, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/pencil.png", size: 1234)
+      @product.product_files << file
+
+      service.perform(@product, {
+                        files: [{
+                          external_id: file.external_id,
+                          url: file.url,
+                          file_name: "renamed file",
+                          file_size: 999_999,
+                          extension: "png",
+                          is_pdf: false,
+                          is_streamable: false,
+                          attached_product_name: @product.name,
+                          status: { type: "saved" },
+                        }]
+                      })
+
+      file.reload
+      expect(file.size).to eq(1234)
+      expect(file.display_name).to eq("renamed file")
+    end
+
+    it "still applies writable flag-backed attributes (stream_only) alongside serializer echoes" do
+      video = create(:streamable_video, link: @product, size: 4321)
+      @product.product_files << video
+
+      service.perform(@product, {
+                        files: [{
+                          external_id: video.external_id,
+                          url: video.url,
+                          file_size: video.size,
+                          stream_only: true,
+                        }]
+                      })
+
+      expect(video.reload.stream_only?).to eq(true)
+    end
+
     it "supports `files` param as an array" do
       installment = create(:installment, workflow: create(:workflow))
       file1 = create(:product_file, installment:, link: nil, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/pencil.png")

--- a/spec/services/save_files_service_spec.rb
+++ b/spec/services/save_files_service_spec.rb
@@ -173,7 +173,7 @@ describe SaveFilesService do
       expect(file.reload.display_name).to eq("renamed file")
     end
 
-    it "is a no-op for serializer-only keys a v2 GET->PUT round-trip echoes (file_size etc.)" do
+    it "drops ProductFile.as_json-only keys from a Hash payload so update! does not raise (file_size etc.)" do
       file = create(:product_file, link: @product, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/pencil.png", size: 1234)
       @product.product_files << file
 
@@ -219,7 +219,7 @@ describe SaveFilesService do
       expect(file.display_name).to eq("renamed file")
     end
 
-    it "still applies writable flag-backed attributes (stream_only) alongside serializer echoes" do
+    it "still applies writable flag-backed attributes (stream_only) when serializer-only keys are also present" do
       video = create(:streamable_video, link: @product, size: 4321)
       @product.product_files << video
 

--- a/spec/services/save_files_service_spec.rb
+++ b/spec/services/save_files_service_spec.rb
@@ -196,6 +196,29 @@ describe SaveFilesService do
       expect(file.display_name).to eq("renamed file")
     end
 
+    it "drops serializer-only keys from ActionController::Parameters (editor PUT string keys)" do
+      file = create(:product_file, link: @product, url: "#{AWS_S3_ENDPOINT}/#{S3_BUCKET}/attachment/pencil.png", size: 1234)
+      @product.product_files << file
+
+      service.perform(@product, ActionController::Parameters.new(
+                                  files: [{
+                                    "external_id" => file.external_id,
+                                    "url" => file.url,
+                                    "file_name" => "renamed file",
+                                    "file_size" => 999_999,
+                                    "extension" => "png",
+                                    "is_pdf" => false,
+                                    "is_streamable" => false,
+                                    "attached_product_name" => @product.name,
+                                    "status" => { "type" => "saved" },
+                                  }]
+                                ).permit!)
+
+      file.reload
+      expect(file.size).to eq(1234)
+      expect(file.display_name).to eq("renamed file")
+    end
+
     it "still applies writable flag-backed attributes (stream_only) alongside serializer echoes" do
       video = create(:streamable_video, link: @product, size: 4321)
       @product.product_files << video


### PR DESCRIPTION
## Status

Ready for review. Behavior is unchanged since `9e63a3f2`; the latest change only corrects comments and spec names that misdescribed the failure mode (they claimed a v2 GET→PUT echo — see Why).

## What

`PUT /v2/products/:id` has no `.permit` allowlist for files: `normalize_params_recursively` feeds the payload straight into `SaveFilesService`. If the `files` array is shaped like `ProductFile.as_json` — the editor/internal serialization, which includes the derived keys `file_size`, `extension`, `is_pdf`, `is_streamable`, `is_transcoding_in_progress`, `attached_product_name`, and `status` — then `product_file.update!` raises `ActiveModel::UnknownAttributeError`, the v2 update path does not rescue it, and the whole request 500s (Sentry GUMROAD-FP).

`SaveFilesService#updated_file_params` now deletes those seven serializer-only keys (symbol and string forms) before writing, at the shared seam every save path goes through (editor, API v2, installments, workflows, customer emails).

## Why

- The seven keys are derived by `ProductFile.as_json` and are not write targets (`file_size` is an alias of the `size` column; the rest aren't columns at all). Raising a 500 on a shape our own serializer produces is a server-side mismatch, not bad client input, so the fix is to strip the keys server-side rather than reject the request.
- **What this is not:** the v2 GET files shape is smaller — `{id, name, size, url (signed), filetype, filegroup}` per `app/models/concerns/product/as_json.rb` — and contains none of these seven keys. A faithful v2 GET→PUT of an S3 file also fails earlier on the canonical-URL guard (the signed URL doesn't match the stored URL) and never reaches this service. The 500 comes from clients or internal callers sending a hand-built `ProductFile.as_json`-shaped files array. Earlier comments and spec names on this branch described it as a GET→PUT echo; that was wrong and is now corrected.
- `delete` per key rather than `Hash#except!`: the product editor's PUT arrives as `ActionController::Parameters`, which has no `except!` — the first commit on this branch broke 159 Minitest examples that way. `delete` works uniformly for Hash, HashWithIndifferentAccess, and Parameters, and both loops cover symbol and string keys (v2 JSON arrives string-keyed).
- Deliberately **not** dropped — writable attributes `ProductFile.as_json` also exposes: the flag-backed `stream_only`, `pdf_stamp_enabled`, `hide_kindle_and_read_buttons`, and genuine columns (`display_name`, `description`, `pagelength`, `duration`, `width`, `height`, `url`, `isbn`, `position`).

## Before/After

- **Before:** a v2 files PUT containing `file_size` (or any of the other six keys) raises `ActiveModel::UnknownAttributeError` and 500s the product update.
- **After:** the serializer-only keys are silently dropped; writable attributes in the same payload still apply, and `size` stays derived from the stored object.

Backend-only change with no rendered surface (screenshot gate does not apply).

## Test Results

- `bundle exec rspec spec/services/save_files_service_spec.rb` — 19 examples, 0 failures.
- Mutation check: with the key-deletion loop reverted, the Hash-payload spec fails with `ActiveModel::UnknownAttributeError`, and the `ActionController::Parameters` spec fails the same way (string keys).

## QA

1. On a product with an S3 file, `PUT /v2/products/:id` with a `files` array containing that file's `external_id` and `url` plus `file_size: 999999`, `extension`, `is_pdf`, `is_streamable`, `attached_product_name`, and `status` keys. Expect 200; the file's stored `size` is unchanged.
2. Repeat with `stream_only: true` alongside the serializer-only keys on a streamable video. Expect `stream_only` to be applied.
3. In the product editor, rename a file and save. Expect the save to succeed (regression check for the `ActionController::Parameters` path).

---

Fix for gumroad-private#2293.

AI disclosure: Claude Fable 5
