### PR TITLE
Pace large workflow email fanouts so a burst cannot stall the site

### DIFF
--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -435,13 +435,7 @@ class Installment < ApplicationRecord
     return if sale.chargedback_not_reversed_or_refunded?
     return if sale.subscription.present? && !sale.subscription.alive?
 
-    other_purchase_ids = Purchase.where(email: sale.email, seller_id: sale.seller_id)
-                                 .all_success_states
-                                 .no_or_active_subscription
-                                 .not_fully_refunded
-                                 .not_chargedback_or_chargedback_reversed
-                                 .pluck(:id)
-    return if other_purchase_ids.present? && CreatorContactingCustomersEmailInfo.where(purchase: other_purchase_ids, installment: id).present?
+    return if already_emailed_workflow_purchase?(sale)
 
     return if workflow.present? && !workflow.applies_to_purchase?(sale)
     expected_delivery_time_for_sale = expected_delivery_time(sale)
@@ -472,13 +466,7 @@ class Installment < ApplicationRecord
     return unless sale.can_contact?
     return if sale.chargedback_not_reversed_or_refunded?
 
-    other_purchase_ids = Purchase.where(email: sale.email, seller_id: sale.seller_id)
-                                 .all_success_states
-                                 .inactive_subscription
-                                 .not_fully_refunded
-                                 .not_chargedback_or_chargedback_reversed
-                                 .pluck(:id)
-    return if other_purchase_ids.present? && CreatorContactingCustomersEmailInfo.where(purchase: other_purchase_ids, installment: id).present?
+    return if already_emailed_workflow_purchase?(sale, subscription_scope: :inactive_subscription)
 
     return if workflow.present? && !workflow.applies_to_purchase?(sale)
 
@@ -1162,6 +1150,17 @@ class Installment < ApplicationRecord
 
       errors.add(:base, "You have to confirm your email address before you can do that.")
       raise InstallmentInvalid, "You have to confirm your email address before you can do that."
+    end
+
+    # Start from this installment's email_infos. The old email+seller pluck scanned
+    # every purchase for the buyer on each of ~100k workers.
+    def already_emailed_workflow_purchase?(sale, subscription_scope: :no_or_active_subscription)
+      purchase_scope = Purchase.where(email: sale.email, seller_id: sale.seller_id)
+                               .all_success_states
+                               .public_send(subscription_scope)
+                               .not_fully_refunded
+                               .not_chargedback_or_chargedback_reversed
+      CreatorContactingCustomersEmailInfo.where(installment_id: id).joins(:purchase).merge(purchase_scope).exists?
     end
 
     def send_email(recipient)

--- a/app/models/workflow_installment_schedule_intent.rb
+++ b/app/models/workflow_installment_schedule_intent.rb
@@ -142,4 +142,17 @@ class WorkflowInstallmentScheduleIntent < ApplicationRecord
       updated_at: now
     ).positive?
   end
+
+  # Keep owning a started fanout across a next-day requeue so recovery cannot
+  # reclaim it during the 2-hour lease gap.
+  def self.defer_fanout(intent_token:, fanout_token:, until_time:)
+    return true if intent_token.blank? && fanout_token.blank?
+    return false if intent_token.blank? || fanout_token.blank?
+
+    now = Time.current
+    pending.where(token: intent_token, fanout_token:).update_all(
+      fanout_expires_at: until_time,
+      updated_at: now
+    ).positive?
+  end
 end

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -116,5 +116,11 @@ class RedisKey
     # only for the length of one render; `product_reviews.seller_notified_at` is what records that
     # the seller was told. See ContactingCreatorMailer#review_submitted.
     def product_review_seller_notified(review_id) = "product_review_seller_notified:#{review_id}"
+    def workflow_seller_fanout_lock(seller_id) = "workflow_seller_fanout_lock:#{seller_id}"
+    def workflow_seller_fanout_lock_ttl_seconds = "workflow_seller_fanout_lock_ttl_seconds"
+    def workflow_seller_fanout_retry_seconds = "workflow_seller_fanout_retry_seconds"
+    def workflow_immediate_fanout_threshold = "workflow_immediate_fanout_threshold"
+    def workflow_immediate_enqueue_per_second = "workflow_immediate_enqueue_per_second"
+    def workflow_immediate_fanout_max_spread_seconds = "workflow_immediate_fanout_max_spread_seconds"
   end
 end

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -122,5 +122,7 @@ class RedisKey
     def workflow_immediate_fanout_threshold = "workflow_immediate_fanout_threshold"
     def workflow_immediate_enqueue_per_second = "workflow_immediate_enqueue_per_second"
     def workflow_immediate_fanout_max_spread_seconds = "workflow_immediate_fanout_max_spread_seconds"
+    def seller_large_blast_threshold = "seller_large_blast_threshold"
+    def seller_large_blast_quota(seller_id, day) = "seller_large_blast_quota:#{seller_id}:#{day}"
   end
 end

--- a/app/services/seller_large_blast_quota.rb
+++ b/app/services/seller_large_blast_quota.rb
@@ -19,8 +19,9 @@ class SellerLargeBlastQuota
 
     $redis.get(key) == claim_id
   rescue Redis::BaseError, RedisClient::Error => e
+    # Fail closed: admitting every large blast during an outage recreates the stampede.
     ErrorNotifier.notify(e, seller_id:)
-    true
+    false
   end
 
   def self.claim_id_for(kind:, blast_id:)

--- a/app/services/seller_large_blast_quota.rb
+++ b/app/services/seller_large_blast_quota.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# One large audience send per seller per day. Five six-figure workflow
+# publishes in the same minute is what filled the primary and stalled checkout.
+class SellerLargeBlastQuota
+  DEFAULT_THRESHOLD = 10_000
+
+  def self.allow?(seller_id:, blast_id:, recipient_count:)
+    return true if recipient_count.to_i < threshold
+
+    claim(seller_id:, blast_id:)
+  end
+
+  def self.claim(seller_id:, blast_id:)
+    return true if seller_id.blank? || blast_id.blank?
+
+    key = RedisKey.seller_large_blast_quota(seller_id, Date.current)
+    return true if $redis.set(key, blast_id.to_s, nx: true, ex: ttl_seconds)
+
+    $redis.get(key) == blast_id.to_s
+  rescue Redis::BaseError, RedisClient::Error => e
+    ErrorNotifier.notify(e, seller_id:)
+    true
+  end
+
+  def self.threshold
+    value = ($redis.get(RedisKey.seller_large_blast_threshold) || DEFAULT_THRESHOLD).to_i
+    value.positive? ? value : DEFAULT_THRESHOLD
+  rescue Redis::BaseError, RedisClient::Error
+    DEFAULT_THRESHOLD
+  end
+
+  def self.ttl_seconds
+    [(Time.zone.now.end_of_day - Time.zone.now).to_i, 60].max
+  end
+end

--- a/app/services/seller_large_blast_quota.rb
+++ b/app/services/seller_large_blast_quota.rb
@@ -5,22 +5,28 @@
 class SellerLargeBlastQuota
   DEFAULT_THRESHOLD = 10_000
 
-  def self.allow?(seller_id:, blast_id:, recipient_count:)
+  def self.allow?(seller_id:, blast_id:, recipient_count:, kind: "blast")
     return true if recipient_count.to_i < threshold
 
-    claim(seller_id:, blast_id:)
+    claim(seller_id:, claim_id: claim_id_for(kind:, blast_id:))
   end
 
