### PR TITLE
Serve email engagement dashboard reads from DynamoDB

### DIFF
--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -759,11 +759,16 @@ class Installment < ApplicationRecord
   def unique_open_count
     Rails.cache.fetch(key_for_cache(:unique_open_count)) do
       if EmailEngagementDynamoStore.reads_enabled?
-        EmailEngagementDynamoStore.summary(id)[:open_count]
+        dynamo_engagement_summary[:open_count]
       else
         CreatorEmailOpenEvent.where(installment_id: id).count
       end
     end
+  end
+
+  # One SUMMARY read serves both counters when a render misses both caches.
+  private def dynamo_engagement_summary
+    @dynamo_engagement_summary ||= EmailEngagementDynamoStore.summary(id)
   end
 
   # How many email_infos rows to read at a time when working out who a post was emailed
@@ -854,7 +859,7 @@ class Installment < ApplicationRecord
   def unique_click_count
     Rails.cache.fetch(key_for_cache(:unique_click_count)) do
       if EmailEngagementDynamoStore.reads_enabled?
-        EmailEngagementDynamoStore.summary(id)[:click_pair_count]
+        dynamo_engagement_summary[:click_pair_count]
       else
         summary = CreatorEmailClickSummary.where(installment_id: id).last
         summary.present? ? summary[:total_unique_clicks] : 0

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -758,7 +758,11 @@ class Installment < ApplicationRecord
 
   def unique_open_count
     Rails.cache.fetch(key_for_cache(:unique_open_count)) do
-      CreatorEmailOpenEvent.where(installment_id: id).count
+      if EmailEngagementDynamoStore.reads_enabled?
+        EmailEngagementDynamoStore.summary(id)[:open_count]
+      else
+        CreatorEmailOpenEvent.where(installment_id: id).count
+      end
     end
   end
 
@@ -849,19 +853,27 @@ class Installment < ApplicationRecord
 
   def unique_click_count
     Rails.cache.fetch(key_for_cache(:unique_click_count)) do
-      summary = CreatorEmailClickSummary.where(installment_id: id).last
-      summary.present? ? summary[:total_unique_clicks] : 0
+      if EmailEngagementDynamoStore.reads_enabled?
+        EmailEngagementDynamoStore.summary(id)[:click_pair_count]
+      else
+        summary = CreatorEmailClickSummary.where(installment_id: id).last
+        summary.present? ? summary[:total_unique_clicks] : 0
+      end
     end
   end
 
-  # Return a breakdown of clicks by url.
   def clicked_urls
-    summary = CreatorEmailClickSummary.where(installment_id: id).last
-    return {} if summary.blank?
+    if EmailEngagementDynamoStore.reads_enabled?
+      counts = EmailEngagementDynamoStore.url_click_counts(id)
+      return {} if counts.blank?
+      counts.sort_by { |_, v| -v }.to_h
+    else
+      summary = CreatorEmailClickSummary.where(installment_id: id).last
+      return {} if summary.blank?
 
