### PR TITLE
Rerun Tests when checkout hangs for 5 minutes

### DIFF
--- a/.github/workflows/rerun-hung-checkout.yml
+++ b/.github/workflows/rerun-hung-checkout.yml
@@ -25,9 +25,13 @@ jobs:
     # run_attempt < 2 is the cap: attempt 1 may be re-run, attempt 2 is where
     # this stops. A hang that survives one re-run is not a flake worth chasing
     # unattended.
+    #
+    # `failure` only: fail-fast cancelling siblings behind a hang still leaves
+    # the run itself `failure`, while a manual cancel or a concurrency
+    # cancel-in-progress leaves it `cancelled` -- and that run was thrown away
+    # on purpose, so re-running its failed jobs is wasted CI.
     if: >-
-      (github.event.workflow_run.conclusion == 'failure' ||
-       github.event.workflow_run.conclusion == 'cancelled') &&
+      github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.run_attempt < 2
     steps:
       - uses: actions/checkout@v4
@@ -46,6 +50,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
           set -euo pipefail
           # --paginate --jq emits one job object per line (gh forbids --slurp
@@ -66,7 +71,11 @@ jobs:
             mv annotations.tmp annotations.json
           done
 
-          jq -s '{jobs: .[0].jobs, annotations: .[1]}' jobs.json annotations.json > attempt.json
+          # The run conclusion rides along so the classifier applies the same
+          # `failure`-only rule as the job `if` above.
+          jq -s --arg conclusion "$CONCLUSION" \
+            '{jobs: .[0].jobs, annotations: .[1], conclusion: $conclusion}' \
+            jobs.json annotations.json > attempt.json
           set +e
           ruby bin/classify-hung-checkout attempt.json
           status=$?

--- a/.github/workflows/rerun-hung-checkout.yml
+++ b/.github/workflows/rerun-hung-checkout.yml
@@ -1,0 +1,84 @@
+name: Rerun hung checkout
+
+# Re-runs the failed jobs of a `Tests` attempt when the only thing that went
+# wrong was actions/checkout sitting at its 5-minute timeout. That failure is
+# unrelated to the commit, and it lands on shards at random, so the red it
+# leaves is noise a human has to clear by hand.
+#
+# Scoped hard on purpose: the classifier refuses unless every red job on the
+# triggering attempt is either a hung checkout or a sibling fail-fast cancelled
+# behind one, so a spec failure is never re-run into a pass.
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types: [completed]
+
+permissions:
+  actions: write # rerun-failed-jobs; the default token cannot re-run without it
+  checks: read # the timeout text lives in the job's check-run annotations
+  contents: read
+
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    # run_attempt < 2 is the cap: attempt 1 may be re-run, attempt 2 is where
+    # this stops. A hang that survives one re-run is not a flake worth chasing
+    # unattended.
+    if: >-
+      (github.event.workflow_run.conclusion == 'failure' ||
+       github.event.workflow_run.conclusion == 'cancelled') &&
+      github.event.workflow_run.run_attempt < 2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            bin/classify-hung-checkout
+          sparse-checkout-cone-mode: false
+
+      # The attempt's own jobs, not the run's latest conclusion: a shard that
+      # hung on attempt 1 reads as SUCCESS once attempt 2 passes, and this
+      # workflow is triggered by that first attempt completing.
+      - name: Classify the triggering attempt
+        id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          set -euo pipefail
+          # --paginate --jq emits one job object per line (gh forbids --slurp
+          # together with --jq). jq -s rebuilds the jobs array the classifier
+          # reads. Use the triggering attempt, not the run's latest jobs.
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/attempts/${ATTEMPT}/jobs?per_page=100" \
+            --jq '.jobs[]' | jq -s '{jobs: .}' > jobs.json
+
+          # Annotations only for the jobs that already look like the hang, so a
+          # 40-shard run does not cost 40 extra API calls.
+          echo '{}' > annotations.json
+          for id in $(ruby bin/classify-hung-checkout --candidates jobs.json); do
+            messages=$(gh api "repos/${GITHUB_REPOSITORY}/check-runs/${id}/annotations" \
+                         --jq '[.[].message]') || messages='[]'
+            jq --arg id "$id" --argjson messages "$messages" \
+              '.[$id] = $messages' annotations.json > annotations.tmp
+            mv annotations.tmp annotations.json
+          done
+
+          jq -s '{jobs: .[0].jobs, annotations: .[1]}' jobs.json annotations.json > attempt.json
+          set +e
+          ruby bin/classify-hung-checkout attempt.json
+          status=$?
+          set -e
+          case "$status" in
+            0) echo "rerun=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "rerun=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Re-run the failed jobs
+        if: steps.classify.outputs.rerun == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: gh run rerun "$RUN_ID" --failed -R "$GITHUB_REPOSITORY"

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -341,6 +341,14 @@ changed.each do |path|
   elsif path == "bin/branch-specs" || path == "spec/bin/branch_specs_test.rb"
     # Standalone ruby test (ruby spec/bin/branch_specs_test.rb), not rspec.
     next
