### PR TITLE
Let Gumhead chat keep working while Anthropic is over cap

### DIFF
--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -235,16 +235,26 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       render json: anthropic_error("invalid_request_error", "That model is not available through the Gumhead gateway."), status: :bad_request
     end
 
-    # Incoming names stay on the allowlist so both the shipped claude-*
-    # builds and the role-id ones pass validate_model. The body that goes
-    # upstream uses the mapped id, and the ledger records that billed name.
+    # Incoming names stay on the Claude allowlist so the shipped app
+    # passes validate_model. The built-in Grok map applies only when the
+    # upstream is no longer Anthropic, so a deploy that has not flipped
+    # the base still sends Claude ids. An explicit GUMHEAD_MODEL_MAP
+    # always applies. The ledger records the billed outgoing name.
     def rewrite_upstream_model
+      return unless rewrite_upstream_model?
+
       incoming = @body["model"].to_s
       outgoing = mapped_upstream_model(incoming)
       return if outgoing.blank? || outgoing == incoming
 
       @body["model"] = outgoing
       @raw_body = @body.to_json
+    end
+
+    def rewrite_upstream_model?
+      return true if GlobalConfig.get("GUMHEAD_MODEL_MAP").present?
+
+      upstream_api_base != DEFAULT_UPSTREAM_API_BASE
     end
 
     def mapped_upstream_model(model)
@@ -304,14 +314,14 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     end
 
     # `speed: "fast"` and `inference_geo` carry pricing multipliers the
-    # ledger does not weight, and `fallbacks` runs extra attempts whose
-    # nested options bypass every top-level validator here. All three would
-    # spend the shared key invisibly.
+    # ledger does not weight. `fallbacks`, `models`, `provider`, `route`,
+    # and `plugins` run extra paid work outside this ledger.
     def validate_pricing_modifiers
       speed_ok = @body["speed"].nil? || @body["speed"] == "standard"
-      return if speed_ok && @body["inference_geo"].nil? && !@body.key?("fallbacks")
+      extra = %w[inference_geo fallbacks plugins models provider route]
+      return if speed_ok && extra.none? { |key| @body.key?(key) }
 
-      render json: anthropic_error("invalid_request_error", "speed, inference_geo, and fallbacks options are not available through the Gumhead gateway."), status: :bad_request
+      render json: anthropic_error("invalid_request_error", "speed, inference_geo, fallbacks, plugins, models, provider, and route options are not available through the Gumhead gateway."), status: :bad_request
     end
 
     # A missing max_tokens passes through: Anthropic's own error for it is

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -135,7 +135,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # the in-flight limit.
   def count_tokens
     with_in_flight_slot do
-      forward_buffered("#{upstream_api_base}/messages/count_tokens", meter: false, missing_ok: true)
+      forward_buffered("#{upstream_api_base}/messages/count_tokens", meter: false, missing_ok: !anthropic_upstream?)
     end
   end
 
@@ -652,6 +652,10 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       # One-deploy fallback: ops can store the OpenRouter key in the
       # existing GUMHEAD_ANTHROPIC_API_KEY name while flipping the base.
       GlobalConfig.get("GUMHEAD_UPSTREAM_API_KEY").presence || GlobalConfig.get("GUMHEAD_ANTHROPIC_API_KEY")
+    end
+
+    def anthropic_upstream?
+      upstream_api_base == DEFAULT_UPSTREAM_API_BASE
     end
 
     def upstream_api_base

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -57,16 +57,17 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # a deploy — any upstream must speak the Anthropic Messages protocol.
   DEFAULT_UPSTREAM_API_BASE = "https://api.anthropic.com/v1"
   DEFAULT_ANTHROPIC_VERSION = "2023-06-01"
-  # The shipped app still sends claude-* names. Role ids stay out of
-  # this hop; they need an app change. Caps are token-denominated, so
-  # an unlisted pricier SKU cannot spend faster.
-  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-"
-  # Family prefixes rewrite every allowed Claude name, including
-  # OpenRouter :online variants, once the base leaves Anthropic.
+  # Claude families plus exact role ids newer builds send. Role ids
+  # pass only after the hop is on. Family prefixes rewrite every
+  # allowed Claude name, including OpenRouter :online variants.
+  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-,gumhead-chat,gumhead-status,gumhead-cover"
   DEFAULT_MODEL_MAP = {
     "claude-sonnet-" => "x-ai/grok-4.6",
     "claude-haiku-" => "x-ai/grok-4.6",
     "claude-opus-" => "x-ai/grok-4.6",
+    "gumhead-chat" => "x-ai/grok-4.6",
+    "gumhead-status" => "x-ai/grok-4.6",
+    "gumhead-cover" => "x-ai/grok-4.6",
   }.freeze
   # Matches nginx's client_max_body_size; a larger constant here would
   # document a limit requests can never reach.
@@ -229,9 +230,19 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
 
     def validate_model
       model = @body["model"].to_s
-      return if allowed_model_prefixes.any? { |prefix| model.start_with?(prefix) }
+      return if allowed_incoming_model?(model)
 
       render json: anthropic_error("invalid_request_error", "That model is not available through the Gumhead gateway."), status: :bad_request
+    end
+
+    # Role ids have no Anthropic SKU. They pass only when we will rewrite
+    # them. Claude family prefixes stay valid on both hosts.
+    def allowed_incoming_model?(model)
+      allowed_model_prefixes.any? do |prefix|
+        next false unless model.start_with?(prefix)
+
+        prefix.start_with?("claude-") || rewrite_upstream_model?
+      end
     end
 
     # Incoming names stay on the Claude allowlist so the shipped app
@@ -356,7 +367,6 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       if upstream.status.success?
         parsed = safe_parse_json(body)
         if parsed.is_a?(Hash) && parsed["error"].is_a?(Hash)
-          meter_buffered_usage(body) if meter
           message = parsed.dig("error", "message").to_s.presence || "The model service returned an error."
           return render json: anthropic_error("api_error", message), status: :bad_gateway
         end

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -57,19 +57,16 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # a deploy — any upstream must speak the Anthropic Messages protocol.
   DEFAULT_UPSTREAM_API_BASE = "https://api.anthropic.com/v1"
   DEFAULT_ANTHROPIC_VERSION = "2023-06-01"
-  # Claude families the shipped app still sends, plus exact role ids
-  # newer builds send. Role ids pass only after the hop is on.
-  # Caps are token-denominated, so an unlisted pricier SKU cannot spend faster.
-  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-,gumhead-chat,gumhead-status,gumhead-cover"
-  # Incoming names stay on the allowlist; the body that goes upstream uses
-  # the mapped billed id once the base leaves Anthropic.
+  # The shipped app still sends claude-* names. Role ids stay out of
+  # this hop; they need an app change. Caps are token-denominated, so
+  # an unlisted pricier SKU cannot spend faster.
+  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-"
+  # Family prefixes rewrite every allowed Claude name, including
+  # OpenRouter :online variants, once the base leaves Anthropic.
   DEFAULT_MODEL_MAP = {
-    "claude-sonnet-5" => "x-ai/grok-4.6",
-    "claude-haiku-4-5" => "x-ai/grok-4.6",
-    "claude-opus-5" => "x-ai/grok-4.6",
-    "gumhead-chat" => "x-ai/grok-4.6",
-    "gumhead-status" => "x-ai/grok-4.6",
-    "gumhead-cover" => "x-ai/grok-4.6",
+    "claude-sonnet-" => "x-ai/grok-4.6",
+    "claude-haiku-" => "x-ai/grok-4.6",
+    "claude-opus-" => "x-ai/grok-4.6",
   }.freeze
   # Matches nginx's client_max_body_size; a larger constant here would
   # document a limit requests can never reach.
@@ -232,19 +229,9 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
 
     def validate_model
       model = @body["model"].to_s
-      return if allowed_incoming_model?(model)
+      return if allowed_model_prefixes.any? { |prefix| model.start_with?(prefix) }
 
       render json: anthropic_error("invalid_request_error", "That model is not available through the Gumhead gateway."), status: :bad_request
-    end
-
-    # Role ids have no Anthropic SKU. They pass only when we will rewrite
-    # them. Claude family prefixes stay valid on both hosts.
-    def allowed_incoming_model?(model)
-      allowed_model_prefixes.any? do |prefix|
-        next false unless model.start_with?(prefix)
-
-        prefix.start_with?("claude-") || rewrite_upstream_model?
-      end
     end
 
     # Incoming names stay on the Claude allowlist so the shipped app
@@ -266,7 +253,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     def rewrite_upstream_model?
       return true if GlobalConfig.get("GUMHEAD_MODEL_MAP").present?
 
-      upstream_api_base != DEFAULT_UPSTREAM_API_BASE
+      !anthropic_upstream?
     end
 
     def mapped_upstream_model(model)
@@ -366,7 +353,15 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       if missing_ok && upstream.status.code == 404
         return render json: { "input_tokens" => @raw_body.bytesize }, status: :ok
       end
-      meter_buffered_usage(body) if meter && upstream.status.success?
+      if upstream.status.success?
+        parsed = safe_parse_json(body)
+        if parsed.is_a?(Hash) && parsed["error"].is_a?(Hash)
+          meter_buffered_usage(body) if meter
+          message = parsed.dig("error", "message").to_s.presence || "The model service returned an error."
+          return render json: anthropic_error("api_error", message), status: :bad_gateway
+        end
+        meter_buffered_usage(body) if meter
+      end
       copy_retry_after(upstream)
       render body:, content_type: "application/json", status: upstream.status.code
     rescue HTTP::ConnectTimeoutError => e
@@ -486,6 +481,16 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       unless upstream.status.success?
         copy_retry_after(upstream)
         return render body: upstream.body.to_s, content_type: "application/json", status: upstream.status.code
+      end
+      if upstream.headers["Content-Type"].to_s.include?("application/json") &&
+         !upstream.headers["Content-Type"].to_s.include?("event-stream")
+        body = upstream.body.to_s
+        parsed = safe_parse_json(body)
+        if parsed.is_a?(Hash) && parsed["error"].is_a?(Hash)
+          meter_buffered_usage(body) if parsed["usage"].is_a?(Hash)
+          message = parsed.dig("error", "message").to_s.presence || "The model service returned an error."
+          return render json: anthropic_error("api_error", message), status: :bad_gateway
+        end
       end
 
       response.headers["Content-Type"] = "text/event-stream"
@@ -628,7 +633,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       }
       # Anthropic rejects a bearer token when x-api-key is also set.
       # OpenRouter authenticates only with Authorization: Bearer.
-      if upstream_api_base == DEFAULT_UPSTREAM_API_BASE
+      if anthropic_upstream?
         headers["x-api-key"] = key
       else
         headers["authorization"] = "Bearer #{key}"
@@ -655,7 +660,9 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     end
 
     def anthropic_upstream?
