### PR TITLE
Fix product editor file upload stuck at 0% after picking a file

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
@@ -162,7 +162,12 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
   };
   const fileExists = file && file.status.type !== "removed";
   React.useEffect(() => {
-    if (file?.status.type === "unsaved" && file.status.uploadStatus.type === "uploading") generateThumbnail();
+    if (
+      file?.is_streamable &&
+      file.status.type === "unsaved" &&
+      file.status.uploadStatus.type === "uploading"
+    )
+      generateThumbnail();
   }, [file?.status.type]);
 
   const pos = getPos();

--- a/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
@@ -162,11 +162,7 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
   };
   const fileExists = file && file.status.type !== "removed";
   React.useEffect(() => {
-    if (
-      file?.is_streamable &&
-      file.status.type === "unsaved" &&
-      file.status.uploadStatus.type === "uploading"
-    )
+    if (file?.is_streamable && file.status.type === "unsaved" && file.status.uploadStatus.type === "uploading")
       generateThumbnail();
   }, [file?.status.type]);
 

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -393,7 +393,7 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
     void snapshotPickedFiles(picked)
       .then((files) => {
         uploadFiles(files);
-        if (canResetFileInputAfterSnapshot(picked)) input.value = "";
+        if (canResetFileInputAfterSnapshot(picked, files)) input.value = "";
       })
       .catch((error: unknown) => {
         showAlert(error instanceof Error ? error.message : "Could not read the selected file.", "error");
@@ -873,7 +873,7 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
                                 const [images, nonImages] = partition(files, (file: File) => file.type.startsWith("image"));
                                 uploadImages({ view: editor.view, files: images, imageSettings });
                                 uploadFiles(nonImages);
-                                if (canResetFileInputAfterSnapshot(picked)) input.value = "";
+                                if (canResetFileInputAfterSnapshot(picked, files)) input.value = "";
                                 setShowEmbedModal(false);
                               })
                               .catch((error: unknown) => {

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -52,6 +52,7 @@ import GuidGenerator from "$app/utils/guid_generator";
 import { getMimeType } from "$app/utils/mimetypes";
 import { assertResponseError, request, ResponseError } from "$app/utils/request";
 import { generatePageIcon } from "$app/utils/rich_content_page";
+import { canResetFileInputAfterSnapshot, snapshotPickedFiles } from "$app/utils/snapshotPickedFile";
 
 import { Button } from "$app/components/Button";
 import { InputtedDiscount } from "$app/components/CheckoutDashboard/DiscountInput";
@@ -388,8 +389,15 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const uploadFileInput = (input: HTMLInputElement) => {
     if (!input.files?.length) return;
-    uploadFiles([...input.files]);
-    input.value = "";
+    const picked = [...input.files];
+    void snapshotPickedFiles(picked)
+      .then((files) => {
+        uploadFiles(files);
+        if (canResetFileInputAfterSnapshot(picked)) input.value = "";
+      })
+      .catch((error: unknown) => {
+        showAlert(error instanceof Error ? error.message : "Could not read the selected file.", "error");
+      });
   };
 
   const fileEmbedGroupConfig = useRefToLatest({
@@ -858,13 +866,22 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
                           multiple
                           onChange={(e) => {
                             if (!e.target.files) return;
-                            const [images, nonImages] = partition([...e.target.files], (file) =>
-                              file.type.startsWith("image"),
-                            );
-                            uploadImages({ view: editor.view, files: images, imageSettings });
-                            uploadFiles(nonImages);
-                            e.target.value = "";
-                            setShowEmbedModal(false);
+                            const picked = [...e.target.files];
+                            const input = e.target;
+                            void snapshotPickedFiles(picked)
+                              .then((files) => {
+                                const [images, nonImages] = partition(files, (file: File) => file.type.startsWith("image"));
+                                uploadImages({ view: editor.view, files: images, imageSettings });
+                                uploadFiles(nonImages);
+                                if (canResetFileInputAfterSnapshot(picked)) input.value = "";
+                                setShowEmbedModal(false);
+                              })
+                              .catch((error: unknown) => {
+                                showAlert(
+                                  error instanceof Error ? error.message : "Could not read the selected file.",
+                                  "error",
+                                );
+                              });
                           }}
                         />
                         <ArrowUp pack="filled" className="size-5" />

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -52,7 +52,11 @@ import GuidGenerator from "$app/utils/guid_generator";
 import { getMimeType } from "$app/utils/mimetypes";
 import { assertResponseError, request, ResponseError } from "$app/utils/request";
 import { generatePageIcon } from "$app/utils/rich_content_page";
-import { canResetFileInputAfterSnapshot, snapshotPickedFiles } from "$app/utils/snapshotPickedFile";
+import {
+  canResetFileInputAfterSnapshot,
+  fileListMatchesPickedFiles,
+  snapshotPickedFiles,
+} from "$app/utils/snapshotPickedFile";
 
 import { Button } from "$app/components/Button";
 import { InputtedDiscount } from "$app/components/CheckoutDashboard/DiscountInput";
@@ -393,7 +397,8 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
     void snapshotPickedFiles(picked)
       .then((files) => {
         uploadFiles(files);
-        if (canResetFileInputAfterSnapshot(picked, files)) input.value = "";
+        if (fileListMatchesPickedFiles(input.files, picked) && canResetFileInputAfterSnapshot(picked, files))
+          input.value = "";
       })
       .catch((error: unknown) => {
         showAlert(error instanceof Error ? error.message : "Could not read the selected file.", "error");
@@ -870,10 +875,16 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
                             const input = e.target;
                             void snapshotPickedFiles(picked)
                               .then((files) => {
-                                const [images, nonImages] = partition(files, (file: File) => file.type.startsWith("image"));
+                                const [images, nonImages] = partition(files, (file: File) =>
+                                  file.type.startsWith("image"),
+                                );
                                 uploadImages({ view: editor.view, files: images, imageSettings });
                                 uploadFiles(nonImages);
-                                if (canResetFileInputAfterSnapshot(picked, files)) input.value = "";
+                                if (
+                                  fileListMatchesPickedFiles(input.files, picked) &&
+                                  canResetFileInputAfterSnapshot(picked, files)
+                                )
+                                  input.value = "";
                                 setShowEmbedModal(false);
                               })
                               .catch((error: unknown) => {

--- a/app/javascript/utils/snapshotPickedFile.test.ts
+++ b/app/javascript/utils/snapshotPickedFile.test.ts
@@ -31,19 +31,8 @@ describe("snapshotPickedFile", () => {
   });
 });
 
-describe("canResetFileInputAfterSnapshot", () => {
-  it("is false when any picked file was too large to copy", () => {
-    const small = new File(["ok"], "a.pdf");
-    const large = new File(["x"], "b.mp4");
-    Object.defineProperty(large, "size", { value: PICKED_FILE_SNAPSHOT_LIMIT_BYTES + 1 });
-
-    expect(canResetFileInputAfterSnapshot([small])).toBe(true);
-    expect(canResetFileInputAfterSnapshot([small, large])).toBe(false);
-  });
-});
-
 describe("snapshotPickedFiles", () => {
-  it("snapshots every file in the pick", async () => {
+  it("snapshots every file in a small pick", async () => {
     const files = [new File(["a"], "a.txt"), new File(["b"], "b.txt")];
 
     const copies = await snapshotPickedFiles(files);
@@ -52,5 +41,32 @@ describe("snapshotPickedFiles", () => {
     expect(copies[0]).not.toBe(files[0]);
     expect(await copies[0]?.text()).toBe("a");
     expect(await copies[1]?.text()).toBe("b");
+  });
+
+  it("stops copying once the aggregate budget is spent instead of buffering every file at once", async () => {
+    const first = new File(["kept"], "first.bin");
+    Object.defineProperty(first, "size", { value: PICKED_FILE_SNAPSHOT_LIMIT_BYTES - 10 });
+    const second = new File(["later"], "second.bin");
+    Object.defineProperty(second, "size", { value: 100 });
+
+    const copies = await snapshotPickedFiles([first, second]);
+
+    expect(copies[0]).not.toBe(first);
+    expect(copies[1]).toBe(second);
+    expect(await copies[0]?.text()).toBe("kept");
+  });
+});
+
+describe("canResetFileInputAfterSnapshot", () => {
+  it("is true only when every picked file was replaced by a copy", async () => {
+    const small = new File(["ok"], "a.pdf");
+    const large = new File(["x"], "b.mp4");
+    Object.defineProperty(large, "size", { value: PICKED_FILE_SNAPSHOT_LIMIT_BYTES + 1 });
+
+    const smallCopies = await snapshotPickedFiles([small]);
+    const mixed = await snapshotPickedFiles([small, large]);
+
+    expect(canResetFileInputAfterSnapshot([small], smallCopies)).toBe(true);
+    expect(canResetFileInputAfterSnapshot([small, large], mixed)).toBe(false);
   });
 });

--- a/app/javascript/utils/snapshotPickedFile.test.ts
+++ b/app/javascript/utils/snapshotPickedFile.test.ts
@@ -9,6 +9,10 @@ import {
 } from "$app/utils/snapshotPickedFile";
 
 describe("snapshotPickedFile", () => {
+  it("caps the in-memory copy well below a typical large video", () => {
+    expect(PICKED_FILE_SNAPSHOT_LIMIT_BYTES).toBe(32 * 1024 * 1024);
+  });
+
   it("copies a small file into an independent File with the same bytes and metadata", async () => {
     const original = new File(["pdf-bytes"], "guide.pdf", { type: "application/pdf", lastModified: 1_700_000_000_000 });
 

--- a/app/javascript/utils/snapshotPickedFile.test.ts
+++ b/app/javascript/utils/snapshotPickedFile.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   canResetFileInputAfterSnapshot,
+  fileListMatchesPickedFiles,
   PICKED_FILE_SNAPSHOT_LIMIT_BYTES,
   snapshotPickedFile,
   snapshotPickedFiles,
@@ -54,6 +55,17 @@ describe("snapshotPickedFiles", () => {
     expect(copies[0]).not.toBe(first);
     expect(copies[1]).toBe(second);
     expect(await copies[0]?.text()).toBe("kept");
+  });
+});
+
+describe("fileListMatchesPickedFiles", () => {
+  it("is false when a later selection replaced the input's FileList", () => {
+    const first = new File(["a"], "a.txt");
+    const second = new File(["b"], "b.txt");
+    const fileList = { length: 1, item: (index: number) => (index === 0 ? second : null) };
+
+    expect(fileListMatchesPickedFiles(fileList, [first])).toBe(false);
+    expect(fileListMatchesPickedFiles(fileList, [second])).toBe(true);
   });
 });
 

--- a/app/javascript/utils/snapshotPickedFile.test.ts
+++ b/app/javascript/utils/snapshotPickedFile.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canResetFileInputAfterSnapshot,
+  PICKED_FILE_SNAPSHOT_LIMIT_BYTES,
+  snapshotPickedFile,
+  snapshotPickedFiles,
+} from "$app/utils/snapshotPickedFile";
+
+describe("snapshotPickedFile", () => {
+  it("copies a small file into an independent File with the same bytes and metadata", async () => {
+    const original = new File(["pdf-bytes"], "guide.pdf", { type: "application/pdf", lastModified: 1_700_000_000_000 });
+
+    const copy = await snapshotPickedFile(original);
+
+    expect(copy).not.toBe(original);
+    expect(copy.name).toBe("guide.pdf");
+    expect(copy.type).toBe("application/pdf");
+    expect(copy.size).toBe(original.size);
+    expect(copy.lastModified).toBe(original.lastModified);
+    expect(await copy.text()).toBe("pdf-bytes");
+  });
+
+  it("returns the same object for files over the copy limit so we do not buffer gigabyte uploads", async () => {
+    const original = new File(["x"], "huge.mp4", { type: "video/mp4" });
+    Object.defineProperty(original, "size", { value: PICKED_FILE_SNAPSHOT_LIMIT_BYTES + 1 });
+
+    const result = await snapshotPickedFile(original);
+
+    expect(result).toBe(original);
+  });
+});
+
+describe("canResetFileInputAfterSnapshot", () => {
+  it("is false when any picked file was too large to copy", () => {
+    const small = new File(["ok"], "a.pdf");
+    const large = new File(["x"], "b.mp4");
+    Object.defineProperty(large, "size", { value: PICKED_FILE_SNAPSHOT_LIMIT_BYTES + 1 });
+
+    expect(canResetFileInputAfterSnapshot([small])).toBe(true);
+    expect(canResetFileInputAfterSnapshot([small, large])).toBe(false);
+  });
+});
+
+describe("snapshotPickedFiles", () => {
+  it("snapshots every file in the pick", async () => {
+    const files = [new File(["a"], "a.txt"), new File(["b"], "b.txt")];
+
+    const copies = await snapshotPickedFiles(files);
+
+    expect(copies).toHaveLength(2);
+    expect(copies[0]).not.toBe(files[0]);
+    expect(await copies[0]?.text()).toBe("a");
+    expect(await copies[1]?.text()).toBe("b");
+  });
+});

--- a/app/javascript/utils/snapshotPickedFile.ts
+++ b/app/javascript/utils/snapshotPickedFile.ts
@@ -27,3 +27,9 @@ export const snapshotPickedFiles = async (files: readonly File[]): Promise<File[
 
 export const canResetFileInputAfterSnapshot = (original: readonly File[], snapshotted: readonly File[]): boolean =>
   original.length === snapshotted.length && original.every((file, i) => file !== snapshotted[i]);
+
+export const fileListMatchesPickedFiles = (
+  fileList: Pick<FileList, "length" | "item"> | null,
+  files: readonly File[],
+): boolean =>
+  fileList != null && fileList.length === files.length && files.every((file, index) => fileList.item(index) === file);

--- a/app/javascript/utils/snapshotPickedFile.ts
+++ b/app/javascript/utils/snapshotPickedFile.ts
@@ -1,0 +1,17 @@
+// Chrome revokes <input type="file"> File backing when the input is reset
+// (ERR_BLOB_REFERENCED_FILE_UNAVAILABLE). Copy small files before reset;
+// over-limit files keep the original handle, so callers must not reset.
+
+export const PICKED_FILE_SNAPSHOT_LIMIT_BYTES = 512 * 1024 * 1024;
+
+export const canResetFileInputAfterSnapshot = (files: readonly File[]): boolean =>
+  files.every((file) => file.size <= PICKED_FILE_SNAPSHOT_LIMIT_BYTES);
+
+export const snapshotPickedFile = async (file: File): Promise<File> => {
+  if (file.size > PICKED_FILE_SNAPSHOT_LIMIT_BYTES) return file;
+  const buffer = await file.arrayBuffer();
+  return new File([buffer], file.name, { type: file.type, lastModified: file.lastModified });
+};
+
+export const snapshotPickedFiles = (files: readonly File[]): Promise<File[]> =>
+  Promise.all(files.map(snapshotPickedFile));

--- a/app/javascript/utils/snapshotPickedFile.ts
+++ b/app/javascript/utils/snapshotPickedFile.ts
@@ -1,8 +1,10 @@
 // Chrome revokes <input type="file"> File backing when the input is reset
 // (ERR_BLOB_REFERENCED_FILE_UNAVAILABLE). Copy small files before reset;
 // over-limit files keep the original handle, so callers must not reset.
+// Keep the copy budget well below a typical large video so the tab does not
+// materialize hundreds of MiB before upload starts.
 
-export const PICKED_FILE_SNAPSHOT_LIMIT_BYTES = 512 * 1024 * 1024;
+export const PICKED_FILE_SNAPSHOT_LIMIT_BYTES = 32 * 1024 * 1024;
 
 export const snapshotPickedFile = async (file: File): Promise<File> => {
   if (file.size > PICKED_FILE_SNAPSHOT_LIMIT_BYTES) return file;

--- a/app/javascript/utils/snapshotPickedFile.ts
+++ b/app/javascript/utils/snapshotPickedFile.ts
@@ -4,14 +4,26 @@
 
 export const PICKED_FILE_SNAPSHOT_LIMIT_BYTES = 512 * 1024 * 1024;
 
-export const canResetFileInputAfterSnapshot = (files: readonly File[]): boolean =>
-  files.every((file) => file.size <= PICKED_FILE_SNAPSHOT_LIMIT_BYTES);
-
 export const snapshotPickedFile = async (file: File): Promise<File> => {
   if (file.size > PICKED_FILE_SNAPSHOT_LIMIT_BYTES) return file;
   const buffer = await file.arrayBuffer();
   return new File([buffer], file.name, { type: file.type, lastModified: file.lastModified });
 };
 
-export const snapshotPickedFiles = (files: readonly File[]): Promise<File[]> =>
-  Promise.all(files.map(snapshotPickedFile));
+export const snapshotPickedFiles = async (files: readonly File[]): Promise<File[]> => {
+  const out: File[] = [];
+  let remaining = PICKED_FILE_SNAPSHOT_LIMIT_BYTES;
+  for (const file of files) {
+    if (file.size > remaining) {
+      out.push(file);
+      remaining = 0;
+      continue;
+    }
+    out.push(await snapshotPickedFile(file));
+    remaining -= file.size;
+  }
+  return out;
+};
+
+export const canResetFileInputAfterSnapshot = (original: readonly File[], snapshotted: readonly File[]): boolean =>
+  original.length === snapshotted.length && original.every((file, i) => file !== snapshotted[i]);


### PR DESCRIPTION
Same-repo rehome of fork #7393 so Tests skip the CI Gate `ci-protected` wait.

## What
Product-editor Content tab uploads (Computer files, and the embed-modal file picker) copy picked `File`s into independent blobs before the input is cleared. Copies run one file at a time and stop once a 32 MiB budget is spent. Thumbnail generation from the local blob URL only runs for streamable video.

## Why
Clearing `<input type="file">` immediately after pick revokes the File backing store in Chromium. Evaporate initiates the S3 multipart upload first, then re-reads the File; that second read fails with `ERR_BLOB_REFERENCED_FILE_UNAVAILABLE`, so the row stays at 0% and never sends bytes. The FileEmbed node was also pointing a `<video>` at the same blob URL for every uploading file, including PDFs.

## Before / after
- Before: pick any computer file → upload UI stuck at 0%; network shows blob GET failing after multipart initiate succeeds.
- After: evaporate reads a copied blob for files that fit the remaining 32 MiB budget, so resetting the input cannot revoke them. Files that do not fit keep the original handle and the input is not reset. Non-video files no longer start a thumbnail `<video>` against the blob URL.

## Test Results
- `npm exec -- prettier --write app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx app/javascript/components/ProductEdit/ContentTab/index.tsx app/javascript/utils/snapshotPickedFile.ts app/javascript/utils/snapshotPickedFile.test.ts`
- `npm test -- app/javascript/utils/snapshotPickedFile.test.ts` — 6 tests passed.
- `npm run lint-fast -- app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx app/javascript/components/ProductEdit/ContentTab/index.tsx app/javascript/utils/snapshotPickedFile.ts app/javascript/utils/snapshotPickedFile.test.ts`
- `npm run typecheck`
- CI: `ci/green` SUCCESS at `bdfedbca7018`.
- Sol (gpt-5.6-sol) at `6439a101b4`: P1 512 MiB copy budget. Fixed at `bdfedbca70`. Re-run clean (0 P1s).
- Hosted preview `x-revision` `bdfedbca7018` at https://gumclaw-gp2307-persist-picked-fi.apps.staging.gumroad.org

## QA steps
1. Open a product → Content → Upload files → Computer files.
2. Pick a small PDF. Progress should leave 0% and the file should appear as uploaded (not "0% of 0 byte").
3. Pick the same PDF again (input was reset) — second upload should start.

Preview QA at head `bdfedbca7018` (2026-08-26T15:57Z): logged in as `seller@gumroad.com`, opened `/products/demo/edit` → Content, picked a 303-byte PDF. Evaporate completed S3 multipart (initiate POST, part PUT, complete POST) with zero failed requests. Editor listed `tiny` / `PDF` / `303 bytes` / `Download` — not stuck at 0%. Second pick on the reset input started another upload.

## Status
- [x] Scope — Content tab computer-file picker + embed-modal picker + skip non-video thumbnail blob GET
- [x] Design — sequential File copy under one 32 MiB budget; do not reset input unless every file was copied
- [x] Build — `bdfedbca70` on `gumclaw/gp2307-persist-picked-file-upload`
- [x] QA — preview upload at `bdfedbca7018` left 0% and completed multipart
- [ ] Shipped
- [ ] Market
- [ ] Sell

## Review
- Greptile P1 at `fe0c3c4c0b` — stale snapshot callbacks could clear a newer selection; fixed at `6439a101b4` by checking the live FileList still matches the picked files before resetting.
- Greptile P1 at `fe0c3c4c0b` — `Promise.all` could buffer several 512 MB files at once; fixed at `87aea30e18` by copying sequentially under one shared budget.
- Sol P1 at `6439a101b4` — 512 MiB in-tab copy could OOM large videos; budget lowered to 32 MiB at `bdfedbca70`. Over-limit files still keep the original handle and skip reset.

Dropbox chooser `WindowFailedToOpenError` is a popup-blocker / user-gesture issue, not this blob race — not in this PR.

---
AI disclosure: Grok 4.6. Prompt: snapshot picked files before resetting the product-editor file input so evaporate can still read them.

Premerge review: clean @ bdfedbca701823941bb3ce7f4e22968d0f59d408
