### PR TITLE
Add Sales API v2 revoke_access and undo_revoke_access

### DIFF
--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -5,7 +5,7 @@ class Api::V2::SalesController < Api::V2::BaseController
   before_action(only: [:index, :show, :export, :summary]) { doorkeeper_authorize! :view_sales }
   before_action(only: [:mark_as_shipped]) { doorkeeper_authorize! :mark_sales_as_shipped }
   before_action(only: [:refund]) { doorkeeper_authorize! :refund_sales, :edit_sales }
-  before_action(only: [:resend_receipt]) { doorkeeper_authorize! :edit_sales }
+  before_action(only: [:resend_receipt, :revoke_access, :undo_revoke_access]) { doorkeeper_authorize! :edit_sales }
   before_action :set_page, only: :index
 
   RESULTS_PER_PAGE = 10
@@ -194,9 +194,42 @@ class Api::V2::SalesController < Api::V2::BaseController
     render_response(true)
   end
 
+  def revoke_access
+    purchase = current_resource_owner.sales.find_by_external_id(params[:id])
+    return error_with_sale if purchase.nil?
+
+    unless sale_purchase_policy(purchase).revoke_access?
+      purchase.errors.add(:base, "Access cannot be revoked for this sale.")
+      return error_with_sale(purchase)
+    end
+
+    purchase.update!(is_access_revoked: true)
+    success_with_sale(purchase.as_json(version: 2, include_buyer_presentment: true))
+  end
+
+  def undo_revoke_access
+    purchase = current_resource_owner.sales.find_by_external_id(params[:id])
+    return error_with_sale if purchase.nil?
+
+    unless sale_purchase_policy(purchase).undo_revoke_access?
+      purchase.errors.add(:base, "Access is not revoked for this sale.")
+      return error_with_sale(purchase)
+    end
+
+    purchase.update!(is_access_revoked: false)
+    success_with_sale(purchase.as_json(version: 2, include_buyer_presentment: true))
+  end
+
   private
     def success_with_sale(sale = nil)
       success_with_object(:sale, sale)
+    end
+
+    def sale_purchase_policy(purchase)
+      Audience::PurchasePolicy.new(
+        SellerContext.new(user: current_resource_owner, seller: current_resource_owner),
+        purchase
+      )
     end
 
     def error_with_sale(sale = nil)

--- a/app/controllers/oauth/device_authorizations_controller.rb
+++ b/app/controllers/oauth/device_authorizations_controller.rb
@@ -179,7 +179,7 @@ class Oauth::DeviceAuthorizationsController < ApplicationController
       when "mark_sales_as_shipped" then "Mark your sales as shipped."
       when "mobile_api" then "Mobile API"
       when "refund_sales" then "Refund your sales."
-      when "edit_sales" then "Refund your sales and resend purchase receipts to customers."
+      when "edit_sales" then "Refund your sales, revoke or restore buyer access, and resend purchase receipts to customers."
       when "revenue_share" then "Revenue Share"
       when "unfurl" then "Fetch public information of any product to preview it in Notion."
       when "view_profile" then "See your profile data."

--- a/app/javascript/components/ApiDocumentation/Endpoints/Sales.tsx
+++ b/app/javascript/components/ApiDocumentation/Endpoints/Sales.tsx
@@ -452,6 +452,56 @@ export const RefundSale = () => (
   </ApiEndpoint>
 );
 