-    # Change urls back into human-readable format (Necessary because Mongo keys cannot contain ".") Also remove leading protocol & www
-    summary.urls.keys.each { |k| summary.urls[k.gsub(/&#46;/, ".").sub(%r{^https?://}, "").sub(/^www./, "")] = summary.urls.delete(k) }
-    Hash[summary.urls.sort_by { |_, v| v }.reverse] # Sort by number of clicks.
+      summary.urls.keys.each { |k| summary.urls[k.gsub(/&#46;/, ".").sub(%r{^https?://}, "").sub(/^www./, "")] = summary.urls.delete(k) }
+      Hash[summary.urls.sort_by { |_, v| v }.reverse]
+    end
   end
 
   # Public: Returns the percentage of email opens for this installment, or nil if one cannot be calculated.

--- a/app/modules/post/caching.rb
+++ b/app/modules/post/caching.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 module Post::Caching
+  # The _ddb namespace keeps legacy cached counters from surviving the read
+  # flip (Memcached cannot bulk-delete): flipping email_engagement_dynamodb_reads
+  # moves every fetch and every invalidation to fresh keys together.
   def key_for_cache(key)
-    "#{key}_for_installment_#{id}"
+    "#{key}_for_installment_#{id}#{EmailEngagementDynamoStore.reads_enabled? ? "_ddb" : ""}"
   end
 
   def invalidate_cache(key)

--- a/app/presenters/api/workflow_presenter.rb
+++ b/app/presenters/api/workflow_presenter.rb
@@ -82,24 +82,32 @@ class Api::WorkflowPresenter
 
     def batched_open_counts(emails)
       batched_counts(emails, :unique_open_count) do |missing_ids|
-        pipeline = [
-          { "$match" => { "installment_id" => { "$in" => missing_ids } } },
-          { "$group" => { "_id" => "$installment_id", "count" => { "$sum" => 1 } } },
-        ]
-        CreatorEmailOpenEvent.collection.aggregate(pipeline).each_with_object({}) do |row, counts|
-          counts[row.fetch("_id").to_i] = row.fetch("count").to_i
+        if EmailEngagementDynamoStore.reads_enabled?
+          EmailEngagementDynamoStore.summaries(missing_ids).transform_values { _1[:open_count] }
+        else
+          pipeline = [
+            { "$match" => { "installment_id" => { "$in" => missing_ids } } },
+            { "$group" => { "_id" => "$installment_id", "count" => { "$sum" => 1 } } },
+          ]
+          CreatorEmailOpenEvent.collection.aggregate(pipeline).each_with_object({}) do |row, counts|
+            counts[row.fetch("_id").to_i] = row.fetch("count").to_i
+          end
         end
       end
     end
 
     def batched_click_counts(emails)
       batched_counts(emails, :unique_click_count) do |missing_ids|
-        CreatorEmailClickSummary
-          .in(installment_id: missing_ids)
-          .only(:installment_id, :total_unique_clicks)
-          .each_with_object({}) do |summary, counts|
-            counts[summary.installment_id] = summary.total_unique_clicks.to_i
-          end
+        if EmailEngagementDynamoStore.reads_enabled?
+          EmailEngagementDynamoStore.summaries(missing_ids).transform_values { _1[:click_pair_count] }
+        else
+          CreatorEmailClickSummary
+            .in(installment_id: missing_ids)
+            .only(:installment_id, :total_unique_clicks)
+            .each_with_object({}) do |summary, counts|
+              counts[summary.installment_id] = summary.total_unique_clicks.to_i
+            end
+        end
       end
     end
 

--- a/app/services/email_engagement_dynamo_store.rb
+++ b/app/services/email_engagement_dynamo_store.rb
@@ -21,6 +21,7 @@ class EmailEngagementDynamoStore
   DUAL_WRITE_FEATURE = :email_engagement_dynamodb_dual_write
   READ_FEATURE = :email_engagement_dynamodb_reads
   BATCH_GET_LIMIT = 100
+  BATCH_GET_MAX_ATTEMPTS = 5
 
   class << self
     attr_writer :client
@@ -90,10 +91,16 @@ class EmailEngagementDynamoStore
 
       counts = {}
       ids.each_slice(BATCH_GET_LIMIT) do |slice|
-        keys = slice.map { item_key(_1, SUMMARY_SORT_KEY) }
-        response = client.batch_get_item(request_items: { table_name => { keys: } })
-        (response.responses[table_name] || []).each do |item|
-          counts[item["pk"].to_i] = summary_from_item(item)
+        request_items = { table_name => { keys: slice.map { |id| item_key(id, SUMMARY_SORT_KEY) } } }
+        BATCH_GET_MAX_ATTEMPTS.times do |attempt|
+          response = client.batch_get_item(request_items:)
+          (response.responses[table_name] || []).each do |item|
+            counts[item["pk"].to_i] = summary_from_item(item)
+          end
+          request_items = response.unprocessed_keys
+          break if request_items.blank?
+          raise "Unprocessed keys remain after #{BATCH_GET_MAX_ATTEMPTS} BatchGetItem attempts" if attempt == BATCH_GET_MAX_ATTEMPTS - 1
+          sleep(2**attempt * 0.1)
         end
       end
       ids.index_with { |id| counts[id] || summary_from_item(nil) }

--- a/app/services/email_engagement_dynamo_store.rb
+++ b/app/services/email_engagement_dynamo_store.rb
@@ -19,6 +19,8 @@ class EmailEngagementDynamoStore
   TABLE_BASE_NAME = "email_engagement"
   SUMMARY_SORT_KEY = "SUMMARY"
   DUAL_WRITE_FEATURE = :email_engagement_dynamodb_dual_write
+  READ_FEATURE = :email_engagement_dynamodb_reads
+  BATCH_GET_LIMIT = 100
 
   class << self
     attr_writer :client
@@ -73,6 +75,56 @@ class EmailEngagementDynamoStore
 
     # Staging and production tables are Terraform-owned (antiwork/infrastructure#998)
     # and deletion-protected; this bootstrap is for dev, test, and branch apps.
+    def reads_enabled?
+      Feature.active?(READ_FEATURE)
+    end
+
+    def summary(installment_id)
+      item = client.get_item(table_name:, key: item_key(installment_id, SUMMARY_SORT_KEY)).item
+      summary_from_item(item)
+    end
+
+    def summaries(installment_ids)
+      ids = installment_ids.map(&:to_i).uniq
+      return {} if ids.empty?
+
+      counts = {}
+      ids.each_slice(BATCH_GET_LIMIT) do |slice|
+        keys = slice.map { item_key(_1, SUMMARY_SORT_KEY) }
+        response = client.batch_get_item(request_items: { table_name => { keys: } })
+        (response.responses[table_name] || []).each do |item|
+          counts[item["pk"].to_i] = summary_from_item(item)
+        end
+      end
+      ids.index_with { |id| counts[id] || summary_from_item(nil) }
+    end
+
+    def url_click_counts(installment_id)
+      items = []
+      exclusive_start_key = nil
+      loop do
+        params = {
+          table_name:,
+          key_condition_expression: "pk = :pk AND begins_with(sk, :prefix)",
+          expression_attribute_values: {
+            ":pk" => partition_key(installment_id),
+            ":prefix" => "URL#",
+          },
+        }
+        params[:exclusive_start_key] = exclusive_start_key if exclusive_start_key.present?
+        response = client.query(params)
+        items.concat(response.items)
+        exclusive_start_key = response.last_evaluated_key
+        break if exclusive_start_key.blank?
+      end
+
+      items.each_with_object({}) do |item, counts|
+        url = display_url(item["click_url"].to_s)
+        next if url.blank?
+        counts[url] = item["click_count"].to_i
+      end
+    end
+
     def create_table!
       client.create_table(
         table_name:,
@@ -221,6 +273,18 @@ class EmailEngagementDynamoStore
 
       def item_key(installment_id, sort_key)
         { "pk" => partition_key(installment_id), "sk" => sort_key }
+      end
+
+      def summary_from_item(item)
+        {
+          open_count: item&.[]("open_count").to_i,
+          click_count: item&.[]("click_count").to_i,
+          click_pair_count: item&.[]("click_pair_count").to_i,
+        }
+      end
+
+      def display_url(url)
+        url.gsub(/&#46;/, ".").sub(%r{\Ahttps?://}i, "").sub(/\Awww\./i, "")
       end
 
       def timestamp

--- a/spec/modules/post/caching_spec.rb
+++ b/spec/modules/post/caching_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe Post::Caching do
+  let(:installment) { create(:installment) }
+
+  describe "#key_for_cache" do
+    it "namespaces keys by the DynamoDB reads flag so legacy cached counters cannot survive the flip" do
+      Feature.deactivate(:email_engagement_dynamodb_reads)
+      expect(installment.key_for_cache(:unique_open_count)).to eq("unique_open_count_for_installment_#{installment.id}")
+
+      Feature.activate(:email_engagement_dynamodb_reads)
+      expect(installment.key_for_cache(:unique_open_count)).to eq("unique_open_count_for_installment_#{installment.id}_ddb")
+    ensure
+      Feature.deactivate(:email_engagement_dynamodb_reads)
+    end
+  end
+
+  describe "#invalidate_cache" do
+    it "deletes the key in the active namespace" do
+      Feature.activate(:email_engagement_dynamodb_reads)
+      expect(Rails.cache).to receive(:delete).with("unique_click_count_for_installment_#{installment.id}_ddb")
+
+      installment.invalidate_cache(:unique_click_count)
+    ensure
+      Feature.deactivate(:email_engagement_dynamodb_reads)
+    end
+  end
+end

--- a/spec/services/email_engagement_dynamo_store_spec.rb
+++ b/spec/services/email_engagement_dynamo_store_spec.rb
@@ -235,4 +235,46 @@ describe EmailEngagementDynamoStore do
       )
     end
   end
+
+  describe ".summary" do
+    it "returns zeroed counters when the item is missing" do
+      client.stub_responses(:get_item, { item: nil })
+
+      expect(described_class.summary(123)).to eq(open_count: 0, click_count: 0, click_pair_count: 0)
+    end
+
+    it "reads open and click-pair counters from SUMMARY" do
+      client.stub_responses(:get_item, { item: { "open_count" => 10, "click_count" => 7, "click_pair_count" => 9 } })
+
+      expect(described_class.summary(123)).to eq(open_count: 10, click_count: 7, click_pair_count: 9)
+    end
+  end
+
+  describe ".summaries" do
+    it "batch-gets SUMMARY items and fills zeros for missing partitions" do
+      client.stub_responses(:batch_get_item, {
+        responses: {
+          "email_engagement" => [{ "pk" => "123", "open_count" => 10, "click_pair_count" => 4 }],
+        },
+      })
+
+      result = described_class.summaries([123, 456])
+      expect(result[123]).to eq(open_count: 10, click_count: 0, click_pair_count: 4)
+      expect(result[456]).to eq(open_count: 0, click_count: 0, click_pair_count: 0)
+    end
+  end
+
+  describe ".url_click_counts" do
+    it "strips protocol and www from URL# click_url values" do
+      client.stub_responses(:query, { items: [
+        { "click_url" => "https://www.gumroad.com/l/a", "click_count" => 5 },
+        { "click_url" => "https://example.com", "click_count" => 2 },
+      ] })
+
+      expect(described_class.url_click_counts(123)).to eq(
+        "gumroad.com/l/a" => 5,
+        "example.com" => 2,
+      )
+    end
+  end
 end

--- a/spec/services/email_engagement_dynamo_store_spec.rb
+++ b/spec/services/email_engagement_dynamo_store_spec.rb
@@ -252,24 +252,71 @@ describe EmailEngagementDynamoStore do
 
   describe ".summaries" do
     it "batch-gets SUMMARY items and fills zeros for missing partitions" do
-      client.stub_responses(:batch_get_item, {
-        responses: {
-          "email_engagement" => [{ "pk" => "123", "open_count" => 10, "click_pair_count" => 4 }],
-        },
-      })
+      client.stub_responses(
+        :batch_get_item,
+        {
+          responses: {
+            "email_engagement" => [{ "pk" => "123", "open_count" => 10, "click_pair_count" => 4 }],
+          },
+        }
+      )
 
       result = described_class.summaries([123, 456])
       expect(result[123]).to eq(open_count: 10, click_count: 0, click_pair_count: 4)
       expect(result[456]).to eq(open_count: 0, click_count: 0, click_pair_count: 0)
     end
+
+    it "retries unprocessed keys instead of zero-filling them" do
+      allow(described_class).to receive(:sleep)
+      client.stub_responses(
+        :batch_get_item,
+        [
+          {
+            responses: { "email_engagement" => [] },
+            unprocessed_keys: {
+              "email_engagement" => { keys: [{ "pk" => "123", "sk" => "SUMMARY" }] },
+            },
+          },
+          {
+            responses: {
+              "email_engagement" => [{ "pk" => "123", "open_count" => 10, "click_pair_count" => 4 }],
+            },
+          },
+        ]
+      )
+
+      result = described_class.summaries([123])
+      expect(result[123]).to eq(open_count: 10, click_count: 0, click_pair_count: 4)
+      expect(requests.map { _1[:operation_name] }).to eq([:batch_get_item, :batch_get_item])
+    end
+
+    it "raises when unprocessed keys remain after retries" do
+      allow(described_class).to receive(:sleep)
+      client.stub_responses(
+        :batch_get_item,
+        {
+          responses: { "email_engagement" => [] },
+          unprocessed_keys: {
+            "email_engagement" => { keys: [{ "pk" => "123", "sk" => "SUMMARY" }] },
+          },
+        }
+      )
+
+      expect { described_class.summaries([123]) }.to raise_error(/Unprocessed keys remain/)
+    end
   end
 
   describe ".url_click_counts" do
     it "strips protocol and www from URL# click_url values" do
-      client.stub_responses(:query, { items: [
-        { "click_url" => "https://www.gumroad.com/l/a", "click_count" => 5 },
-        { "click_url" => "https://example.com", "click_count" => 2 },
-      ] })
+      client.stub_responses(
+        :query,
+        {
+          items: [
+            { "click_url" => "https://www.gumroad.com/l/a", "click_count" => 5 },
+            { "click_url" => "https://example.com", "click_count" => 2 },
+          ],
+        }
+      )
 
       expect(described_class.url_click_counts(123)).to eq(
         "gumroad.com/l/a" => 5,


### PR DESCRIPTION
## What
Closes the next slice of [gp#2158](https://github.com/antiwork/gumroad-private/issues/2158): dashboard opens, clicks, and clicked-url breakdowns can read DynamoDB.

Behind `email_engagement_dynamodb_reads` (off until `verify!` is clean). Mongo stays the source of truth until then. Clicks use `click_pair_count` (unique recipient+url pairs).

## Tests
- `DISABLE_SPRING=1 bundle exec rspec spec/modules/post/caching_spec.rb spec/services/email_engagement_dynamo_store_spec.rb` — 24 examples, 0 failures.
- Sol autoreview (`autoreview --mode branch --base origin/main --engine codex --max-priority P1`) — clean at `34ad724a7d0821b8f1cf3dfc16af3a856dbc314c`.

## Status
- [x] Scope — DynamoDB readers for installment and workflow engagement metrics.
- [x] Design — flag-gated Mongo fallback; unique recipient+url click pairs.
- [x] Build — readers + specs; Greptile BatchGetItem P1 fixed in `5d43114325`; cache-source namespace + shared SUMMARY read added in `34ad724a7d`.
- [ ] Ship — `email_engagement_dynamodb_reads` stays off until Ershad's `verify!`.
- [ ] Market
- [ ] Sell

Backend-only — flag off; adjacent audience dashboard unchanged. Diff + specs are the reviewable artifact.

AI disclosure: Authored by gumclaw using Hermes Agent. Model: grok-4.6.

Premerge review: clean @ 34ad724a7d0821b8f1cf3dfc16af3a856dbc314c
