### PR TITLE
Let sellers pick the same large file again after cancel

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/FileEmbed.test.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/FileEmbed.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import * as React from "react";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { FileEmbed, FileEmbedConfig } from "$app/components/ProductEdit/ContentTab/FileEmbed";
+import { FileEntry } from "$app/components/ProductEdit/state";
+
+// vite.config.ts replaces the bare `SSR` identifier at build time.
+Object.assign(globalThis, { SSR: false });
+
+const FILE_ID = "file-1";
+
+const context = vi.hoisted(() => ({
+  id: "product-id",
+  updateProduct: (_update: unknown) => {},
+  filesById: new Map<string, FileEntry>(),
+}));
+
+vi.mock("$app/components/ProductEdit/state", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("$app/components/ProductEdit/state")>();
+  return { ...mod, useProductEditContext: () => context };
+});
+const cancelUpload = vi.hoisted(() => vi.fn());
+vi.mock("$app/components/EvaporateUploader", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("$app/components/EvaporateUploader")>();
+  return { ...mod, useEvaporateUploader: () => ({ scheduleUpload: () => 0, cancelUpload }) };
+});
+vi.mock("$app/components/S3UploadConfig", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("$app/components/S3UploadConfig")>();
+  return {
+    ...mod,
+    useS3UploadConfig: () => ({ generateS3KeyForUpload: () => ({ s3key: "key", fileUrl: "url" }) }),
+  };
+});
+// Pin the row visible so the Cancel button isn't virtualized away.
+vi.mock("$app/components/ProductEdit/ContentTab/useNodeVisibility", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("$app/components/ProductEdit/ContentTab/useNodeVisibility")>();
+  const react = await import("react");
+  return {
+    ...mod,
+    useNodeVisibility: () => ({ ref: react.useRef(null), visible: true, lastHeight: { current: 82 } }),
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  cancelUpload.mockReset();
+});
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- fixture only needs the fields the node view reads
+const uploadingFile = {
+  id: FILE_ID,
+  display_name: "huge",
+  description: null,
+  extension: "ZIP",
+  file_size: 1024,
+  is_pdf: false,
+  pdf_stamp_enabled: false,
+  hide_kindle_and_read_buttons: false,
+  is_streamable: false,
+  stream_only: false,
+  is_transcoding_in_progress: false,
+  url: null,
+  subtitle_files: [],
+  status: {
+    type: "unsaved",
+    uploadStatus: { type: "uploading", progress: { percent: 0.1, bitrate: 0 } },
+    url: "blob:huge",
+  },
+  thumbnail: null,
+} as FileEntry;
+
+const FileEmbedEditor = ({ config }: { config: FileEmbedConfig }) => {
+  const editor = useEditor({
+    extensions: [StarterKit, FileEmbed.configure({ getConfig: () => config })],
+    content: { type: "doc", content: [{ type: "fileEmbed", attrs: { id: FILE_ID, uid: "uid-1" } }] },
+    immediatelyRender: false,
+  });
+  return <EditorContent editor={editor} />;
+};
+
+it("tells the config which file was cancelled when the seller cancels an in-progress upload", async () => {
+  const onUploadCancelled = vi.fn();
+  const filesById = new Map<string, FileEntry>([[FILE_ID, uploadingFile]]);
+  context.filesById = filesById;
+
+  render(<FileEmbedEditor config={{ filesById, onUploadCancelled }} />);
+  await act(() => Promise.resolve());
+
+  act(() => {
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+  });
+
+  expect(cancelUpload).toHaveBeenCalledWith(`file_${FILE_ID}`);
+  expect(onUploadCancelled).toHaveBeenCalledWith(FILE_ID);
+});

