### PR TITLE
Make the Gumhead role-to-model map live-editable in Redis

### DIFF
--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -64,13 +64,10 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # OpenRouter :online variants.
   DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-,gumhead-chat,gumhead-status,gumhead-cover"
   # The fallback map. The live one is a JSON object in Redis under
-  # RedisKey.gumhead_model_map, so moving a role to another model is one
-  # write with no deploy and no restart:
-  #   $redis.set(RedisKey.gumhead_model_map, { "gumhead-status" => "..." }.to_json)
-  # Entries merge over this one, so a partial map moves a single role.
-  # Point a role at an upstream id, never at the incoming name: a value
-  # equal to what the app sent is not a mapping, and validate_model
-  # rejects the request rather than forward a client-chosen name.
+  # RedisKey.gumhead_model_map, merged over this one, so a partial write
+  # moves one role with no deploy. Point a role at an upstream id, never
+  # at the incoming name: a value equal to what the app sent is not a
+  # mapping, and validate_model rejects the request.
   DEFAULT_MODEL_MAP = {
     "claude-sonnet-" => "x-ai/grok-4.6",
     "claude-haiku-" => "x-ai/grok-4.6",
@@ -322,14 +319,10 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       match ? match[1] : model
     end
 
-    # Which model serves each role is ops policy that has to change
-    # without a deploy: every `secret/web/` write re-renders one
-    # secrets.env and restarts a whole Puma colour at once, which took
-    # checkout down for four minutes on Aug 27 (gp#2273). So the live
-    # value is a Redis string and the deployed value is the fallback.
-    # Precedence: Redis, then GUMHEAD_MODEL_MAP, then the built-in map;
-    # deleting the Redis key reverts to what is deployed. Memoised
-    # because one request consults the map several times.
+    # Precedence: Redis, then GUMHEAD_MODEL_MAP, then the built-in map.
+    # The live value lives in Redis because a secret/web write restarts a
+    # whole Puma colour (gp#2273); deleting the key reverts to what is
+    # deployed. Memoised: one request consults the map several times.
     def model_map = resolved_model_map.first
 
     def model_map_source = resolved_model_map.last
@@ -343,12 +336,12 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
 
     def raw_model_map
       live = live_model_map
-      if live.present?
+      # Any stored value, empty string included: an operator who wrote one
+      # needs to hear that it is not serving. Only an absent key is silent.
+      unless live.nil?
         parsed = safe_parse_json(live)
         return [parsed, "redis"] if parsed.is_a?(Hash)
 
-        # Serving the deployed map while an operator believes their write
-        # is live is the one failure they cannot see from the outside.
         Rails.logger.warn("Gumhead model map in Redis is not a JSON object; serving the deployed map.")
       end
 
@@ -412,11 +405,9 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     # request was already answered with the error envelope, and logging must
     # not turn that answer into a 500.
     def append_info_to_payload(payload)
-      # Which source chose this request's model, so a lost Redis key
-      # reads as a model change in the logs rather than as silence. Read
-      # from the memo, not through model_map_source: a request rejected
-      # before validate_model never consults the map, and logging must
-      # not be what sends it to Redis.
+      # A lost Redis key is a model change; log the source so it is not a
+      # silent one. Read the memo rather than model_map_source, so logging
+      # never triggers the Redis read for a request that skipped the map.
       payload[:gumhead_model_map_source] = @resolved_model_map.last if @resolved_model_map
       super
     rescue ActionDispatch::Http::Parameters::ParseError

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -63,6 +63,14 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # Family prefixes rewrite every allowed Claude name, including
   # OpenRouter :online variants.
   DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-,gumhead-chat,gumhead-status,gumhead-cover"
+  # The fallback map. The live one is a JSON object in Redis under
+  # RedisKey.gumhead_model_map, so moving a role to another model is one
+  # write with no deploy and no restart:
+  #   $redis.set(RedisKey.gumhead_model_map, { "gumhead-status" => "..." }.to_json)
+  # Entries merge over this one, so a partial map moves a single role.
+  # Point a role at an upstream id, never at the incoming name: a value
+  # equal to what the app sent is not a mapping, and validate_model
+  # rejects the request rather than forward a client-chosen name.
   DEFAULT_MODEL_MAP = {
     "claude-sonnet-" => "x-ai/grok-4.6",
     "claude-haiku-" => "x-ai/grok-4.6",
@@ -292,9 +300,16 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     end
 
     def rewrite_upstream_model?
-      return true if GlobalConfig.get("GUMHEAD_MODEL_MAP").present?
+      return true if configured_model_map?
 
       !anthropic_upstream?
+    end
+
+    # An operator-set map — in Redis or in the deployed config — always
+    # rewrites. Only the built-in map waits for the upstream to move off
+    # Anthropic.
+    def configured_model_map?
+      model_map_source != "default"
     end
 
     def mapped_upstream_model(model)
@@ -307,18 +322,59 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       match ? match[1] : model
     end
 
-    def model_map
-      raw = GlobalConfig.get("GUMHEAD_MODEL_MAP", DEFAULT_MODEL_MAP)
-      parsed = raw.is_a?(String) ? safe_parse_json(raw) : raw
-      overrides = {}
-      if parsed.is_a?(Hash)
-        parsed.each do |key, value|
-          next if key.blank? || value.blank?
+    # Which model serves each role is ops policy that has to change
+    # without a deploy: every `secret/web/` write re-renders one
+    # secrets.env and restarts a whole Puma colour at once, which took
+    # checkout down for four minutes on Aug 27 (gp#2273). So the live
+    # value is a Redis string and the deployed value is the fallback.
+    # Precedence: Redis, then GUMHEAD_MODEL_MAP, then the built-in map;
+    # deleting the Redis key reverts to what is deployed. Memoised
+    # because one request consults the map several times.
+    def model_map = resolved_model_map.first
 
-          overrides[key.to_s] = value.to_s
-        end
+    def model_map_source = resolved_model_map.last
+
+    def resolved_model_map
+      @resolved_model_map ||= begin
+        raw, source = raw_model_map
+        [DEFAULT_MODEL_MAP.merge(normalized_model_map(raw)), source]
       end
-      DEFAULT_MODEL_MAP.merge(overrides)
+    end
+
+    def raw_model_map
+      live = live_model_map
+      if live.present?
+        parsed = safe_parse_json(live)
+        return [parsed, "redis"] if parsed.is_a?(Hash)
+
+        # Serving the deployed map while an operator believes their write
+        # is live is the one failure they cannot see from the outside.
+        Rails.logger.warn("Gumhead model map in Redis is not a JSON object; serving the deployed map.")
+      end
+
+      configured = GlobalConfig.get("GUMHEAD_MODEL_MAP")
+      return [configured, "config"] if configured.present?
+
+      [DEFAULT_MODEL_MAP, "default"]
+    end
+
+    def live_model_map
+      $redis.get(RedisKey.gumhead_model_map)
+    rescue Redis::BaseError => e
+      # Reading ops policy must not fail the turn; the deployed map serves.
+      Rails.logger.warn("Gumhead model map Redis read failed: #{e.class} #{e.message}")
+      nil
+    end
+
+    def normalized_model_map(raw)
+      parsed = raw.is_a?(String) ? safe_parse_json(raw) : raw
+      return {} unless parsed.is_a?(Hash)
+
+      parsed.each_with_object({}) do |(key, value), map|
+        next if key.blank? || value.blank?
+
+        map[key.to_s] = value.to_s
+      end
     end
 
     def allowed_model_prefixes
@@ -356,6 +412,12 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     # request was already answered with the error envelope, and logging must
     # not turn that answer into a 500.
     def append_info_to_payload(payload)
+      # Which source chose this request's model, so a lost Redis key
+      # reads as a model change in the logs rather than as silence. Read
+      # from the memo, not through model_map_source: a request rejected
+      # before validate_model never consults the map, and logging must
+      # not be what sends it to Redis.
+      payload[:gumhead_model_map_source] = @resolved_model_map.last if @resolved_model_map
       super
     rescue ActionDispatch::Http::Parameters::ParseError
       nil

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -29,6 +29,7 @@ class RedisKey
     def agent_request_throttle(user_id) = "agent_request_throttle:#{user_id}"
     def gumhead_gateway_throttle(user_id) = "gumhead_gateway_throttle:#{user_id}"
     def gumhead_gateway_in_flight(user_id) = "gumhead_gateway_in_flight:#{user_id}"
+    def gumhead_model_map = "gumhead_model_map"
     def agent_turn_status(user_id, client_turn_id) = "agent_turn_status:#{user_id}:#{client_turn_id}"
     def agent_custom_html_preview(user_id, token) = "agent_custom_html_preview:#{user_id}:#{token}"
     def agent_custom_html_preview_index(user_id) = "agent_custom_html_preview_index:#{user_id}"

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -1077,6 +1077,19 @@ describe Api::V2::Gumhead::MessagesController do
       expect_forwarded_model(openrouter_messages_url, "x-ai/grok-4.6")
     end
 
+    it "warns on a stored empty value instead of treating it as unset" do
+      use_openrouter_base
+      $redis.set(RedisKey.gumhead_model_map, "")
+      stub_openrouter
+      allow(Rails.logger).to receive(:warn)
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect(Rails.logger).to have_received(:warn).with(/not a JSON object/).at_least(:once)
+      expect_forwarded_model(openrouter_messages_url, "x-ai/grok-4.6")
+    end
+
     it "serves the deployed map when Redis is unreachable" do
       use_openrouter_base
       # Other services read $redis on this path; only the map read fails.

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -900,9 +900,7 @@ describe Api::V2::Gumhead::MessagesController do
 
     it "still rewrites Claude names when the configured map is empty" do
       use_openrouter_base
-      allow(GlobalConfig).to receive(:get)
-        .with("GUMHEAD_MODEL_MAP", described_class::DEFAULT_MODEL_MAP)
-        .and_return({})
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_MODEL_MAP").and_return("{}")
       stub_request(:post, openrouter_messages_url)
         .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
 
@@ -989,6 +987,135 @@ describe Api::V2::Gumhead::MessagesController do
 
       expect(response.status).to eq(502)
       expect(GumheadUsageEvent.sole.input_tokens).to eq(rewritten_payload_bytesize)
+    end
+  end
+
+  describe "live model map in Redis" do
+    let(:openrouter_messages_url) { "https://openrouter.ai/api/v1/messages" }
+
+    after { $redis.del(RedisKey.gumhead_model_map) }
+
+    def use_openrouter_base
+      allow(GlobalConfig).to receive(:get)
+        .with("GUMHEAD_UPSTREAM_API_BASE", described_class::DEFAULT_UPSTREAM_API_BASE)
+        .and_return("https://openrouter.ai/api/v1")
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_UPSTREAM_API_KEY").and_return("sk-or-test")
+    end
+
+    # Response without a model, so the ledger has to take the name from
+    # the rewritten body. A stub naming the mapped model would pass with
+    # the rewrite reverted.
+    def stub_openrouter
+      stub_request(:post, openrouter_messages_url)
+        .to_return(status: 200, body: anthropic_response.except(:model).to_json, headers: { "Content-Type" => "application/json" })
+    end
+
+    def expect_forwarded_model(url, model)
+      expect(WebMock).to have_requested(:post, url).with { |req|
+        JSON.parse(req.body)["model"] == model
+      }
+    end
+
+    it "serves the model a Redis write names, without a deploy" do
+      use_openrouter_base
+      $redis.set(RedisKey.gumhead_model_map, { "claude-sonnet-" => "openai/gpt-5.6-luna" }.to_json)
+      stub_openrouter
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect_forwarded_model(openrouter_messages_url, "openai/gpt-5.6-luna")
+      expect(GumheadUsageEvent.sole.model).to eq("openai/gpt-5.6-luna")
+    end
+
+    it "moves one role and leaves the rest on the built-in map" do
+      use_openrouter_base
+      $redis.set(RedisKey.gumhead_model_map, { "gumhead-status" => "openai/gpt-5.6-luna" }.to_json)
+      stub_openrouter
+
+      post_messages(request_payload.merge(model: "gumhead-status"))
+      post_messages(request_payload.merge(model: "gumhead-chat"))
+
+      expect_forwarded_model(openrouter_messages_url, "openai/gpt-5.6-luna")
+      expect_forwarded_model(openrouter_messages_url, "x-ai/grok-4.6")
+    end
+
+    it "outranks the deployed GUMHEAD_MODEL_MAP" do
+      use_openrouter_base
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_MODEL_MAP")
+        .and_return({ "claude-sonnet-" => "x-ai/grok-4.5" }.to_json)
+      $redis.set(RedisKey.gumhead_model_map, { "claude-sonnet-" => "openai/gpt-5.6-luna" }.to_json)
+      stub_openrouter
+
+      post_messages
+
+      expect_forwarded_model(openrouter_messages_url, "openai/gpt-5.6-luna")
+    end
+
+    it "falls back to the deployed map once the Redis key is deleted" do
+      use_openrouter_base
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_MODEL_MAP")
+        .and_return({ "claude-sonnet-" => "x-ai/grok-4.5" }.to_json)
+      $redis.del(RedisKey.gumhead_model_map)
+      stub_openrouter
+
+      post_messages
+
+      expect_forwarded_model(openrouter_messages_url, "x-ai/grok-4.5")
+    end
+
+    it "serves the deployed map and warns when the Redis value is not a JSON object" do
+      use_openrouter_base
+      $redis.set(RedisKey.gumhead_model_map, "x-ai/grok-4.5")
+      stub_openrouter
+      allow(Rails.logger).to receive(:warn)
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect(Rails.logger).to have_received(:warn).with(/not a JSON object/).at_least(:once)
+      expect_forwarded_model(openrouter_messages_url, "x-ai/grok-4.6")
+    end
+
+    it "serves the deployed map when Redis is unreachable" do
+      use_openrouter_base
+      # Other services read $redis on this path; only the map read fails.
+      allow($redis).to receive(:get).and_call_original
+      allow($redis).to receive(:get).with(RedisKey.gumhead_model_map).and_raise(Redis::CannotConnectError)
+      stub_openrouter
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect_forwarded_model(openrouter_messages_url, "x-ai/grok-4.6")
+    end
+
+    it "rewrites on an Anthropic upstream when only Redis names a map" do
+      $redis.set(RedisKey.gumhead_model_map, { "claude-sonnet-" => "claude-sonnet-4.5" }.to_json)
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect_forwarded_model(messages_url, "claude-sonnet-4.5")
+    end
+
+    it "records which source chose the model" do
+      use_openrouter_base
+      $redis.set(RedisKey.gumhead_model_map, { "claude-sonnet-" => "openai/gpt-5.6-luna" }.to_json)
+      stub_openrouter
+      sources = []
+      subscriber = ActiveSupport::Notifications.subscribe("process_action.action_controller") do |*, payload|
+        sources << payload[:gumhead_model_map_source]
+      end
+
+      begin
+        post_messages
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(sources).to include("redis")
     end
   end
 end


### PR DESCRIPTION
## What

The Gumhead role→model map becomes live-editable in Redis. Moving a role to another model no longer needs a deploy or a restart:

```ruby
$redis.set(RedisKey.gumhead_model_map, { "gumhead-status" => "openai/gpt-5.6-luna" }.to_json)
```

- Precedence: Redis → deployed `GUMHEAD_MODEL_MAP` → built-in map.
- Entries merge, so a partial write moves one role. Deleting the key reverts to what is deployed.
- Read once per request. Redis failure or bad JSON logs a warning and serves the deployed map.
- Every request logs `gumhead_model_map_source` (`redis` / `config` / `default`).

Point a role at an upstream id, never at the name the app sent — the allowlist is fail-closed, so an identity mapping 400s that role.

## Why

**The old write channel is dangerous.** Every `secret/web/` Vault write restarts a whole Puma colour at once. On Aug 27 one did: 18,368 5xx and 15,200 edge 502s across checkout and storefront over four minutes (gumroad-private#2273). Model tuning is routine and must not ride that channel.

**We need to change a model now.** The status role runs on Grok 4.6, a reasoning model: a three-word reply took 6.4s and spent 240 of 244 output tokens reasoning. I measured that this is not tunable — `thinking: {type: "disabled"}` is refused, OpenRouter's `reasoning` param is silently ignored, and a low `budget_tokens` only raises reasoning. So the fix is a different model, which is a map change.

Redis is where this controller already keeps its throttle and in-flight counters, and `RedisKey` already holds live ops settings of the same shape.

## Before/After

No user-visible surface. Covered by specs rather than media, as in #7406.

## Test Results

`DISABLE_SPRING=1 bin/rspec spec/controllers/api/v2/gumhead/messages_controller_spec.rb` — 87 examples, 0 failures. Rubocop clean.

New examples cover precedence, partial overrides, deletion, malformed and empty stored values, an unreachable Redis, rewrite activation, and the log field. Stubbing out the Redis read fails 6 of them.

One existing example was stubbing `GlobalConfig.get("GUMHEAD_MODEL_MAP", DEFAULT_MODEL_MAP)`. This PR reads that key without a default, so the stub would no longer match and the example would pass for the wrong reason. It now stubs the one-argument form.

## QA

After deploy the Redis key is unset, so behaviour is unchanged (source `config` or `default`). To exercise the live path: set the key, send a status-role turn, confirm the new model serves with no deploy, then `del` the key to revert.

---

AI disclosure: Claude Fable 5 (Claude Code) wrote this change.
