### PR TITLE
Point the Gumhead download URL at the dmg

### DIFF
--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -7,7 +7,7 @@ class CreatorHomePresenter
   BALANCE_ITEMS_LIMIT = 3
   GUMHEAD_FEATURE = :gumhead
   # A fixed tag, because releases/latest here is a deploy release.
-  GUMHEAD_DOWNLOAD_URL = "https://github.com/antiwork/gumroad/releases/download/gumhead-latest/Gumhead.zip"
+  GUMHEAD_DOWNLOAD_URL = "https://github.com/antiwork/gumroad/releases/download/gumhead-latest/Gumhead.dmg"
 
   attr_reader :pundit_user, :seller
 


### PR DESCRIPTION
## What

Point `CreatorHomePresenter::GUMHEAD_DOWNLOAD_URL` at `Gumhead.dmg` instead of `Gumhead.zip`.

## Why

[antiwork/gumhead#16](https://github.com/antiwork/gumhead/pull/16) (merged) switched the Gumhead release to a dmg. Its mirror job now serves `Gumhead.dmg` as the stable URL and deletes the legacy `Gumhead.zip` once the dmg holds its final name — so the dashboard's Gumhead download would 404 on the next gumhead release. This PR is the gumroad-side half the gumhead PR's body explicitly deferred ("a separate gumroad PR moves that URL to Gumhead.dmg").

## Before-After

`GUMHEAD_DOWNLOAD_URL`:
- Before: `.../gumhead-latest/Gumhead.zip` (asset the mirror now deletes)
- After: `.../gumhead-latest/Gumhead.dmg` (the stable, stapled install dmg)

## Test Results

- `DISABLE_SPRING=1 bundle exec rspec spec/presenters/creator_home_presenter_spec.rb -e "gumhead"` — 3 examples, 0 failures. The gumhead specs reference the constant `GUMHEAD_DOWNLOAD_URL` rather than the literal, so they pass against the new value.
- `DISABLE_SPRING=1 bundle exec rspec spec/controllers/dashboard_controller_spec.rb -e "gumhead"` — 3 examples, 0 failures.
- `autoreview --mode branch --base origin/main --engine codex` (Sol/gpt-5.6-sol): clean — "patch is correct (0.98), no P0/P1." TruffleHog clean.

## QA steps

No scriptable UI surface changed (the Gumhead promo card takes its `download_url` from this constant; the value now resolves to a real published asset). Verify the release link after the next gumhead release: `https://github.com/antiwork/gumroad/releases/tag/gumhead-latest` serves `Gumhead.dmg`.

## Status

- [x] Scope — point the Gumhead download URL at the dmg; closes the residual named in the merged gumhead PR body.
- [x] Design — one-line constant change; specs reference the constant so they keep passing.
- [x] Build — diff is `app/presenters/creator_home_presenter.rb` (1 line).
- [x] QA — gumhead presenter + dashboard controller specs green (3 + 3 examples); Sol adversarial review clean at `de566e0`.
- [ ] Shipped — pending CI green + merge/deploy.
- [ ] Market / Sell — n/a.

---

AI disclosure: grok-4.6.

Premerge review: clean @ de566e0f00767f097e0ea55625da20e1fef493e5