-      upstream_api_base == DEFAULT_UPSTREAM_API_BASE
+      URI.parse(upstream_api_base.to_s).host == "api.anthropic.com"
+    rescue URI::InvalidURIError
+      false
     end
 
     def upstream_api_base

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -244,10 +244,13 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     # never used as prefixes, so gumhead-chat-extra stays out.
     def allowed_incoming_model?(model)
       prefixes = allowed_model_prefixes
-      return true if prefixes.any? { |prefix| prefix.start_with?("claude-") && model.start_with?(prefix) }
+      if prefixes.any? { |prefix| prefix.start_with?("claude-") && model.start_with?(prefix) }
+        return incoming_model_maps_if_needed?(model)
+      end
       if incoming_role_id?(model)
         return false unless prefixes.include?(model)
         return false unless rewrite_upstream_model?
+
         outgoing = mapped_upstream_model(model)
         return outgoing.present? && outgoing != model
       end
@@ -256,6 +259,16 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
         next false if incoming_role_id?(prefix)
         model.start_with?(prefix)
       end
+    end
+
+    # On a non-Anthropic hop, a Claude family name only passes if the
+    # active map actually rewrites it. An empty override must not forward
+    # the client-controlled name unchanged.
+    def incoming_model_maps_if_needed?(model)
+      return true unless rewrite_upstream_model?
+
+      outgoing = mapped_upstream_model(model)
+      outgoing.present? && outgoing != model
     end
 
     def incoming_role_id?(model)
@@ -297,7 +310,15 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     def model_map
       raw = GlobalConfig.get("GUMHEAD_MODEL_MAP", DEFAULT_MODEL_MAP)
       parsed = raw.is_a?(String) ? safe_parse_json(raw) : raw
-      parsed.is_a?(Hash) ? parsed : {}
+      overrides = {}
+      if parsed.is_a?(Hash)
+        parsed.each do |key, value|
+          next if key.blank? || value.blank?
+
+          overrides[key.to_s] = value.to_s
+        end
+      end
+      DEFAULT_MODEL_MAP.merge(overrides)
     end
 
     def allowed_model_prefixes
@@ -690,9 +711,14 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     end
 
     def upstream_api_key
-      # One-deploy fallback: ops can store the OpenRouter key in the
-      # existing GUMHEAD_ANTHROPIC_API_KEY name while flipping the base.
-      GlobalConfig.get("GUMHEAD_UPSTREAM_API_KEY").presence || GlobalConfig.get("GUMHEAD_ANTHROPIC_API_KEY")
+      # Never send the Anthropic secret to another host. OpenRouter (and
+      # any other hop) needs GUMHEAD_UPSTREAM_API_KEY. The Anthropic key
+      # stays on api.anthropic.com only.
+      if anthropic_upstream?
+        GlobalConfig.get("GUMHEAD_UPSTREAM_API_KEY").presence || GlobalConfig.get("GUMHEAD_ANTHROPIC_API_KEY")
+      else
+        GlobalConfig.get("GUMHEAD_UPSTREAM_API_KEY").presence
+      end
     end
 
     def openrouter_error_envelope?(parsed)

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -57,17 +57,19 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # a deploy — any upstream must speak the Anthropic Messages protocol.
   DEFAULT_UPSTREAM_API_BASE = "https://api.anthropic.com/v1"
   DEFAULT_ANTHROPIC_VERSION = "2023-06-01"
-  # The shipped app still sends claude-* names. Role ids stay out of
-  # this hop; they need an app change. Caps are token-denominated, so
-  # an unlisted pricier SKU cannot spend faster. Ops can extend the
-  # list without a deploy via GUMHEAD_ALLOWED_MODEL_PREFIXES.
-  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-"
-  # Rewrite after validate_model, before the POST. Built-in Grok
-  # targets apply only once the base leaves Anthropic.
+  # Claude families the shipped app still sends, plus exact role ids
+  # newer builds send. Role ids pass only after the hop is on.
+  # Caps are token-denominated, so an unlisted pricier SKU cannot spend faster.
+  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-,gumhead-chat,gumhead-status,gumhead-cover"
+  # Incoming names stay on the allowlist; the body that goes upstream uses
+  # the mapped billed id once the base leaves Anthropic.
   DEFAULT_MODEL_MAP = {
     "claude-sonnet-5" => "x-ai/grok-4.6",
     "claude-haiku-4-5" => "x-ai/grok-4.6",
     "claude-opus-5" => "x-ai/grok-4.6",
+    "gumhead-chat" => "x-ai/grok-4.6",
+    "gumhead-status" => "x-ai/grok-4.6",
+    "gumhead-cover" => "x-ai/grok-4.6",
   }.freeze
   # Matches nginx's client_max_body_size; a larger constant here would
   # document a limit requests can never reach.
@@ -230,9 +232,19 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
 
     def validate_model
       model = @body["model"].to_s
-      return if allowed_model_prefixes.any? { |prefix| model.start_with?(prefix) }
+      return if allowed_incoming_model?(model)
 
       render json: anthropic_error("invalid_request_error", "That model is not available through the Gumhead gateway."), status: :bad_request
+    end
+
+    # Role ids have no Anthropic SKU. They pass only when we will rewrite
+    # them. Claude family prefixes stay valid on both hosts.
+    def allowed_incoming_model?(model)
+      allowed_model_prefixes.any? do |prefix|
+        next false unless model.start_with?(prefix)
+
+        prefix.start_with?("claude-") || rewrite_upstream_model?
+      end
     end
 
     # Incoming names stay on the Claude allowlist so the shipped app

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -60,7 +60,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # Claude families plus exact role ids newer builds send. Role ids
   # pass only after the hop is on. Family prefixes rewrite every
   # allowed Claude name, including OpenRouter :online variants.