-  def self.claim(seller_id:, blast_id:)
-    return true if seller_id.blank? || blast_id.blank?
+  def self.claim(seller_id:, claim_id:)
+    return true if seller_id.blank? || claim_id.blank?
 
     key = RedisKey.seller_large_blast_quota(seller_id, Date.current)
-    return true if $redis.set(key, blast_id.to_s, nx: true, ex: ttl_seconds)
+    return true if $redis.set(key, claim_id, nx: true, ex: ttl_seconds)
 
-    $redis.get(key) == blast_id.to_s
+    $redis.get(key) == claim_id
   rescue Redis::BaseError, RedisClient::Error => e
     ErrorNotifier.notify(e, seller_id:)
     true
+  end
+
+  def self.claim_id_for(kind:, blast_id:)
+    return if blast_id.blank?
+
+    "#{kind}:#{blast_id}"
   end
 
   def self.threshold

--- a/app/services/workflow_seller_fanout_lock.rb
+++ b/app/services/workflow_seller_fanout_lock.rb
@@ -30,8 +30,9 @@ class WorkflowSellerFanoutLock
 
     new(seller_id:, token:)
   rescue Redis::BaseError, RedisClient::Error => e
+    # Fail closed: a synthetic lock would let concurrent publishes stampede during an outage.
     ErrorNotifier.notify(e, seller_id:)
-    new(seller_id:, token: nil, fail_open: true)
+    nil
   end
 
   def self.retry_in
@@ -57,8 +58,9 @@ class WorkflowSellerFanoutLock
 
     $redis.eval(RENEW_IF_HELD, keys: [key], argv: [@token, self.class.ttl_seconds]).to_i == 1
   rescue Redis::BaseError, RedisClient::Error => e
+    # Fail closed: continuing without a verifiable TTL lets a second publisher overlap.
     ErrorNotifier.notify(e, seller_id: @seller_id)
-    true
+    false
   end
 
   def release

--- a/app/services/workflow_seller_fanout_lock.rb
+++ b/app/services/workflow_seller_fanout_lock.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# One large workflow publish at a time per seller. Publishing several six-figure
+# posts together used to enqueue every recipient immediately and stall checkout.
+class WorkflowSellerFanoutLock
+  DEFAULT_TTL = 20.minutes
+  DEFAULT_RETRY = 30.seconds
+
+  RELEASE_IF_HELD = <<~LUA
+    if redis.call("GET", KEYS[1]) == ARGV[1] then
+      return redis.call("DEL", KEYS[1])
+    end
+    return 0
+  LUA
+
+  RENEW_IF_HELD = <<~LUA
+    if redis.call("GET", KEYS[1]) == ARGV[1] then
+      return redis.call("EXPIRE", KEYS[1], ARGV[2])
+    end
+    return 0
+  LUA
+
+  def self.acquire(seller_id)
+    return new(seller_id: seller_id, token: nil, fail_open: true) if seller_id.blank?
+
+    token = SecureRandom.uuid
+    key = RedisKey.workflow_seller_fanout_lock(seller_id)
+    acquired = $redis.set(key, token, nx: true, ex: ttl_seconds)
+    return unless acquired
+
+    new(seller_id:, token:)
+  rescue Redis::BaseError, RedisClient::Error => e
+    ErrorNotifier.notify(e, seller_id:)
+    new(seller_id:, token: nil, fail_open: true)
+  end
+
+  def self.retry_in
+    ($redis.get(RedisKey.workflow_seller_fanout_retry_seconds) || DEFAULT_RETRY).to_i.seconds
+  rescue Redis::BaseError, RedisClient::Error
+    DEFAULT_RETRY
+  end
+
+  def self.ttl_seconds
+    ($redis.get(RedisKey.workflow_seller_fanout_lock_ttl_seconds) || DEFAULT_TTL).to_i
+  rescue Redis::BaseError, RedisClient::Error
+    DEFAULT_TTL.to_i
+  end
+
+  def initialize(seller_id:, token:, fail_open: false)
+    @seller_id = seller_id
+    @token = token
+    @fail_open = fail_open
+  end
+
+  def renew
+    return true if @fail_open || @token.blank?
+
+    $redis.eval(RENEW_IF_HELD, keys: [key], argv: [@token, self.class.ttl_seconds]).to_i == 1
+  rescue Redis::BaseError, RedisClient::Error => e
+    ErrorNotifier.notify(e, seller_id: @seller_id)
+    true
+  end
+
+  def release
+    return if @fail_open || @token.blank?
+
+    $redis.eval(RELEASE_IF_HELD, keys: [key], argv: [@token])
+  rescue Redis::BaseError, RedisClient::Error => e
+    ErrorNotifier.notify(e, seller_id: @seller_id)
+  end
+
+  private
+    def key
+      RedisKey.workflow_seller_fanout_lock(@seller_id)
+    end
+end

--- a/app/services/workflow_seller_fanout_lock.rb
+++ b/app/services/workflow_seller_fanout_lock.rb
@@ -3,7 +3,9 @@
 # One large workflow publish at a time per seller. Publishing several six-figure
 # posts together used to enqueue every recipient immediately and stall checkout.
 class WorkflowSellerFanoutLock
-  DEFAULT_TTL = 20.minutes
+  # Longer than the audience-load statement cap (1 hour) plus margin. The job
+  # cannot renew while blocked in that query.
+  DEFAULT_TTL = 75.minutes
   DEFAULT_RETRY = 30.seconds
 
   RELEASE_IF_HELD = <<~LUA

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -47,6 +47,14 @@ class SendPostBlastEmailsJob
     end
 
     return mark_blast_as_completed if @members.empty?
+    unless SellerLargeBlastQuota.allow?(
+      seller_id: @post.seller_id,
+      blast_id: @blast.id,
+      recipient_count: @members.size
+    )
+      requeue_for_daily_blast_limit
+      return
+    end
 
     start_pending_recipients
     cache = {}
@@ -432,5 +440,12 @@ class SendPostBlastEmailsJob
     # Tunable via Redis so a stuck blast can be unblocked without a deploy.
     def audience_load_timeout_seconds
       ($redis.get(RedisKey.audience_member_load_max_execution_time_seconds) || 1.hour).to_i
+    end
+
+    def requeue_for_daily_blast_limit
+      job_id = self.class.perform_at(Time.zone.tomorrow.beginning_of_day, @blast.id)
+      return if job_id.present?
+
+      raise "Sidekiq did not requeue the blast for the daily limit"
     end
 end

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -49,6 +49,7 @@ class SendPostBlastEmailsJob
     return mark_blast_as_completed if @members.empty?
     unless SellerLargeBlastQuota.allow?(
       seller_id: @post.seller_id,
+      kind: "post_blast",
       blast_id: @blast.id,
       recipient_count: @members.size
     )

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -287,6 +287,7 @@ class SendWorkflowPostEmailsJob
     def claim_daily_large_blast_slot
       SellerLargeBlastQuota.allow?(
         seller_id: @post.seller_id,
+        kind: "workflow",
         blast_id: @post.id,
         recipient_count: @members.size
       )

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -364,10 +364,21 @@ class SendWorkflowPostEmailsJob
     end
 
     def requeue_for_daily_blast_limit(*args)
-      job_id = self.class.perform_at(Time.zone.tomorrow.beginning_of_day, *args)
+      run_at = Time.zone.tomorrow.beginning_of_day
+      return unless defer_schedule_intent_until(run_at)
+
+      job_id = self.class.perform_at(run_at, *args)
       return if job_id.present?
 
       raise FanoutNotEnqueuedError, "Sidekiq did not requeue the workflow fanout for the daily limit"