+  elsif path == "bin/classify-hung-checkout" || path == "spec/bin/classify_hung_checkout_test.rb"
+    # Same: standalone ruby (ruby spec/bin/classify_hung_checkout_test.rb), not rspec.
+    next
+  elsif path == ".github/workflows/rerun-hung-checkout.yml"
+    # Only invokes the classifier; the job `if` is asserted in that standalone
+    # test. Other workflows still go through unattributed; tests.yml still
+    # escalates via ESCALATE_PATTERNS.
+    next
   elsif path.match?(%r{\A(lib|app)/.*\.rb\z}) &&
         (by_content = specs_mentioning(File.basename(path, ".rb"))).any?
     # Name-based mapping missed (spec lives under another name, e.g.

--- a/bin/classify-hung-checkout
+++ b/bin/classify-hung-checkout
@@ -1,0 +1,142 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Decides whether a failed `Tests` attempt failed *only* because actions/checkout
+# hung -- the one failure mode where re-running unattended tells us something new.
+# A spec failure re-run tells us nothing and hides a real red, so anything that
+# reached a non-checkout failure blocks the whole verdict, not just its own job.
+#
+# Reads the attempt's jobs payload on stdin, or from a file argument:
+#
+#   { "jobs": [ ... GET /repos/{repo}/actions/runs/{id}/attempts/{n}/jobs ... ],
+#     "annotations": { "<job_id>": ["<check-run annotation message>", ...] } }
+#
+# `--candidates` prints the job ids whose first bad step already looks like the
+# hang, so the caller only fetches annotations for that short list before asking
+# for the verdict. No network in here: the file the workflow runs is the file the
+# test runs.
+#
+# Exit codes are a contract -- 0 rerun, 1 skip, 2 could not run (bad input) --
+# because the caller turns 0 into a real re-run and must treat everything else as
+# "leave it alone".
+
+require "json"
+require "time"
+
+EXIT_SKIP = 1
+EXIT_OPERATIONAL = 2
+
+# Only these two steps carry `timeout-minutes: 5` on a checkout in tests.yml.
+# `Check out fork fixtures` is deliberately absent: it also has the timeout, but
+# it pulls untrusted fork refs and is not a step we re-run on a guess.
+HANG_STEPS = ["Check out repository", "Check out trusted workflow files"].freeze
+
+# The observed hangs sat at exactly 300.0s. The window allows for the runner's
+# clock resolution without admitting a checkout that failed fast for some other
+# reason and happened to be slow.
+HANG_SECONDS = (270.0..330.0)
+
+# `timed_out` is a failure, not a cancellation: a job that ran out of its own
+# budget is a red we must not paper over.
+FAILED = %w[failure timed_out].freeze
+BAD = (FAILED + %w[cancelled]).freeze
+JOB_FAILED = %w[failure timed_out startup_failure cancelled].freeze
+
+def timeout_message(step_name)
+  "The action '#{step_name}' has timed out after 5 minutes"
+end
+
+def steps_of(job)
+  Array(job["steps"]).sort_by { |step| step["number"] || 0 }
+end
+
+def first_bad_step(job)
+  steps_of(job).find { |step| BAD.include?(step["conclusion"]) }
+end
+
+def first_failed_step(job)
+  steps_of(job).find { |step| FAILED.include?(step["conclusion"]) }
+end
+
+def step_seconds(step)
+  started = step["started_at"]
+  completed = step["completed_at"]
+  return nil if started.nil? || completed.nil?
+  Time.iso8601(completed) - Time.iso8601(started)
+rescue ArgumentError
+  nil
+end
+
+# Jobs with no `Run tests` step at all (Build images, Compute relevant specs)
+# satisfy this too -- what matters is that no specs got the chance to run, so a
+# re-run cannot be laundering a spec failure.
+def run_tests_started?(job)
+  steps_of(job).any? do |step|
+    next false unless step["name"] == "Run tests"
+    step["status"] == "in_progress" || BAD.include?(step["conclusion"]) || step["conclusion"] == "success"
+  end
+end
+
+def candidate?(job)
+  step = first_bad_step(job)
+  return false unless step && HANG_STEPS.include?(step["name"])
+  seconds = step_seconds(step)
+  !seconds.nil? && HANG_SECONDS.cover?(seconds)
+end
+
+def hung?(job, annotations)
+  return false unless candidate?(job)
+  return false if run_tests_started?(job)
+  wanted = timeout_message(first_bad_step(job)["name"])
+  Array(annotations[job["id"].to_s]).any? { |message| message.to_s.include?(wanted) }
+end
+
+def job_label(job)
+  job["name"] || "job #{job['id']}"
+end
+
+def verdict(jobs, annotations)
+  # A run that was cancelled before anything was scheduled has nothing to
+  # attribute the failure to, so there is nothing to re-run.
+  return [EXIT_SKIP, "skip: the attempt has no jobs"] if jobs.empty?
+
+  jobs.each do |job|
+    step = first_failed_step(job)
+    next if step.nil? || HANG_STEPS.include?(step["name"])
+    return [EXIT_SKIP, "skip: #{job_label(job)} failed at #{step['name'].inspect}"]
+  end
+
+  failing = jobs.select { |job| JOB_FAILED.include?(job["conclusion"]) }
+  hangs = failing.select { |job| hung?(job, annotations) }
+  return [EXIT_SKIP, "skip: no hung checkout on this attempt"] if hangs.empty?
+
+  # Everything else that went red has to be collateral: fail-fast cancelling a
+  # sibling mid-`Run tests` is not evidence of anything. A job that reached
+  # `failure` on its own is, whatever its steps say.
+  collateral = failing - hangs
+  offender = collateral.find { |job| job["conclusion"] != "cancelled" }
+  return [EXIT_SKIP, "skip: #{job_label(offender)} concluded #{offender['conclusion']}"] if offender
+
+  [0, "rerun: checkout hung on #{hangs.map { |job| job_label(job) }.join(', ')}"]
+end
+
+raw = ARGV.reject { |arg| arg.start_with?("--") }.first
+candidates_only = ARGV.include?("--candidates")
+
+begin
+  payload = JSON.parse(raw ? File.read(raw) : $stdin.read)
+rescue JSON::ParserError, Errno::ENOENT => e
+  warn "Hung-checkout classifier could not run: #{e.message}"
+  exit EXIT_OPERATIONAL
+end
+
+jobs = Array(payload.is_a?(Hash) ? payload["jobs"] : payload)
+
+if candidates_only
+  jobs.each { |job| puts job["id"] if candidate?(job) }
+  exit 0
+end
+
+code, message = verdict(jobs, payload.is_a?(Hash) ? payload["annotations"].to_h : {})
+puts message
+exit code