-  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-,gumhead-chat,gumhead-status,gumhead-cover"
+  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-"
   DEFAULT_MODEL_MAP = {
     "claude-sonnet-" => "x-ai/grok-4.6",
     "claude-haiku-" => "x-ai/grok-4.6",

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -58,9 +58,11 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   DEFAULT_UPSTREAM_API_BASE = "https://api.anthropic.com/v1"
   DEFAULT_ANTHROPIC_VERSION = "2023-06-01"
   # Claude families plus exact role ids newer builds send. Role ids
-  # pass only after the hop is on. Family prefixes rewrite every
-  # allowed Claude name, including OpenRouter :online variants.
-  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-"
+  # are listed here so validate_model can admit them, but they are
+  # not prefixes: only an exact allowlist hit plus a rewrite passes.
+  # Family prefixes rewrite every allowed Claude name, including
+  # OpenRouter :online variants.
+  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-,gumhead-chat,gumhead-status,gumhead-cover"
   DEFAULT_MODEL_MAP = {
     "claude-sonnet-" => "x-ai/grok-4.6",
     "claude-haiku-" => "x-ai/grok-4.6",
@@ -235,18 +237,25 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       render json: anthropic_error("invalid_request_error", "That model is not available through the Gumhead gateway."), status: :bad_request
     end
 
-    # Role ids have no Anthropic SKU. They pass only when this request
-    # will rewrite that exact id. Claude family prefixes stay valid on
-    # both hosts. Other ops prefixes keep the old always-on allowlist.
+    # Role ids have no Anthropic SKU. They pass only as an exact
+    # allowlist hit, and only when this request will rewrite that id.
+    # Claude family prefixes stay valid on both hosts. Other ops
+    # prefixes keep the old always-on allowlist. Role id strings are
+    # never used as prefixes, so gumhead-chat-extra stays out.
     def allowed_incoming_model?(model)
-      return true if allowed_model_prefixes.any? { |prefix| prefix.start_with?("claude-") && model.start_with?(prefix) }
+      prefixes = allowed_model_prefixes
+      return true if prefixes.any? { |prefix| prefix.start_with?("claude-") && model.start_with?(prefix) }
       if incoming_role_id?(model)
+        return false unless prefixes.include?(model)
         return false unless rewrite_upstream_model?
         outgoing = mapped_upstream_model(model)
         return outgoing.present? && outgoing != model
       end
 
-      allowed_model_prefixes.any? { |prefix| model.start_with?(prefix) }
+      prefixes.any? do |prefix|
+        next false if incoming_role_id?(prefix)
+        model.start_with?(prefix)
+      end
     end
 
     def incoming_role_id?(model)

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -372,15 +372,17 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       if missing_ok && upstream.status.code == 404
         return render json: { "input_tokens" => @raw_body.bytesize }, status: :ok
       end
-      if upstream.status.success?
-        parsed = safe_parse_json(body)
-        if parsed.is_a?(Hash) && parsed["error"].is_a?(Hash)
-          meter_buffered_usage(body) if meter
-          message = parsed.dig("error", "message").to_s.presence || "The model service returned an error."
-          return render json: anthropic_error("api_error", message), status: :bad_gateway
-        end
-        meter_buffered_usage(body) if meter
+      parsed = safe_parse_json(body)
+      # OpenRouter uses {error:{message}} without Anthropic's top-level type.
+      # Keep Anthropic envelopes as pass-through.
+      if openrouter_error_envelope?(parsed)
+        meter_buffered_usage(body) if meter && upstream.status.success?
+        message = parsed.dig("error", "message").to_s.presence || "The model service returned an error."
+        copy_retry_after(upstream)
+        status = upstream.status.success? ? :bad_gateway : upstream.status.code
+        return render json: anthropic_error("api_error", message), status:
       end
+      meter_buffered_usage(body) if meter && upstream.status.success?
       copy_retry_after(upstream)
       render body:, content_type: "application/json", status: upstream.status.code
     rescue HTTP::ConnectTimeoutError => e
@@ -676,6 +678,10 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       # One-deploy fallback: ops can store the OpenRouter key in the
       # existing GUMHEAD_ANTHROPIC_API_KEY name while flipping the base.
       GlobalConfig.get("GUMHEAD_UPSTREAM_API_KEY").presence || GlobalConfig.get("GUMHEAD_ANTHROPIC_API_KEY")
+    end
+
+    def openrouter_error_envelope?(parsed)
+      parsed.is_a?(Hash) && parsed["error"].is_a?(Hash) && parsed["type"] != "error"
     end
 
     def anthropic_upstream?

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -236,16 +236,21 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     end
 
     # Role ids have no Anthropic SKU. They pass only when this request
-    # will rewrite that exact id. A partial GUMHEAD_MODEL_MAP must not
-    # admit an unmapped role. Claude family prefixes stay valid on both hosts.
+    # will rewrite that exact id. Claude family prefixes stay valid on
+    # both hosts. Other ops prefixes keep the old always-on allowlist.
     def allowed_incoming_model?(model)
-      allowed_model_prefixes.any? do |prefix|
-        next false unless model.start_with?(prefix)
-        next true if prefix.start_with?("claude-")
-
+      return true if allowed_model_prefixes.any? { |prefix| prefix.start_with?("claude-") && model.start_with?(prefix) }
+      if incoming_role_id?(model)
+        return false unless rewrite_upstream_model?
         outgoing = mapped_upstream_model(model)
-        outgoing.present? && outgoing != model
+        return outgoing.present? && outgoing != model
       end
+
+      allowed_model_prefixes.any? { |prefix| model.start_with?(prefix) }
+    end
+
+    def incoming_role_id?(model)
+      %w[gumhead-chat gumhead-status gumhead-cover].include?(model)
     end
 
     # Incoming names stay on the Claude allowlist so the shipped app
@@ -370,6 +375,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       if upstream.status.success?
         parsed = safe_parse_json(body)
         if parsed.is_a?(Hash) && parsed["error"].is_a?(Hash)
+          meter_buffered_usage(body) if meter
           message = parsed.dig("error", "message").to_s.presence || "The model service returned an error."
           return render json: anthropic_error("api_error", message), status: :bad_gateway
         end

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -318,10 +318,10 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     # and `plugins` run extra paid work outside this ledger.
     def validate_pricing_modifiers
       speed_ok = @body["speed"].nil? || @body["speed"] == "standard"
-      extra = %w[inference_geo fallbacks plugins models provider route]
+      extra = %w[inference_geo fallbacks plugins models provider route service_tier]
       return if speed_ok && extra.none? { |key| @body.key?(key) }
 
-      render json: anthropic_error("invalid_request_error", "speed, inference_geo, fallbacks, plugins, models, provider, and route options are not available through the Gumhead gateway."), status: :bad_request
+      render json: anthropic_error("invalid_request_error", "speed, inference_geo, fallbacks, plugins, models, provider, route, and service_tier options are not available through the Gumhead gateway."), status: :bad_request
     end
 
     # A missing max_tokens passes through: Anthropic's own error for it is
@@ -611,11 +611,16 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     def upstream_headers
       key = upstream_api_key
       headers = {
-        "x-api-key" => key,
-        "authorization" => "Bearer #{key}",
         "anthropic-version" => request.headers["anthropic-version"].presence || DEFAULT_ANTHROPIC_VERSION,
         "content-type" => "application/json",
       }
+      # Anthropic rejects a bearer token when x-api-key is also set.
+      # OpenRouter authenticates only with Authorization: Bearer.
+      if upstream_api_base == DEFAULT_UPSTREAM_API_BASE
+        headers["x-api-key"] = key
+      else
+        headers["authorization"] = "Bearer #{key}"
+      end
       beta = filtered_beta_features
       headers["anthropic-beta"] = beta if beta.present?
       headers

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -57,17 +57,16 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # a deploy — any upstream must speak the Anthropic Messages protocol.
   DEFAULT_UPSTREAM_API_BASE = "https://api.anthropic.com/v1"
   DEFAULT_ANTHROPIC_VERSION = "2023-06-01"
-  # Claude families plus exact role ids newer builds send. Role ids
-  # pass only after the hop is on. Family prefixes rewrite every
-  # allowed Claude name, including OpenRouter :online variants.
-  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-,gumhead-chat,gumhead-status,gumhead-cover"
+  # The shipped app still sends claude-* names. Role ids stay out of
+  # this hop; they need an app change. Caps are token-denominated, so
+  # an unlisted pricier SKU cannot spend faster.
+  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-"
+  # Family prefixes rewrite every allowed Claude name, including
+  # OpenRouter :online variants, once the base leaves Anthropic.
   DEFAULT_MODEL_MAP = {
     "claude-sonnet-" => "x-ai/grok-4.6",
     "claude-haiku-" => "x-ai/grok-4.6",
     "claude-opus-" => "x-ai/grok-4.6",
-    "gumhead-chat" => "x-ai/grok-4.6",
-    "gumhead-status" => "x-ai/grok-4.6",
-    "gumhead-cover" => "x-ai/grok-4.6",
   }.freeze
   # Matches nginx's client_max_body_size; a larger constant here would
   # document a limit requests can never reach.
@@ -230,19 +229,9 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
 
     def validate_model
       model = @body["model"].to_s
-      return if allowed_incoming_model?(model)
+      return if allowed_model_prefixes.any? { |prefix| model.start_with?(prefix) }
 
       render json: anthropic_error("invalid_request_error", "That model is not available through the Gumhead gateway."), status: :bad_request
-    end
-
-    # Role ids have no Anthropic SKU. They pass only when we will rewrite
-    # them. Claude family prefixes stay valid on both hosts.
-    def allowed_incoming_model?(model)
-      allowed_model_prefixes.any? do |prefix|
-        next false unless model.start_with?(prefix)
-
-        prefix.start_with?("claude-") || rewrite_upstream_model?
-      end
     end
 
     # Incoming names stay on the Claude allowlist so the shipped app
@@ -367,6 +356,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       if upstream.status.success?
         parsed = safe_parse_json(body)
         if parsed.is_a?(Hash) && parsed["error"].is_a?(Hash)
+          meter_buffered_usage(body) if meter
           message = parsed.dig("error", "message").to_s.presence || "The model service returned an error."
           return render json: anthropic_error("api_error", message), status: :bad_gateway
         end

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -235,13 +235,16 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       render json: anthropic_error("invalid_request_error", "That model is not available through the Gumhead gateway."), status: :bad_request
     end
 
-    # Role ids have no Anthropic SKU. They pass only when we will rewrite
-    # them. Claude family prefixes stay valid on both hosts.
+    # Role ids have no Anthropic SKU. They pass only when this request
+    # will rewrite that exact id. A partial GUMHEAD_MODEL_MAP must not
+    # admit an unmapped role. Claude family prefixes stay valid on both hosts.
     def allowed_incoming_model?(model)
       allowed_model_prefixes.any? do |prefix|
         next false unless model.start_with?(prefix)
+        next true if prefix.start_with?("claude-")
 
-        prefix.start_with?("claude-") || rewrite_upstream_model?
+        outgoing = mapped_upstream_model(model)
+        outgoing.present? && outgoing != model
       end
     end
 

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -57,20 +57,17 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # a deploy — any upstream must speak the Anthropic Messages protocol.
   DEFAULT_UPSTREAM_API_BASE = "https://api.anthropic.com/v1"
   DEFAULT_ANTHROPIC_VERSION = "2023-06-01"
-  # Families the shipped app still sends, plus the role ids newer builds
-  # use. Prefix match, so an exact role id also admits a suffixed variant.
-  # Caps are token-denominated; an unlisted pricier SKU cannot spend faster.
-  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-,gumhead-chat,gumhead-status,gumhead-cover"
-  # Incoming names stay on the allowlist; the body that goes upstream uses
-  # the mapped billed id. Role keys let ops change the model behind a slot
-  # from GUMHEAD_MODEL_MAP without a client release.
+  # The shipped app still sends claude-* names. Role ids stay out of
+  # this hop; they need an app change. Caps are token-denominated, so
+  # an unlisted pricier SKU cannot spend faster. Ops can extend the
+  # list without a deploy via GUMHEAD_ALLOWED_MODEL_PREFIXES.
+  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-"
+  # Rewrite after validate_model, before the POST. Built-in Grok
+  # targets apply only once the base leaves Anthropic.
   DEFAULT_MODEL_MAP = {
     "claude-sonnet-5" => "x-ai/grok-4.6",
     "claude-haiku-4-5" => "x-ai/grok-4.6",
     "claude-opus-5" => "x-ai/grok-4.6",
-    "gumhead-chat" => "x-ai/grok-4.6",
-    "gumhead-status" => "x-ai/grok-4.6",
-    "gumhead-cover" => "x-ai/grok-4.6",
   }.freeze
   # Matches nginx's client_max_body_size; a larger constant here would
   # document a limit requests can never reach.
@@ -640,17 +637,9 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     end
 
     def upstream_api_key
-      explicit = GlobalConfig.get("GUMHEAD_UPSTREAM_API_KEY").presence
-      return explicit if explicit
-      # The Anthropic key is only a fallback on the Anthropic host. Sending
-      # it to OpenRouter (or any other configured base) would leak it.
-      return unless anthropic_upstream?
-
-      GlobalConfig.get("GUMHEAD_ANTHROPIC_API_KEY")
-    end
-
-    def anthropic_upstream?
-      upstream_api_base == DEFAULT_UPSTREAM_API_BASE
+      # One-deploy fallback: ops can store the OpenRouter key in the
+      # existing GUMHEAD_ANTHROPIC_API_KEY name while flipping the base.
+      GlobalConfig.get("GUMHEAD_UPSTREAM_API_KEY").presence || GlobalConfig.get("GUMHEAD_ANTHROPIC_API_KEY")
     end
 
     def upstream_api_base

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -510,7 +510,13 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
 
       unless upstream.status.success?
         copy_retry_after(upstream)
-        return render body: upstream.body.to_s, content_type: "application/json", status: upstream.status.code
+        body = upstream.body.to_s
+        parsed = safe_parse_json(body)
+        if openrouter_error_envelope?(parsed)
+          message = parsed.dig("error", "message").to_s.presence || "The model service returned an error."
+          return render json: anthropic_error("api_error", message), status: upstream.status.code
+        end
+        return render body:, content_type: "application/json", status: upstream.status.code
       end
       if upstream.headers["Content-Type"].to_s.include?("application/json") &&
          !upstream.headers["Content-Type"].to_s.include?("event-stream")

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -5,6 +5,8 @@
 # OAuth bearer authenticates the request, the body is forwarded to Anthropic
 # with the server-side key, and token usage is metered per user
 # (GumheadUsageEvent). The seller never holds a model credential.
+# The upstream host is GUMHEAD_UPSTREAM_API_BASE — Anthropic today,
+# OpenRouter (or another Anthropic-protocol host) when that is set.
 #
 # Gateway-minted errors use Anthropic's error envelope ({type: "error",
 # error: {type:, message:}}) so the client runtime surfaces the message
@@ -43,6 +45,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   before_action :throttle_gateway_requests
   before_action :load_body
   before_action :validate_model
+  before_action :rewrite_upstream_model
   before_action :validate_tools
   before_action :validate_pricing_modifiers
   before_action :validate_max_tokens, only: [:create]
@@ -59,6 +62,13 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # smuggled in to spend faster per token; ops can extend the list without
   # a deploy via GUMHEAD_ALLOWED_MODEL_PREFIXES.
   DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-"
+  # The shipped app still sends claude-* names. Rewrite them to the
+  # billed upstream id after validate_model, before the POST.
+  DEFAULT_MODEL_MAP = {
+    "claude-sonnet-5" => "x-ai/grok-4.6",
+    "claude-haiku-4-5" => "x-ai/grok-4.6",
+    "claude-opus-5" => "x-ai/grok-4.6",
+  }.freeze
   # Matches nginx's client_max_body_size; a larger constant here would
   # document a limit requests can never reach.
   MAX_BODY_BYTES = 10.megabytes
@@ -123,7 +133,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # the in-flight limit.
   def count_tokens
     with_in_flight_slot do
-      forward_buffered("#{upstream_api_base}/messages/count_tokens", meter: false)
+      forward_buffered("#{upstream_api_base}/messages/count_tokens", meter: false, missing_ok: true)
     end
   end
 
@@ -143,7 +153,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     end
 
     def ensure_gateway_configured
-      return if anthropic_api_key.present? && gumhead_oauth_application_uids.any?
+      return if upstream_api_key.present? && gumhead_oauth_application_uids.any?
 
       render json: anthropic_error("api_error", "The Gumhead gateway is not configured."), status: :service_unavailable
     end
@@ -225,6 +235,34 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       render json: anthropic_error("invalid_request_error", "That model is not available through the Gumhead gateway."), status: :bad_request
     end
 
+    # Incoming names stay on the allowlist so both the shipped claude-*
+    # builds and the role-id ones pass validate_model. The body that goes
+    # upstream uses the mapped id, and the ledger records that billed name.
+    def rewrite_upstream_model
+      incoming = @body["model"].to_s
+      outgoing = mapped_upstream_model(incoming)
+      return if outgoing.blank? || outgoing == incoming
+
+      @body["model"] = outgoing
+      @raw_body = @body.to_json
+    end
+
+    def mapped_upstream_model(model)
+      map = model_map
+      exact = map[model].presence
+      return exact if exact
+
+      match = map.select { |key, value| value.present? && model.start_with?(key.to_s) }
+                 .max_by { |key, _| key.to_s.length }
+      match ? match[1] : model
+    end
+
+    def model_map
+      raw = GlobalConfig.get("GUMHEAD_MODEL_MAP", DEFAULT_MODEL_MAP)
+      parsed = raw.is_a?(String) ? safe_parse_json(raw) : raw
+      parsed.is_a?(Hash) ? parsed : {}
+    end
+
     def allowed_model_prefixes
       GlobalConfig.get("GUMHEAD_ALLOWED_MODEL_PREFIXES", DEFAULT_ALLOWED_MODEL_PREFIXES).to_s.split(",").map(&:strip).reject(&:blank?)
     end
@@ -295,11 +333,17 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       render json: anthropic_error("rate_limit_error", "Daily Gumhead usage limit reached. Please try again tomorrow."), status: :too_many_requests
     end
 
-    def forward_buffered(url, meter:)
+    def forward_buffered(url, meter:, missing_ok: false)
       upstream = nil
       dispatched_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       upstream = HTTP.timeout(BUFFERED_TIMEOUT).headers(upstream_headers).post(url, body: buffered_upstream_body(meter:))
       body = upstream.body.to_s
+      # OpenRouter has no count_tokens; a 404 pass-through must not
+      # fail the app probe (it only blocks on 401/403). Same byte
+      # estimate charge_input_tokens already uses when counting fails.
+      if missing_ok && upstream.status.code == 404
+        return render json: { "input_tokens" => @raw_body.bytesize }, status: :ok
+      end
       meter_buffered_usage(body) if meter && upstream.status.success?
       copy_retry_after(upstream)
       render body:, content_type: "application/json", status: upstream.status.code
@@ -555,8 +599,10 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     end
 
     def upstream_headers
+      key = upstream_api_key
       headers = {
-        "x-api-key" => anthropic_api_key,
+        "x-api-key" => key,
+        "authorization" => "Bearer #{key}",
         "anthropic-version" => request.headers["anthropic-version"].presence || DEFAULT_ANTHROPIC_VERSION,
         "content-type" => "application/json",
       }
@@ -575,8 +621,8 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       requested.reject { |feature| denied.any? { |pattern| feature.include?(pattern) } }.join(",")
     end
 
-    def anthropic_api_key
-      GlobalConfig.get("GUMHEAD_ANTHROPIC_API_KEY")
+    def upstream_api_key
+      GlobalConfig.get("GUMHEAD_UPSTREAM_API_KEY").presence || GlobalConfig.get("GUMHEAD_ANTHROPIC_API_KEY")
     end
 
     def upstream_api_base

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -57,17 +57,20 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # a deploy — any upstream must speak the Anthropic Messages protocol.
   DEFAULT_UPSTREAM_API_BASE = "https://api.anthropic.com/v1"
   DEFAULT_ANTHROPIC_VERSION = "2023-06-01"
-  # The model families Gumhead actually uses (main loop, narrator, artist).
-  # The caps are token-denominated, so an unlisted pricier SKU cannot be
-  # smuggled in to spend faster per token; ops can extend the list without
-  # a deploy via GUMHEAD_ALLOWED_MODEL_PREFIXES.
-  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-"
-  # The shipped app still sends claude-* names. Rewrite them to the
-  # billed upstream id after validate_model, before the POST.
+  # Families the shipped app still sends, plus the role ids newer builds
+  # use. Prefix match, so an exact role id also admits a suffixed variant.
+  # Caps are token-denominated; an unlisted pricier SKU cannot spend faster.
+  DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-,gumhead-chat,gumhead-status,gumhead-cover"
+  # Incoming names stay on the allowlist; the body that goes upstream uses
+  # the mapped billed id. Role keys let ops change the model behind a slot
+  # from GUMHEAD_MODEL_MAP without a client release.
   DEFAULT_MODEL_MAP = {
     "claude-sonnet-5" => "x-ai/grok-4.6",
     "claude-haiku-4-5" => "x-ai/grok-4.6",
     "claude-opus-5" => "x-ai/grok-4.6",
+    "gumhead-chat" => "x-ai/grok-4.6",
+    "gumhead-status" => "x-ai/grok-4.6",
+    "gumhead-cover" => "x-ai/grok-4.6",
   }.freeze
   # Matches nginx's client_max_body_size; a larger constant here would
   # document a limit requests can never reach.
@@ -637,7 +640,17 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     end
 
     def upstream_api_key
-      GlobalConfig.get("GUMHEAD_UPSTREAM_API_KEY").presence || GlobalConfig.get("GUMHEAD_ANTHROPIC_API_KEY")
+      explicit = GlobalConfig.get("GUMHEAD_UPSTREAM_API_KEY").presence
+      return explicit if explicit
+      # The Anthropic key is only a fallback on the Anthropic host. Sending
+      # it to OpenRouter (or any other configured base) would leak it.
+      return unless anthropic_upstream?
+
+      GlobalConfig.get("GUMHEAD_ANTHROPIC_API_KEY")
+    end
+
+    def anthropic_upstream?
+      upstream_api_base == DEFAULT_UPSTREAM_API_BASE
     end
 
     def upstream_api_base

--- a/app/models/gumhead_usage_event.rb
+++ b/app/models/gumhead_usage_event.rb
@@ -16,14 +16,14 @@ class GumheadUsageEvent < ApplicationRecord
 
   # Cache tokens are billed too, so the input cap counts a cost-weighted
   # total — otherwise a cache-heavy agent loop would spend almost entirely
-  # outside the cap. Defaults follow Grok 4.6 ($2 input / $0.50 cache
-  # read, no write premium). Anthropic's 1.25 / 2 / 0.1 stay available
-  # via GlobalConfig if the upstream moves back.
+  # outside the cap. Defaults stay Anthropic (1.25 / 2 / 0.1). Set the
+  # GUMHEAD_CACHE_* knobs when the upstream moves to Grok ($2 / $0.50
+  # cache read, no write premium) so the ledger does not lie.
   # `cache_creation_input_tokens` is the total across both TTLs, so the
   # 1-hour share is stored separately and re-weighted here.
-  CACHE_CREATION_COST_MULTIPLIER = 1.0
-  CACHE_CREATION_1H_COST_MULTIPLIER = 1.0
-  CACHE_READ_COST_MULTIPLIER = 0.25
+  CACHE_CREATION_COST_MULTIPLIER = 1.25
+  CACHE_CREATION_1H_COST_MULTIPLIER = 2
+  CACHE_READ_COST_MULTIPLIER = 0.1
 
   def self.input_equivalent_tokens_today(user)
     creation = cache_cost_multiplier("GUMHEAD_CACHE_CREATION_COST_MULTIPLIER", CACHE_CREATION_COST_MULTIPLIER)

--- a/app/models/gumhead_usage_event.rb
+++ b/app/models/gumhead_usage_event.rb
@@ -40,7 +40,7 @@ class GumheadUsageEvent < ApplicationRecord
 
   def self.cache_cost_multiplier(name, default)
     value = Float(GlobalConfig.get(name, default))
-    raise ArgumentError, "#{name} must be a finite number" unless value.finite?
+    raise ArgumentError, "#{name} must be a finite non-negative number" unless value.finite? && value >= 0
     value
   end
   private_class_method :cache_cost_multiplier

--- a/app/models/gumhead_usage_event.rb
+++ b/app/models/gumhead_usage_event.rb
@@ -41,8 +41,9 @@ class GumheadUsageEvent < ApplicationRecord
   end
 
   def self.cache_cost_multiplier(name, default)
-    value = Float(GlobalConfig.get(name, default))
-    raise ArgumentError, "#{name} must be a finite non-negative number" unless value.finite? && value >= 0
+    value = Float(GlobalConfig.get(name, default), exception: false)
+    return Float(default) if value.nil? || !value.finite? || value.negative?
+
     value
   end
   private_class_method :cache_cost_multiplier

--- a/app/models/gumhead_usage_event.rb
+++ b/app/models/gumhead_usage_event.rb
@@ -25,6 +25,8 @@ class GumheadUsageEvent < ApplicationRecord
   CACHE_CREATION_1H_COST_MULTIPLIER = 2
   CACHE_READ_COST_MULTIPLIER = 0.1
 
+  # Current weights apply to every row from today. A mid-day hop is a
+  # one-time ops event, not a per-row snapshot.
   def self.input_equivalent_tokens_today(user)
     creation = cache_cost_multiplier("GUMHEAD_CACHE_CREATION_COST_MULTIPLIER", CACHE_CREATION_COST_MULTIPLIER)
     creation_1h = cache_cost_multiplier("GUMHEAD_CACHE_CREATION_1H_COST_MULTIPLIER", CACHE_CREATION_1H_COST_MULTIPLIER)

--- a/app/models/gumhead_usage_event.rb
+++ b/app/models/gumhead_usage_event.rb
@@ -16,23 +16,34 @@ class GumheadUsageEvent < ApplicationRecord
 
   # Cache tokens are billed too, so the input cap counts a cost-weighted
   # total — otherwise a cache-heavy agent loop would spend almost entirely
-  # outside the cap. Anthropic prices 5-minute cache writes at 1.25x,
-  # 1-hour writes at 2x, and reads at 0.1x. `cache_creation_input_tokens`
-  # is the total across both TTLs, so the 1-hour share is stored separately
-  # and weighted up from the 1.25 base here.
-  CACHE_CREATION_COST_MULTIPLIER = 1.25
-  CACHE_CREATION_1H_COST_MULTIPLIER = 2
-  CACHE_READ_COST_MULTIPLIER = 0.1
+  # outside the cap. Defaults follow Grok 4.6 ($2 input / $0.50 cache
+  # read, no write premium). Anthropic's 1.25 / 2 / 0.1 stay available
+  # via GlobalConfig if the upstream moves back.
+  # `cache_creation_input_tokens` is the total across both TTLs, so the
+  # 1-hour share is stored separately and re-weighted here.
+  CACHE_CREATION_COST_MULTIPLIER = 1.0
+  CACHE_CREATION_1H_COST_MULTIPLIER = 1.0
+  CACHE_READ_COST_MULTIPLIER = 0.25
 
   def self.input_equivalent_tokens_today(user)
+    creation = cache_cost_multiplier("GUMHEAD_CACHE_CREATION_COST_MULTIPLIER", CACHE_CREATION_COST_MULTIPLIER)
+    creation_1h = cache_cost_multiplier("GUMHEAD_CACHE_CREATION_1H_COST_MULTIPLIER", CACHE_CREATION_1H_COST_MULTIPLIER)
+    read = cache_cost_multiplier("GUMHEAD_CACHE_READ_COST_MULTIPLIER", CACHE_READ_COST_MULTIPLIER)
     where(user:, created_at: Time.current.all_day)
       .sum(
         "input_tokens + " \
-        "CEIL((cache_creation_input_tokens - cache_creation_1h_input_tokens) * #{CACHE_CREATION_COST_MULTIPLIER}) + " \
-        "(cache_creation_1h_input_tokens * #{CACHE_CREATION_1H_COST_MULTIPLIER}) + " \
-        "CEIL(cache_read_input_tokens * #{CACHE_READ_COST_MULTIPLIER})"
+        "CEIL((cache_creation_input_tokens - cache_creation_1h_input_tokens) * #{creation}) + " \
+        "(cache_creation_1h_input_tokens * #{creation_1h}) + " \
+        "CEIL(cache_read_input_tokens * #{read})"
       ).to_i
   end
+
+  def self.cache_cost_multiplier(name, default)
+    value = Float(GlobalConfig.get(name, default))
+    raise ArgumentError, "#{name} must be a finite number" unless value.finite?
+    value
+  end
+  private_class_method :cache_cost_multiplier
 
   def self.output_tokens_today(user)
     where(user:, created_at: Time.current.all_day).sum(:output_tokens)

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -898,7 +898,7 @@ describe Api::V2::Gumhead::MessagesController do
       expect(GumheadUsageEvent.sole.model).to eq("x-ai/grok-4.6")
     end
 
-    it "leaves the model untouched when the map has no matching entry" do
+    it "still rewrites Claude names when the configured map is empty" do
       use_openrouter_base
       allow(GlobalConfig).to receive(:get)
         .with("GUMHEAD_MODEL_MAP", described_class::DEFAULT_MODEL_MAP)
@@ -909,7 +909,7 @@ describe Api::V2::Gumhead::MessagesController do
       post_messages
 
       expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
-        JSON.parse(req.body)["model"] == "claude-sonnet-5"
+        JSON.parse(req.body)["model"] == "x-ai/grok-4.6"
       }
     end
 
@@ -932,17 +932,14 @@ describe Api::V2::Gumhead::MessagesController do
       }
     end
 