+    end
+
+    def defer_schedule_intent_until(run_at)
+      WorkflowInstallmentScheduleIntent.defer_fanout(
+        intent_token: @schedule_intent_token,
+        fanout_token: @schedule_intent_fanout_token,
+        until_time: run_at + WorkflowInstallmentScheduleIntent::FANOUT_LEASE
+      )
     end
 
     def confirmed_follower_member_ids_after_cutoff

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -232,9 +232,9 @@ class SendWorkflowPostEmailsJob
       now = Time.current
       return natural_at if natural_at > now
 
-      offset = @immediate_fanout_index.to_f / immediate_enqueue_per_second
+      offset = @immediate_fanout_index.to_f / effective_immediate_enqueue_per_second
       @immediate_fanout_index += 1
-      now + [offset, max_immediate_spread_seconds].min
+      now + offset
     end
 
     def pace_immediate_fanout?
@@ -247,6 +247,10 @@ class SendWorkflowPostEmailsJob
       IMMEDIATE_FANOUT_THRESHOLD
     end
 
+    def effective_immediate_enqueue_per_second
+      [immediate_enqueue_per_second, @members.size.to_f / max_immediate_spread_seconds].max
+    end
+
     def immediate_enqueue_per_second
       per_second = ($redis.get(RedisKey.workflow_immediate_enqueue_per_second) || DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND).to_f
       per_second.positive? ? per_second : DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND
@@ -255,7 +259,8 @@ class SendWorkflowPostEmailsJob
     end
 
     def max_immediate_spread_seconds
-      ($redis.get(RedisKey.workflow_immediate_fanout_max_spread_seconds) || MAX_IMMEDIATE_SPREAD).to_i
+      spread_seconds = ($redis.get(RedisKey.workflow_immediate_fanout_max_spread_seconds) || MAX_IMMEDIATE_SPREAD).to_i
+      spread_seconds.positive? ? spread_seconds : MAX_IMMEDIATE_SPREAD.to_i
     rescue Redis::BaseError, RedisClient::Error
       MAX_IMMEDIATE_SPREAD.to_i
     end

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -128,10 +128,14 @@ class SendWorkflowPostEmailsJob
         fanout_token: schedule_intent_fanout_token
       )
     when :ownership_lost
-      requeue_for_seller_fanout_limit(
-        post_id, earliest_valid_time, reschedule_on_stale, minimum_rule_version,
-        schedule_intent_token, schedule_intent_fanout_token
-      )
+      # Requeue only if no recipient jobs went out. Restarting after a partial
+      # enqueue would dump the whole audience onto the queue again.
+      unless @fanout_emitted_recipient_jobs
+        requeue_for_seller_fanout_limit(
+          post_id, earliest_valid_time, reschedule_on_stale, minimum_rule_version,
+          schedule_intent_token, schedule_intent_fanout_token
+        )
+      end
     else
       raise FanoutNotEnqueuedError, "Unexpected fanout result"
     end
@@ -149,12 +153,14 @@ class SendWorkflowPostEmailsJob
 
     def enqueue_all_member_jobs
       @immediate_fanout_index = 0
+      @fanout_emitted_recipient_jobs = false
       return :ownership_lost unless prepare_immediate_fanout_pacing
 
       @members.each do |member|
         return :ownership_lost unless renew_fanout_lease
 
         enqueue_email_jobs_for(member)
+        @fanout_emitted_recipient_jobs = true
       end
       :complete
     end

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -179,7 +179,8 @@ class SendWorkflowPostEmailsJob
       @members.each do |member|
         return :ownership_lost unless renew_fanout_lease
 
-        @fanout_emitted_recipient_jobs ||= enqueue_email_jobs_for(member)
+        enqueued = enqueue_email_jobs_for(member)
+        @fanout_emitted_recipient_jobs ||= enqueued
       end
       :complete
     end

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -113,6 +113,13 @@ class SendWorkflowPostEmailsJob
       Makara::Context.release_all
       primary_pinned = false
     end
+    unless claim_daily_large_blast_slot
+      requeue_for_daily_blast_limit(
+        post_id, earliest_valid_time, reschedule_on_stale, minimum_rule_version,
+        schedule_intent_token, schedule_intent_fanout_token
+      )
+      return
+    end
 
     case enqueue_all_member_jobs
     when :complete
@@ -275,6 +282,21 @@ class SendWorkflowPostEmailsJob
       return if job_id.present?
 
       raise FanoutNotEnqueuedError, "Sidekiq did not requeue the workflow fanout"
+    end
+
+    def claim_daily_large_blast_slot
+      SellerLargeBlastQuota.allow?(
+        seller_id: @post.seller_id,
+        blast_id: @post.id,
+        recipient_count: @members.size
+      )
+    end
+
+    def requeue_for_daily_blast_limit(*args)
+      job_id = self.class.perform_at(Time.zone.tomorrow.beginning_of_day, *args)
+      return if job_id.present?
+
+      raise FanoutNotEnqueuedError, "Sidekiq did not requeue the workflow fanout for the daily limit"
     end
 
     def confirmed_follower_member_ids_after_cutoff

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -17,6 +17,9 @@ class SendWorkflowPostEmailsJob
     @schedule_intent_token = schedule_intent_token
     @schedule_intent_fanout_token = schedule_intent_fanout_token
     @seller_fanout_lock = nil
+    @fanout_emitted_recipient_jobs = false
+    @fanout_requeue_args = [post_id, earliest_valid_time, reschedule_on_stale, minimum_rule_version,
+                            schedule_intent_token, schedule_intent_fanout_token]
     primary_pinned = minimum_rule_version.present? || schedule_intent_token.present? ||
                      schedule_intent_fanout_token.present? || earliest_valid_time.present? || reschedule_on_stale
     ActiveRecord::Base.connection.stick_to_primary! if primary_pinned
@@ -82,7 +85,7 @@ class SendWorkflowPostEmailsJob
     # filter query can exceed the database's default 5-minute statement cap, so raise it for
     # this one query.
     audience_timeout = audience_load_timeout_seconds
-    return unless renew_fanout_lease(force: true)
+    return unless keep_unemitted_fanout
     @members = WithMaxExecutionTime.timeout_queries(seconds: audience_timeout) do
       filter_params = @post.affiliate_type? && @recipient_cutoff_time ? @original_filters : @filters
       filter_ids = affiliate_member_ids_after_cutoff if @post.affiliate_type? && @recipient_cutoff_time
@@ -91,23 +94,35 @@ class SendWorkflowPostEmailsJob
       AudienceMember.filter(**filter_options).
         select(:id, :email, :details, :purchase_id, :follower_id, :affiliate_id).to_a
     end
-    return unless renew_fanout_lease(force: true)
+    return unless keep_unemitted_fanout
     if confirmed_follower_recovery?
-      return unless WithMaxExecutionTime.timeout_queries(seconds: audience_timeout) { merge_confirmed_followers_after_cutoff(@members) }
-      return unless renew_fanout_lease(force: true)
+      unless WithMaxExecutionTime.timeout_queries(seconds: audience_timeout) { merge_confirmed_followers_after_cutoff(@members) }
+        requeue_unemitted_fanout
+        return
+      end
+      return unless keep_unemitted_fanout
     end
     if affiliate_recovery?
-      return unless WithMaxExecutionTime.timeout_queries(seconds: audience_timeout) { merge_affiliates_after_cutoff(@members) }
-      return unless renew_fanout_lease(force: true)
+      unless WithMaxExecutionTime.timeout_queries(seconds: audience_timeout) { merge_affiliates_after_cutoff(@members) }
+        requeue_unemitted_fanout
+        return
+      end
+      return unless keep_unemitted_fanout
     end
     @follower_confirmation_times_by_id = follower_confirmation_times_by_id(@members)