--- a/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
@@ -63,7 +63,13 @@ export const getDraggedFileEmbed = (editor: Editor) => {
 
 const DEFAULT_FILE_ROW_HEIGHT = 82;
 
-const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewProps) => {
+const FileEmbedNodeView = ({
+  node,
+  editor,
+  getPos,
+  updateAttributes,
+  config,
+}: NodeViewProps & { config: FileEmbedConfig | undefined }) => {
   if (!node.attrs.id) return;
 
   const { ref, visible, lastHeight } = useNodeVisibility(DEFAULT_FILE_ROW_HEIGHT);
@@ -234,6 +240,7 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
   const onCancel = () => {
     deleteNode();
     uploader.cancelUpload(`file_${file.id}`);
+    config?.onUploadCancelled?.(file.id);
     if (file.status.type === "dropbox") void cancelDropboxFileUpload(file.id);
     updateProduct((product) => {
       product.files = product.files.filter((f) => f.id !== file.id);
@@ -752,7 +759,12 @@ const FileEmbedNodeView = ({ node, editor, getPos, updateAttributes }: NodeViewP
   );
 };
 
-export type FileEmbedConfig = { filesById: Map<string, FileEntry> };
+export type FileEmbedConfig = {
+  filesById: Map<string, FileEntry>;
+  // Cancelling releases Evaporate's hold on the picked File; the content tab uses this
+  // to know when the toolbar file input can be reset.
+  onUploadCancelled?: (fileId: string) => void;
+};
 
 export const FileEmbed = TiptapNode.create<{ getConfig?: () => FileEmbedConfig }>({
   name: "fileEmbed",
@@ -767,7 +779,9 @@ export const FileEmbed = TiptapNode.create<{ getConfig?: () => FileEmbedConfig }
   renderHTML: ({ HTMLAttributes }) => ["file-embed", HTMLAttributes],
 
   addNodeView() {
-    return ReactNodeViewRenderer(FileEmbedNodeView);
+    return ReactNodeViewRenderer((props: NodeViewProps) =>
+      FileEmbedNodeView({ ...props, config: this.options.getConfig?.() }),
+    );
   },
 
   addProseMirrorPlugins() {

--- a/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
@@ -1,10 +1,13 @@
 // @vitest-environment happy-dom
-import { cleanup, render, act } from "@testing-library/react";
+import { cleanup, render, act, fireEvent } from "@testing-library/react";
 import type { Editor } from "@tiptap/core";
 import * as React from "react";
 import { afterEach, expect, it, vi } from "vitest";
 
+import { PICKED_FILE_SNAPSHOT_LIMIT_BYTES } from "$app/utils/snapshotPickedFile";
+
 import { ContentTabContent, rawDocContainsNode } from "$app/components/ProductEdit/ContentTab";
+import { FileEmbed } from "$app/components/ProductEdit/ContentTab/FileEmbed";
 import { Product } from "$app/components/ProductEdit/state";
 
 // Capture the real mounted TipTap editor so the test can fire an update inside
@@ -54,11 +57,18 @@ vi.mock("$app/components/ProductEdit/Layout", async (importOriginal) => {
   const mod = await importOriginal<typeof import("$app/components/ProductEdit/Layout")>();
   return { ...mod, useProductUrl: () => "#" };
 });
+const scheduledUploads = vi.hoisted((): { file: File; onComplete: () => void }[] => []);
 vi.mock("$app/components/EvaporateUploader", async (importOriginal) => {
   const mod = await importOriginal<typeof import("$app/components/EvaporateUploader")>();
   return {
     ...mod,
-    useEvaporateUploader: () => ({ scheduleUpload: () => 0, cancelUpload: () => {} }),
+    useEvaporateUploader: () => ({
+      scheduleUpload: ({ file, onComplete }: { file: File; onComplete: () => void }) => {
+        scheduledUploads.push({ file, onComplete });
+        return 0;
+      },
+      cancelUpload: () => {},
+    }),
   };
 });
 vi.mock("$app/components/S3UploadConfig", async (importOriginal) => {
@@ -103,6 +113,7 @@ afterEach(() => {
   cleanup();
   mountedEditor = null;
   alerts.length = 0;
+  scheduledUploads.length = 0;
   sortable.echoList = false;
 });
 
@@ -604,4 +615,101 @@ it("keeps the newly selected variant's pages when a raw id is shared across tier
     { id: "shared-id", title: "Alpha" },
     { id: "extra-a", title: "A extra" },
   ]);
+});
+
+const attachToolbarFile = (input: HTMLInputElement, picked: File) => {
+  const valueWrites: string[] = [];
+  Object.defineProperty(input, "files", {
+    configurable: true,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal FileList for the handler
+    value: {
+      length: 1,
+      item: (index: number) => (index === 0 ? picked : null),
+      [Symbol.iterator]: () => [picked][Symbol.iterator](),
+    } as unknown as FileList,
+  });
+  Object.defineProperty(input, "value", {
+    configurable: true,
+    get: () => "",
+    set: (value: string) => valueWrites.push(value),
+  });
+  return valueWrites;
+};
+
+const renderToolbarPicker = async () => {
+  const product = buildProduct([{ id: "variant-a", name: "A", rich_content: [makePage("page-1", "PAGE")] }]);
+  context.product = product;
+  context.updateProduct = (update: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing the update union for the fixture
+    if (typeof update === "function") (update as (p: Product) => void)(product);
+    else Object.assign(product, update);
+  };
+  render(<ContentTabContent selectedVariantId="variant-a" />);
+  await act(async () => {});
+  const input = document.querySelector<HTMLInputElement>('input[name="file"]');
+  if (!input) throw new Error("Toolbar file input did not mount");
+  return { product, input };
+};
+
+it("uploads a snapshot copy of a small picked file and resets the toolbar input", async () => {
+  const { input } = await renderToolbarPicker();
+  const picked = new File(["file-bytes"], "notes.txt", { type: "text/plain" });
+  const valueWrites = attachToolbarFile(input, picked);
+
+  await act(async () => {
+    fireEvent.change(input);
+  });
+
+  const uploaded = scheduledUploads[0]?.file;
+  if (!uploaded) throw new Error("No upload was scheduled");
+  // A copy must be uploaded, not the picked File: resetting the input revokes the
+  // original's backing in Chromium, stranding the upload at 0%.
+  expect(uploaded).not.toBe(picked);
+  expect(uploaded.name).toBe("notes.txt");
+  expect(await uploaded.text()).toBe("file-bytes");
+  expect(valueWrites).toEqual([""]);
+});
+
+it("does not reset an over-budget pick until Evaporate completes", async () => {
+  const { input } = await renderToolbarPicker();
+  const picked = new File(["x"], "huge.mp4", { type: "video/mp4" });
+  Object.defineProperty(picked, "size", { value: PICKED_FILE_SNAPSHOT_LIMIT_BYTES + 1 });
+  const valueWrites = attachToolbarFile(input, picked);
+
+  await act(async () => {
+    fireEvent.change(input);
+  });
+
+  const uploaded = scheduledUploads[0];
+  if (!uploaded) throw new Error("No upload was scheduled");
+  expect(uploaded.file).toBe(picked);
+  expect(valueWrites).toEqual([]);
+
+  await act(async () => {
+    uploaded.onComplete();
+  });
+  expect(valueWrites).toEqual([""]);
+});
+
+it("resets an over-budget pick when the seller cancels the upload", async () => {
+  const { product, input } = await renderToolbarPicker();
+  const picked = new File(["x"], "huge.mp4", { type: "video/mp4" });
+  Object.defineProperty(picked, "size", { value: PICKED_FILE_SNAPSHOT_LIMIT_BYTES + 1 });
+  const valueWrites = attachToolbarFile(input, picked);
+
+  await act(async () => {
+    fireEvent.change(input);
+  });
+  expect(valueWrites).toEqual([]);
+
+  const fileId = product.files.at(-1)?.id;
+  if (!fileId) throw new Error("Picked file was not added");
+  const fileEmbed = getMountedEditor().extensionManager.extensions.find((ext) => ext.name === FileEmbed.name);
+  const onUploadCancelled = fileEmbed?.options.getConfig?.()?.onUploadCancelled;
+  if (!onUploadCancelled) throw new Error("FileEmbed cancel hook was not wired");
+
+  await act(async () => {
+    onUploadCancelled(fileId);
+  });
+  expect(valueWrites).toEqual([""]);
 });

--- a/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
@@ -789,4 +789,3 @@ it("ignores a second toolbar pick while a mixed pick is still snapshotting", asy
     File.prototype.arrayBuffer = originalArrayBuffer;
   }
 });
-

--- a/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
@@ -713,3 +713,30 @@ it("resets an over-budget pick when the seller cancels the upload", async () => 
   });
   expect(valueWrites).toEqual([""]);
 });
+
+it("ignores a second toolbar pick while an over-budget upload still needs the input", async () => {
+  const { input } = await renderToolbarPicker();
+  const first = new File(["x"], "huge.mp4", { type: "video/mp4" });
+  Object.defineProperty(first, "size", { value: PICKED_FILE_SNAPSHOT_LIMIT_BYTES + 1 });
+  const valueWrites = attachToolbarFile(input, first);
+
+  await act(async () => {
+    fireEvent.change(input);
+  });
+  expect(scheduledUploads).toHaveLength(1);
+  expect(scheduledUploads[0]?.file).toBe(first);
+  expect(input.disabled).toBe(true);
+  expect(valueWrites).toEqual([]);
+
+  await act(async () => {
+    fireEvent.change(input);
+  });
+  expect(scheduledUploads).toHaveLength(1);
+  expect(scheduledUploads[0]?.file).toBe(first);
+
+  await act(async () => {
+    scheduledUploads[0]?.onComplete();
+  });
+  expect(valueWrites).toEqual([""]);
+  expect(input.disabled).toBe(false);
+});

--- a/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.test.tsx
@@ -617,15 +617,15 @@ it("keeps the newly selected variant's pages when a raw id is shared across tier
   ]);
 });
 