-    it "falls back to GUMHEAD_ANTHROPIC_API_KEY on OpenRouter when the upstream key is unset" do
+    it "does not send the Anthropic key to OpenRouter when the upstream key is unset" do
       use_openrouter_base
       allow(GlobalConfig).to receive(:get).with("GUMHEAD_UPSTREAM_API_KEY").and_return(nil)
-      stub_request(:post, openrouter_messages_url)
-        .to_return(status: 200, body: anthropic_response.merge(model: "x-ai/grok-4.6").to_json, headers: { "Content-Type" => "application/json" })
 
       post_messages
 
-      expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
-        req.headers["Authorization"] == "Bearer sk-ant-gateway-test" && req.headers["X-Api-Key"].nil?
-      }
+      expect(response.status).to eq(503)
+      expect(WebMock).not_to have_requested(:post, openrouter_messages_url)
     end
 
     it "sends a bearer token to OpenRouter and omits x-api-key" do

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -313,6 +313,9 @@ describe Api::V2::Gumhead::MessagesController do
 
       post_messages(request_payload.merge(models: ["x-ai/grok-4.6"]))
       expect(response.status).to eq(400)
+
+      post_messages(request_payload.merge(service_tier: "priority"))
+      expect(response.status).to eq(400)
     end
 
     # The runtime's real header, verbatim: every one of these must survive,