-    return if @follower_confirmation_times_by_id.nil?
-    return unless renew_fanout_lease(force: true)
+    if @follower_confirmation_times_by_id.nil?
+      requeue_unemitted_fanout
+      return
+    end
+    return unless keep_unemitted_fanout
     @affiliate_recipients_by_key = affiliate_recipients_by_key(@members)
-    return if @affiliate_recipients_by_key.nil?
-    return unless renew_fanout_lease(force: true)
+    if @affiliate_recipients_by_key.nil?
+      requeue_unemitted_fanout
+      return
+    end
+    return unless keep_unemitted_fanout
     normalize_affiliate_matches(@members)
-    return unless renew_fanout_lease(force: true)
+    return unless keep_unemitted_fanout
     if @keep_primary_for_cutoff_scan
       @keep_primary_for_cutoff_scan = false
       Makara::Context.release_all
@@ -128,14 +143,7 @@ class SendWorkflowPostEmailsJob
         fanout_token: schedule_intent_fanout_token
       )
     when :ownership_lost
-      # Requeue only if no recipient jobs went out. Restarting after a partial
-      # enqueue would dump the whole audience onto the queue again.
-      unless @fanout_emitted_recipient_jobs
-        requeue_for_seller_fanout_limit(
-          post_id, earliest_valid_time, reschedule_on_stale, minimum_rule_version,
-          schedule_intent_token, schedule_intent_fanout_token
-        )
-      end
+      requeue_unemitted_fanout
     else
       raise FanoutNotEnqueuedError, "Unexpected fanout result"
     end
@@ -145,6 +153,18 @@ class SendWorkflowPostEmailsJob
   end
 
   private
+    def keep_unemitted_fanout
+      return true if renew_fanout_lease(force: true)
+
+      requeue_unemitted_fanout
+      false
+    end
+
+    def requeue_unemitted_fanout
+      # Restarting after a partial enqueue would dump the whole audience on the queue again.
+      requeue_for_seller_fanout_limit(*@fanout_requeue_args) unless @fanout_emitted_recipient_jobs
+    end
+
     def cache_rule_version(rule)
       rule.cache_version!
     rescue Redis::BaseError, RedisClient::Error => e

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -146,26 +146,35 @@ class SendWorkflowPostEmailsJob
 
     def enqueue_all_member_jobs
       @immediate_fanout_index = 0
+      return :ownership_lost unless prepare_immediate_fanout_pacing
+
       @members.each do |member|
         return :ownership_lost unless renew_fanout_lease
 
-        if @post.seller_or_product_or_variant_type?
-          enqueue_email_job(member:, type: :purchase, id: member.purchase_id)
-        elsif @post.follower_type?
-          enqueue_email_job(member:, type: :follower, id: member.follower_id)
-        elsif @post.affiliate_type?
-          enqueue_email_job(member:, type: :affiliate, id: member.affiliate_id)
-        elsif @post.audience_type?
-          if member.follower_id
-            enqueue_email_job(member:, type: :follower, id: member.follower_id)
-          elsif member.affiliate_id
-            enqueue_email_job(member:, type: :affiliate, id: member.affiliate_id)
-          else
-            enqueue_email_job(member:, type: :purchase, id: member.purchase_id)
-          end
-        end
+        enqueue_email_jobs_for(member)
       end
       :complete
+    end
+
+    def enqueue_email_jobs_for(member)
+      delivery_targets_for(member, log_unresolvable: true).each do |target|
+        enqueue_installment_worker(**target)
+      end
+    end
+
+    def prepare_immediate_fanout_pacing
+      @immediate_fanout_started_at = Time.current
+      @immediate_fanout_recipient_count = 0
+      return true if @members.size < immediate_fanout_threshold
+
+      @members.each do |member|
+        return false unless renew_fanout_lease
+
+        @immediate_fanout_recipient_count += delivery_targets_for(member, log_unresolvable: false).count do |target|
+          target[:created_at] + @rule_delay <= @immediate_fanout_started_at
+        end
+      end
+      true
     end
 
     def renew_fanout_lease(force: false)
@@ -193,33 +202,62 @@ class SendWorkflowPostEmailsJob
       @filters[:created_after] = [configured_cutoff, @recipient_filter_cutoff_time].compact.max
     end
 
-    def enqueue_email_job(member:, type:, id:)
-      if type == :purchase
-        # `with_ids` supplies the matching purchase. Another embedded purchase can bypass the workflow filters.
-        return log_unresolvable_recipient(member:, type:) if id.nil?
-
-        purchase = member.details["purchases"].find { _1["id"] == id }
-        return log_unresolvable_recipient(member:, type:) if purchase.nil?
-        created_at = Time.zone.parse(purchase["created_at"])
-        enqueue_installment_worker(created_at:, purchase_id: id)
-      elsif type == :follower
-        id ||= member.details.dig("follower", "id")
-        return log_unresolvable_recipient(member:, type:) if id.nil?
-        confirmed_at = @follower_confirmation_times_by_id[id]
-        return log_unresolvable_recipient(member:, type:) if confirmed_at.nil?
-        enqueue_installment_worker(created_at: confirmed_at, follower_id: id, preserve_reference_time: true)
-      elsif type == :affiliate
-        affiliate_triggers = resolve_affiliate_triggers(member:, id:)
-        return log_unresolvable_recipient(member:, type:) if affiliate_triggers.empty?
-
-        affiliate_triggers.each do |affiliate|
-          enqueue_installment_worker(
-            created_at: affiliate[:created_at],
-            affiliate_user_id: affiliate[:affiliate_user_id],
-            preserve_reference_time: true
-          )
+    def delivery_targets_for(member, log_unresolvable:)
+      if @post.seller_or_product_or_variant_type?
+        delivery_targets_for_purchase(member:, id: member.purchase_id, log_unresolvable:)
+      elsif @post.follower_type?
+        delivery_targets_for_follower(member:, id: member.follower_id, log_unresolvable:)
+      elsif @post.affiliate_type?
+        delivery_targets_for_affiliate(member:, id: member.affiliate_id, log_unresolvable:)
+      elsif @post.audience_type?
+        if member.follower_id
+          delivery_targets_for_follower(member:, id: member.follower_id, log_unresolvable:)
+        elsif member.affiliate_id
+          delivery_targets_for_affiliate(member:, id: member.affiliate_id, log_unresolvable:)
+        else
+          delivery_targets_for_purchase(member:, id: member.purchase_id, log_unresolvable:)
         end
+      else
+        []
       end
