### PR TITLE
Sum affiliate sales in cents so the CSV totals row is not off by 100x

### DIFF
--- a/app/services/exports/affiliate_export_service.rb
+++ b/app/services/exports/affiliate_export_service.rb
@@ -5,7 +5,6 @@ class Exports::AffiliateExportService
     "Affiliate ID", "Name", "Email", "Fee", "Products", "Sales ($)",
     "Referral URL", "Destination URL", "Created At",
   ].freeze
-  TOTALS_FIELDS = ["Sales ($)"].freeze
   TOTALS_COLUMN_NAME = "Totals"
   SYNCHRONOUS_EXPORT_THRESHOLD = 500
   attr_reader :filename, :tempfile
@@ -28,8 +27,8 @@ class Exports::AffiliateExportService
 
       totals_row = Array.new(AFFILIATE_FIELDS.size)
       totals_row[0] = TOTALS_COLUMN_NAME
-      totals.each do |column_name, value|
-        totals_row[AFFILIATE_FIELDS.index(column_name)] = value.round(2)
+      totals.each do |column_name, amount_cents|
+        totals_row[AFFILIATE_FIELDS.index(column_name)] = MoneyFormatter.format(amount_cents, :usd, symbol: false)
       end
       csv << totals_row
     end
@@ -51,12 +50,13 @@ class Exports::AffiliateExportService
     attr_reader :totals
 
     def affiliate_row(affiliate)
+      sales_cents = affiliate.total_amount_cents
       data = {
         "Affiliate ID" => affiliate.external_id_numeric,
         "Name" => affiliate.affiliate_user.name.presence || affiliate.affiliate_user.username,
         "Email" => affiliate.affiliate_user.email,
         "Fee" => "#{affiliate.affiliate_percentage} %",
-        "Sales ($)" => MoneyFormatter.format(affiliate.total_amount_cents, :usd, symbol: false),
+        "Sales ($)" => MoneyFormatter.format(sales_cents, :usd, symbol: false),
         "Products" => affiliate.products.map(&:name),
         "Referral URL" => affiliate.referral_url,
         "Destination URL" => affiliate.destination_url,
@@ -65,9 +65,12 @@ class Exports::AffiliateExportService
 
       row = Array.new(AFFILIATE_FIELDS.size)
 
+      # Sum cents, not the rendered cell: MoneyFormatter delimits thousands, and
+      # "1,234.56".to_f is 1.0, so every affiliate past $999.99 counted as a dollar.
+      @totals["Sales ($)"] += sales_cents
+
       data.each do |column_name, value|
         row[AFFILIATE_FIELDS.index(column_name)] = value
-        @totals[column_name] += value.to_f if TOTALS_FIELDS.include?(column_name)
       end
       row
     end

--- a/spec/services/exports/affiliate_export_service_spec.rb
+++ b/spec/services/exports/affiliate_export_service_spec.rb
@@ -30,11 +30,27 @@ describe Exports::AffiliateExportService do
       expect(field_value(data_row, "Email")).to eq("affiliate@gumroad.com")
       expect(field_value(data_row, "Fee")).to eq("10 %")
       expect(field_value(data_row, "Sales ($)")).to eq("10.00")
-      expect(field_value(totals_row, "Sales ($)")).to eq("10.0")
+      expect(field_value(totals_row, "Sales ($)")).to eq("10.00")
       expect(field_value(data_row, "Products")).to eq('["Product 1"]')
       expect(field_value(data_row, "Referral URL")).to eq(@direct_affiliate.referral_url)
       expect(field_value(data_row, "Destination URL")).to eq(@direct_affiliate.destination_url)
       expect(field_value(data_row, "Created At")).to eq(@direct_affiliate.created_at.in_time_zone(@direct_affiliate.affiliate_user.timezone).to_date.to_s)
+    end
+
+    it "totals affiliates whose sales cross the thousands delimiter" do
+      # MoneyFormatter delimits thousands, and "1,234.56".to_f is 1.0, so summing the
+      # rendered cell counted every affiliate past $999.99 as one dollar.
+      big_product = create(:product, user: @seller, price_cents: 1_234_56, name: "Product 2")
+      big_affiliate = create(:direct_affiliate, seller: @seller, affiliate_basis_points: 1000, products: [big_product])
+      big_purchase = create(:purchase_in_progress, seller: @seller, link: big_product, affiliate: big_affiliate)
+      big_purchase.process!
+      big_purchase.update_balance_and_mark_successful!
+
+      rows = CSV.parse(described_class.new(@seller).perform.tempfile.read)
+      cells = rows[1..-2].map { field_value(_1, "Sales ($)") }
+
+      expect(cells).to match_array(["10.00", "1,234.56"])
+      expect(field_value(rows.last, "Sales ($)")).to eq("1,244.56")
     end
 
     it "sets a filename" do


### PR DESCRIPTION
Premerge review: clean @ 404d92ca6e4bcdfd34468295e442ffb1b0e806ea

## What

The Affiliates CSV totals row added the **rendered cell** rather than the amount:

```ruby
@totals[column_name] += value.to_f
```

`MoneyFormatter` delimits thousands, and `"1,234.56".to_f` is `1.0`. So every affiliate past
$999.99 lifetime counted as one dollar. Two affiliates worth $1,234.56 and $10.00 produced a
totals row reading **11.0**, while the per-affiliate rows stayed correct.

This accumulates `total_amount_cents` and formats once when writing the row.

## Why it matters

A seller reconciling affiliate payouts reads a grand total that is wrong by up to 100x, with no
indication anything is off, because every individual row above it is right.

## One deliberate change worth flagging

The totals cell now renders through `MoneyFormatter`, like the data cells it sums. That moves the
existing expectation from `"10.0"` to `"10.00"`, which is in the diff.

I kept the delimiter rather than emitting a bare `1244.56`, so the totals row matches the column
above it. The tradeoff: anything downstream calling `.to_f` on that cell hits the same trap. Nothing
in this repo does, and the per-affiliate cells have always been delimited, so a parser that breaks
on the totals row was already broken on every row above it. Happy to switch to undelimited if you
would rather the CSV be machine-parseable over consistent.

`TOTALS_FIELDS` had exactly one use, the guard this replaces, so it goes with it.

## Test Results

```
rspec spec/services/exports/affiliate_export_service_spec.rb
  before: 5 examples, 2 failures
  after:  5 examples, 0 failures

rubocop / npm run lint-fast / npm run typecheck / bin/check-migration-versions   all clean
```

---

Based on https://github.com/AJ0070/gumroad/pull/5 by @AJ0070.

AI Disclosure: DeepSeek V4 Flash was used to verify the root cause against `origin/main` (the bug is real: `format(...).to_f` collapses delimited amounts), run the spec locally (5 examples, 0 failures), and import the change into this branch.