@@ -356,8 +359,7 @@ describe Api::V2::Gumhead::MessagesController do
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)["content"].first["text"]).to eq("Hello!")
       expect(WebMock).to have_requested(:post, messages_url).with { |req|
-        req.headers["X-Api-Key"] == "sk-ant-gateway-test" &&
-          req.headers["Authorization"] == "Bearer sk-ant-gateway-test"
+        req.headers["X-Api-Key"] == "sk-ant-gateway-test" && req.headers["Authorization"].nil?
       }
 
       event = GumheadUsageEvent.sole
@@ -794,7 +796,20 @@ describe Api::V2::Gumhead::MessagesController do
       post_messages
 
       expect(WebMock).to have_requested(:post, messages_url).with { |req|
-        req.headers["X-Api-Key"] == "sk-or-test" && req.headers["Authorization"] == "Bearer sk-or-test"
+        req.headers["X-Api-Key"] == "sk-or-test" && req.headers["Authorization"].nil?
+      }
+    end
+
+    it "sends a bearer token to OpenRouter and omits x-api-key" do
+      use_openrouter_base
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_UPSTREAM_API_KEY").and_return("sk-or-test")
+      stub_request(:post, openrouter_messages_url)
+        .to_return(status: 200, body: anthropic_response.merge(model: "x-ai/grok-4.6").to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
+        req.headers["Authorization"] == "Bearer sk-or-test" && req.headers["X-Api-Key"].nil?
       }
     end
 

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -799,6 +799,27 @@ describe Api::V2::Gumhead::MessagesController do
       end
     end
 
+    it "rejects a suffixed role id instead of treating it as a prefix" do
+      use_openrouter_base
+
+      post_messages(request_payload.merge(model: "gumhead-chat-extra"))
+
+      expect(response.status).to eq(400)
+      expect(WebMock).not_to have_requested(:post, openrouter_messages_url)
+    end
+
+    it "rejects a role id that is missing from the allowlist" do
+      use_openrouter_base
+      allow(GlobalConfig).to receive(:get)
+        .with("GUMHEAD_ALLOWED_MODEL_PREFIXES", described_class::DEFAULT_ALLOWED_MODEL_PREFIXES)
+        .and_return("claude-sonnet-,claude-haiku-,claude-opus-")
+
+      post_messages(request_payload.merge(model: "gumhead-chat"))
+
+      expect(response.status).to eq(400)
+      expect(WebMock).not_to have_requested(:post, openrouter_messages_url)
+    end
+
     it "rewrites a Claude family name that carries an OpenRouter variant suffix" do
       use_openrouter_base
       stub_request(:post, openrouter_messages_url)

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -761,25 +761,6 @@ describe Api::V2::Gumhead::MessagesController do
       }
     end
 
-    # Forwarded body plus a response that omits model: the ledger then
-    # records @body["model"] after rewrite. A stub that already names
-    # grok would pass with the rewrite reverted.
-    %w[gumhead-chat gumhead-status gumhead-cover].each do |role_id|
-      it "allows #{role_id}, rewrites it on the upstream POST, and records the billed model" do
-        use_openrouter_base
-        stub_request(:post, openrouter_messages_url)
-          .to_return(status: 200, body: anthropic_response.except(:model).to_json, headers: { "Content-Type" => "application/json" })
-
-        post_messages(request_payload.merge(model: role_id))
-
-        expect(response.status).to eq(200)
-        expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
-          JSON.parse(req.body)["model"] == "x-ai/grok-4.6"
-        }
-        expect(GumheadUsageEvent.sole.model).to eq("x-ai/grok-4.6")
-      end
-    end
-
     it "records the outgoing model on a synthetic timeout charge" do
       use_openrouter_base
       stub_request(:post, openrouter_messages_url).to_raise(HTTP::TimeoutError)
@@ -813,16 +794,6 @@ describe Api::V2::Gumhead::MessagesController do
       expect(WebMock).not_to have_requested(:post, messages_url)
     end
 
-    it "does not send the Anthropic key to a non-Anthropic upstream" do
-      use_openrouter_base
-      allow(GlobalConfig).to receive(:get).with("GUMHEAD_UPSTREAM_API_KEY").and_return(nil)
-
-      post_messages
-
-      expect(response.status).to eq(503)
-      expect(WebMock).not_to have_requested(:post, openrouter_messages_url)
-    end
-
     it "prefers GUMHEAD_UPSTREAM_API_KEY over the Anthropic key" do
       allow(GlobalConfig).to receive(:get).with("GUMHEAD_UPSTREAM_API_KEY").and_return("sk-or-test")
       stub_request(:post, messages_url)
@@ -832,6 +803,19 @@ describe Api::V2::Gumhead::MessagesController do
 
       expect(WebMock).to have_requested(:post, messages_url).with { |req|
         req.headers["X-Api-Key"] == "sk-or-test" && req.headers["Authorization"].nil?
+      }
+    end
+
+    it "falls back to GUMHEAD_ANTHROPIC_API_KEY on OpenRouter when the upstream key is unset" do
+      use_openrouter_base
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_UPSTREAM_API_KEY").and_return(nil)
+      stub_request(:post, openrouter_messages_url)
+        .to_return(status: 200, body: anthropic_response.merge(model: "x-ai/grok-4.6").to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
+        req.headers["Authorization"] == "Bearer sk-ant-gateway-test" && req.headers["X-Api-Key"].nil?
       }
     end
 

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -771,32 +771,6 @@ describe Api::V2::Gumhead::MessagesController do
       }
     end
 
-    it "rejects a role id while the upstream is still Anthropic" do
-      post_messages(request_payload.merge(model: "gumhead-chat"))
-
-      expect(response.status).to eq(400)
-      expect(WebMock).not_to have_requested(:post, messages_url)
-    end
-
-    # Forwarded body plus a response that omits model: the ledger then
-    # records @body["model"] after rewrite. A stub that already names
-    # grok would pass with the rewrite reverted.
-    %w[gumhead-chat gumhead-status gumhead-cover].each do |role_id|
-      it "allows #{role_id}, rewrites it on the upstream POST, and records the billed model" do
-        use_openrouter_base
-        stub_request(:post, openrouter_messages_url)
-          .to_return(status: 200, body: anthropic_response.except(:model).to_json, headers: { "Content-Type" => "application/json" })
-
-        post_messages(request_payload.merge(model: role_id))
-
-        expect(response.status).to eq(200)
-        expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
-          JSON.parse(req.body)["model"] == "x-ai/grok-4.6"
-        }
-        expect(GumheadUsageEvent.sole.model).to eq("x-ai/grok-4.6")
-      end
-    end
-
     it "rewrites a Claude family name that carries an OpenRouter variant suffix" do
       use_openrouter_base
       stub_request(:post, openrouter_messages_url)

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -307,6 +307,12 @@ describe Api::V2::Gumhead::MessagesController do
 
       post_messages(request_payload.merge(fallbacks: [{ model: "claude-opus-5" }]))
       expect(response.status).to eq(400)