+    end
+
+    def delivery_targets_for_purchase(member:, id:, log_unresolvable:)
+      # `with_ids` supplies the matching purchase. Another embedded purchase can bypass the workflow filters.
+      return unresolved_recipient(member:, type: :purchase, log_unresolvable:) if id.nil?
+
+      purchase = member.details["purchases"].find { _1["id"] == id }
+      return unresolved_recipient(member:, type: :purchase, log_unresolvable:) if purchase.nil?
+
+      [{ created_at: Time.zone.parse(purchase["created_at"]), purchase_id: id }]
+    end
+
+    def delivery_targets_for_follower(member:, id:, log_unresolvable:)
+      id ||= member.details.dig("follower", "id")
+      return unresolved_recipient(member:, type: :follower, log_unresolvable:) if id.nil?
+
+      confirmed_at = @follower_confirmation_times_by_id[id]
+      return unresolved_recipient(member:, type: :follower, log_unresolvable:) if confirmed_at.nil?
+
+      [{ created_at: confirmed_at, follower_id: id, preserve_reference_time: true }]
+    end
+
+    def delivery_targets_for_affiliate(member:, id:, log_unresolvable:)
+      affiliate_triggers = resolve_affiliate_triggers(member:, id:)
+      return unresolved_recipient(member:, type: :affiliate, log_unresolvable:) if affiliate_triggers.empty?
+
+      affiliate_triggers.map do |affiliate|
+        {
+          created_at: affiliate[:created_at],
+          affiliate_user_id: affiliate[:affiliate_user_id],
+          preserve_reference_time: true
+        }
+      end
+    end
+
+    def unresolved_recipient(member:, type:, log_unresolvable:)
+      log_unresolvable_recipient(member:, type:) if log_unresolvable
+      []
     end
 
     def enqueue_installment_worker(created_at:, purchase_id: nil, follower_id: nil, affiliate_user_id: nil, preserve_reference_time: false)
@@ -236,7 +274,7 @@ class SendWorkflowPostEmailsJob
     def paced_deliver_at(natural_at)
       return natural_at unless pace_immediate_fanout?
 
-      now = Time.current
+      now = @immediate_fanout_started_at || Time.current
       return natural_at if natural_at > now
 
       offset = @immediate_fanout_index.to_f / effective_immediate_enqueue_per_second
@@ -245,7 +283,7 @@ class SendWorkflowPostEmailsJob
     end
 
     def pace_immediate_fanout?
-      @members.size >= immediate_fanout_threshold
+      @immediate_fanout_recipient_count.to_i >= immediate_fanout_threshold
     end
 
     def immediate_fanout_threshold
@@ -255,7 +293,7 @@ class SendWorkflowPostEmailsJob
     end
 
     def effective_immediate_enqueue_per_second
-      [immediate_enqueue_per_second, @members.size.to_f / max_immediate_spread_seconds].max
+      [immediate_enqueue_per_second, @immediate_fanout_recipient_count.to_f / max_immediate_spread_seconds].max
     end
 
     def immediate_enqueue_per_second

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -128,7 +128,10 @@ class SendWorkflowPostEmailsJob
         fanout_token: schedule_intent_fanout_token
       )
     when :ownership_lost
-      nil
+      requeue_for_seller_fanout_limit(
+        post_id, earliest_valid_time, reschedule_on_stale, minimum_rule_version,
+        schedule_intent_token, schedule_intent_fanout_token
+      )
     else
       raise FanoutNotEnqueuedError, "Unexpected fanout result"
     end

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -9,18 +9,17 @@ class SendWorkflowPostEmailsJob
 
   FOLLOWER_LOOKUP_BATCH_SIZE = 1_000
   AFFILIATE_LOOKUP_BATCH_SIZE = 1_000
+  IMMEDIATE_FANOUT_THRESHOLD = 2_000
+  DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND = 80
+  MAX_IMMEDIATE_SPREAD = 15.minutes
 
   def perform(post_id, earliest_valid_time = nil, reschedule_on_stale = false, minimum_rule_version = nil, schedule_intent_token = nil, schedule_intent_fanout_token = nil)
     @schedule_intent_token = schedule_intent_token
     @schedule_intent_fanout_token = schedule_intent_fanout_token
+    @seller_fanout_lock = nil
     primary_pinned = minimum_rule_version.present? || schedule_intent_token.present? ||
                      schedule_intent_fanout_token.present? || earliest_valid_time.present? || reschedule_on_stale
     ActiveRecord::Base.connection.stick_to_primary! if primary_pinned
-    return unless WorkflowInstallmentScheduleIntent.begin_fanout(
-      intent_token: schedule_intent_token,
-      fanout_token: schedule_intent_fanout_token
-    )
-    @next_fanout_heartbeat_at = fanout_heartbeat_time + WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f
     @post = Installment.find_by(id: post_id)
     if @post.nil?
       WorkflowInstallmentScheduleIntent.mark_processed(
@@ -29,6 +28,18 @@ class SendWorkflowPostEmailsJob
       )
       return
     end
+    unless claim_seller_fanout_lock
+      requeue_for_seller_fanout_limit(
+        post_id, earliest_valid_time, reschedule_on_stale, minimum_rule_version,
+        schedule_intent_token, schedule_intent_fanout_token
+      )
+      return
+    end
+    return unless WorkflowInstallmentScheduleIntent.begin_fanout(
+      intent_token: schedule_intent_token,
+      fanout_token: schedule_intent_fanout_token
+    )
+    @next_fanout_heartbeat_at = fanout_heartbeat_time + WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f
     @workflow = @post.workflow
     @reschedule_on_stale = reschedule_on_stale
     unless @workflow&.alive? && @post.alive? && @post.published?
@@ -115,6 +126,7 @@ class SendWorkflowPostEmailsJob
       raise FanoutNotEnqueuedError, "Unexpected fanout result"
     end
   ensure
+    @seller_fanout_lock&.release
     Makara::Context.release_all if primary_pinned
   end
 
@@ -126,6 +138,7 @@ class SendWorkflowPostEmailsJob
     end
 
     def enqueue_all_member_jobs
+      @immediate_fanout_index = 0
       @members.each do |member|
         return :ownership_lost unless renew_fanout_lease
 
@@ -149,15 +162,14 @@ class SendWorkflowPostEmailsJob
     end
 
     def renew_fanout_lease(force: false)
-      return true if @schedule_intent_token.blank? && @schedule_intent_fanout_token.blank?
-
       now = fanout_heartbeat_time
-      return true unless force || now >= @next_fanout_heartbeat_at
+      return true unless force || @next_fanout_heartbeat_at.nil? || now >= @next_fanout_heartbeat_at
 
       renewed = WorkflowInstallmentScheduleIntent.renew_fanout(
         intent_token: @schedule_intent_token,
         fanout_token: @schedule_intent_fanout_token
       )
+      renewed &&= @seller_fanout_lock.nil? || @seller_fanout_lock.renew
       Makara::Context.release_all unless @keep_primary_for_cutoff_scan
       @next_fanout_heartbeat_at = now + WorkflowInstallmentScheduleIntent::FANOUT_HEARTBEAT_INTERVAL.to_f if renewed
       renewed
@@ -208,10 +220,56 @@ class SendWorkflowPostEmailsJob
       reschedule_recipient = @reschedule_on_stale && [purchase_id, follower_id, affiliate_user_id].one?(&:present?)
       args.push(nil, created_at.iso8601) if reschedule_recipient || preserve_reference_time
       worker = reschedule_recipient ? SendWorkflowInstallmentRescheduleJob : SendWorkflowInstallmentWorker
-      job_id = worker.perform_at(created_at + @rule_delay, *args)
+      job_id = worker.perform_at(paced_deliver_at(created_at + @rule_delay), *args)
       return job_id if job_id.present?
 
       raise FanoutNotEnqueuedError, "Sidekiq did not enqueue the workflow installment"
