### PR TITLE
Stop routing internal notifications to hi@

### DIFF
--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -52,6 +52,8 @@ class AlertOnStalledPostEmailBlastsJob
     live = Feature.active?(:auto_resume_stalled_post_blasts)
     scan[:stalled].each { |entry| entry[:action] = resolve_action(entry, live:) }
 
+    return unless notify?(scan, live:)
+
     InternalNotificationWorker.perform_async("payments", "Stalled post email blasts", message_for(scan, live:))
   end
 
@@ -89,6 +91,16 @@ class AlertOnStalledPostEmailBlastsJob
       end
 
       { stalled:, truncated: }
+    end
+
+    # Live auto-resume already handles DEAD/UNACCOUNTED rows. Email only when a
+    # human (now: Gumclaw, via finance@ + ALWAYS_CC) still has to look — HELD
+    # rows or a truncated scan. Silent ticks are the path to deleting this mail.
+    def notify?(scan, live:)
+      return true if scan[:truncated]
+      return true unless live
+
+      scan[:stalled].any? { |entry| entry[:action].to_s.start_with?("held_") }
     end
 
     def resolve_action(entry, live:)

--- a/config/initializers/chat_rooms.rb
+++ b/config/initializers/chat_rooms.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-INTERNAL_NOTIFICATION_EMAIL = GlobalConfig.get("INTERNAL_NOTIFICATION_EMAIL", "hi@gumroad.com")
-PAYMENTS_NOTIFICATION_EMAIL = GlobalConfig.get("PAYMENTS_NOTIFICATION_EMAIL", "hi@gumroad.com")
+# Risk / ops / announcements: Gumclaw inbox only. Never hi@ (Sahil, 2026-08-25).
+INTERNAL_NOTIFICATION_EMAIL = GlobalConfig.get("INTERNAL_NOTIFICATION_EMAIL", "gumclaw@gumroad.com")
+# Finance reports + payments/payouts alerts: finance@, plus ALWAYS_CC gumclaw.
+PAYMENTS_NOTIFICATION_EMAIL = GlobalConfig.get("PAYMENTS_NOTIFICATION_EMAIL", "finance@gumroad.com")
 
 # Address CC'd on EVERY internal notification (all CHAT_ROOMS), in addition to each
-# room's own recipient. Lets Gumclaw ingest the full internal-notification stream
-# (risk alerts, payments, payouts, etc.) alongside the existing human recipients.
+# room's own recipient. Risk/ops rooms now default to this same inbox (never hi@);
+# payments/payouts still go to finance@ with this CC.
 INTERNAL_NOTIFICATION_ALWAYS_CC = GlobalConfig.get("INTERNAL_NOTIFICATION_ALWAYS_CC", "gumclaw@gumroad.com")
 
 CHAT_ROOMS = {

--- a/spec/mailers/internal_notification_mailer_spec.rb
+++ b/spec/mailers/internal_notification_mailer_spec.rb
@@ -4,32 +4,28 @@ require "spec_helper"
 
 describe InternalNotificationMailer do
   describe "#notify" do
-    # Use the "risk" room, which maps to INTERNAL_NOTIFICATION_EMAIL — a recipient
-    # that is intentionally distinct from INTERNAL_NOTIFICATION_ALWAYS_CC. This keeps
-    # the `to` and `cc` assertions below meaningful even if PAYMENTS_NOTIFICATION_EMAIL
-    # and the always-CC address ever resolve to the same value in a shared config.
+    # Payments is finance@, always-CC is gumclaw@ — distinct, so To vs Cc is meaningful.
+    # Risk/ops rooms now also default to gumclaw (never hi@), so they cannot be used
+    # to assert a distinct CC.
     subject(:mail) do
       described_class.notify(
-        room_name: "risk",
+        room_name: "payments",
         sender: "VAT Reporting",
         message_text: "VAT report generated successfully."
       )
     end
 
     it "sends to the configured email for the room" do
-      expect(mail.to).to eq([INTERNAL_NOTIFICATION_EMAIL])
+      expect(mail.to).to eq([PAYMENTS_NOTIFICATION_EMAIL])
     end
 
     it "CCs Gumclaw on every notification in addition to the room recipient" do
-      # The mailer dedups the CC when it equals the room's own recipient, so this
-      # assertion is only meaningful while the two addresses are distinct. Assert the
-      # prerequisite explicitly rather than relying on it implicitly.
       expect(INTERNAL_NOTIFICATION_ALWAYS_CC).not_to eq(mail.to.first)
       expect(mail.cc).to eq([INTERNAL_NOTIFICATION_ALWAYS_CC])
     end
 
     it "sets the subject with room name and sender" do
-      expect(mail.subject).to eq("[test] [risk] VAT Reporting")
+      expect(mail.subject).to eq("[test] [payments] VAT Reporting")
     end
 
     it "includes the sender and message in the body" do
@@ -62,11 +58,12 @@ describe InternalNotificationMailer do
         )
       end
 
-      # The room exists to keep autonomously-worked reports out of human inboxes
-      # (gumroad-private#2106); pointing it at a human recipient regresses that silently.
+      # Agent-only inbox. Risk/ops also go to gumclaw now (never hi@), so the
+      # regression to watch is leaking to finance@ or hi@.
       it "delivers to the agent inbox only" do
         expect(mail.to).to eq([INTERNAL_NOTIFICATION_ALWAYS_CC])