--- a/bin/classify-hung-checkout
+++ b/bin/classify-hung-checkout
@@ -9,7 +9,8 @@
 # Reads the attempt's jobs payload on stdin, or from a file argument:
 #
 #   { "jobs": [ ... GET /repos/{repo}/actions/runs/{id}/attempts/{n}/jobs ... ],
-#     "annotations": { "<job_id>": ["<check-run annotation message>", ...] } }
+#     "annotations": { "<job_id>": ["<check-run annotation message>", ...] },
+#     "conclusion": "<the triggering run's own conclusion>" }
 #
 # `--candidates` prints the job ids whose first bad step already looks like the
 # hang, so the caller only fetches annotations for that short list before asking
@@ -95,7 +96,15 @@ def job_label(job)
   job["name"] || "job #{job['id']}"
 end
 
-def verdict(jobs, annotations)
+def verdict(jobs, annotations, conclusion = nil)
+  # Fail-fast behind a hang still leaves the run `failure`; `cancelled` means a
+  # human or a cancel-in-progress threw the run away, and job-level `cancelled`
+  # cannot tell those two apart. An absent field falls through to the job-level
+  # gates below.
+  if !conclusion.nil? && conclusion != "" && conclusion != "failure"
+    return [EXIT_SKIP, "skip: the attempt concluded #{conclusion}"]
+  end
+
   # A run that was cancelled before anything was scheduled has nothing to
   # attribute the failure to, so there is nothing to re-run.
   return [EXIT_SKIP, "skip: the attempt has no jobs"] if jobs.empty?