+    end
+
+    def paced_deliver_at(natural_at)
+      return natural_at unless pace_immediate_fanout?
+
+      now = Time.current
+      return natural_at if natural_at > now
+
+      offset = @immediate_fanout_index.to_f / immediate_enqueue_per_second
+      @immediate_fanout_index += 1
+      now + [offset, max_immediate_spread_seconds].min
+    end
+
+    def pace_immediate_fanout?
+      @members.size >= immediate_fanout_threshold
+    end
+
+    def immediate_fanout_threshold
+      ($redis.get(RedisKey.workflow_immediate_fanout_threshold) || IMMEDIATE_FANOUT_THRESHOLD).to_i
+    rescue Redis::BaseError, RedisClient::Error
+      IMMEDIATE_FANOUT_THRESHOLD
+    end
+
+    def immediate_enqueue_per_second
+      per_second = ($redis.get(RedisKey.workflow_immediate_enqueue_per_second) || DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND).to_f
+      per_second.positive? ? per_second : DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND
+    rescue Redis::BaseError, RedisClient::Error
+      DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND
+    end
+
+    def max_immediate_spread_seconds
+      ($redis.get(RedisKey.workflow_immediate_fanout_max_spread_seconds) || MAX_IMMEDIATE_SPREAD).to_i
+    rescue Redis::BaseError, RedisClient::Error
+      MAX_IMMEDIATE_SPREAD.to_i
+    end
+
+    def claim_seller_fanout_lock
+      @seller_fanout_lock = WorkflowSellerFanoutLock.acquire(@post.seller_id)
+      @seller_fanout_lock.present?
+    end
+
+    def requeue_for_seller_fanout_limit(*args)
+      job_id = self.class.perform_in(WorkflowSellerFanoutLock.retry_in, *args)
+      return if job_id.present?
+
+      raise FanoutNotEnqueuedError, "Sidekiq did not requeue the workflow fanout"
     end
 
     def confirmed_follower_member_ids_after_cutoff

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -179,16 +179,18 @@ class SendWorkflowPostEmailsJob
       @members.each do |member|
         return :ownership_lost unless renew_fanout_lease
 
-        enqueue_email_jobs_for(member)
-        @fanout_emitted_recipient_jobs = true
+        @fanout_emitted_recipient_jobs ||= enqueue_email_jobs_for(member)
       end
       :complete
     end
 
     def enqueue_email_jobs_for(member)
+      enqueued = false
       delivery_targets_for(member, log_unresolvable: true).each do |target|
         enqueue_installment_worker(**target)
+        enqueued = true
       end
+      enqueued
     end
 
     def prepare_immediate_fanout_pacing