-        expect(mail.to).not_to include(INTERNAL_NOTIFICATION_EMAIL)
+        expect(mail.to).not_to include(PAYMENTS_NOTIFICATION_EMAIL)
+        expect(mail.to).not_to include("hi@gumroad.com")
         expect(mail.cc).to be_nil
       end
     end

--- a/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
+++ b/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
@@ -136,9 +136,7 @@ describe AlertOnStalledPostEmailBlastsJob do
 
         expect(@dead_jobs.fetch(blast.id)).to have_received(:retry)
         expect($redis.exists?(RedisKey.stalled_blast_auto_resumed(blast.id))).to be(true)
-        expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
-          expect(message).to match(/blast #{blast.id}.*DEAD → RESUMED/)
-        end
+        expect(InternalNotificationWorker).not_to have_received(:perform_async)
       end
 
       it "re-enqueues an UNACCOUNTED blast inside the resume window" do
@@ -148,9 +146,7 @@ describe AlertOnStalledPostEmailBlastsJob do
         described_class.new.perform
 
         expect(SendPostBlastEmailsJob).to have_received(:perform_async).with(blast.id)
-        expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
-          expect(message).to match(/blast #{blast.id}.*UNACCOUNTED → RESUMED/)
-        end
+        expect(InternalNotificationWorker).not_to have_received(:perform_async)
       end
 
       it "holds a blast past the resume window for a human" do
@@ -215,6 +211,7 @@ describe AlertOnStalledPostEmailBlastsJob do
         described_class.new.perform
 
         expect(@dead_jobs.fetch(blast.id)).to have_received(:retry)
+        expect(InternalNotificationWorker).not_to have_received(:perform_async)
       end
 
       it "skips the resume without burning the once-per-blast marker when the sender reappears at action time" do
@@ -227,9 +224,7 @@ describe AlertOnStalledPostEmailBlastsJob do
 
         expect(SendPostBlastEmailsJob).not_to have_received(:perform_async)
         expect($redis.exists?(RedisKey.stalled_blast_auto_resumed(blast.id))).to be(false)
-        expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
-          expect(message).to match(/blast #{blast.id}.*UNACCOUNTED → SKIPPED \(sender reappeared/)
-        end
+        expect(InternalNotificationWorker).not_to have_received(:perform_async)
       end
 
       it "does not touch RUNNING, QUEUED, or RETRYING blasts" do
@@ -241,9 +236,7 @@ describe AlertOnStalledPostEmailBlastsJob do
         described_class.new.perform
 
         expect(SendPostBlastEmailsJob).not_to have_received(:perform_async)
-        expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
-          expect(message).not_to include("RESUMED")
-        end
+        expect(InternalNotificationWorker).not_to have_received(:perform_async)
       end
     end
 
@@ -264,9 +257,7 @@ describe AlertOnStalledPostEmailBlastsJob do
         described_class.new.perform
 
         expect(@dead_jobs.fetch(blast.id)).to have_received(:retry)
-        expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
-          expect(message).to match(/blast #{blast.id}.*DEAD → RESUMED \(already fully delivered/)
-        end
+        expect(InternalNotificationWorker).not_to have_received(:perform_async)
       end
 
       it "resumes past the window and after a previous auto-resume, since it cannot double-send" do
@@ -277,9 +268,7 @@ describe AlertOnStalledPostEmailBlastsJob do
         described_class.new.perform
 
         expect(SendPostBlastEmailsJob).to have_received(:perform_async).with(blast.id)
-        expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
-          expect(message).to match(/blast #{blast.id}.*UNACCOUNTED → RESUMED \(already fully delivered/)
-        end
+        expect(InternalNotificationWorker).not_to have_received(:perform_async)
       end
 
       it "resumes an UNACCOUNTED non-opener resend, which the double-delivery hold would otherwise block" do
@@ -331,9 +320,7 @@ describe AlertOnStalledPostEmailBlastsJob do
 
         expect(SendPostBlastEmailsJob).to have_received(:perform_async).with(blast.id)
         expect($redis.exists?(RedisKey.stalled_blast_auto_resumed(blast.id))).to be(true)
-        expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
-          expect(message).not_to include("already fully delivered")
-        end
+        expect(InternalNotificationWorker).not_to have_received(:perform_async)
       end
     end
 


### PR DESCRIPTION
Stop sending internal/finance alerts to hi@.

Sahil 2026-08-25: finance mail goes to finance@ and gumclaw@ only. Nothing should go to hi@. Handle autonomously until the alert email can be deleted.

- Default `INTERNAL_NOTIFICATION_EMAIL` is now gumclaw@ (was hi@). Risk/ops/announcements stop landing in Sahil's inbox after deploy.
- Default `PAYMENTS_NOTIFICATION_EMAIL` is now finance@ (already live via credentials; this matches the code default).
- Stalled post-blast alerts stay silent when auto-resume handled every row. Email only on HELD rows or a truncated scan.

Local: 36 examples, 0 failures
`bin/rspec spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb spec/mailers/internal_notification_mailer_spec.rb`

Premerge review: clean @ 177b5be133e8abb59a1d1bb5b9393bf3d21d9c7a

Automerge: squash armed. `working` removed. Lands when Greptile and required specs pass.
