### PR TITLE
Require explicit edit_sales scope for access revocation

### DIFF
--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -6,6 +6,9 @@ class Api::V2::SalesController < Api::V2::BaseController
   before_action(only: [:mark_as_shipped]) { doorkeeper_authorize! :mark_sales_as_shipped }
   before_action(only: [:refund]) { doorkeeper_authorize! :refund_sales, :edit_sales }
   before_action(only: [:resend_receipt, :revoke_access, :undo_revoke_access]) { doorkeeper_authorize! :edit_sales }
+  # BaseController appends the legacy `account` scope to doorkeeper_authorize!.
+  # Revoking buyer access must require the seller's explicit edit_sales grant.
+  before_action(only: [:revoke_access, :undo_revoke_access]) { require_oauth_scope! :edit_sales }
   before_action :set_page, only: :index
 
   RESULTS_PER_PAGE = 10

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -1418,6 +1418,15 @@ describe Api::V2::SalesController do
         expect(@sale.reload.is_access_revoked).to eq(false)
       end
     end
+
+    it "refuses a broad account-scope token without edit_sales" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "account")
+
+      put :revoke_access, params: @params.merge(format: :json, access_token: token.token)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(@sale.reload.is_access_revoked).to eq(false)
+    end
   end
 
   describe "PUT 'undo_revoke_access'" do
@@ -1471,6 +1480,15 @@ describe Api::V2::SalesController do
         expect(response.code).to eq "403"
         expect(@sale.reload.is_access_revoked).to eq(true)
       end
+    end
+
+    it "refuses a broad account-scope token without edit_sales" do
+      token = create("doorkeeper/access_token", application: @app, resource_owner_id: @seller.id, scopes: "account")
+
+      put :undo_revoke_access, params: @params.merge(format: :json, access_token: token.token)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(@sale.reload.is_access_revoked).to eq(true)
     end
   end
 


### PR DESCRIPTION
## Vulnerability

The new sale access revocation endpoints use `doorkeeper_authorize! :edit_sales`, but the v2 base controller automatically appends the legacy broad `account` scope. Doorkeeper accepts any requested scope, so an account-only token can currently revoke or restore buyer access without an explicit `edit_sales` grant.

## Security impact

A third-party integration holding only the broad legacy account scope can deny buyers library and download access, or restore previously revoked access, for any sale owned by the token resource owner. Sale lookup remains seller-scoped, so this is not a cross-seller IDOR; it is an OAuth authorization-boundary bypass.

## Fix

Require `edit_sales` itself with `require_oauth_scope!` after normal Doorkeeper authentication for both endpoints. Regression specs probe both actions with an account-only token and verify that the sale is unchanged.

This follows OAuth least privilege and RFC 6749 section 3.3: access-token privileges must stay within the scope granted by the resource owner.

## Verification

`bundle _2.5.10_ exec rspec spec/controllers/api/v2/sales_controller_spec.rb:1326 spec/controllers/api/v2/sales_controller_spec.rb:1432`

15 examples, 0 failures.

Premerge review: clean @ 270153c0d06c5c4d47492a4945604160bc1e7326