--- a/spec/services/seller_large_blast_quota_spec.rb
+++ b/spec/services/seller_large_blast_quota_spec.rb
@@ -27,6 +27,12 @@ describe SellerLargeBlastQuota, :freeze_time do
     expect(described_class.allow?(seller_id:, blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(true)
   end
 
+  it "does not treat a workflow post and a one-off blast as the same claim when their ids match" do
+    expect(described_class.allow?(seller_id:, kind: "post_blast", blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(true)
+    expect(described_class.allow?(seller_id:, kind: "workflow", blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(false)
+    expect(described_class.allow?(seller_id:, kind: "post_blast", blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(true)
+  end
+
   it "opens a new slot the next day" do
     expect(described_class.allow?(seller_id:, blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(true)
 

--- a/spec/services/seller_large_blast_quota_spec.rb
+++ b/spec/services/seller_large_blast_quota_spec.rb
@@ -33,6 +33,13 @@ describe SellerLargeBlastQuota, :freeze_time do
     expect(described_class.allow?(seller_id:, kind: "post_blast", blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(true)
   end
 
+  it "does not admit a large send when Redis is down" do
+    allow($redis).to receive(:set).and_raise(Redis::CannotConnectError, "no connection")
+    expect(ErrorNotifier).to receive(:notify)
+
+    expect(described_class.allow?(seller_id:, blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(false)
+  end
+
   it "opens a new slot the next day" do
     expect(described_class.allow?(seller_id:, blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(true)
 

--- a/spec/services/seller_large_blast_quota_spec.rb
+++ b/spec/services/seller_large_blast_quota_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe SellerLargeBlastQuota, :freeze_time do
+  let(:seller_id) { 1888878 }
+  let(:first_blast) { 11 }
+  let(:second_blast) { 22 }
+
+  after do
+    $redis.del(RedisKey.seller_large_blast_quota(seller_id, Date.current))
+    $redis.del(RedisKey.seller_large_blast_threshold)
+  end
+
+  it "lets any send under the threshold through without claiming the day" do
+    expect(described_class.allow?(seller_id:, blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD - 1)).to eq(true)
+    expect($redis.get(RedisKey.seller_large_blast_quota(seller_id, Date.current))).to be_nil
+  end
+
+  it "lets the first large send through and holds the rest of the day" do
+    expect(described_class.allow?(seller_id:, blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(true)
+    expect(described_class.allow?(seller_id:, blast_id: second_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(false)
+  end
+
+  it "lets the same blast retry after it already claimed the day" do
+    expect(described_class.allow?(seller_id:, blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(true)
+    expect(described_class.allow?(seller_id:, blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(true)
+  end
+
+  it "opens a new slot the next day" do
+    expect(described_class.allow?(seller_id:, blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(true)
+
+    travel 1.day
+    expect(described_class.allow?(seller_id:, blast_id: second_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(true)
+  end
+end

--- a/spec/services/workflow_seller_fanout_lock_spec.rb
+++ b/spec/services/workflow_seller_fanout_lock_spec.rb
@@ -18,6 +18,21 @@ describe WorkflowSellerFanoutLock do
     expect(described_class.acquire(seller_id)).to be_present
   end
 
+  it "does not grant a lock when Redis is down" do
+    allow($redis).to receive(:set).and_raise(Redis::CannotConnectError, "no connection")
+    expect(ErrorNotifier).to receive(:notify)
+
+    expect(described_class.acquire(seller_id)).to be_nil
+  end
+
+  it "treats a renewal error as lost ownership" do
+    lock = described_class.acquire(seller_id)
+    allow($redis).to receive(:eval).and_raise(Redis::CannotConnectError, "no connection")
+    expect(ErrorNotifier).to receive(:notify)
+
+    expect(lock.renew).to eq(false)
+  end
+
   it "does not release a successor's lock" do
     first = described_class.acquire(seller_id)
     $redis.del(RedisKey.workflow_seller_fanout_lock(seller_id))

--- a/spec/services/workflow_seller_fanout_lock_spec.rb
+++ b/spec/services/workflow_seller_fanout_lock_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe WorkflowSellerFanoutLock do
+  let(:seller_id) { 1888877 }
+
+  after { $redis.del(RedisKey.workflow_seller_fanout_lock(seller_id)) }
+
+  it "gives the second acquire nothing while the first is held" do
+    first = described_class.acquire(seller_id)
+    second = described_class.acquire(seller_id)
+
+    expect(first).to be_present
+    expect(second).to be_nil
+
+    first.release
+    expect(described_class.acquire(seller_id)).to be_present
+  end
+
+  it "does not release a successor's lock" do
+    first = described_class.acquire(seller_id)
+    $redis.del(RedisKey.workflow_seller_fanout_lock(seller_id))
+    successor = described_class.acquire(seller_id)
+
+    first.release
+
+    expect($redis.get(RedisKey.workflow_seller_fanout_lock(seller_id))).to be_present
+    successor.release
+  end
+end

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -783,6 +783,19 @@ describe SendPostBlastEmailsJob, :freeze_time do
     end
   end
 
+  describe "one large blast per seller per day" do
+    it "holds a second large blast until tomorrow" do
+      blast = create(:blast, :just_requested, post: basic_post_with_audience)
+      allow(SellerLargeBlastQuota).to receive(:allow?).and_return(false)
+
+      described_class.new.perform(blast.id)
+
+      expect(PostSendgridApi.mails).to be_empty
+      expect(described_class).to have_enqueued_sidekiq_job(blast.id).at(Time.zone.tomorrow.beginning_of_day)
+      expect(blast.reload.completed_at).to be_nil
+    end
+  end
+
   def expect_sent_count(count)
     expect(PostSendgridApi.mails.size).to eq(count)
   end

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -822,4 +822,89 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       end
     end
   end
+
+  describe "seller fanout lock" do
+    before do
+      @product = create(:product, user: @seller, price_cents: 0)
+      @post.update!(
+        installment_type: Installment::PRODUCT_TYPE,
+        link: @product,
+        bought_products: [@product.unique_permalink]
+      )
+      purchase = create(:free_purchase, link: @product, created_at: 2.days.ago)
+      purchase.rebuild_audience_member_details
+    end
+
+    it "requeues when another fanout for the seller is running" do
+      $redis.set(RedisKey.workflow_seller_fanout_lock(@seller.id), "held", nx: true, ex: 60)
+
+      described_class.new.perform(@post.id)
+
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+      expect(described_class).to have_enqueued_sidekiq_job(
+        @post.id, nil, false, nil, nil, nil
+      ).in(30.seconds)
+    end
+
+    it "releases the seller lock after a successful fanout" do
+      described_class.new.perform(@post.id)
+
+      expect($redis.get(RedisKey.workflow_seller_fanout_lock(@seller.id))).to be_nil
+      expect(SendWorkflowInstallmentWorker.jobs.size).to eq(1)
+    end
+
+    it "lets a second post fan out after the first releases the seller lock" do
+      second_post = create(:installment, :published, seller: @seller, link: @product, workflow: @workflow,
+                                                     installment_type: Installment::PRODUCT_TYPE,
+                                                     bought_products: [@product.unique_permalink])
+      create(:post_rule, installment: second_post, delayed_delivery_time: 1.day)
+
+      described_class.new.perform(@post.id)
+      SendWorkflowInstallmentWorker.jobs.clear
+      described_class.new.perform(second_post.id)
+
+      expect(SendWorkflowInstallmentWorker.jobs.size).to eq(1)
+    end
+  end
+
+  describe "immediate fanout pacing" do
+    before do
+      @product = create(:product, user: @seller, price_cents: 0)
+      @post.update!(
+        installment_type: Installment::PRODUCT_TYPE,
+        link: @product,
+        bought_products: [@product.unique_permalink]
+      )
+      @post_rule.update!(delayed_delivery_time: 0)
+      stub_const("#{described_class}::IMMEDIATE_FANOUT_THRESHOLD", 3)
+      stub_const("#{described_class}::DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND", 2)
+      4.times do |i|
+        purchase = create(:free_purchase, link: @product, email: "paced-buyer-#{i}@example.com", created_at: 1.hour.ago)
+        purchase.rebuild_audience_member_details
+      end
+    end
+
+    it "spreads due-now jobs across the paced window" do
+      described_class.new.perform(@post.id)
+
+      jobs = SendWorkflowInstallmentWorker.jobs
+      expect(jobs.size).to eq(4)
+      ats = jobs.filter_map { _1["at"] }.sort
+      expect(ats.size).to eq(3)
+      expect(ats.last - Time.current.to_f).to be_within(0.05).of(1.5)
+    end
+
+    it "keeps future deliveries on their original schedule" do
+      @post_rule.update!(delayed_delivery_time: 3.days)
+      SendWorkflowInstallmentWorker.jobs.clear
+
+      described_class.new.perform(@post.id)
+
+      expected_at = 1.hour.ago + 3.days
+      expect(SendWorkflowInstallmentWorker.jobs.size).to eq(4)
+      SendWorkflowInstallmentWorker.jobs.each do |job|
+        expect(job["at"]).to be_within(1).of(expected_at.to_f)
+      end
+    end
+  end
 end

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -925,8 +925,10 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       @post_rule.update!(delayed_delivery_time: 0)
       stub_const("#{described_class}::IMMEDIATE_FANOUT_THRESHOLD", 3)
       stub_const("#{described_class}::DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND", 2)
+      @paced_purchases = []
       4.times do |i|
         purchase = create(:free_purchase, link: @product, email: "paced-buyer-#{i}@example.com", created_at: 1.hour.ago)
+        @paced_purchases << purchase
         purchase.rebuild_audience_member_details
       end
     end
@@ -952,6 +954,22 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       expect(ats.size).to eq(3)
       expect(ats.last - Time.current.to_f).to be_between(0.6, 1.0)
       expect(ats.last - ats[-2]).to be > 0.1
+    ensure
+      $redis.del(RedisKey.workflow_immediate_fanout_max_spread_seconds)
+    end
+
+    it "sizes the pacing rate from due-now recipients, not future recipients" do
+      $redis.set(RedisKey.workflow_immediate_fanout_max_spread_seconds, 1)
+      @paced_purchases.last.update!(created_at: 1.day.from_now)
+      @paced_purchases.last.rebuild_audience_member_details
+
+      described_class.new.perform(@post.id)
+
+      ats = SendWorkflowInstallmentWorker.jobs.filter_map { _1["at"] }.sort
+      due_now_ats = ats.select { _1 < 1.hour.from_now.to_f }
+      expect(due_now_ats.size).to eq(2)
+      expect(due_now_ats.last - Time.current.to_f).to be_between(0.6, 0.8)
+      expect(ats.last).to be_within(1).of(1.day.from_now.to_f)
     ensure
       $redis.del(RedisKey.workflow_immediate_fanout_max_spread_seconds)
     end

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -823,6 +823,53 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
     end
   end
 
+  describe "one large blast per seller per day" do
+    before do
+      @product = create(:product, user: @seller, price_cents: 0)
+      @post.update!(
+        installment_type: Installment::PRODUCT_TYPE,
+        link: @product,
+        bought_products: [@product.unique_permalink]
+      )
+      @post_rule.update!(delayed_delivery_time: 0)
+      stub_const("SellerLargeBlastQuota::DEFAULT_THRESHOLD", 3)
+      4.times do |i|
+        purchase = create(:free_purchase, link: @product, email: "daily-buyer-#{i}@example.com", created_at: 1.hour.ago)
+        purchase.rebuild_audience_member_details
+      end
+    end
+
+    after { $redis.del(RedisKey.seller_large_blast_quota(@seller.id, Date.current)) }
+
+    it "fans out the first large post and holds the next one until tomorrow" do
+      second_post = create(:installment, :published, seller: @seller, link: @product, workflow: @workflow,
+                                                     installment_type: Installment::PRODUCT_TYPE,
+                                                     bought_products: [@product.unique_permalink])
+      create(:post_rule, installment: second_post, delayed_delivery_time: 0)
+
+      described_class.new.perform(@post.id)
+      expect(SendWorkflowInstallmentWorker.jobs.size).to eq(4)
+
+      SendWorkflowInstallmentWorker.jobs.clear
+      described_class.jobs.clear
+      described_class.new.perform(second_post.id)
+
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+      expect(described_class).to have_enqueued_sidekiq_job(
+        second_post.id, nil, false, nil, nil, nil
+      ).at(Time.zone.tomorrow.beginning_of_day)
+    end
+
+    it "does not consume the day for a small audience" do
+      stub_const("SellerLargeBlastQuota::DEFAULT_THRESHOLD", 100)
+
+      described_class.new.perform(@post.id)
+
+      expect(SendWorkflowInstallmentWorker.jobs.size).to eq(4)
+      expect($redis.get(RedisKey.seller_large_blast_quota(@seller.id, Date.current))).to be_nil
+    end
+  end
+
   describe "seller fanout lock" do
     before do
       @product = create(:product, user: @seller, price_cents: 0)

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -894,6 +894,21 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       expect(ats.last - Time.current.to_f).to be_within(0.05).of(1.5)
     end
 
+    it "keeps oversized due-now fanouts inside the window without a terminal burst" do
+      $redis.set(RedisKey.workflow_immediate_fanout_max_spread_seconds, 1)
+
+      described_class.new.perform(@post.id)
+
+      jobs = SendWorkflowInstallmentWorker.jobs
+      expect(jobs.size).to eq(4)
+      ats = jobs.filter_map { _1["at"] }.sort
+      expect(ats.size).to eq(3)
+      expect(ats.last - Time.current.to_f).to be_between(0.6, 1.0)
+      expect(ats.last - ats[-2]).to be > 0.1
+    ensure
+      $redis.del(RedisKey.workflow_immediate_fanout_max_spread_seconds)
+    end
+
     it "keeps future deliveries on their original schedule" do
       @post_rule.update!(delayed_delivery_time: 3.days)
       SendWorkflowInstallmentWorker.jobs.clear

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -893,6 +893,18 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       ).in(30.seconds)
     end
 
+    it "requeues when the seller lock cannot be renewed before any recipient is enqueued" do
+      described_class.jobs.clear
+      allow_any_instance_of(WorkflowSellerFanoutLock).to receive(:renew).and_return(false)
+
+      described_class.new.perform(@post.id)
+
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+      expect(described_class).to have_enqueued_sidekiq_job(
+        @post.id, nil, false, nil, nil, nil
+      ).in(30.seconds)
+    end
+
     it "releases the seller lock after a successful fanout" do
       described_class.new.perform(@post.id)
 

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -868,6 +868,37 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       expect(SendWorkflowInstallmentWorker.jobs.size).to eq(4)
       expect($redis.get(RedisKey.seller_large_blast_quota(@seller.id, Date.current))).to be_nil
     end
+
+    it "holds a started schedule intent until the deferred job, so recovery cannot steal it" do
+      described_class.new.perform(@post.id)
+      SendWorkflowInstallmentWorker.jobs.clear
+      described_class.jobs.clear
+
+      second_post = create(:installment, :published, seller: @seller, link: @product, workflow: @workflow,
+                                                     installment_type: Installment::PRODUCT_TYPE,
+                                                     bought_products: [@product.unique_permalink])
+      second_rule = create(:post_rule, installment: second_post, delayed_delivery_time: 0)
+      intent = WorkflowInstallmentScheduleIntent.create!(
+        token: SecureRandom.uuid,
+        installment_id: second_post.id,
+        rule_version: second_rule.version,
+        cutoff_reference_time: Time.current
+      )
+      fanout_token = intent.with_lock { intent.claim_fanout! }
+
+      described_class.new.perform(second_post.id, nil, false, nil, intent.token, fanout_token)
+
+      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
+      expect(described_class).to have_enqueued_sidekiq_job(
+        second_post.id, nil, false, nil, intent.token, fanout_token
+      ).at(Time.zone.tomorrow.beginning_of_day)
+      expect(intent.reload.processed_at).to be_nil
+      expect(intent.fanout_token).to eq(fanout_token)
+      expect(intent.fanout_expires_at).to eq(
+        Time.zone.tomorrow.beginning_of_day + WorkflowInstallmentScheduleIntent::FANOUT_LEASE
+      )
+      expect(WorkflowInstallmentScheduleIntent.dispatchable).not_to include(intent)
+    end
   end
 
   describe "seller fanout lock" do


### PR DESCRIPTION
Pace large workflow email fanouts so a burst cannot stall the site

> Fail-closed Redis lock/quota. Unemitted fanouts requeue on lock-renewal failure; partial fanouts do not restart. Head `860cc35e41`. Backend-only. `working` until CI + Sol at this head.

## What

Serialize `SendWorkflowPostEmailsJob` per seller, spread due-now recipient jobs over a bounded window once the audience is large, replace the per-recipient `Purchase...pluck(:id)` eligibility check with an installment-scoped `exists?`, and allow only one 10,000+ recipient blast per seller per day (extras wait until tomorrow).

Part of antiwork/gumroad-private#2302.

## Why

Publishing several large workflow posts at once enqueued every recipient immediately. Each worker then scanned that buyer's full purchase history on the primary. Shoppers waited tens of seconds and some checkouts 500'd. Pacing still lets five 100k sends start the same day; the daily cap is what stops that.

## Before / after

- Before: five ~100k-recipient posts could start ~770k low-queue workers in minutes; the dominant query was `Purchase.where(email:, seller_id:).…pluck(:id)`.
- After: a second post for the same seller waits on a Redis lock; due-now jobs for audiences ≥ 2,000 are spread over the configured window. A second 10,000+ recipient send (workflow or one-off blast) is held until the next day. If the configured per-second rate cannot fit the due-now subset inside that window, the rate rises enough to avoid a terminal burst instead of clamping the excess jobs to one timestamp; future-scheduled recipients do not inflate the immediate rate. Redis errors on the lock or daily quota fail closed and requeue instead of admitting a stampede. A lock-renewal failure before any recipient job is enqueued requeues the parent; after a partial enqueue it stops without restarting the audience.

## Checklist

- [x] Scope — fanout pacing + per-seller lock + inverted eligibility lookup + one large blast per seller per day. Not changing send copy or audience filters.
- [x] Design — lock then begin_fanout; pace only past-due jobs on large audiences so small workflows stay immediate; over-window due-now subsets raise the effective rate instead of bursting at the cap; future recipients stay on their natural schedule and do not inflate the immediate rate; 10k+ audiences claim a daily Redis slot keyed by seller + date; lock acquire/renew and quota claim fail closed when Redis is down; unemitted fanouts requeue on renewal failure.
- [x] Build — `gumclaw/gp2302-workflow-fanout-pacing` at `860cc35e41`
- [x] QA — lock + quota Redis-down specs 10/0; seller fanout lock examples 4/0 including pre-enqueue renewal requeue
- [ ] Shipped
- [ ] Market — n/a, internal reliability
- [ ] Sell — n/a

## Test Results

```text
DISABLE_SPRING=1 bundle exec rspec spec/services/workflow_seller_fanout_lock_spec.rb spec/services/seller_large_blast_quota_spec.rb
10 examples, 0 failures

DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/send_workflow_post_emails_job_spec.rb -e "seller fanout lock"
4 examples, 0 failures

DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/send_workflow_post_emails_job_spec.rb -e "one large blast per seller per day"
3 examples, 0 failures
```

## QA

Backend-only. No product UI. No qa-media — the reviewable artifact is the Sidekiq/spec diff. Verify after deploy: publishing several large workflow posts for one seller should enqueue the parent jobs serially, and only the first 10,000+ audience should fan out today. The rest should sit until tomorrow. A Redis outage must not start overlapping large fanouts.

Tunables (Redis): `workflow_seller_fanout_lock_ttl_seconds`, `workflow_seller_fanout_retry_seconds`, `workflow_immediate_fanout_threshold`, `workflow_immediate_enqueue_per_second`, `workflow_immediate_fanout_max_spread_seconds`, `seller_large_blast_threshold`.

---

AI disclosure: grok-4.6. Prompt/instructions: Sahil asked whether one big blast per day was worth adding on gumroad-private#2302 / PR #7387.

Premerge review: clean @ 860cc35e41d521d561f46596d078009d52b19d20

