### PR TITLE
chore: trim restated comments in CreatorHomePresenter

### DIFF
--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -41,7 +41,6 @@ class CreatorHomePresenter
     top_sales_data = analytics[:by_date][:sales]
       .sort_by { |_, sales| -sales&.sum }.take(BALANCE_ITEMS_LIMIT)
 
-    # Preload products with thumbnail attachments to avoid N+1 queries
     product_permalinks = top_sales_data.map(&:first)
     products_by_permalink = seller.products
       .where(unique_permalink: product_permalinks)
@@ -76,12 +75,9 @@ class CreatorHomePresenter
       end
     end
 
-    # Unconfirmed sellers hit invisible walls all over the product (publishing,
-    # payouts, API access all require a confirmed email), but until now the only
-    # places offering a resend were the Settings page and a few gated flows. The
-    # dashboard is where sellers land, so surface the recovery path here. Only the
-    # account owner can trigger the resend (same policy as the Settings button), so
-    # team members see the notice without the CTA.
+    # Unconfirmed sellers can't publish, take payouts, or use the API. Surface
+    # the resend path on the dashboard. Only the account owner gets the CTA
+    # (same policy as Settings); team members see the notice without it.
     email_confirmation = nil
     if seller.has_unconfirmed_email?
       email_confirmation = {
@@ -142,18 +138,6 @@ class CreatorHomePresenter
       items.sort_by { |item| item["timestamp"] }.last(ACTIVITY_ITEMS_LIMIT).reverse
     end
 
-    # Returns an array for sales to be processed by the frontend.
-    # {
-    #   "type" => String ("new_sale"),
-    #   "timestamp" => String (iso8601 UTC, example: "2022-05-16T01:01:01Z"),
-    #   "details" => {
-    #     "price_cents" => Integer,
-    #     "email" => String,
-    #     "full_name" => Nullable String,
-    #     "product_name" => String,
-    #     "product_unique_permalink" => String,
-    #   }
-    # }
     def sales_activity_items
       sales = seller.sales.successful.not_is_bundle_product_purchase.includes(:link).order(created_at: :desc).limit(ACTIVITY_ITEMS_LIMIT).load
       sales.map do |sale|
@@ -171,15 +155,6 @@ class CreatorHomePresenter
       end
     end
 
-    # Returns an array for followers activity to be processed by the frontend.
-    # {
-    #   "type" => String (one of: "follower_added" | "follower_removed"),
-    #   "timestamp" => String (iso8601 UTC, example: "2022-05-16T01:01:01Z"),
-    #   "details" => {
-    #     "email" => String,
-    #     "name" => Nullable String,
-    #   }
-    # }
     def followers_activity_items
       results = ConfirmedFollowerEvent.search(
         query: { bool: { filter: [{ term: { followed_user_id: seller.id } }] } },
@@ -188,7 +163,6 @@ class CreatorHomePresenter
         _source: [:name, :email, :timestamp, :follower_user_id],
       ).map { |result| result["_source"] }
 
-      # Collect followers' users in one DB query
       followers_user_ids = results.map { |result| result["follower_user_id"] }.compact.uniq
       followers_users_by_id = User.where(id: followers_user_ids).select(:id, :name, :timezone).index_by(&:id)
 


### PR DESCRIPTION
## What

Comments only, no behaviour change.

In `CreatorHomePresenter`, drop comments that restate the hashes and queries they sit on, and compress the unconfirmed-email note.

- Deleted the JSON-shape comments on `sales_activity_items` / `followers_activity_items` (they duplicated the hashes those methods return).
- Deleted `# Preload products with thumbnail attachments to avoid N+1 queries` and `# Collect followers' users in one DB query` (the next lines already say that).
- Compressed the unconfirmed-email block: cut the “until now / Settings page” history; kept the policy (dashboard resend CTA is owner-only, same as Settings).

## Why

Maintainers already know this file. A comment that restates the code below it is noise.

## Line counts

`app/presenters/creator_home_presenter.rb`: 207 → 181 (−26 net; 3 inserted, 29 deleted).

## Kept (on purpose)

- `GUMHEAD_DOWNLOAD_URL` — `releases/latest` is a deploy tag, not GitHub’s latest-release alias.
- 4-year tax-form cap — unbounded `eligible_for_1099?` per year times out on long-lived accounts.
- Unconfirmed-email policy (compressed) — owner-only resend CTA; team members see the notice without it.

## Not slop (left alone this run)

- `Installment#reply_to_email` — product vs account support address; do not use `Link#support_email_or_default` (can fall back to a different owner).
- `Installment#targeted_at_all_seller_customers?` — memberships library vs `single_recipient_email?` exclusion.
- `PURCHASE_LOOKUP_BATCH_SIZE` — MySQL range optimizer silently full-scans `purchases` past ~2k ids.
- Inertia download-page poll drop — same-URL non-Inertia 404 vs redirect trap.
- `SalesController#refund` `amount_cents` — listed vs presentment currency.
- `RichTextEditor` `useEditor(deps: [])` vs live schema.
- `Pages::RichTextDocument` — public render vs API pull path for agents.

## Test Results

- `ruby -c app/presenters/creator_home_presenter.rb` — Syntax OK
- `bundle exec rubocop app/presenters/creator_home_presenter.rb` — no offenses
- `bundle exec rspec spec/presenters/creator_home_presenter_spec.rb` — 29 examples passed; 1 failure is the known shared-DB collision (`create(:merchant_account)` vs fixture `charge_processor_merchant_id "000000001"`), not this diff
- Branch CI `Tests` run 33091602490 — **success**, 0 pending, 0 failures (lints, minitest, relevant rspec shards)

Premerge review: exempt (comments-only, no behaviour change)