@@ -137,6 +146,10 @@ if candidates_only
   exit 0
 end
 
-code, message = verdict(jobs, payload.is_a?(Hash) ? payload["annotations"].to_h : {})
+code, message = verdict(
+  jobs,
+  payload.is_a?(Hash) ? payload["annotations"].to_h : {},
+  payload.is_a?(Hash) ? payload["conclusion"] : nil
+)
 puts message
 exit code

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -132,6 +132,35 @@ check(
   expect_escalate: true,
 )
 
+# Hung-checkout files are standalone ruby + a workflow that only invokes
+# them, so they must not trip the mapping-gap escalate the way an unmapped
+# helper would. Sibling model+spec so the run is not an empty selection.
+check(
+  "hung-checkout classifier, its test, and workflow do not escalate",
+  base_files: {
+    ".github/workflows/rerun-hung-checkout.yml" => "old",
+    "bin/classify-hung-checkout" => "old",
+    "spec/bin/classify_hung_checkout_test.rb" => "old",
+    "app/models/widget.rb" => "old",
+    "spec/models/widget_spec.rb" => SPEC_STUB,
+  },
+  head_files: {
+    ".github/workflows/rerun-hung-checkout.yml" => "new",
+    "bin/classify-hung-checkout" => "new",
+    "spec/bin/classify_hung_checkout_test.rb" => "new",
+    "app/models/widget.rb" => "new",
+  },
+  expect_specs: %w[spec/models/widget_spec.rb],
+)
+
+# tests.yml is the suite itself and must still force the full suite.
+check(
+  "tests.yml still escalates",
+  base_files: { ".github/workflows/tests.yml" => "old" },
+  head_files: { ".github/workflows/tests.yml" => "new" },
+  expect_escalate: true,
+)
+
 # Co-located vitest module is not a mapping gap
 check(
   "TS module with co-located .test.ts does not escalate",

--- a/spec/bin/classify_hung_checkout_test.rb
+++ b/spec/bin/classify_hung_checkout_test.rb
@@ -71,7 +71,7 @@ SPEC_FAILURE = [["Check out repository", "success", 10], ["Run tests", "failure"
 hang = job("Slow 3", "failure", HUNG_CHECKOUT)
 check(
   "a 300s checkout timeout with tests never started",
-  { "jobs" => [hang], "annotations" => hang_annotations(hang) },
+  { "jobs" => [hang], "annotations" => hang_annotations(hang), "conclusion" => "failure" },
   expect: :rerun
 )
 
@@ -79,7 +79,7 @@ check(
 trusted = job("Relevant 2", "failure", HUNG_TRUSTED)
 check(
   "a trusted-workflow-files checkout timeout",
-  { "jobs" => [trusted], "annotations" => hang_annotations(trusted, "Check out trusted workflow files") },
+  { "jobs" => [trusted], "annotations" => hang_annotations(trusted, "Check out trusted workflow files"), "conclusion" => "failure" },
   expect: :rerun
 )
 
@@ -88,7 +88,7 @@ check(
 build = job("Build images", "failure", [["Set up job", "success", 3], ["Check out repository", "failure", 300]])
 check(
   "a job with no Run tests step at all",
-  { "jobs" => [build], "annotations" => hang_annotations(build) },
+  { "jobs" => [build], "annotations" => hang_annotations(build), "conclusion" => "failure" },
   expect: :rerun
 )
 
@@ -114,13 +114,26 @@ check(
 )
 
 # test_fast is fail-fast, so one hang cancels siblings mid-`Run tests`. That
-# cancellation is collateral, not evidence.
+# cancellation is collateral, not evidence -- and the run still concluded
+# `failure`, which is what separates this from the case below.
 fast_hang = job("Fast 16", "failure", HUNG_CHECKOUT)
 fast_cancelled = job("Fast 17", "cancelled", [["Check out repository", "success", 10], ["Run tests", "cancelled", 400]])
 check(
   "a hang plus a sibling cancelled mid-Run tests",
-  { "jobs" => [fast_hang, fast_cancelled], "annotations" => hang_annotations(fast_hang) },
+  { "jobs" => [fast_hang, fast_cancelled], "annotations" => hang_annotations(fast_hang), "conclusion" => "failure" },
   expect: :rerun
+)
+
+# The same jobs, but the run was cancelled outright -- someone hit cancel, or a
+# new push cancelled it in progress. Job-level `cancelled` is indistinguishable
+# from fail-fast collateral, so the run conclusion is the only thing that tells
+# them apart, and re-running a run that was thrown away is wasted CI.
+cancelled_hang = job("Fast 16", "failure", HUNG_CHECKOUT)
+cancelled_sibling = job("Fast 17", "cancelled", [["Check out repository", "success", 10], ["Run tests", "cancelled", 400]])
+check(
+  "a hang on a run that was cancelled outright",
+  { "jobs" => [cancelled_hang, cancelled_sibling], "annotations" => hang_annotations(cancelled_hang), "conclusion" => "cancelled" },
+  expect: :skip
 )
 
 # Same shape, except the sibling's specs actually failed. One real red blocks the
@@ -168,10 +181,12 @@ WORKFLOW = File.expand_path("../../.github/workflows/rerun-hung-checkout.yml", _
 
 $count += 1
 gate = YAML.load_file(WORKFLOW).fetch("jobs").fetch("rerun").fetch("if")
-if gate.include?("run_attempt < 2") && gate.include?("conclusion == 'failure'") && gate.include?("conclusion == 'cancelled'")
-  puts "  ok    the workflow gate caps attempts and only runs on red"
+# `cancelled` has to stay out of the gate: fail-fast behind a hang still leaves
+# the run `failure`, so anything `cancelled` was thrown away on purpose.
+if gate.include?("run_attempt < 2") && gate.include?("conclusion == 'failure'") && !gate.include?("conclusion == 'cancelled'")
+  puts "  ok    the workflow gate caps attempts and only runs on a failed run"
 else
-  puts "  FAIL  the workflow gate caps attempts and only runs on red"
+  puts "  FAIL  the workflow gate caps attempts and only runs on a failed run"
   $failures << "workflow gate: #{gate.inspect}"
 end
 

--- a/spec/bin/classify_hung_checkout_test.rb
+++ b/spec/bin/classify_hung_checkout_test.rb
@@ -1,0 +1,186 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Tests for bin/classify-hung-checkout.
+#
+# Plain ruby, no Rails: the classifier only ever sees a GitHub jobs payload, and
+# the reason it lives in a file at all is so this test drives the same code the
+# workflow runs.
+#
+#   ruby spec/bin/classify_hung_checkout_test.rb
+
+require "json"
+require "open3"
+require "time"
+require "yaml"
+
+CLASSIFIER = File.expand_path("../../bin/classify-hung-checkout", __dir__)
+
+$failures = []
+$count = 0
+
+# Steps arrive as [name, conclusion, seconds]; timestamps are synthesised in
+# order because the classifier reads step durations, not wall-clock positions.
+def job(name, conclusion, steps)
+  clock = Time.utc(2026, 8, 20, 12, 0, 0)
+  @next_id = (@next_id || 100) + 1
+  built = steps.each_with_index.map do |(step_name, step_conclusion, seconds), index|
+    started = clock
+    clock += (seconds || 0)
+    {
+      "name" => step_name,
+      "number" => index + 1,
+      "status" => "completed",
+      "conclusion" => step_conclusion,
+      "started_at" => started.iso8601,
+      "completed_at" => clock.iso8601
+    }
+  end
+  { "id" => @next_id, "name" => name, "conclusion" => conclusion, "steps" => built }
+end
+
+def hang_annotations(job, step_name = "Check out repository")
+  { job["id"].to_s => ["The action '#{step_name}' has timed out after 5 minutes"] }
+end
+
+def run(payload, *argv)
+  stdout, stderr, status = Open3.capture3("ruby", CLASSIFIER, *argv, stdin_data: JSON.dump(payload))
+  [status.exitstatus, stdout + stderr]
+end
+
+def check(name, payload, expect:)
+  $count += 1
+  code, output = run(payload)
+  # Exact code, not just nonzero: the workflow re-runs on 0 and has to leave the
+  # run alone on everything else.
+  actual = code.zero? ? :rerun : :skip
+  if actual == expect
+    puts "  ok    #{name}"
+  else
+    puts "  FAIL  #{name}"
+    $failures << "#{name}\n    expected #{expect}, got #{actual} (exit #{code})\n    #{output.strip}"
+  end
+end
+
+puts "classify-hung-checkout"
+
+HUNG_CHECKOUT = [["Set up job", "success", 3], ["Check out repository", "failure", 300], ["Run tests", "skipped", 0]].freeze
+HUNG_TRUSTED = [["Set up job", "success", 3], ["Check out repository", "success", 11], ["Check out trusted workflow files", "failure", 300], ["Run tests", "skipped", 0]].freeze
+SPEC_FAILURE = [["Check out repository", "success", 10], ["Run tests", "failure", 700]].freeze
+
+hang = job("Slow 3", "failure", HUNG_CHECKOUT)
+check(
+  "a 300s checkout timeout with tests never started",
+  { "jobs" => [hang], "annotations" => hang_annotations(hang) },
+  expect: :rerun
+)
+
+# Relevant shards can hang on either checkout; both carry the same timeout.
+trusted = job("Relevant 2", "failure", HUNG_TRUSTED)
+check(
+  "a trusted-workflow-files checkout timeout",
+  { "jobs" => [trusted], "annotations" => hang_annotations(trusted, "Check out trusted workflow files") },
+  expect: :rerun
+)
+
+# Jobs with no `Run tests` step at all still qualify: no specs got the chance to
+# run, so the re-run cannot be laundering a red suite.
+build = job("Build images", "failure", [["Set up job", "success", 3], ["Check out repository", "failure", 300]])
+check(
+  "a job with no Run tests step at all",
+  { "jobs" => [build], "annotations" => hang_annotations(build) },
+  expect: :rerun
+)
+
+# The one this exists to never do.
+check(
+  "a spec failure",
+  { "jobs" => [job("Fast 4", "failure", SPEC_FAILURE)] },
+  expect: :skip
+)
+
+check(
+  "a docker login failure",
+  { "jobs" => [job("Slow 1", "failure", [["Set up job", "success", 3], ["Log in to Docker Hub", "failure", 20]])] },
+  expect: :skip
+)
+
+# Checkout cancelled seconds in, with no timeout anywhere on the attempt. Nothing
+# here says a hang happened, so nothing gets re-run.
+check(
+  "a short cancelled checkout with no hang on the attempt",
+  { "jobs" => [job("Fast 9", "cancelled", [["Set up job", "success", 3], ["Check out repository", "cancelled", 12]])] },
+  expect: :skip
+)
+
+# test_fast is fail-fast, so one hang cancels siblings mid-`Run tests`. That
+# cancellation is collateral, not evidence.
+fast_hang = job("Fast 16", "failure", HUNG_CHECKOUT)
+fast_cancelled = job("Fast 17", "cancelled", [["Check out repository", "success", 10], ["Run tests", "cancelled", 400]])
+check(
+  "a hang plus a sibling cancelled mid-Run tests",
+  { "jobs" => [fast_hang, fast_cancelled], "annotations" => hang_annotations(fast_hang) },
+  expect: :rerun
+)
+
+# Same shape, except the sibling's specs actually failed. One real red blocks the
+# whole verdict, hang or no hang.
+blocked_hang = job("Fast 16", "failure", HUNG_CHECKOUT)
+check(
+  "a hang plus a sibling whose specs failed",
+  { "jobs" => [blocked_hang, job("Fast 17", "failure", SPEC_FAILURE)], "annotations" => hang_annotations(blocked_hang) },
+  expect: :skip
+)
+
+# Without the annotation, 300s is just a checkout that was slow and then failed,
+# and a checkout failing for a real reason will keep failing.
+check(
+  "a 300s checkout with no timeout annotation",
+  { "jobs" => [job("Slow 3", "failure", HUNG_CHECKOUT)] },
+  expect: :skip
+)
+
+# A concurrency cancel: red, but nothing hung.
+check(
+  "a cancelled attempt that never scheduled a job",
+  { "jobs" => [] },
+  expect: :skip
+)
+
+# The workflow fetches annotations only for the ids this prints, so a candidate
+# it misses can never be classified as a hang.
+$count += 1
+candidate = job("Slow 3", "failure", HUNG_CHECKOUT)
+_, listed = run({ "jobs" => [candidate, job("Fast 1", "failure", SPEC_FAILURE)] }, "--candidates")
+if listed.split.map(&:to_i) == [candidate["id"]]
+  puts "  ok    --candidates lists only the checkout-timeout jobs"
+else
+  puts "  FAIL  --candidates lists only the checkout-timeout jobs"
+  $failures << "--candidates: expected #{[candidate['id']].inspect}, got #{listed.strip.inspect}"
+end
+
+# --- The workflow's own gate ----------------------------------------------
+#
+# The 2-attempt cap lives in the job `if`, not in the classifier, so nothing
+# above can catch its removal.
+
+WORKFLOW = File.expand_path("../../.github/workflows/rerun-hung-checkout.yml", __dir__)
+
+$count += 1
+gate = YAML.load_file(WORKFLOW).fetch("jobs").fetch("rerun").fetch("if")
+if gate.include?("run_attempt < 2") && gate.include?("conclusion == 'failure'") && gate.include?("conclusion == 'cancelled'")
+  puts "  ok    the workflow gate caps attempts and only runs on red"
+else
+  puts "  FAIL  the workflow gate caps attempts and only runs on red"
+  $failures << "workflow gate: #{gate.inspect}"
+end
+
+puts
+if $failures.empty?
+  puts "#{$count} checks passed."
+  exit 0
+end
+
+warn "#{$failures.size} of #{$count} checks FAILED:\n\n"
+$failures.each { |f| warn "  #{f}\n\n" }
+exit 1


### PR DESCRIPTION
## Status

This workflow is a default-branch `workflow_run` listener. It does not run on this pull request. It starts only after this change merges to `main`.

## What

Add a new workflow, `Rerun hung checkout`, that watches the `Tests` workflow. When that run finishes as `failure`, the new job reads the **triggering attempt** jobs and, if they match the checkout-hang classifier, runs `gh run rerun --failed` once. Cancelled runs are not rerun.

The classifier treats a job as a hang only when all of these are true:

1. The first failed or cancelled step is `Check out repository` or `Check out trusted workflow files`.
2. That step ran for 270–330 seconds (live hangs were 300 seconds).
3. The check-run annotation is `The action '<step>' has timed out after 5 minutes`.
4. `Run tests` never started.

It then reruns only when every failed or cancelled job on that attempt is either a hang or a fail-fast cancel behind a sibling hang. A first **failed** step of `Run tests`, Docker/login/compose, lint, typecheck, or setup blocks the rerun. Attempt 2 is the cap (`run_attempt >= 2` does nothing). Spec failures are never retried. The 5-minute checkout timeout on `Tests` is unchanged.

## Why

Relevant, Fast, and Slow can paint `main` red when `git fetch` stalls for 5 minutes on one Ubicloud VM. Sibling shards clone the same SHA in about 30 seconds. Specs never start on the hung shard. A new-runner `rerun --failed` already turned [#7378](https://github.com/antiwork/gumroad/pull/7378) Slow 3 green. This workflow does that automatically when the classifier matches, once.

## Before/After

**Before:** A 5-minute checkout timeout on one shard leaves the `Tests` run red. A person has to re-run the failed jobs by hand.

**After:** If the triggering attempt matches the hang rule, failed jobs are re-run once on a new runner. A second hang, or any spec/docker/lint/setup failure, is left alone.

## Test Results

- Local classifier self-check: 13/13 passed (`ruby spec/bin/classify_hung_checkout_test.rb`).
- 14-day dry-run of the same rule: 11/11 known hangs, 0 of 913 assertion false positives, 9 extra real hangs.

## QA

Cannot be proven until a real hang occurs after merge. The classifier was dry-run against 2057 `Tests` runs.

AI disclosure: Claude Opus 5
