### PR TITLE
Fix intent completion specs stale after fanout pacing refactor

### DIFF
--- a/spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb
+++ b/spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb
@@ -189,10 +189,16 @@ describe "workflow installment schedule intent completion", :freeze_time do
 
     it "runs a direct fanout without an intent lease" do
       rule
-      expect(WorkflowInstallmentScheduleIntent).not_to receive(:renew_fanout)
+      # The heartbeat runs on every path but must stay a no-op here: blank tokens only.
+      lease_renewals = []
+      allow(WorkflowInstallmentScheduleIntent).to receive(:renew_fanout).and_wrap_original do |method, **kwargs|
+        lease_renewals << kwargs
+        method.call(**kwargs)
+      end
 
       described_class.new.perform(post.id)
 
+      expect(lease_renewals).to all(eq(intent_token: nil, fanout_token: nil))
       expect(SendWorkflowInstallmentWorker).to have_enqueued_sidekiq_job(
         post.id,
         rule.version,
@@ -202,22 +208,6 @@ describe "workflow installment schedule intent completion", :freeze_time do
         nil,
         follower.confirmed_at.change(usec: 0).iso8601
       )
-    end
-
-    it "does not replace a missing matching purchase with another embedded purchase" do
-      job = described_class.new
-      job.instance_variable_set(:@post, post)
-      job.instance_variable_set(:@rule_version, rule.version)
-      job.instance_variable_set(:@rule_delay, rule.delayed_delivery_time)
-      member = instance_double(
-        AudienceMember,
-        id: 1,
-        details: { "purchases" => [{ "id" => 99, "created_at" => 1.day.ago.iso8601 }] }
-      )
-
-      job.send(:enqueue_email_job, member:, type: :purchase, id: nil)
-
-      expect(SendWorkflowInstallmentWorker.jobs).to be_empty
     end
   end
 


### PR DESCRIPTION
## What

Updates two specs in `spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb` that broke on main after #7387 (Test Fast 3 shard red, `ci/green` failing, deploys blocked):

- "runs a direct fanout without an intent lease" now asserts the durable invariant — every `WorkflowInstallmentScheduleIntent.renew_fanout` call during a direct fanout carries blank tokens (a no-op), so no intent lease is ever touched — instead of asserting `renew_fanout` is never called at all.
- "does not replace a missing matching purchase with another embedded purchase" is removed: it poked the private method `enqueue_email_job`, which #7387 deleted, and the same behavior is already covered through the public `perform` path in `spec/sidekiq/send_workflow_post_emails_job_spec.rb` ("does not use an embedded purchase when the aggregate id is nil"), including the skip-log assertion.

## Why

#7387 rewrote `SendWorkflowPostEmailsJob` so every path — including the legacy no-intent `perform(post_id)` invocation — runs through the fanout lease heartbeat, and replaced `enqueue_email_job` with `enqueue_email_jobs_for`. This pre-existing spec file (from #7169) wasn't updated with the refactor, so it failed with a stale mock expectation and a `NoMethodError` on the removed method. Both behaviors the old specs guarded are preserved by the new code (`renew_fanout` deliberately no-ops on blank tokens); only the spec coupling to the old implementation was stale.

## Before/After

Spec-only change repairing main's CI; no user-facing or runtime behavior is touched. Before: Test Fast 3 fails on main with `NoMethodError: undefined method 'enqueue_email_job'` and a `renew_fanout` mock expectation violation. After: the file passes.

## Test Results

- `bundle exec rspec spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb` — 19 examples, 0 failures
- `bundle exec rubocop spec/sidekiq/workflow_installment_schedule_intent_completion_spec.rb` — no offenses

---

AI disclosure: written with Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