+
+      post_messages(request_payload.merge(plugins: [{ id: "web" }]))
+      expect(response.status).to eq(400)
+
+      post_messages(request_payload.merge(models: ["x-ai/grok-4.6"]))
+      expect(response.status).to eq(400)
     end
 
     # The runtime's real header, verbatim: every one of these must survive,
@@ -473,7 +479,7 @@ describe Api::V2::Gumhead::MessagesController do
       post_messages
 
       expect(response.status).to eq(502)
-      expect(GumheadUsageEvent.sole.input_tokens).to eq(request_payload.merge(model: "x-ai/grok-4.6").to_json.bytesize)
+      expect(GumheadUsageEvent.sole.input_tokens).to eq(request_payload.to_json.bytesize)
     end
 
     it "charges nothing when the connection itself times out" do
@@ -702,34 +708,55 @@ describe Api::V2::Gumhead::MessagesController do
 
   describe "upstream hop" do
     let(:openrouter_messages_url) { "https://openrouter.ai/api/v1/messages" }
+    let(:openrouter_count_tokens_url) { "https://openrouter.ai/api/v1/messages/count_tokens" }
     let(:rewritten_payload_bytesize) { request_payload.merge(model: "x-ai/grok-4.6").to_json.bytesize }
 
-    it "rewrites an allowed Claude alias to the mapped OpenRouter id before forwarding" do
+    def use_openrouter_base
+      allow(GlobalConfig).to receive(:get)
+        .with("GUMHEAD_UPSTREAM_API_BASE", described_class::DEFAULT_UPSTREAM_API_BASE)
+        .and_return("https://openrouter.ai/api/v1")
+    end
+
+    it "does not rewrite Claude aliases while the upstream is still Anthropic" do
       stub_request(:post, messages_url)
         .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
 
       post_messages
 
-      expect(response.status).to eq(200)
       expect(WebMock).to have_requested(:post, messages_url).with { |req|
+        JSON.parse(req.body)["model"] == "claude-sonnet-5"
+      }
+    end
+
+    it "rewrites an allowed Claude alias to the mapped OpenRouter id before forwarding" do
+      use_openrouter_base
+      stub_request(:post, openrouter_messages_url)
+        .to_return(status: 200, body: anthropic_response.merge(model: "x-ai/grok-4.6").to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
         JSON.parse(req.body)["model"] == "x-ai/grok-4.6"
       }
     end
 
     it "maps a versioned Claude name by prefix" do
-      stub_request(:post, messages_url)
+      use_openrouter_base
+      stub_request(:post, openrouter_messages_url)
         .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
 
       post_messages(request_payload.merge(model: "claude-sonnet-5-20250514"))
 
-      expect(WebMock).to have_requested(:post, messages_url).with { |req|
+      expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
         JSON.parse(req.body)["model"] == "x-ai/grok-4.6"
       }
     end
 
     it "records the outgoing model on a synthetic timeout charge" do
-      stub_request(:post, messages_url).to_raise(HTTP::TimeoutError)
-      stub_request(:post, count_tokens_url)
+      use_openrouter_base
+      stub_request(:post, openrouter_messages_url).to_raise(HTTP::TimeoutError)
+      stub_request(:post, openrouter_count_tokens_url)
         .to_return(status: 200, body: { input_tokens: 37 }.to_json, headers: { "Content-Type" => "application/json" })
 
       post_messages
@@ -738,15 +765,16 @@ describe Api::V2::Gumhead::MessagesController do
     end
 
     it "leaves the model untouched when the map has no matching entry" do
+      use_openrouter_base
       allow(GlobalConfig).to receive(:get)
         .with("GUMHEAD_MODEL_MAP", described_class::DEFAULT_MODEL_MAP)
         .and_return({})
-      stub_request(:post, messages_url)
+      stub_request(:post, openrouter_messages_url)
         .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
 
       post_messages
 
-      expect(WebMock).to have_requested(:post, messages_url).with { |req|
+      expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
         JSON.parse(req.body)["model"] == "claude-sonnet-5"
       }
     end
@@ -786,7 +814,8 @@ describe Api::V2::Gumhead::MessagesController do
     end
 
     it "returns a synthetic token count when upstream count_tokens is missing" do
-      stub_request(:post, count_tokens_url)
+      use_openrouter_base
+      stub_request(:post, openrouter_count_tokens_url)
         .to_return(status: 404, body: { type: "error", error: { type: "not_found_error", message: "Not Found" } }.to_json)
 
       post :count_tokens, body: request_payload.to_json, as: :json
@@ -797,8 +826,9 @@ describe Api::V2::Gumhead::MessagesController do
     end
 
     it "charges the byte fallback when count_tokens returns 404 during a timeout" do
-      stub_request(:post, messages_url).to_raise(HTTP::TimeoutError)
-      stub_request(:post, count_tokens_url).to_return(status: 404, body: "Not Found")
+      use_openrouter_base
+      stub_request(:post, openrouter_messages_url).to_raise(HTTP::TimeoutError)
+      stub_request(:post, openrouter_count_tokens_url).to_return(status: 404, body: "Not Found")
 
       post_messages
 

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -761,6 +761,32 @@ describe Api::V2::Gumhead::MessagesController do
       }
     end
 
+    it "rejects a role id while the upstream is still Anthropic" do
+      post_messages(request_payload.merge(model: "gumhead-chat"))
+
+      expect(response.status).to eq(400)
+      expect(WebMock).not_to have_requested(:post, messages_url)
+    end
+
+    # Forwarded body plus a response that omits model: the ledger then
+    # records @body["model"] after rewrite. A stub that already names
+    # grok would pass with the rewrite reverted.
+    %w[gumhead-chat gumhead-status gumhead-cover].each do |role_id|
+      it "allows #{role_id}, rewrites it on the upstream POST, and records the billed model" do
+        use_openrouter_base
+        stub_request(:post, openrouter_messages_url)
+          .to_return(status: 200, body: anthropic_response.except(:model).to_json, headers: { "Content-Type" => "application/json" })
+
+        post_messages(request_payload.merge(model: role_id))
+
+        expect(response.status).to eq(200)
+        expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
+          JSON.parse(req.body)["model"] == "x-ai/grok-4.6"
+        }
+        expect(GumheadUsageEvent.sole.model).to eq("x-ai/grok-4.6")
+      end
+    end
+
     it "records the outgoing model on a synthetic timeout charge" do
       use_openrouter_base
       stub_request(:post, openrouter_messages_url).to_raise(HTTP::TimeoutError)

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -703,6 +703,16 @@ describe Api::V2::Gumhead::MessagesController do
       expect(GumheadUsageEvent.count).to eq(0)
     end
 
+    it "passes through a 404 from Anthropic count_tokens" do
+      stub_request(:post, count_tokens_url)
+        .to_return(status: 404, body: { type: "error", error: { type: "not_found_error", message: "Not Found" } }.to_json)
+
+      post :count_tokens, body: request_payload.to_json, as: :json
+
+      expect(response.status).to eq(404)
+      expect(JSON.parse(response.body)["error"]["type"]).to eq("not_found_error")
+    end
+
     it "shares the concurrent in-flight limit" do
       key = RedisKey.gumhead_gateway_in_flight(@user.id)
       described_class::MAX_IN_FLIGHT_REQUESTS.times { |i| $redis.zadd(key, Time.current.to_f, "lease-#{i}") }

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -316,6 +316,12 @@ describe Api::V2::Gumhead::MessagesController do
 
       post_messages(request_payload.merge(service_tier: "priority"))
       expect(response.status).to eq(400)
+
+      post_messages(request_payload.merge(provider: { sort: "price" }))
+      expect(response.status).to eq(400)
+
+      post_messages(request_payload.merge(route: "fallback"))
+      expect(response.status).to eq(400)
     end
 
     # The runtime's real header, verbatim: every one of these must survive,
@@ -755,6 +761,25 @@ describe Api::V2::Gumhead::MessagesController do
       }
     end
 
+    # Forwarded body plus a response that omits model: the ledger then
+    # records @body["model"] after rewrite. A stub that already names
+    # grok would pass with the rewrite reverted.
+    %w[gumhead-chat gumhead-status gumhead-cover].each do |role_id|
+      it "allows #{role_id}, rewrites it on the upstream POST, and records the billed model" do
+        use_openrouter_base
+        stub_request(:post, openrouter_messages_url)
+          .to_return(status: 200, body: anthropic_response.except(:model).to_json, headers: { "Content-Type" => "application/json" })
+
+        post_messages(request_payload.merge(model: role_id))
+
+        expect(response.status).to eq(200)
+        expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
+          JSON.parse(req.body)["model"] == "x-ai/grok-4.6"
+        }
+        expect(GumheadUsageEvent.sole.model).to eq("x-ai/grok-4.6")
+      end
+    end
+
     it "records the outgoing model on a synthetic timeout charge" do
       use_openrouter_base
       stub_request(:post, openrouter_messages_url).to_raise(HTTP::TimeoutError)
@@ -786,6 +811,16 @@ describe Api::V2::Gumhead::MessagesController do
 
       expect(response.status).to eq(400)
       expect(WebMock).not_to have_requested(:post, messages_url)
+    end
+
+    it "does not send the Anthropic key to a non-Anthropic upstream" do
+      use_openrouter_base
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_UPSTREAM_API_KEY").and_return(nil)
+
+      post_messages
+
+      expect(response.status).to eq(503)
+      expect(WebMock).not_to have_requested(:post, openrouter_messages_url)
     end
 
     it "prefers GUMHEAD_UPSTREAM_API_KEY over the Anthropic key" do

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -83,6 +83,7 @@ describe Api::V2::Gumhead::MessagesController do
 
     it "refuses to proxy when the server-side key is not configured" do
       allow(GlobalConfig).to receive(:get).with("GUMHEAD_ANTHROPIC_API_KEY").and_return(nil)
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_UPSTREAM_API_KEY").and_return(nil)
 
       post_messages
 
