### PR TITLE
Fix Ping url params fallback

### DIFF
--- a/app/sidekiq/post_to_ping_endpoints_worker.rb
+++ b/app/sidekiq/post_to_ping_endpoints_worker.rb
@@ -16,7 +16,7 @@ class PostToPingEndpointsWorker
     else
       purchase = Purchase.find(purchase_id)
       user = purchase.seller
-      ping_params = purchase.payload_for_ping_notification(url_parameters:, resource_name:)
+      ping_params = purchase.payload_for_ping_notification(url_parameters: url_parameters.presence || purchase.url_parameters, resource_name:)
     end
 
     targets = user.ping_notification_targets(resource_name)

--- a/spec/sidekiq/post_to_ping_endpoints_worker_spec.rb
+++ b/spec/sidekiq/post_to_ping_endpoints_worker_spec.rb
@@ -67,6 +67,19 @@ describe PostToPingEndpointsWorker, :vcr do
     expect(PostToIndividualPingEndpointWorker).to have_enqueued_sidekiq_job(@user.notification_endpoint, params, @user.notification_content_type, @user.id)
   end
 
+  it "falls back to persisted purchase url parameters when the enqueued value is blank" do
+    purchase = create(:purchase, link: @product, price_cents: 500)
+    purchase.url_parameters = { "order_ref" => "test-order-ref" }
+    purchase.save!
+
+    PostToPingEndpointsWorker.new.perform(purchase.id, nil)
+
+    params = @default_params.call(purchase).merge(
+      url_params: { "order_ref" => "test-order-ref" }
+    )
+    expect(PostToIndividualPingEndpointWorker).to have_enqueued_sidekiq_job(@user.notification_endpoint, params, @user.notification_content_type, @user.id)
+  end
+
   it "includes a license key if the purchase has one" do
     link = create(:product, user: @user, unique_permalink: "lic", is_licensed: true)
     purchase = create(:purchase, link:, price_cents: 500)


### PR DESCRIPTION
## What

- Makes `PostToPingEndpointsWorker` fall back to the purchase's persisted `url_parameters` when the enqueued argument is blank.
- Adds a worker spec for the reloaded-purchase path where the persisted params exist but the queued argument is nil.

## Why

Automatic sale Ping delivery can run from a freshly loaded purchase and lose the enqueue-time `url_parameters` snapshot even though the `purchase_url_parameters` row exists. The worker already reloads the purchase, so it should use the persisted value before building the payload.

## Before-After

- Before: `perform(purchase.id, nil)` built a sale Ping payload without `url_params`, even when `purchase.url_parameters` returned persisted params.
- After: the same worker call includes persisted `url_params`; explicit nonblank enqueue arguments still win.

## Test Results

- `ruby -c app/sidekiq/post_to_ping_endpoints_worker.rb`
- `ruby -c spec/sidekiq/post_to_ping_endpoints_worker_spec.rb`
- `DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/post_to_ping_endpoints_worker_spec.rb:70` — 1 example, 0 failures
- `DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/post_to_ping_endpoints_worker_spec.rb` — 34 examples, 0 failures
- Mutation proof: removing `|| purchase.url_parameters` kept syntax valid and made `spec/sidekiq/post_to_ping_endpoints_worker_spec.rb:70` fail because the enqueued payload lacked `url_params`; restored the file afterward.

Premerge review: clean @ 8a4f24ddb21c236dd8317143e6cc399495f065d2

## QA steps

- Backend-only worker payload change; no rendered surface applies.
- Verified the focused worker spec exercises the nil queued-argument path and asserts the enqueued individual Ping payload includes `url_params` from the persisted purchase record.

## Scope

- [x] antiwork/gumroad-private#2308 automatic sale Ping `url_params` delivery gap.

## Design

- [x] Worker reads the persisted purchase value only when the queued value is blank.

## Build

- [x] Committed on `gp2308-ping-url-params`.

## Ship

- [x] CI green + premerge clean at `8a4f24ddb21c236dd8317143e6cc399495f065d2`. Backend-only; Fable-5 still 400 until 2026-09-01 so parked unassigned + working.

## Market

- [x] Not applicable — customer-visible behavior fix, no launch surface.

## Sell

- [x] Not applicable — no seller-facing copy change.

---
AI disclosure: assisted by Hermes Agent using grok-4.6 via xAI.