-const attachToolbarFile = (input: HTMLInputElement, picked: File) => {
+const attachToolbarFiles = (input: HTMLInputElement, picked: File[]) => {
   const valueWrites: string[] = [];
   Object.defineProperty(input, "files", {
     configurable: true,
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal FileList for the handler
     value: {
-      length: 1,
-      item: (index: number) => (index === 0 ? picked : null),
-      [Symbol.iterator]: () => [picked][Symbol.iterator](),
+      length: picked.length,
+      item: (index: number) => picked[index] ?? null,
+      [Symbol.iterator]: () => picked[Symbol.iterator](),
     } as unknown as FileList,
   });
   Object.defineProperty(input, "value", {
@@ -635,6 +635,8 @@ const attachToolbarFile = (input: HTMLInputElement, picked: File) => {
   });
   return valueWrites;
 };
+
+const attachToolbarFile = (input: HTMLInputElement, picked: File) => attachToolbarFiles(input, [picked]);
 
 const renderToolbarPicker = async () => {
   const product = buildProduct([{ id: "variant-a", name: "A", rich_content: [makePage("page-1", "PAGE")] }]);
@@ -740,3 +742,51 @@ it("ignores a second toolbar pick while an over-budget upload still needs the in
   expect(valueWrites).toEqual([""]);
   expect(input.disabled).toBe(false);
 });
+it("ignores a second toolbar pick while a mixed pick is still snapshotting", async () => {
+  const waiters: { file: File; resolve: (buffer: ArrayBuffer) => void }[] = [];
+  const originalArrayBuffer = File.prototype.arrayBuffer;
+  File.prototype.arrayBuffer = function (this: File) {
+    return new Promise((resolve) => {
+      waiters.push({ file: this, resolve });
+    });
+  };
+
+  try {
+    const { input } = await renderToolbarPicker();
+    const small = new File(["abc"], "notes.txt", { type: "text/plain" });
+    const large = new File(["x"], "huge.mp4", { type: "video/mp4" });
+    Object.defineProperty(large, "size", { value: PICKED_FILE_SNAPSHOT_LIMIT_BYTES + 1 });
+    const valueWrites = attachToolbarFiles(input, [small, large]);
+
+    fireEvent.change(input);
+    expect(waiters).toHaveLength(1);
+    expect(input.disabled).toBe(true);
+    expect(scheduledUploads).toHaveLength(0);
+
+    await act(async () => {
+      fireEvent.change(input);
+    });
+    expect(waiters).toHaveLength(1);
+    expect(scheduledUploads).toHaveLength(0);
+
+    await act(async () => {
+      for (const waiter of waiters) {
+        waiter.resolve(await originalArrayBuffer.call(waiter.file));
+      }
+    });
+    expect(scheduledUploads).toHaveLength(2);
+    expect(scheduledUploads[0]?.file).not.toBe(small);
+    expect(scheduledUploads[1]?.file).toBe(large);
+    expect(valueWrites).toEqual([]);
+
+    await act(async () => {
+      scheduledUploads[0]?.onComplete();
+      scheduledUploads[1]?.onComplete();
+    });
+    expect(valueWrites).toEqual([""]);
+    expect(input.disabled).toBe(false);
+  } finally {
+    File.prototype.arrayBuffer = originalArrayBuffer;
+  }
+});
+

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -339,10 +339,12 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
   // Evaporate re-slices that handle for every part, so the toolbar input can only be
   // reset once each upload from the pick has completed or been cancelled.
   const pendingFileInputResetRef = React.useRef<{ picked: File[]; uploadIds: Set<string> } | null>(null);
+  const [fileInputHeld, setFileInputHeld] = React.useState(false);
   const settleFileInputUpload = (fileId: string) => {
     const pending = pendingFileInputResetRef.current;
     if (!pending?.uploadIds.delete(fileId) || pending.uploadIds.size > 0) return;
     pendingFileInputResetRef.current = null;
+    setFileInputHeld(false);
     const input = fileInputRef.current;
     if (input && fileListMatchesPickedFiles(input.files, pending.picked)) input.value = "";
   };
@@ -407,8 +409,14 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
     return scheduledIds;
   };
   const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const openToolbarFileInput = () => {
+    if (pendingFileInputResetRef.current) return;
+    fileInputRef.current?.click();
+  };
   const uploadFileInput = (input: HTMLInputElement) => {
-    if (!input.files?.length) return;
+    // A second pick replaces this input's FileList; Chromium can revoke the
+    // original handles an in-flight over-budget upload still needs.
+    if (pendingFileInputResetRef.current || !input.files?.length) return;
     const picked = [...input.files];
     void snapshotPickedFiles(picked)
       .then((files) => {
@@ -417,7 +425,10 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
         // With no scheduled upload left, nothing holds the original handles and an
         // immediate reset is safe.
         if (canResetFileInputAfterSnapshot(picked, files) || uploadIds.length === 0) input.value = "";
-        else pendingFileInputResetRef.current = { picked, uploadIds: new Set(uploadIds) };
+        else {
+          pendingFileInputResetRef.current = { picked, uploadIds: new Set(uploadIds) };
+          setFileInputHeld(true);
+        }
       })
       .catch((error: unknown) => {
         showAlert(error instanceof Error ? error.message : "Could not read the selected file.", "error");
@@ -768,6 +779,7 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
         name="file"
         className="sr-only"
         multiple
+        disabled={fileInputHeld}
         onChange={(e) => uploadFileInput(e.target)}
       />
       <div className="h-screen sm:h-full md:flex md:flex-col">
@@ -784,7 +796,7 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
                   <FileUploadMenu
                     existingFiles={existingFiles}
                     onEmbedMedia={() => setShowEmbedModal(true)}
-                    onClickComputerFiles={() => fileInputRef.current?.click()}
+                    onClickComputerFiles={openToolbarFileInput}
                     onSelectExistingFiles={() => {
                       setSelectingExistingFiles({ selected: [], query: "", isLoading: true });
                       void fetchLatestExistingFiles();
@@ -1200,7 +1212,7 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
                         <FileUploadMenu
                           existingFiles={existingFiles}
                           onEmbedMedia={() => setShowEmbedModal(true)}
-                          onClickComputerFiles={() => fileInputRef.current?.click()}
+                          onClickComputerFiles={openToolbarFileInput}
                           onSelectExistingFiles={() => {
                             setSelectingExistingFiles({ selected: [], query: "", isLoading: true });
                             void fetchLatestExistingFiles();

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -335,7 +335,19 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
   };
   const uploader = assertDefined(useEvaporateUploader());
   const s3UploadConfig = useS3UploadConfig();
+  // An over-budget pick keeps the original File handle (see snapshotPickedFiles), and
+  // Evaporate re-slices that handle for every part, so the toolbar input can only be
+  // reset once each upload from the pick has completed or been cancelled.
+  const pendingFileInputResetRef = React.useRef<{ picked: File[]; uploadIds: Set<string> } | null>(null);
+  const settleFileInputUpload = (fileId: string) => {
+    const pending = pendingFileInputResetRef.current;
+    if (!pending?.uploadIds.delete(fileId) || pending.uploadIds.size > 0) return;
+    pendingFileInputResetRef.current = null;
+    const input = fileInputRef.current;
+    if (input && fileListMatchesPickedFiles(input.files, pending.picked)) input.value = "";
+  };
   const uploadFiles = (files: File[]) => {
+    const scheduledIds: string[] = [];
     const fileEntries = files.map((file) => {
       const id = FileUtils.generateGuid();
       const { s3key, fileUrl } = s3UploadConfig.generateS3KeyForUpload(id, file.name);
@@ -373,6 +385,7 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
           updateProduct((product) => {
             product.files = [...product.files];
           });
+          settleFileInputUpload(id);
         },
         onProgress: (progress) => {
           fileStatus.uploadStatus = { type: "uploading", progress };
@@ -384,11 +397,14 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
       if (typeof status === "string") {
         // status contains error string if any, otherwise index of file in array
         showAlert(status, "error");
+      } else {
+        scheduledIds.push(id);
       }
       return fileEntry;
     });
     updateProduct({ files: [...product.files, ...fileEntries] });
     onSelectFiles(fileEntries.map((file) => file.id));
+    return scheduledIds;
   };
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const uploadFileInput = (input: HTMLInputElement) => {
@@ -396,9 +412,12 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
     const picked = [...input.files];
     void snapshotPickedFiles(picked)
       .then((files) => {
-        uploadFiles(files);
-        if (fileListMatchesPickedFiles(input.files, picked) && canResetFileInputAfterSnapshot(picked, files))
-          input.value = "";
+        const uploadIds = uploadFiles(files);
+        if (!fileListMatchesPickedFiles(input.files, picked)) return;
+        // With no scheduled upload left, nothing holds the original handles and an
+        // immediate reset is safe.
+        if (canResetFileInputAfterSnapshot(picked, files) || uploadIds.length === 0) input.value = "";
+        else pendingFileInputResetRef.current = { picked, uploadIds: new Set(uploadIds) };
       })
       .catch((error: unknown) => {
         showAlert(error instanceof Error ? error.message : "Could not read the selected file.", "error");
@@ -411,7 +430,7 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
     prepareDownload: save,
     filesById,
   });
-  const fileEmbedConfig = useRefToLatest<FileEmbedConfig>({ filesById });
+  const fileEmbedConfig = useRefToLatest<FileEmbedConfig>({ filesById, onUploadCancelled: settleFileInputUpload });
   const uploadFilesRef = useRefToLatest(uploadFiles);
   const contentEditorExtensions = extensions(id, [
     FileEmbedGroup.configure({ getConfig: () => fileEmbedGroupConfig.current }),

--- a/app/javascript/components/ProductEdit/ContentTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/index.tsx
@@ -340,11 +340,16 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
   // reset once each upload from the pick has completed or been cancelled.
   const pendingFileInputResetRef = React.useRef<{ picked: File[]; uploadIds: Set<string> } | null>(null);
   const [fileInputHeld, setFileInputHeld] = React.useState(false);
+  const fileInputHeldRef = React.useRef(false);
+  const holdFileInput = (held: boolean) => {
+    fileInputHeldRef.current = held;
+    setFileInputHeld(held);
+  };
   const settleFileInputUpload = (fileId: string) => {
     const pending = pendingFileInputResetRef.current;
     if (!pending?.uploadIds.delete(fileId) || pending.uploadIds.size > 0) return;
     pendingFileInputResetRef.current = null;
-    setFileInputHeld(false);
+    holdFileInput(false);
     const input = fileInputRef.current;
     if (input && fileListMatchesPickedFiles(input.files, pending.picked)) input.value = "";
   };
@@ -410,27 +415,31 @@ export const ContentTabContent = ({ selectedVariantId }: { selectedVariantId: st
   };
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const openToolbarFileInput = () => {
-    if (pendingFileInputResetRef.current) return;
+    if (fileInputHeldRef.current || pendingFileInputResetRef.current) return;
     fileInputRef.current?.click();
   };
   const uploadFileInput = (input: HTMLInputElement) => {
     // A second pick replaces this input's FileList; Chromium can revoke the
     // original handles an in-flight over-budget upload still needs.
-    if (pendingFileInputResetRef.current || !input.files?.length) return;
+    if (fileInputHeldRef.current || pendingFileInputResetRef.current || !input.files?.length) return;
     const picked = [...input.files];
+    holdFileInput(true);
     void snapshotPickedFiles(picked)
       .then((files) => {
         const uploadIds = uploadFiles(files);
-        if (!fileListMatchesPickedFiles(input.files, picked)) return;
+        if (!fileListMatchesPickedFiles(input.files, picked)) {
+          holdFileInput(false);
+          return;
+        }
         // With no scheduled upload left, nothing holds the original handles and an
         // immediate reset is safe.
-        if (canResetFileInputAfterSnapshot(picked, files) || uploadIds.length === 0) input.value = "";
-        else {
-          pendingFileInputResetRef.current = { picked, uploadIds: new Set(uploadIds) };
-          setFileInputHeld(true);
-        }
+        if (canResetFileInputAfterSnapshot(picked, files) || uploadIds.length === 0) {
+          input.value = "";
+          holdFileInput(false);
+        } else pendingFileInputResetRef.current = { picked, uploadIds: new Set(uploadIds) };
       })
       .catch((error: unknown) => {
+        holdFileInput(false);
         showAlert(error instanceof Error ? error.message : "Could not read the selected file.", "error");
       });
   };

--- a/app/javascript/components/useConfigureEvaporate.test.ts
+++ b/app/javascript/components/useConfigureEvaporate.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+import { renderHook } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { useConfigureEvaporate } from "$app/components/useConfigureEvaporate";
+
+const evaporate = vi.hoisted(() => ({ add: vi.fn(), cancel: vi.fn() }));
+const Evaporate = vi.hoisted(() =>
+  // `new Evaporate()` must be constructable and return the shared spies.
+  // eslint-disable-next-line prefer-arrow-callback
+  vi.fn(function Evaporate() {
+    return evaporate;
+  }),
+);
+
+vi.mock("$vendor/evaporate.cjs", () => ({ default: Evaporate }));
+
+vi.stubGlobal(
+  "Routes",
+  new Proxy(
+    {},
+    {
+      get: () => () => "#",
+    },
+  ),
+);
+
+afterEach(() => {
+  evaporate.add.mockReset();
+  evaporate.cancel.mockReset();
+  Evaporate.mockClear();
+});
+
+it("cancels Evaporate's first queued file when its id is 0", () => {
+  evaporate.add.mockImplementation((params: { initiated: (id: number) => void }) => {
+    // Vendor addFile uses files.length, so the first queued file is numeric 0.
+    params.initiated(0);
+    return 0;
+  });
+
+  const { result } = renderHook(() =>
+    useConfigureEvaporate({
+      aws_access_key_id: "key",
+      s3_url: "https://s3.amazonaws.com/bucket",
+      user_id: "user-1",
+    }),
+  );
+
+  result.current.evaporateUploader.scheduleUpload({
+    cancellationKey: "file_abc",
+    name: "key",
+    file: new File(["x"], "notes.txt", { type: "text/plain" }),
+    mimeType: "text/plain",
+    onComplete: () => {},
+    onProgress: () => {},
+  });
+  result.current.evaporateUploader.cancelUpload("file_abc");
+
+  expect(evaporate.cancel).toHaveBeenCalledWith(0);
+});

--- a/app/javascript/components/useConfigureEvaporate.ts
+++ b/app/javascript/components/useConfigureEvaporate.ts
@@ -101,7 +101,9 @@ export const useConfigureEvaporate = (props: Props) => {
 
   const cancelUpload = (cancellationKey: string) => {
     const uploadId = cancellationKeysToUploadIdsRef.current[cancellationKey];
-    if (uploadId) evaporate.cancel(uploadId);
+    // Evaporate's first queued file is id 0; a truthy check would skip cancel and
+    // leave the original File in use after the toolbar input is reset.
+    if (uploadId != null) evaporate.cancel(uploadId);
   };
 
   return { evaporateUploader: { scheduleUpload, cancelUpload }, s3UploadConfig };


### PR DESCRIPTION
## What

After an over-budget Content-tab Computer files pick, the persistent toolbar input now resets when Evaporate is done with the File: on complete, or when the seller cancels the row. Small files still copy and reset immediately.

Also fixes cancelUpload ignoring Evaporate first queued file (id 0), which made cancel a no-op for the first upload in the tab.

Adds a Content-tab onChange test that fails if snapshotPickedFiles is unwired, plus tests that an over-budget pick does not reset until complete or cancel.

Adds sibling tests for FileEmbed Cancel and Evaporate cancel of id 0 so bin/branch-specs maps those two production files.

## Why

#7394 keeps the original File for picks over the 32 MiB snapshot budget and skips reset so Evaporate can still slice each part. That left the toolbar input dirty. Chrome and Firefox do not fire change when the seller picks the same path again, so after cancel or delete the same large video could not be re-picked.

## Before / After

- Before: pick a file larger than 32 MiB, cancel or wait for complete, pick the same path again, nothing happens.
- After: the input clears once Evaporate completes or is cancelled, so the same path fires change again. Small files still reset immediately after the copy.

Blob-URL revoke was skipped. status.url and subtitle signed_url are used until save (thumbnail, play-before-save, captions).

## Test Results

- `npm test -- app/javascript/components/useConfigureEvaporate.test.ts app/javascript/components/ProductEdit/ContentTab/FileEmbed.test.tsx app/javascript/components/ProductEdit/ContentTab/index.test.tsx` — 18 passed
- Revert: drop the pending-pick ignore in uploadFileInput and the overlapping-pick test fails (second change schedules another upload)

## QA

The sibling tests are the proof the seams are wired. FileEmbed Cancel calls onUploadCancelled. cancelUpload with Evaporate id 0 calls evaporate.cancel(0). Both cases fail if that behavior is removed.

---

Implemented by Claude Fable 5 (Claude Code).