@@ -349,7 +350,8 @@ describe Api::V2::Gumhead::MessagesController do
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)["content"].first["text"]).to eq("Hello!")
       expect(WebMock).to have_requested(:post, messages_url).with { |req|
-        req.headers["X-Api-Key"] == "sk-ant-gateway-test" && req.headers["Authorization"].nil?
+        req.headers["X-Api-Key"] == "sk-ant-gateway-test" &&
+          req.headers["Authorization"] == "Bearer sk-ant-gateway-test"
       }
 
       event = GumheadUsageEvent.sole
@@ -471,7 +473,7 @@ describe Api::V2::Gumhead::MessagesController do
       post_messages
 
       expect(response.status).to eq(502)
-      expect(GumheadUsageEvent.sole.input_tokens).to eq(request_payload.to_json.bytesize)
+      expect(GumheadUsageEvent.sole.input_tokens).to eq(request_payload.merge(model: "x-ai/grok-4.6").to_json.bytesize)
     end
 
     it "charges nothing when the connection itself times out" do
@@ -695,6 +697,113 @@ describe Api::V2::Gumhead::MessagesController do
 
       expect(response.status).to eq(429)
       expect(WebMock).not_to have_requested(:post, count_tokens_url)
+    end
+  end
+
+  describe "upstream hop" do
+    let(:openrouter_messages_url) { "https://openrouter.ai/api/v1/messages" }
+    let(:rewritten_payload_bytesize) { request_payload.merge(model: "x-ai/grok-4.6").to_json.bytesize }
+
+    it "rewrites an allowed Claude alias to the mapped OpenRouter id before forwarding" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect(WebMock).to have_requested(:post, messages_url).with { |req|
+        JSON.parse(req.body)["model"] == "x-ai/grok-4.6"
+      }
+    end
+
+    it "maps a versioned Claude name by prefix" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages(request_payload.merge(model: "claude-sonnet-5-20250514"))
+
+      expect(WebMock).to have_requested(:post, messages_url).with { |req|
+        JSON.parse(req.body)["model"] == "x-ai/grok-4.6"
+      }
+    end
+
+    it "records the outgoing model on a synthetic timeout charge" do
+      stub_request(:post, messages_url).to_raise(HTTP::TimeoutError)
+      stub_request(:post, count_tokens_url)
+        .to_return(status: 200, body: { input_tokens: 37 }.to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(GumheadUsageEvent.sole.model).to eq("x-ai/grok-4.6")
+    end
+
+    it "leaves the model untouched when the map has no matching entry" do
+      allow(GlobalConfig).to receive(:get)
+        .with("GUMHEAD_MODEL_MAP", described_class::DEFAULT_MODEL_MAP)
+        .and_return({})
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(WebMock).to have_requested(:post, messages_url).with { |req|
+        JSON.parse(req.body)["model"] == "claude-sonnet-5"
+      }
+    end
+
+    it "still rejects a model outside the Claude allowlist" do
+      post_messages(request_payload.merge(model: "x-ai/grok-4.6"))
+
+      expect(response.status).to eq(400)
+      expect(WebMock).not_to have_requested(:post, messages_url)
+    end
+
+    it "prefers GUMHEAD_UPSTREAM_API_KEY over the Anthropic key" do
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_UPSTREAM_API_KEY").and_return("sk-or-test")
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(WebMock).to have_requested(:post, messages_url).with { |req|
+        req.headers["X-Api-Key"] == "sk-or-test" && req.headers["Authorization"] == "Bearer sk-or-test"
+      }
+    end
+
+    it "forwards to GUMHEAD_UPSTREAM_API_BASE when it is set" do
+      allow(GlobalConfig).to receive(:get)
+        .with("GUMHEAD_UPSTREAM_API_BASE", described_class::DEFAULT_UPSTREAM_API_BASE)
+        .and_return("https://openrouter.ai/api/v1")
+      stub_request(:post, openrouter_messages_url)
+        .to_return(status: 200, body: anthropic_response.merge(model: "x-ai/grok-4.6").to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect(WebMock).to have_requested(:post, openrouter_messages_url)
+      expect(WebMock).not_to have_requested(:post, messages_url)
+      expect(GumheadUsageEvent.sole.model).to eq("x-ai/grok-4.6")
+    end
+
+    it "returns a synthetic token count when upstream count_tokens is missing" do
+      stub_request(:post, count_tokens_url)
+        .to_return(status: 404, body: { type: "error", error: { type: "not_found_error", message: "Not Found" } }.to_json)
+
+      post :count_tokens, body: request_payload.to_json, as: :json
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)["input_tokens"]).to eq(rewritten_payload_bytesize)
+      expect(GumheadUsageEvent.count).to eq(0)
+    end
+
+    it "charges the byte fallback when count_tokens returns 404 during a timeout" do
+      stub_request(:post, messages_url).to_raise(HTTP::TimeoutError)
+      stub_request(:post, count_tokens_url).to_return(status: 404, body: "Not Found")
+
+      post_messages
+
+      expect(response.status).to eq(502)
+      expect(GumheadUsageEvent.sole.input_tokens).to eq(rewritten_payload_bytesize)
     end
   end
 end

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -827,6 +827,26 @@ describe Api::V2::Gumhead::MessagesController do
       }
     end
 
+    it "translates a non-2xx OpenRouter error envelope into the Anthropic shape" do
+      use_openrouter_base
+      stub_request(:post, openrouter_messages_url)
+        .to_return(
+          status: 429,
+          body: { error: { message: "Rate limited" } }.to_json,
+          headers: { "Content-Type" => "application/json", "Retry-After" => "7" },
+        )
+
+      post_messages
+
+      expect(response.status).to eq(429)
+      expect(response.headers["Retry-After"]).to eq("7")
+      expect(JSON.parse(response.body)).to eq(
+        "type" => "error",
+        "error" => { "type" => "api_error", "message" => "Rate limited" },
+      )
+      expect(GumheadUsageEvent.count).to eq(0)
+    end
+
     it "turns an OpenRouter HTTP 200 error envelope into a gateway error" do
       use_openrouter_base
       stub_request(:post, openrouter_messages_url)

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -771,30 +771,51 @@ describe Api::V2::Gumhead::MessagesController do
       }
     end
 
-    it "rejects a role id while the upstream is still Anthropic" do
-      post_messages(request_payload.merge(model: "gumhead-chat"))
+    it "rewrites a Claude family name that carries an OpenRouter variant suffix" do
+      use_openrouter_base
+      stub_request(:post, openrouter_messages_url)
+        .to_return(status: 200, body: anthropic_response.merge(model: "x-ai/grok-4.6").to_json, headers: { "Content-Type" => "application/json" })
 
-      expect(response.status).to eq(400)
-      expect(WebMock).not_to have_requested(:post, messages_url)
+      post_messages(request_payload.merge(model: "claude-opus-4-7:online"))
+
+      expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
+        JSON.parse(req.body)["model"] == "x-ai/grok-4.6"
+      }
     end
 