+export const RevokeSaleAccess = () => (
+  <ApiEndpoint
+    method="put"
+    path="/sales/:id/revoke_access"
+    description="Revokes the buyer's access to a sale without refunding it. The sale stays in the seller's records and the buyer loses library/download access. Same rules as the dashboard Customers page: refused for refunded sales, physical products, and subscriptions. Available with the 'edit_sales' scope."
+  >
+    <SaleResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/sales/FO8TXN-dvxYabdavG97Y-Q==/revoke_access \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -X PUT`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "sale": {
+    "id": "FO8TXN-dvxYabdavG97Y-Q==",
+    "email": "calvin@gumroad.com",
+    "access_revoked": true
+  }
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);
+
+export const UndoRevokeSaleAccess = () => (
+  <ApiEndpoint
+    method="put"
+    path="/sales/:id/undo_revoke_access"
+    description="Restores the buyer's access to a sale that was previously revoked. Available with the 'edit_sales' scope."
+  >
+    <SaleResponseFields />
+    <CodeSnippet caption="cURL example">
+      {`curl https://api.gumroad.com/v2/sales/FO8TXN-dvxYabdavG97Y-Q==/undo_revoke_access \\
+  -d "access_token=ACCESS_TOKEN" \\
+  -X PUT`}
+    </CodeSnippet>
+    <CodeSnippet caption="Example response:">
+      {`{
+  "success": true,
+  "sale": {
+    "id": "FO8TXN-dvxYabdavG97Y-Q==",
+    "email": "calvin@gumroad.com",
+    "access_revoked": false
+  }
+}`}
+    </CodeSnippet>
+  </ApiEndpoint>
+);
+
 export const ResendReceipt = () => (
   <ApiEndpoint
     method="post"

--- a/app/javascript/components/ApiDocumentation/Scopes.tsx
+++ b/app/javascript/components/ApiDocumentation/Scopes.tsx
@@ -43,7 +43,8 @@ const SCOPES = [
   },
   {
     name: "edit_sales",
-    description: "write access to refund the user's products' sales, revoke or restore buyer access, and resend purchase receipts to customers.",
+    description:
+      "write access to refund the user's products' sales, revoke or restore buyer access, and resend purchase receipts to customers.",
   },
 ];
 

--- a/app/javascript/components/ApiDocumentation/Scopes.tsx
+++ b/app/javascript/components/ApiDocumentation/Scopes.tsx
@@ -43,7 +43,7 @@ const SCOPES = [
   },
   {
     name: "edit_sales",
-    description: "write access to refund the user's products' sales and resend purchase receipts to customers.",
+    description: "write access to refund the user's products' sales, revoke or restore buyer access, and resend purchase receipts to customers.",
   },
 ];
 

--- a/app/javascript/pages/Public/Api.tsx
+++ b/app/javascript/pages/Public/Api.tsx
@@ -67,6 +67,8 @@ import {
   MarkSaleAsShipped,
   RefundSale,
   ResendReceipt,
+  RevokeSaleAccess,
+  UndoRevokeSaleAccess,
   GetSale,
   GetSales,
 } from "$app/components/ApiDocumentation/Endpoints/Sales";
@@ -265,6 +267,8 @@ export default function Api() {
                 <GetSale />
                 <MarkSaleAsShipped />
                 <RefundSale />
+                <RevokeSaleAccess />
+                <UndoRevokeSaleAccess />
                 <ResendReceipt />
               </ApiResource>
 

--- a/app/javascript/pages/Settings/AuthorizedApplications/Index.tsx
+++ b/app/javascript/pages/Settings/AuthorizedApplications/Index.tsx
@@ -52,7 +52,7 @@ const SCOPE_DESCRIPTIONS: Record<Scope, string> = {
   ifttt: "See your sales data.",
   mark_sales_as_shipped: "Mark your sales as shipped.",
   refund_sales: "Refund your sales.",
-  edit_sales: "Refund your sales and resend purchase receipts to customers.",
+  edit_sales: "Refund your sales, revoke or restore buyer access, and resend purchase receipts to customers.",
   unfurl: "Fetch public information of any product to preview it in Notion.",
   view_profile: "See your profile data.",
   edit_profile: "Edit your profile name and bio.",

--- a/app/services/ai/store_agent_api_catalog.rb
+++ b/app/services/ai/store_agent_api_catalog.rb
@@ -254,6 +254,8 @@ module Ai::StoreAgentApiCatalog
                                                                                                                          path_params: %w[id], params: %w[tracking_url]),
     ep("refund_sale", :put, "/sales/:id/refund", "Refund a sale, fully or partially.", scope: "refund_sales", path_params: %w[id], params: %w[amount_cents]),
     ep("resend_receipt", :post, "/sales/:id/resend_receipt", "Resend the purchase receipt email to the buyer.", scope: "edit_sales", path_params: %w[id]),
+    ep("revoke_sale_access", :put, "/sales/:id/revoke_access", "Revoke the buyer's access to a sale without refunding it. Refused for refunded, physical, and subscription sales.", scope: "edit_sales", path_params: %w[id]),
+    ep("undo_revoke_sale_access", :put, "/sales/:id/undo_revoke_access", "Restore the buyer's access to a previously revoked sale.", scope: "edit_sales", path_params: %w[id]),
 
     # ---- Payouts ----
     ep("list_payouts", :get, "/payouts", "List the creator's payouts. Returns 10 per page; when the response includes next_page_key, pass it back as page_key to fetch the next page.", read: true, scope: "view_payouts", params: %w[page_key]),

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -24,7 +24,7 @@
               when "mark_sales_as_shipped" then "Mark your sales as shipped."
               when "mobile_api" then "Mobile API"
               when "refund_sales" then "Refund your sales."
-              when "edit_sales" then "Refund your sales and resend purchase receipts to customers."
+              when "edit_sales" then "Refund your sales, revoke or restore buyer access, and resend purchase receipts to customers."
               when "revenue_share" then "Revenue Share"
               when "unfurl" then "Fetch public information of any product to preview it in Notion."
               when "view_profile" then "See your profile data."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,6 +163,8 @@ Rails.application.routes.draw do
           put :mark_as_shipped
           put :refund
           post :resend_receipt
+          put :revoke_access
+          put :undo_revoke_access
         end
       end
       resources :payouts, only: [:index, :show] do

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -1323,6 +1323,157 @@ describe Api::V2::SalesController do
     end
   end
 
+  describe "PUT 'revoke_access'" do
+    before do
+      @sale = create(:purchase, seller: @seller, link: @product)
+      @params = { id: @sale.external_id }
+    end
+
+    describe "when logged in with edit_sales scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "edit_sales")
+        @params.merge!(format: :json, access_token: @token.token)
+      end
+
+      it "revokes access and returns the updated sale" do
+        put :revoke_access, params: @params
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(response.parsed_body["sale"]["id"]).to eq(@sale.external_id)
+        expect(response.parsed_body["sale"]["access_revoked"]).to eq(true)
+        expect(@sale.reload.is_access_revoked).to eq(true)
+      end
+
+      it "does not refund the sale" do
+        put :revoke_access, params: @params
+
+        expect(@sale.reload.refunded?).to eq(false)
+      end
+
+      it "returns a not found error when sale does not exist" do
+        @params[:id] = "non-existent"
+        put :revoke_access, params: @params
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("The sale was not found.")
+      end
+
+      it "returns a not found error when sale belongs to another user" do
+        other_user = create(:user)
+        other_product = create(:product, user: other_user)
+        other_sale = create(:purchase, seller: other_user, link: other_product)
+        @params[:id] = other_sale.external_id
+        put :revoke_access, params: @params
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("The sale was not found.")
+        expect(other_sale.reload.is_access_revoked).to eq(false)
+      end
+
+      it "refuses an already-revoked sale" do
+        @sale.update!(is_access_revoked: true)
+        put :revoke_access, params: @params
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("Access cannot be revoked for this sale.")
+      end
+
+      it "refuses a refunded sale" do
+        allow_any_instance_of(Purchase).to receive(:refunded?).and_return(true)
+        put :revoke_access, params: @params
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("Access cannot be revoked for this sale.")
+        expect(@sale.reload.is_access_revoked).to eq(false)
+      end
+
+      it "refuses a physical sale" do
+        physical_product = create(:physical_product, user: @seller)
+        physical_sale = create(:physical_purchase, link: physical_product, seller: @seller)
+        @params[:id] = physical_sale.external_id
+        put :revoke_access, params: @params
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("Access cannot be revoked for this sale.")
+        expect(physical_sale.reload.is_access_revoked).to eq(false)
+      end
+
+      it "refuses a subscription sale" do
+        membership_product = create(:membership_product, user: @seller)
+        subscription = create(:subscription, link: membership_product, seller: @seller)
+        subscription_sale = create(:purchase, link: membership_product, seller: @seller, subscription:, is_original_subscription_purchase: true)
+        @params[:id] = subscription_sale.external_id
+        put :revoke_access, params: @params
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("Access cannot be revoked for this sale.")
+        expect(subscription_sale.reload.is_access_revoked).to eq(false)
+      end
+    end
+
+    describe "when logged in with incorrect scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "view_sales")
+        @params.merge!(format: :json, access_token: @token.token)
+      end
+
+      it "the response is 403 forbidden for incorrect scope" do
+        put :revoke_access, params: @params
+        expect(response.code).to eq "403"
+        expect(@sale.reload.is_access_revoked).to eq(false)
+      end
+    end
+  end
+
+  describe "PUT 'undo_revoke_access'" do
+    before do
+      @sale = create(:purchase, seller: @seller, link: @product, is_access_revoked: true)
+      @params = { id: @sale.external_id }
+    end
+
+    describe "when logged in with edit_sales scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "edit_sales")
+        @params.merge!(format: :json, access_token: @token.token)
+      end
+
+      it "restores access and returns the updated sale" do
+        put :undo_revoke_access, params: @params
+
+        expect(response).to be_successful
+        expect(response.parsed_body["success"]).to eq(true)
+        expect(response.parsed_body["sale"]["access_revoked"]).to eq(false)
+        expect(@sale.reload.is_access_revoked).to eq(false)
+      end
+
+      it "refuses a sale whose access is not revoked" do
+        @sale.update!(is_access_revoked: false)
+        put :undo_revoke_access, params: @params
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("Access is not revoked for this sale.")
+      end
+
+      it "returns a not found error when sale belongs to another user" do
+        other_user = create(:user)
+        other_product = create(:product, user: other_user)
+        other_sale = create(:purchase, seller: other_user, link: other_product, is_access_revoked: true)
+        @params[:id] = other_sale.external_id
+        put :undo_revoke_access, params: @params
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.parsed_body["message"]).to eq("The sale was not found.")
+        expect(other_sale.reload.is_access_revoked).to eq(true)
+      end
+    end
+
+    describe "when logged in with incorrect scope" do
+      before do
+        @token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "view_sales")
+        @params.merge!(format: :json, access_token: @token.token)
+      end
+
+      it "the response is 403 forbidden for incorrect scope" do
+        put :undo_revoke_access, params: @params
+        expect(response.code).to eq "403"
+        expect(@sale.reload.is_access_revoked).to eq(true)
+      end
+    end
+  end
+
   def add_web_csv_api_fields(purchase)
     utm_link = create(:utm_link, seller: purchase.seller, utm_source: "newsletter", utm_medium: "email", utm_campaign: "launch", utm_term: "founders", utm_content: "hero")
     create(:utm_link_driven_sale, utm_link:, purchase:)


### PR DESCRIPTION
# Add Sales API v2 revoke_access / undo_revoke_access

> Draft: endpoints + docs + specs pushed. Preview screenshot of /api Sales section still owed; full-suite CI requested because the routes diff escalated branch-spec selection.

Ref: https://github.com/antiwork/gumroad-private/issues/2303

## What

Adds `PUT /v2/sales/:id/revoke_access` and `PUT /v2/sales/:id/undo_revoke_access` so a creator can revoke (or restore) a buyer's access to a sale without refunding it. Same gates as the dashboard Customers page and the mobile sales API: refused for refunded sales, physical products, and subscriptions. Scoped to `edit_sales`, same as `resend_receipt`.

## Why

An established seller asked to revoke access at catalog scale. The only public write today is refund, which is a money move. The dashboard already has the action; this is the public Sales API v2 counterpart.

## Before / after

- Before: `Api::V2::SalesController` exposes index/show/export/summary/mark_as_shipped/refund/resend_receipt. Revoke exists only on the web Customers page and `/api/mobile/sales/:id/revoke_access`.
- After: a token with `edit_sales` (or the legacy `account` fallback, matching `resend_receipt`) can PUT revoke/undo on the seller's own sale and gets the updated sale JSON with `access_revoked` true/false.

## Checklist

- [x] Scope — public v2 member actions + docs + store-agent catalog + OAuth scope copy. CLI follow-up after this ships. No new Doorkeeper scope.
- [x] Design — reuse `Audience::PurchasePolicy` rather than re-implementing the four gates. Rejected a single PATCH `access_revoked=` so the surface matches the existing dashboard/mobile verbs.
- [x] Build — `d950a273` on `gumclaw/gp2303-sales-revoke-access`
- [ ] QA — preview /api screenshot owed
- [ ] Shipped
- [x] Market — n/a (docs ship on gumroad.com/api in this PR)
- [ ] Sell — gumroad-cli structs after this is live

## Test Results

`DISABLE_SPRING=1 bundle exec rspec spec/controllers/api/v2/sales_controller_spec.rb:1326 spec/controllers/api/v2/sales_controller_spec.rb:1423` at `3169f2c30`: 13 examples, 0 failures (7.3s). Full-file run of the same spec: 98 examples, 1 failure at line 58 (`serializes buyer_presentment on index without per-sale presentment or refund queries`) — `ActiveRecord::RecordInvalid: Charge processor merchant This account is already connected with another Gumroad account` in `spec/support/factories/charges.rb:10`. That example is not in this diff (merchant-account factory collision on a shared test DB).

`npm ci && npm run lint-fast -- app/javascript/components/ApiDocumentation/Scopes.tsx` at `d950a273`: passed. CI `bin/branch-specs` escalated on `config/routes.rb`; `run-all-specs` label is now applied so the next push/CI run uses the full suite.

## QA

Backend + `/api` docs. Walkthrough: `PUT /v2/sales/:id/revoke_access` with `edit_sales` returns `access_revoked: true` and does not refund; physical/subscription/refunded/already-revoked return the refusal message and leave the flag unchanged; `view_sales` is 403. Preview screenshot of the Sales section on `/api` still owed after the branch preview app boots.

---

AI disclosure: grok-4.6. Prompt/instructions: autonomous-product-dev webhook on gumroad-private#2303; gumroad-api-surface-changes; gumroad-engineering api-v2-narrow-oauth-scopes (kept the existing `account` fallback to match `resend_receipt`).

Premerge review: clean @ d950a273d15d7eb14fde68ef1e26c3aed7fee149
