### PR TITLE
Scope bundle archives to the download token purchase

### DIFF
--- a/app/models/url_redirect.rb
+++ b/app/models/url_redirect.rb
@@ -158,14 +158,7 @@ class UrlRedirect < ApplicationRecord
   def bundle_archive_product_files
     return ProductFile.none unless purchase&.is_bundle_purchase?
 
-    bundle_purchases = if purchase.purchaser_id.present?
-      Purchase.visible_in_library.is_bundle_purchase.where(purchaser_id: purchase.purchaser_id, link_id: purchase.link_id)
-    else
-      Purchase.where(id: purchase.id)
-    end
-    member_redirects = bundle_purchases.flat_map do |bundle_purchase|
-      bundle_purchase.product_purchases.visible_in_library.includes(:url_redirect).filter_map(&:url_redirect)
-    end
+    member_redirects = purchase.product_purchases.visible_in_library.includes(:url_redirect).filter_map(&:url_redirect)
     return ProductFile.none if member_redirects.any? { _1.with_product_files.has_stampable_pdfs? }
 
     file_ids = member_redirects.flat_map do |url_redirect|

--- a/spec/models/url_redirect_spec.rb
+++ b/spec/models/url_redirect_spec.rb
@@ -245,6 +245,23 @@ describe UrlRedirect do
       expect(bundle_purchase.url_redirect.bundle_archive).to eq(nil)
       expect(bundle.product_files_archives.alive).to be_empty
     end
+
+    it "does not include files from another purchase of the same bundle" do
+      add_member_files
+      bundle_purchase.create_artifacts_and_send_receipt!
+      original_product_ids = bundle_purchase.product_purchases.map(&:link_id)
+
+      removed_bundle_product = bundle.bundle_products.first
+      removed_bundle_product.mark_deleted!
+      new_bundle_product = create(:bundle_product, bundle:)
+      create(:product_file, link: new_bundle_product.product, display_name: "new-file")
+      repeat_purchase = create(:purchase, purchaser: buyer, link: bundle)
+      repeat_purchase.create_artifacts_and_send_receipt!
+
+      files_for_original_token = bundle_purchase.url_redirect.bundle_archive_product_files
+      expect(files_for_original_token.map(&:link_id)).to match_array(original_product_ids)
+      expect(files_for_original_token.map(&:link_id)).not_to include(new_bundle_product.product_id)
+    end
   end
 
   describe "streaming" do

--- a/spec/presenters/library_presenter_spec.rb
+++ b/spec/presenters/library_presenter_spec.rb
@@ -596,7 +596,7 @@ describe LibraryPresenter do
         expect(props[:bundle_downloads]).to eq([expected_download])
       end
 
-      it "includes files from repeat purchases of the same bundle link" do
+      it "keeps a bundle archive scoped to the selected purchase" do
         removed_bundle_product = purchase1.link.bundle_products.first
         removed_bundle_product.mark_deleted!
         new_bundle_product = create(:bundle_product, bundle: purchase1.link)
@@ -606,9 +606,10 @@ describe LibraryPresenter do
 
         library_props(bundle_ids: [purchase1.link.external_id])
 
-        archive = repeat_purchase.link.product_files_archives.alive.entity_archives.sole
+        archive = purchase1.link.product_files_archives.alive.entity_archives.sole
         archived_link_ids = archive.product_files.map(&:link_id)
-        expect(archived_link_ids).to include(removed_bundle_product.product_id, new_bundle_product.product_id)
+        expect(archived_link_ids).to include(new_bundle_product.product_id)
+        expect(archived_link_ids).not_to include(removed_bundle_product.product_id)
       end
 
       it "does not create a combined ZIP when a member product has stampable pdfs" do


### PR DESCRIPTION
## Summary

This fixes a security issue in the bundle Download all ZIP path. A bundle download token should only authorize files attached to that token's purchase. The current lookup gathered every visible purchase for the same buyer and bundle link, so an older or shared bundle token could include files from another purchase of the same bundle.

The fix scopes bundle archive file selection to the purchase attached to the current UrlRedirect token and adds regression coverage for repeat purchases of the same bundle.

## Security impact

A leaked or shared bundle download token could expose paid files from a different purchase of the same bundle by the same Gumroad account. The archive endpoint is bearer-token based, so it should not expand authorization beyond the purchase represented by the token.

## Tests

- bundle exec rspec spec/models/url_redirect_spec.rb:249 spec/presenters/library_presenter_spec.rb:599
- ruby -c app/models/url_redirect.rb
- ruby -c spec/models/url_redirect_spec.rb
- ruby -c spec/presenters/library_presenter_spec.rb
- python3 /Users/gumclaw/.agents/skills/autoreview/scripts/autoreview --engine codex --model gpt-5.6-sol

I also ran the broader UrlRedirect and LibraryPresenter specs. The LibraryPresenter specs passed, but two pre-existing UrlRedirect examples failed because their video fixture S3 key was missing during product file analysis; they were unrelated to this change.

Panel premerge note: the Codex reviewer was clean. The Claude panel reviewer could not run because the Anthropic account reported an API usage limit until September 1, so this is parked as a draft instead of being presented as fully premerge-reviewed.