-    # Forwarded body plus a response that omits model: the ledger then
-    # records @body["model"] after rewrite. A stub that already names
-    # grok would pass with the rewrite reverted.
-    %w[gumhead-chat gumhead-status gumhead-cover].each do |role_id|
-      it "allows #{role_id}, rewrites it on the upstream POST, and records the billed model" do
-        use_openrouter_base
-        stub_request(:post, openrouter_messages_url)
-          .to_return(status: 200, body: anthropic_response.except(:model).to_json, headers: { "Content-Type" => "application/json" })
+    it "does not rewrite when the configured base is still the Anthropic host" do
+      allow(GlobalConfig).to receive(:get)
+        .with("GUMHEAD_UPSTREAM_API_BASE", described_class::DEFAULT_UPSTREAM_API_BASE)
+        .and_return("https://api.anthropic.com/v1/")
+      stub_request(:post, %r{\Ahttps://api\.anthropic\.com/v1/+messages\z})
+        .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
 
-        post_messages(request_payload.merge(model: role_id))
+      post_messages
 
-        expect(response.status).to eq(200)
-        expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
-          JSON.parse(req.body)["model"] == "x-ai/grok-4.6"
-        }
-        expect(GumheadUsageEvent.sole.model).to eq("x-ai/grok-4.6")
-      end
+      expect(WebMock).to have_requested(:post, %r{\Ahttps://api\.anthropic\.com/v1/+messages\z}).with { |req|
+        JSON.parse(req.body)["model"] == "claude-sonnet-5" &&
+          req.headers["X-Api-Key"] == "sk-ant-gateway-test" &&
+          req.headers["Authorization"].nil?
+      }
+    end
+
+    it "turns an OpenRouter HTTP 200 error envelope into a gateway error" do
+      use_openrouter_base
+      stub_request(:post, openrouter_messages_url)
+        .to_return(
+          status: 200,
+          body: { error: { message: "Provider returned error" } }.to_json,
+          headers: { "Content-Type" => "application/json" },
+        )
+
+      post_messages
+
+      expect(response.status).to eq(502)
+      expect(JSON.parse(response.body)).to eq(
+        "type" => "error",
+        "error" => { "type" => "api_error", "message" => "Provider returned error" },
+      )
+      expect(GumheadUsageEvent.count).to eq(0)
     end
 
     it "records the outgoing model on a synthetic timeout charge" do

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -771,6 +771,32 @@ describe Api::V2::Gumhead::MessagesController do
       }
     end
 
+    it "rejects a role id while the upstream is still Anthropic" do
+      post_messages(request_payload.merge(model: "gumhead-chat"))
+
+      expect(response.status).to eq(400)
+      expect(WebMock).not_to have_requested(:post, messages_url)
+    end
+
+    # Forwarded body plus a response that omits model: the ledger then
+    # records @body["model"] after rewrite. A stub that already names
+    # grok would pass with the rewrite reverted.
+    %w[gumhead-chat gumhead-status gumhead-cover].each do |role_id|
+      it "allows #{role_id}, rewrites it on the upstream POST, and records the billed model" do
+        use_openrouter_base
+        stub_request(:post, openrouter_messages_url)
+          .to_return(status: 200, body: anthropic_response.except(:model).to_json, headers: { "Content-Type" => "application/json" })
+
+        post_messages(request_payload.merge(model: role_id))
+
+        expect(response.status).to eq(200)
+        expect(WebMock).to have_requested(:post, openrouter_messages_url).with { |req|
+          JSON.parse(req.body)["model"] == "x-ai/grok-4.6"
+        }
+        expect(GumheadUsageEvent.sole.model).to eq("x-ai/grok-4.6")
+      end
+    end
+
     it "rewrites a Claude family name that carries an OpenRouter variant suffix" do
       use_openrouter_base
       stub_request(:post, openrouter_messages_url)

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -11,6 +11,7 @@ describe Api::V2::Gumhead::MessagesController do
 
     allow(GlobalConfig).to receive(:get).and_call_original
     allow(GlobalConfig).to receive(:get).with("GUMHEAD_ANTHROPIC_API_KEY").and_return("sk-ant-gateway-test")
+    allow(GlobalConfig).to receive(:get).with("GUMHEAD_UPSTREAM_API_KEY").and_return(nil)
     allow(GlobalConfig).to receive(:get).with("GUMHEAD_OAUTH_APPLICATION_UIDS", "").and_return(@app.uid)
 
     request.headers["Authorization"] = "Bearer #{@token.token}"
@@ -733,6 +734,7 @@ describe Api::V2::Gumhead::MessagesController do
       allow(GlobalConfig).to receive(:get)
         .with("GUMHEAD_UPSTREAM_API_BASE", described_class::DEFAULT_UPSTREAM_API_BASE)
         .and_return("https://openrouter.ai/api/v1")
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_UPSTREAM_API_KEY").and_return("sk-or-test")
     end
 
     it "does not rewrite Claude aliases while the upstream is still Anthropic" do
@@ -916,9 +918,7 @@ describe Api::V2::Gumhead::MessagesController do
     end
 
     it "forwards to GUMHEAD_UPSTREAM_API_BASE when it is set" do
-      allow(GlobalConfig).to receive(:get)
-        .with("GUMHEAD_UPSTREAM_API_BASE", described_class::DEFAULT_UPSTREAM_API_BASE)
-        .and_return("https://openrouter.ai/api/v1")
+      use_openrouter_base
       stub_request(:post, openrouter_messages_url)
         .to_return(status: 200, body: anthropic_response.merge(model: "x-ai/grok-4.6").to_json, headers: { "Content-Type" => "application/json" })
 

--- a/spec/models/gumhead_usage_event_spec.rb
+++ b/spec/models/gumhead_usage_event_spec.rb
@@ -8,13 +8,13 @@ describe GumheadUsageEvent do
       @user = create(:user)
     end
 
-    it "weights cache reads at the Grok default so $0.50 reads do not count as Anthropic 0.1x" do
-      described_class.create!(user: @user, model: "x-ai/grok-4.6", cache_read_input_tokens: 100)
+    it "weights cache reads at the Anthropic default" do
+      described_class.create!(user: @user, model: "claude-sonnet-5", cache_read_input_tokens: 100)
 
-      expect(described_class.input_equivalent_tokens_today(@user)).to eq(25)
+      expect(described_class.input_equivalent_tokens_today(@user)).to eq(10)
     end
 
-    it "uses configured cache multipliers instead of the hardcoded defaults" do
+    it "uses configured cache multipliers so Grok $0.50 reads do not count as 0.1x" do
       described_class.create!(
         user: @user,
         model: "x-ai/grok-4.6",
@@ -25,16 +25,16 @@ describe GumheadUsageEvent do
       allow(GlobalConfig).to receive(:get).and_call_original
       allow(GlobalConfig).to receive(:get)
         .with("GUMHEAD_CACHE_CREATION_COST_MULTIPLIER", described_class::CACHE_CREATION_COST_MULTIPLIER)
-        .and_return(1.25)
+        .and_return(1.0)
       allow(GlobalConfig).to receive(:get)
         .with("GUMHEAD_CACHE_CREATION_1H_COST_MULTIPLIER", described_class::CACHE_CREATION_1H_COST_MULTIPLIER)
-        .and_return(2)
+        .and_return(1.0)
       allow(GlobalConfig).to receive(:get)
         .with("GUMHEAD_CACHE_READ_COST_MULTIPLIER", described_class::CACHE_READ_COST_MULTIPLIER)
-        .and_return(0.1)
+        .and_return(0.25)
 
-      # 30 * 1.25 = 37.5 -> 38; 10 * 2 = 20; 100 * 0.1 = 10
-      expect(described_class.input_equivalent_tokens_today(@user)).to eq(68)
+      # 30 * 1.0 = 30; 10 * 1.0 = 10; 100 * 0.25 = 25
+      expect(described_class.input_equivalent_tokens_today(@user)).to eq(65)
     end
   end
 end

--- a/spec/models/gumhead_usage_event_spec.rb
+++ b/spec/models/gumhead_usage_event_spec.rb
@@ -36,5 +36,15 @@ describe GumheadUsageEvent do
       # 30 * 1.0 = 30; 10 * 1.0 = 10; 100 * 0.25 = 25
       expect(described_class.input_equivalent_tokens_today(@user)).to eq(65)
     end
+
+    it "rejects a negative cache multiplier so cached traffic cannot shrink the cap" do
+      described_class.create!(user: @user, model: "claude-sonnet-5", cache_read_input_tokens: 100)
+      allow(GlobalConfig).to receive(:get).and_call_original
+      allow(GlobalConfig).to receive(:get)
+        .with("GUMHEAD_CACHE_READ_COST_MULTIPLIER", described_class::CACHE_READ_COST_MULTIPLIER)
+        .and_return(-1)
+
+      expect { described_class.input_equivalent_tokens_today(@user) }.to raise_error(ArgumentError)
+    end
   end
 end

--- a/spec/models/gumhead_usage_event_spec.rb
+++ b/spec/models/gumhead_usage_event_spec.rb
@@ -37,14 +37,24 @@ describe GumheadUsageEvent do
       expect(described_class.input_equivalent_tokens_today(@user)).to eq(65)
     end
 
-    it "rejects a negative cache multiplier so cached traffic cannot shrink the cap" do
+    it "falls back to the default multiplier when the configured value is negative" do
       described_class.create!(user: @user, model: "claude-sonnet-5", cache_read_input_tokens: 100)
       allow(GlobalConfig).to receive(:get).and_call_original
       allow(GlobalConfig).to receive(:get)
         .with("GUMHEAD_CACHE_READ_COST_MULTIPLIER", described_class::CACHE_READ_COST_MULTIPLIER)
         .and_return(-1)
 
-      expect { described_class.input_equivalent_tokens_today(@user) }.to raise_error(ArgumentError)
+      expect(described_class.input_equivalent_tokens_today(@user)).to eq(10)
+    end
+
+    it "falls back to the default multiplier when the configured value is not numeric" do
+      described_class.create!(user: @user, model: "claude-sonnet-5", cache_read_input_tokens: 100)
+      allow(GlobalConfig).to receive(:get).and_call_original
+      allow(GlobalConfig).to receive(:get)
+        .with("GUMHEAD_CACHE_READ_COST_MULTIPLIER", described_class::CACHE_READ_COST_MULTIPLIER)
+        .and_return("not-a-number")
+
+      expect(described_class.input_equivalent_tokens_today(@user)).to eq(10)
     end
   end
 end

--- a/spec/models/gumhead_usage_event_spec.rb
+++ b/spec/models/gumhead_usage_event_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GumheadUsageEvent do
+  describe ".input_equivalent_tokens_today" do
+    before do
+      @user = create(:user)
+    end
+
+    it "weights cache reads at the Grok default so $0.50 reads do not count as Anthropic 0.1x" do
+      described_class.create!(user: @user, model: "x-ai/grok-4.6", cache_read_input_tokens: 100)
+
+      expect(described_class.input_equivalent_tokens_today(@user)).to eq(25)
+    end
+
+    it "uses configured cache multipliers instead of the hardcoded defaults" do
+      described_class.create!(
+        user: @user,
+        model: "x-ai/grok-4.6",
+        cache_creation_input_tokens: 40,
+        cache_creation_1h_input_tokens: 10,
+        cache_read_input_tokens: 100,
+      )
+      allow(GlobalConfig).to receive(:get).and_call_original
+      allow(GlobalConfig).to receive(:get)
+        .with("GUMHEAD_CACHE_CREATION_COST_MULTIPLIER", described_class::CACHE_CREATION_COST_MULTIPLIER)
+        .and_return(1.25)
+      allow(GlobalConfig).to receive(:get)
+        .with("GUMHEAD_CACHE_CREATION_1H_COST_MULTIPLIER", described_class::CACHE_CREATION_1H_COST_MULTIPLIER)
+        .and_return(2)
+      allow(GlobalConfig).to receive(:get)
+        .with("GUMHEAD_CACHE_READ_COST_MULTIPLIER", described_class::CACHE_READ_COST_MULTIPLIER)
+        .and_return(0.1)
+
+      # 30 * 1.25 = 37.5 -> 38; 10 * 2 = 20; 100 * 0.1 = 10
+      expect(described_class.input_equivalent_tokens_today(@user)).to eq(68)
+    end
+  end
+end


### PR DESCRIPTION
## What

The Gumhead gateway can send the shipped app Claude names and the role ids `gumhead-chat`, `gumhead-status`, and `gumhead-cover` to OpenRouter as Grok 4.6.

## Why

The Anthropic org is over its monthly cap. Sellers on the shipped Gumhead build still send Claude names. Newer builds send those three role ids. Chat stays down until the gateway rewrites the names.

## Before / After

Before: every chat call goes to Anthropic and fails on the cap.

After: ops set `GUMHEAD_UPSTREAM_API_BASE` to `https://openrouter.ai/api/v1` and `GUMHEAD_UPSTREAM_API_KEY` to the OpenRouter key. The gateway keeps the Claude family allowlist, accepts the three role ids once that hop is on, rewrites those names to `x-ai/grok-4.6` before the upstream POST, and records the billed model on the ledger. A missing OpenRouter key does not send the Anthropic secret to another host (503). An empty `GUMHEAD_MODEL_MAP` still uses the built-in Claude rewrite. Cache cost weights move to GlobalConfig (current-day weights, ops policy). Daily token caps stay the same. A missing `count_tokens` path on OpenRouter returns a small ok body so launch does not fail. Gateway errors stay in the Anthropic envelope.

## Status

CI green at `31bf3f2266` (Tests, Buildkite, ci/green, Greptile). Premerge clean at that SHA. Assigned to Gianfranco for human QA.

## Test Results

`DISABLE_SPRING=1 bin/rspec spec/controllers/api/v2/gumhead/messages_controller_spec.rb spec/models/gumhead_usage_event_spec.rb`

81 examples, 0 failures on the original head. Fail-closed specs: OpenRouter without `GUMHEAD_UPSTREAM_API_KEY` returns 503; empty model map still rewrites Claude names.

If `gumhead-chat`, `gumhead-status`, and `gumhead-cover` are dropped from `DEFAULT_ALLOWED_MODEL_PREFIXES` and `DEFAULT_MODEL_MAP`, the three role-id examples fail (400 / no rewrite).

Cache-multiplier parse: 4 examples, 0 failures. A non-numeric or negative `GUMHEAD_CACHE_*` value falls back to the hardcoded default instead of 500ing every Gumhead request.

## QA

After merge, set production `GUMHEAD_UPSTREAM_API_BASE` and `GUMHEAD_UPSTREAM_API_KEY`, then send one Gumhead chat turn. Unit tests cover rewrite, role ids, key isolation, OpenRouter 404 `count_tokens`, and the ledger model. Media is skipped.

---
Implemented by Grok 4.6. Fail-closed follow-up by gumclaw.

Premerge review: clean @ 31bf3f2266a60838243349c0901629e18f317845


