### PR TITLE
Mint the gateway's own message for an upstream failure

### DIFF
--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -100,12 +100,14 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # upstream vendor does. Forwarding the vendor's own text made the client
   # match Anthropic's exact wording, which meant every later vendor fell
   # back to a generic "busy" line for failures the pet should name.
+  # Operational failures only. A request the client got wrong — a missing
+  # max_tokens, a bad tool history — keeps the provider's own message,
+  # because that names the field and this gateway cannot.
   UPSTREAM_ERRORS = {
     out_of_budget: ["api_error", "The Gumhead model service is out of budget."],
     credentials: ["api_error", "The Gumhead model service rejected the gateway credentials."],
     rate_limited: ["rate_limit_error", "The Gumhead model service is rate limited. Please retry shortly."],
     busy: ["api_error", "The Gumhead model service is busy. Please retry shortly."],
-    other: ["api_error", "The model service returned an error."],
   }.freeze
   # A spend cap or exhausted credit lasts hours or days, so it must not
   # reach the pet as a transient. Providers report it on several statuses
@@ -494,7 +496,16 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
         meter_buffered_usage(body) if meter && upstream.status.success?
         copy_retry_after(upstream)
         status = upstream.status.success? ? :bad_gateway : upstream.status.code
-        return render json: minted_upstream_error(upstream.status.code, parsed, body), status:
+        minted = minted_upstream_error(upstream.status.code, parsed, body)
+        return render(json: minted, status:) if minted
+        # Unclassified: the provider's own message names what to fix, so it
+        # goes through. Only OpenRouter's shape is rewrapped, since the
+        # runtime reads the Anthropic envelope.
+        if openrouter_error_envelope?(parsed)
+          return render(json: anthropic_error("api_error", upstream_error_detail(parsed, body)), status:)
+        end
+
+        return render body:, content_type: "application/json", status: upstream.status.code
       end
       meter_buffered_usage(body) if meter
       copy_retry_after(upstream)
@@ -616,7 +627,14 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       unless upstream.status.success?
         copy_retry_after(upstream)
         body = upstream.body.to_s
-        return render json: minted_upstream_error(upstream.status.code, safe_parse_json(body), body), status: upstream.status.code
+        parsed = safe_parse_json(body)
+        minted = minted_upstream_error(upstream.status.code, parsed, body)
+        return render(json: minted, status: upstream.status.code) if minted
+        if openrouter_error_envelope?(parsed)
+          return render(json: anthropic_error("api_error", upstream_error_detail(parsed, body)), status: upstream.status.code)
+        end
+
+        return render body:, content_type: "application/json", status: upstream.status.code
       end
       if upstream.headers["Content-Type"].to_s.include?("application/json") &&
          !upstream.headers["Content-Type"].to_s.include?("event-stream")
@@ -624,7 +642,8 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
         parsed = safe_parse_json(body)
         if parsed.is_a?(Hash) && parsed["error"].is_a?(Hash)
           meter_buffered_usage(body) if parsed["usage"].is_a?(Hash)
-          return render json: minted_upstream_error(upstream.status.code, parsed, body), status: :bad_gateway
+          minted = minted_upstream_error(upstream.status.code, parsed, body)
+          return render json: minted || anthropic_error("api_error", upstream_error_detail(parsed, body)), status: :bad_gateway
         end
       end
 
@@ -807,10 +826,16 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
 
     # One of this gateway's own messages for an upstream failure, and the
     # upstream's text in the log where an engineer can read it.
+    # This gateway's own message for an operational failure, or nil when
+    # the failure is the request's own fault and the provider's message
+    # says more than any fixed string could. Either way the provider's
+    # text reaches the log.
     def minted_upstream_error(status, parsed, body)
       detail = upstream_error_detail(parsed, body)
       Rails.logger.warn("Gumhead gateway upstream error: status=#{status} #{detail}")
       key = upstream_error_key(status, parsed, detail)
+      return nil if key.nil?
+
       # A spend limit answers 429, which the runtime's SDK retries on
       # status alone; every attempt fails until the cap resets. The SDK
       # reads this header before it reaches that rule.
@@ -825,7 +850,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       return :rate_limited if status == 429
       return :busy if status >= 500
 
-      :other
+      nil
     end
 
     def spend_limit_code?(parsed)

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -96,13 +96,11 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # timeout charge a true upper bound on upstream spend; anything larger
   # must stream, and streams meter incrementally.
   MAX_BUFFERED_OUTPUT_TOKENS = BUFFERED_TIMEOUT * TIMEOUT_OUTPUT_TOKENS_PER_SECOND
-  # The seller's pet reads these strings, so they must not change when the
-  # upstream vendor does. Forwarding the vendor's own text made the client
-  # match Anthropic's exact wording, which meant every later vendor fell
-  # back to a generic "busy" line for failures the pet should name.
-  # Operational failures only. A request the client got wrong — a missing
-  # max_tokens, a bad tool history — keeps the provider's own message,
-  # because that names the field and this gateway cannot.
+  # Operational failures only: a request the client got wrong keeps the
+  # provider's message, which names the field this gateway cannot. These
+  # strings are a contract with the pet, which matches them to choose what
+  # it says (core/src/errors.ts in antiwork/gumhead), so changing one needs
+  # a client release in the same window.
   UPSTREAM_ERRORS = {
     out_of_budget: ["api_error", "The Gumhead model service is out of budget."],
     credentials: ["api_error", "The Gumhead model service rejected the gateway credentials."],

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -117,6 +117,10 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # The structured marker for a tier spend cap, authoritative where the
   # wording is not.
   UPSTREAM_SPEND_LIMIT_CODE = "enforced_spend_limit_reached"
+  # 401 is unambiguous, but a 403 is not proof of a credential problem:
+  # model allowlists, policy, and guardrails answer 403 too, and naming
+  # those a rejected key sends ops looking in the wrong place.
+  UPSTREAM_CREDENTIALS_PATTERN = /unauthorized|authenticat|credential|api.?key|permission denied|not permitted/i
 
   # Client feature flags forward as sent: the spend boundary is the body
   # validators above, not this header, and dropping a flag the body relies
@@ -802,13 +806,18 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     def minted_upstream_error(status, parsed, body)
       detail = upstream_error_detail(parsed, body)
       Rails.logger.warn("Gumhead gateway upstream error: status=#{status} #{detail}")
-      type, message = UPSTREAM_ERRORS.fetch(upstream_error_key(status, parsed, detail))
+      key = upstream_error_key(status, parsed, detail)
+      # A spend limit answers 429, which the runtime's SDK retries on
+      # status alone; every attempt fails until the cap resets. The SDK
+      # reads this header before it reaches that rule.
+      response.set_header("x-should-retry", "false") if key == :out_of_budget
+      type, message = UPSTREAM_ERRORS.fetch(key)
       anthropic_error(type, message)
     end
 
     def upstream_error_key(status, parsed, detail)
       return :out_of_budget if status == 402 || spend_limit_code?(parsed) || detail.match?(UPSTREAM_OUT_OF_BUDGET_PATTERN)
-      return :credentials if [401, 403].include?(status)
+      return :credentials if status == 401 || (status == 403 && detail.match?(UPSTREAM_CREDENTIALS_PATTERN))
       return :rate_limited if status == 429
       return :busy if status >= 500
 

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -12,9 +12,9 @@
 # error: {type:, message:}}) so the client runtime surfaces the message
 # instead of choking on an unfamiliar shape. An upstream failure keeps its
 # original status, so the runtime's own retry logic (429/529) keeps
-# working, but its message is replaced by one of this gateway's own — the
-# pet must not have to recognise each vendor's phrasing. The upstream
-# text goes to the log.
+# working, but its message is replaced by one of this gateway's own, so
+# Gumhead need not recognise each vendor's phrasing. The upstream text
+# goes to the log.
 #
 # ActionController::Live turns every render in this controller into a
 # streamed body; that is fine — the buffered paths (count_tokens, validation
@@ -97,24 +97,20 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # must stream, and streams meter incrementally.
   MAX_BUFFERED_OUTPUT_TOKENS = BUFFERED_TIMEOUT * TIMEOUT_OUTPUT_TOKENS_PER_SECOND
   # Operational failures only: a request the client got wrong keeps the
-  # provider's message, which names the field this gateway cannot. These
-  # strings are a contract with the pet, which matches them to choose what
-  # it says (core/src/errors.ts in antiwork/gumhead), so changing one needs
-  # a client release in the same window.
+  # provider's message, which names the field this gateway cannot. Gumhead
+  # matches these strings to choose what it says (core/src/errors.ts), so
+  # changing one needs a client release in the same window.
   UPSTREAM_ERRORS = {
     out_of_budget: ["api_error", "The Gumhead model service is out of budget."],
     credentials: ["api_error", "The Gumhead model service rejected the gateway credentials."],
     rate_limited: ["rate_limit_error", "The Gumhead model service is rate limited. Please retry shortly."],
     busy: ["api_error", "The Gumhead model service is busy. Please retry shortly."],
   }.freeze
-  # A spend cap or exhausted credit lasts hours or days, so it must not
-  # reach the pet as a transient. Providers report it on several statuses
-  # (400 for a self-set limit, 429 for a tier cap, 402 for empty credit),
-  # so status alone cannot separate it from a real rate limit. Only the
-  # documented wordings are matched: a broad "quota" would also swallow
-  # the per-minute limits, which recover on their own.
-  # "budget ... exceeded" is OpenRouter's workspace cap, which answers 403
-  # with no structured code, so the wording is the only signal there.
+  # A spend cap lasts hours or days, and providers report it on 400, 402,
+  # and 429, so status alone cannot separate it from a real rate limit.
+  # Only documented wordings match: a broad "quota" would swallow the
+  # per-minute limits, which recover on their own. "budget ... exceeded"
+  # is OpenRouter's workspace cap, which carries no structured code.
   UPSTREAM_OUT_OF_BUDGET_PATTERN = /api usage limits|credit balance|insufficient.{0,12}(credit|balance|fund)|out of credit|budget.{0,40}exceeded/i
   # The structured marker for a tier spend cap, authoritative where the
   # wording is not.
@@ -830,11 +826,10 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     # text reaches the log.
     def minted_upstream_error(status, parsed, body)
       detail = upstream_error_detail(parsed, body)
-      # The provider's request id is the only handle for finding this
-      # failure in their logs, and it used to reach the client inside the
-      # body this replaces.
-      request_id = parsed.is_a?(Hash) ? parsed["request_id"].to_s.presence : nil
-      Rails.logger.warn("Gumhead gateway upstream error: status=#{status} request_id=#{request_id || "none"} #{detail}")
+      # The request id is the handle for finding this failure in the
+      # provider's logs; it used to reach the client inside the body this
+      # replaces.
+      Rails.logger.warn("Gumhead gateway upstream error: status=#{status} request_id=#{upstream_request_id(parsed)} #{detail}")
       key = upstream_error_key(status, parsed, detail)
       return nil if key.nil?
 
@@ -867,15 +862,26 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
 
     # Providers put the message in {error:{message}}, but `error` is also
     # a bare string in the wild, where a nested dig would raise. Anything
-    # else — an HTML error page from a proxy, a truncated body — is logged
-    # as it arrived, bounded so one bad response cannot flood the log.
+    # else — an HTML error page from a proxy — is logged as it arrived.
+    #
+    # Both this and the request id are upstream-controlled and go into one
+    # log line, so control characters are flattened: a newline in either
+    # would forge a second record. Bounded so one bad response cannot
+    # flood the log.
     def upstream_error_detail(parsed, body)
       error = parsed.is_a?(Hash) ? parsed["error"] : nil
       message = case error
                 when Hash then error["message"].to_s
                 when String then error
       end
-      (message.presence || body.to_s).slice(0, 500)
+      (message.presence || body.to_s).gsub(/[[:cntrl:]]/, " ").squeeze(" ").strip.slice(0, 500)
+    end
+
+    # A known shape, so it is validated rather than sanitised: anything
+    # else is not a request id and should not reach the log as one.
+    def upstream_request_id(parsed)
+      id = parsed.is_a?(Hash) ? parsed["request_id"].to_s : ""
+      id[/\A[\w.-]{1,64}\z/] || "none"
     end
 
     def openrouter_error_envelope?(parsed)

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -64,13 +64,10 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # OpenRouter :online variants.
   DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-,gumhead-chat,gumhead-status,gumhead-cover"
   # The fallback map. The live one is a JSON object in Redis under
-  # RedisKey.gumhead_model_map, so moving a role to another model is one
-  # write with no deploy and no restart:
-  #   $redis.set(RedisKey.gumhead_model_map, { "gumhead-status" => "..." }.to_json)
-  # Entries merge over this one, so a partial map moves a single role.
-  # Point a role at an upstream id, never at the incoming name: a value
-  # equal to what the app sent is not a mapping, and validate_model
-  # rejects the request rather than forward a client-chosen name.
+  # RedisKey.gumhead_model_map, merged over this one, so a partial write
+  # moves one role with no deploy. Point a role at an upstream id, never
+  # at the incoming name: a value equal to what the app sent is not a
+  # mapping, and validate_model rejects the request.
   DEFAULT_MODEL_MAP = {
     "claude-sonnet-" => "x-ai/grok-4.6",
     "claude-haiku-" => "x-ai/grok-4.6",
@@ -322,14 +319,10 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       match ? match[1] : model
     end
 
-    # Which model serves each role is ops policy that has to change
-    # without a deploy: every `secret/web/` write re-renders one
-    # secrets.env and restarts a whole Puma colour at once, which took
-    # checkout down for four minutes on Aug 27 (gp#2273). So the live
-    # value is a Redis string and the deployed value is the fallback.
-    # Precedence: Redis, then GUMHEAD_MODEL_MAP, then the built-in map;
-    # deleting the Redis key reverts to what is deployed. Memoised
-    # because one request consults the map several times.
+    # Precedence: Redis, then GUMHEAD_MODEL_MAP, then the built-in map.
+    # The live value lives in Redis because a secret/web write restarts a
+    # whole Puma colour (gp#2273); deleting the key reverts to what is
+    # deployed. Memoised: one request consults the map several times.
     def model_map = resolved_model_map.first
 
     def model_map_source = resolved_model_map.last
@@ -343,12 +336,12 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
 
     def raw_model_map
       live = live_model_map
-      if live.present?
+      # Any stored value, empty string included: an operator who wrote one
+      # needs to hear that it is not serving. Only an absent key is silent.
+      unless live.nil?
         parsed = safe_parse_json(live)
         return [parsed, "redis"] if parsed.is_a?(Hash)
 
-        # Serving the deployed map while an operator believes their write
-        # is live is the one failure they cannot see from the outside.
         Rails.logger.warn("Gumhead model map in Redis is not a JSON object; serving the deployed map.")
       end
 
@@ -412,11 +405,9 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     # request was already answered with the error envelope, and logging must
     # not turn that answer into a 500.
     def append_info_to_payload(payload)
-      # Which source chose this request's model, so a lost Redis key
-      # reads as a model change in the logs rather than as silence. Read
-      # from the memo, not through model_map_source: a request rejected
-      # before validate_model never consults the map, and logging must
-      # not be what sends it to Redis.
+      # A lost Redis key is a model change; log the source so it is not a
+      # silent one. Read the memo rather than model_map_source, so logging
+      # never triggers the Redis read for a request that skipped the map.
       payload[:gumhead_model_map_source] = @resolved_model_map.last if @resolved_model_map
       super
     rescue ActionDispatch::Http::Parameters::ParseError

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -10,9 +10,11 @@
 #
 # Gateway-minted errors use Anthropic's error envelope ({type: "error",
 # error: {type:, message:}}) so the client runtime surfaces the message
-# instead of choking on an unfamiliar shape. Upstream errors pass through
-# with their original status so the runtime's own retry logic (429/529)
-# keeps working.
+# instead of choking on an unfamiliar shape. An upstream failure keeps its
+# original status, so the runtime's own retry logic (429/529) keeps
+# working, but its message is replaced by one of this gateway's own — the
+# pet must not have to recognise each vendor's phrasing. The upstream
+# text goes to the log.
 #
 # ActionController::Live turns every render in this controller into a
 # streamed body; that is fine — the buffered paths (count_tokens, validation
@@ -94,6 +96,28 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # timeout charge a true upper bound on upstream spend; anything larger
   # must stream, and streams meter incrementally.
   MAX_BUFFERED_OUTPUT_TOKENS = BUFFERED_TIMEOUT * TIMEOUT_OUTPUT_TOKENS_PER_SECOND
+  # The seller's pet reads these strings, so they must not change when the
+  # upstream vendor does. Forwarding the vendor's own text made the client
+  # match Anthropic's exact wording, which meant every later vendor fell
+  # back to a generic "busy" line for failures the pet should name.
+  UPSTREAM_ERRORS = {
+    out_of_budget: ["api_error", "The Gumhead model service is out of budget."],
+    credentials: ["api_error", "The Gumhead model service rejected the gateway credentials."],
+    rate_limited: ["rate_limit_error", "The Gumhead model service is rate limited. Please retry shortly."],
+    busy: ["api_error", "The Gumhead model service is busy. Please retry shortly."],
+    other: ["api_error", "The model service returned an error."],
+  }.freeze
+  # A spend cap or exhausted credit lasts hours or days, so it must not
+  # reach the pet as a transient. Providers report it on several statuses
+  # (400 for a self-set limit, 429 for a tier cap, 402 for empty credit),
+  # so status alone cannot separate it from a real rate limit. Only the
+  # documented wordings are matched: a broad "quota" would also swallow
+  # the per-minute limits, which recover on their own.
+  UPSTREAM_OUT_OF_BUDGET_PATTERN = /api usage limits|credit balance|insufficient.{0,12}(credit|balance|fund)|out of credit/i
+  # The structured marker for a tier spend cap, authoritative where the
+  # wording is not.
+  UPSTREAM_SPEND_LIMIT_CODE = "enforced_spend_limit_reached"
+
   # Client feature flags forward as sent: the spend boundary is the body
   # validators above, not this header, and dropping a flag the body relies
   # on fails the request. `fallback` is denied because it runs extra models
@@ -456,16 +480,15 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
         return render json: { "input_tokens" => @raw_body.bytesize }, status: :ok
       end
       parsed = safe_parse_json(body)
-      # OpenRouter uses {error:{message}} without Anthropic's top-level type.
-      # Keep Anthropic envelopes as pass-through.
-      if openrouter_error_envelope?(parsed)
+      # A 200 carrying an error envelope (OpenRouter's shape omits
+      # Anthropic's top-level type) was still generated and billed.
+      if !upstream.status.success? || openrouter_error_envelope?(parsed)
         meter_buffered_usage(body) if meter && upstream.status.success?
-        message = parsed.dig("error", "message").to_s.presence || "The model service returned an error."
         copy_retry_after(upstream)
         status = upstream.status.success? ? :bad_gateway : upstream.status.code
-        return render json: anthropic_error("api_error", message), status:
+        return render json: minted_upstream_error(upstream.status.code, parsed, body), status:
       end
-      meter_buffered_usage(body) if meter && upstream.status.success?
+      meter_buffered_usage(body) if meter
       copy_retry_after(upstream)
       render body:, content_type: "application/json", status: upstream.status.code
     rescue HTTP::ConnectTimeoutError => e
@@ -585,12 +608,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       unless upstream.status.success?
         copy_retry_after(upstream)
         body = upstream.body.to_s
-        parsed = safe_parse_json(body)
-        if openrouter_error_envelope?(parsed)
-          message = parsed.dig("error", "message").to_s.presence || "The model service returned an error."
-          return render json: anthropic_error("api_error", message), status: upstream.status.code
-        end
-        return render body:, content_type: "application/json", status: upstream.status.code
+        return render json: minted_upstream_error(upstream.status.code, safe_parse_json(body), body), status: upstream.status.code
       end
       if upstream.headers["Content-Type"].to_s.include?("application/json") &&
          !upstream.headers["Content-Type"].to_s.include?("event-stream")
@@ -598,8 +616,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
         parsed = safe_parse_json(body)
         if parsed.is_a?(Hash) && parsed["error"].is_a?(Hash)
           meter_buffered_usage(body) if parsed["usage"].is_a?(Hash)
-          message = parsed.dig("error", "message").to_s.presence || "The model service returned an error."
-          return render json: anthropic_error("api_error", message), status: :bad_gateway
+          return render json: minted_upstream_error(upstream.status.code, parsed, body), status: :bad_gateway
         end
       end
 
@@ -612,6 +629,12 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       scanner = GumheadStreamUsageScanner.new
       begin
         last_renewal = Time.current
+        # Committed bytes pass through untouched, so an error event the
+        # provider sends after this point still carries its own wording —
+        # the one failure this gateway does not mint. Rewriting it means
+        # re-framing SSE across chunk boundaries and teaching the scanner
+        # to separate an error ending from message_stop; that belongs in
+        # its own change, not in the middle of this loop.
         while (chunk = upstream.body.readpartial)
           scanner << chunk
           response.stream.write(chunk)
@@ -772,6 +795,47 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       else
         GlobalConfig.get("GUMHEAD_UPSTREAM_API_KEY").presence
       end
+    end
+
+    # One of this gateway's own messages for an upstream failure, and the
+    # upstream's text in the log where an engineer can read it.
+    def minted_upstream_error(status, parsed, body)
+      detail = upstream_error_detail(parsed, body)
+      Rails.logger.warn("Gumhead gateway upstream error: status=#{status} #{detail}")
+      type, message = UPSTREAM_ERRORS.fetch(upstream_error_key(status, parsed, detail))
+      anthropic_error(type, message)
+    end
+
+    def upstream_error_key(status, parsed, detail)
+      return :out_of_budget if status == 402 || spend_limit_code?(parsed) || detail.match?(UPSTREAM_OUT_OF_BUDGET_PATTERN)
+      return :credentials if [401, 403].include?(status)
+      return :rate_limited if status == 429
+      return :busy if status >= 500
+
+      :other
+    end
+
+    def spend_limit_code?(parsed)
+      return false unless parsed.is_a?(Hash)
+
+      error = parsed["error"]
+      return false unless error.is_a?(Hash)
+
+      details = error["details"]
+      details.is_a?(Hash) && details["error_code"].to_s == UPSTREAM_SPEND_LIMIT_CODE
+    end
+
+    # Providers put the message in {error:{message}}, but `error` is also
+    # a bare string in the wild, where a nested dig would raise. Anything
+    # else — an HTML error page from a proxy, a truncated body — is logged
+    # as it arrived, bounded so one bad response cannot flood the log.
+    def upstream_error_detail(parsed, body)
+      error = parsed.is_a?(Hash) ? parsed["error"] : nil
+      message = case error
+                when Hash then error["message"].to_s
+                when String then error
+      end
+      (message.presence || body.to_s).slice(0, 500)
     end
 
     def openrouter_error_envelope?(parsed)

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -63,6 +63,14 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # Family prefixes rewrite every allowed Claude name, including
   # OpenRouter :online variants.
   DEFAULT_ALLOWED_MODEL_PREFIXES = "claude-sonnet-,claude-haiku-,claude-opus-,gumhead-chat,gumhead-status,gumhead-cover"
+  # The fallback map. The live one is a JSON object in Redis under
+  # RedisKey.gumhead_model_map, so moving a role to another model is one
+  # write with no deploy and no restart:
+  #   $redis.set(RedisKey.gumhead_model_map, { "gumhead-status" => "..." }.to_json)
+  # Entries merge over this one, so a partial map moves a single role.
+  # Point a role at an upstream id, never at the incoming name: a value
+  # equal to what the app sent is not a mapping, and validate_model
+  # rejects the request rather than forward a client-chosen name.
   DEFAULT_MODEL_MAP = {
     "claude-sonnet-" => "x-ai/grok-4.6",
     "claude-haiku-" => "x-ai/grok-4.6",
@@ -292,9 +300,16 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     end
 
     def rewrite_upstream_model?
-      return true if GlobalConfig.get("GUMHEAD_MODEL_MAP").present?
+      return true if configured_model_map?
 
       !anthropic_upstream?
+    end
+
+    # An operator-set map — in Redis or in the deployed config — always
+    # rewrites. Only the built-in map waits for the upstream to move off
+    # Anthropic.
+    def configured_model_map?
+      model_map_source != "default"
     end
 
     def mapped_upstream_model(model)
@@ -307,18 +322,59 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       match ? match[1] : model
     end
 
-    def model_map
-      raw = GlobalConfig.get("GUMHEAD_MODEL_MAP", DEFAULT_MODEL_MAP)
-      parsed = raw.is_a?(String) ? safe_parse_json(raw) : raw
-      overrides = {}
-      if parsed.is_a?(Hash)
-        parsed.each do |key, value|
-          next if key.blank? || value.blank?
+    # Which model serves each role is ops policy that has to change
+    # without a deploy: every `secret/web/` write re-renders one
+    # secrets.env and restarts a whole Puma colour at once, which took
+    # checkout down for four minutes on Aug 27 (gp#2273). So the live
+    # value is a Redis string and the deployed value is the fallback.
+    # Precedence: Redis, then GUMHEAD_MODEL_MAP, then the built-in map;
+    # deleting the Redis key reverts to what is deployed. Memoised
+    # because one request consults the map several times.
+    def model_map = resolved_model_map.first
 
-          overrides[key.to_s] = value.to_s
-        end
+    def model_map_source = resolved_model_map.last
+
+    def resolved_model_map
+      @resolved_model_map ||= begin
+        raw, source = raw_model_map
+        [DEFAULT_MODEL_MAP.merge(normalized_model_map(raw)), source]
       end
-      DEFAULT_MODEL_MAP.merge(overrides)
+    end
+
+    def raw_model_map
+      live = live_model_map
+      if live.present?
+        parsed = safe_parse_json(live)
+        return [parsed, "redis"] if parsed.is_a?(Hash)
+
+        # Serving the deployed map while an operator believes their write
+        # is live is the one failure they cannot see from the outside.
+        Rails.logger.warn("Gumhead model map in Redis is not a JSON object; serving the deployed map.")
+      end
+
+      configured = GlobalConfig.get("GUMHEAD_MODEL_MAP")
+      return [configured, "config"] if configured.present?
+
+      [DEFAULT_MODEL_MAP, "default"]
+    end
+
+    def live_model_map
+      $redis.get(RedisKey.gumhead_model_map)
+    rescue Redis::BaseError => e
+      # Reading ops policy must not fail the turn; the deployed map serves.
+      Rails.logger.warn("Gumhead model map Redis read failed: #{e.class} #{e.message}")
+      nil
+    end
+
+    def normalized_model_map(raw)
+      parsed = raw.is_a?(String) ? safe_parse_json(raw) : raw
+      return {} unless parsed.is_a?(Hash)
+
+      parsed.each_with_object({}) do |(key, value), map|
+        next if key.blank? || value.blank?
+
+        map[key.to_s] = value.to_s
+      end
     end
 
     def allowed_model_prefixes
@@ -356,6 +412,12 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     # request was already answered with the error envelope, and logging must
     # not turn that answer into a 500.
     def append_info_to_payload(payload)
+      # Which source chose this request's model, so a lost Redis key
+      # reads as a model change in the logs rather than as silence. Read
+      # from the memo, not through model_map_source: a request rejected
+      # before validate_model never consults the map, and logging must
+      # not be what sends it to Redis.
+      payload[:gumhead_model_map_source] = @resolved_model_map.last if @resolved_model_map
       super
     rescue ActionDispatch::Http::Parameters::ParseError
       nil

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -832,7 +832,11 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     # text reaches the log.
     def minted_upstream_error(status, parsed, body)
       detail = upstream_error_detail(parsed, body)
-      Rails.logger.warn("Gumhead gateway upstream error: status=#{status} #{detail}")
+      # The provider's request id is the only handle for finding this
+      # failure in their logs, and it used to reach the client inside the
+      # body this replaces.
+      request_id = parsed.is_a?(Hash) ? parsed["request_id"].to_s.presence : nil
+      Rails.logger.warn("Gumhead gateway upstream error: status=#{status} request_id=#{request_id || "none"} #{detail}")
       key = upstream_error_key(status, parsed, detail)
       return nil if key.nil?
 

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -113,14 +113,18 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # so status alone cannot separate it from a real rate limit. Only the
   # documented wordings are matched: a broad "quota" would also swallow
   # the per-minute limits, which recover on their own.
-  UPSTREAM_OUT_OF_BUDGET_PATTERN = /api usage limits|credit balance|insufficient.{0,12}(credit|balance|fund)|out of credit/i
+  # "budget ... exceeded" is OpenRouter's workspace cap, which answers 403
+  # with no structured code, so the wording is the only signal there.
+  UPSTREAM_OUT_OF_BUDGET_PATTERN = /api usage limits|credit balance|insufficient.{0,12}(credit|balance|fund)|out of credit|budget.{0,40}exceeded/i
   # The structured marker for a tier spend cap, authoritative where the
   # wording is not.
   UPSTREAM_SPEND_LIMIT_CODE = "enforced_spend_limit_reached"
   # 401 is unambiguous, but a 403 is not proof of a credential problem:
-  # model allowlists, policy, and guardrails answer 403 too, and naming
-  # those a rejected key sends ops looking in the wrong place.
-  UPSTREAM_CREDENTIALS_PATTERN = /unauthorized|authenticat|credential|api.?key|permission denied|not permitted/i
+  # model allowlists, guardrails, and budget caps answer 403 too, and
+  # naming those a rejected key sends ops looking in the wrong place. Only
+  # authentication wording counts — "not permitted" and "permission
+  # denied" are what a policy block says about a perfectly good key.
+  UPSTREAM_CREDENTIALS_PATTERN = /unauthorized|authenticat|credential|api.?key|invalid.{0,10}key|no auth/i
 
   # Client feature flags forward as sent: the spend boundary is the body
   # validators above, not this header, and dropping a flag the body relies

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -29,6 +29,7 @@ class RedisKey
     def agent_request_throttle(user_id) = "agent_request_throttle:#{user_id}"
     def gumhead_gateway_throttle(user_id) = "gumhead_gateway_throttle:#{user_id}"
     def gumhead_gateway_in_flight(user_id) = "gumhead_gateway_in_flight:#{user_id}"
+    def gumhead_model_map = "gumhead_model_map"
     def agent_turn_status(user_id, client_turn_id) = "agent_turn_status:#{user_id}:#{client_turn_id}"
     def agent_custom_html_preview(user_id, token) = "agent_custom_html_preview:#{user_id}:#{token}"
     def agent_custom_html_preview_index(user_id) = "agent_custom_html_preview_index:#{user_id}"

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -706,14 +706,14 @@ describe Api::V2::Gumhead::MessagesController do
       expect(GumheadUsageEvent.count).to eq(0)
     end
 
-    it "keeps the status of a 404 from Anthropic count_tokens but mints its message" do
+    it "passes through a 404 from Anthropic count_tokens" do
       stub_request(:post, count_tokens_url)
         .to_return(status: 404, body: { type: "error", error: { type: "not_found_error", message: "Not Found" } }.to_json)
 
       post :count_tokens, body: request_payload.to_json, as: :json
 
       expect(response.status).to eq(404)
-      expect(JSON.parse(response.body)["error"]["message"]).to eq(described_class::UPSTREAM_ERRORS.fetch(:other).last)
+      expect(JSON.parse(response.body)["error"]["type"]).to eq("not_found_error")
     end
 
     it "shares the concurrent in-flight limit" do
@@ -884,9 +884,8 @@ describe Api::V2::Gumhead::MessagesController do
       expect(response.status).to eq(502)
       expect(JSON.parse(response.body)).to eq(
         "type" => "error",
-        "error" => { "type" => "api_error", "message" => described_class::UPSTREAM_ERRORS.fetch(:other).last },
+        "error" => { "type" => "api_error", "message" => "Provider returned error" },
       )
-      expect(response.body).not_to include("Provider returned error")
       expect(GumheadUsageEvent.count).to eq(0)
     end
 
@@ -1034,7 +1033,8 @@ describe Api::V2::Gumhead::MessagesController do
     end
 
     # Guardrails, model allowlists, and budget caps all answer 403; calling
-    # those a rejected key would send ops looking at the wrong thing.
+    # those a rejected key would send ops looking at the wrong thing, and a
+    # fixed string would say less than the provider already did.
     ["Blocked by a guardrail policy", "This model is not permitted", "Permission denied for this route"].each do |message|
       it "does not blame credentials for a 403 saying #{message.inspect}" do
         stub_upstream_error(status: 403, message:)
@@ -1042,8 +1042,17 @@ describe Api::V2::Gumhead::MessagesController do
         post_messages
 
         expect(response.status).to eq(403)
-        expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:other))
+        expect(JSON.parse(response.body)["error"]["message"]).to eq(message)
       end
+    end
+
+    it "keeps a client-correctable 400 as the provider wrote it" do
+      stub_upstream_error(status: 400, message: "max_tokens: Field required")
+
+      post_messages
+
+      expect(response.status).to eq(400)
+      expect(response.body).to include("max_tokens: Field required")
     end
 
     it "reads OpenRouter's 403 workspace budget cap as out of budget" do

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -379,15 +379,16 @@ describe Api::V2::Gumhead::MessagesController do
       expect(event.cache_read_input_tokens).to eq(11)
     end
 
-    it "passes an upstream error through with its status, body, and retry timing" do
+    it "keeps an upstream error's status and retry timing but mints its message" do
       stub_request(:post, messages_url)
         .to_return(status: 429, body: { type: "error", error: { type: "rate_limit_error", message: "Slow down" } }.to_json, headers: { "Retry-After" => "13" })
 
       post_messages
 
       expect(response.status).to eq(429)
-      expect(response.body).to include("Slow down")
       expect(response.headers["Retry-After"]).to eq("13")
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(described_class::UPSTREAM_ERRORS.fetch(:rate_limited).last)
+      expect(response.body).not_to include("Slow down")
       expect(GumheadUsageEvent.count).to eq(0)
     end
 
@@ -642,7 +643,8 @@ describe Api::V2::Gumhead::MessagesController do
       post_messages(request_payload.merge(stream: true))
 
       expect(response.status).to eq(401)
-      expect(response.body).to include("bad key")
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(described_class::UPSTREAM_ERRORS.fetch(:credentials).last)
+      expect(response.body).not_to include("bad key")
       expect(GumheadUsageEvent.count).to eq(0)
     end
   end
@@ -704,14 +706,14 @@ describe Api::V2::Gumhead::MessagesController do
       expect(GumheadUsageEvent.count).to eq(0)
     end
 
-    it "passes through a 404 from Anthropic count_tokens" do
+    it "keeps the status of a 404 from Anthropic count_tokens but mints its message" do
       stub_request(:post, count_tokens_url)
         .to_return(status: 404, body: { type: "error", error: { type: "not_found_error", message: "Not Found" } }.to_json)
 
       post :count_tokens, body: request_payload.to_json, as: :json
 
       expect(response.status).to eq(404)
-      expect(JSON.parse(response.body)["error"]["type"]).to eq("not_found_error")
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(described_class::UPSTREAM_ERRORS.fetch(:other).last)
     end
 
     it "shares the concurrent in-flight limit" do
@@ -863,7 +865,7 @@ describe Api::V2::Gumhead::MessagesController do
       expect(response.headers["Retry-After"]).to eq("7")
       expect(JSON.parse(response.body)).to eq(
         "type" => "error",
-        "error" => { "type" => "api_error", "message" => "Rate limited" },
+        "error" => { "type" => "rate_limit_error", "message" => described_class::UPSTREAM_ERRORS.fetch(:rate_limited).last },
       )
       expect(GumheadUsageEvent.count).to eq(0)
     end
@@ -882,8 +884,9 @@ describe Api::V2::Gumhead::MessagesController do
       expect(response.status).to eq(502)
       expect(JSON.parse(response.body)).to eq(
         "type" => "error",
-        "error" => { "type" => "api_error", "message" => "Provider returned error" },
+        "error" => { "type" => "api_error", "message" => described_class::UPSTREAM_ERRORS.fetch(:other).last },
       )
+      expect(response.body).not_to include("Provider returned error")
       expect(GumheadUsageEvent.count).to eq(0)
     end
 
@@ -987,6 +990,127 @@ describe Api::V2::Gumhead::MessagesController do
 
       expect(response.status).to eq(502)
       expect(GumheadUsageEvent.sole.input_tokens).to eq(rewritten_payload_bytesize)
+    end
+  end
+
+  describe "minted upstream errors" do
+    def minted(key) = described_class::UPSTREAM_ERRORS.fetch(key).last
+
+    def stub_upstream_error(status:, message:, headers: {})
+      stub_request(:post, messages_url).to_return(
+        status:,
+        body: { type: "error", error: { type: "invalid_request_error", message: } }.to_json,
+        headers: { "Content-Type" => "application/json" }.merge(headers),
+      )
+    end
+
+    # The spend limit that took Gumhead chat down, in all three shapes the
+    # provider reports it. None may reach the pet as a transient retry.
+    [
+      ["a self-set organization limit", 400, "You have reached your specified API usage limits. You will regain access on 2026-09-01 at 00:00 UTC."],
+      ["a workspace limit", 400, "You have reached your specified workspace API usage limits."],
+      ["a tier spend cap", 429, "You have reached your API usage limits: your organization has crossed its monthly API usage threshold."],
+      ["exhausted credit", 402, "Insufficient credits."],
+    ].each do |label, status, message|
+      it "mints an out-of-budget error for #{label}" do
+        stub_upstream_error(status:, message:)
+
+        post_messages
+
+        expect(response.status).to eq(status)
+        expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:out_of_budget))
+        expect(response.body).not_to include("usage limits")
+        expect(response.body).not_to include("Insufficient credits")
+      end
+    end
+
+    it "mints a credentials error for an upstream 403" do
+      stub_upstream_error(status: 403, message: "Your key is not permitted")
+
+      post_messages
+
+      expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:credentials))
+    end
+
+    it "mints a busy error for an upstream overload" do
+      stub_upstream_error(status: 529, message: "Overloaded")
+
+      post_messages
+
+      expect(response.status).to eq(529)
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:busy))
+    end
+
+    it "separates a real rate limit from a spend limit on the same status" do
+      stub_upstream_error(status: 429, message: "Number of request tokens has exceeded your per-minute rate limit")
+
+      post_messages
+
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:rate_limited))
+    end
+
+    it "keeps a per-minute quota transient rather than reading it as a budget" do
+      stub_upstream_error(status: 429, message: "You have exceeded your per-minute request quota")
+
+      post_messages
+
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:rate_limited))
+    end
+
+    it "trusts the structured spend-limit code over the wording" do
+      stub_request(:post, messages_url).to_return(
+        status: 429,
+        body: {
+          type: "error",
+          error: { type: "rate_limit_error", message: "Access paused.", details: { error_code: "enforced_spend_limit_reached" } },
+        }.to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+      post_messages
+
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:out_of_budget))
+    end
+
+    it "mints instead of raising when the upstream puts a bare string in error" do
+      stub_request(:post, messages_url)
+        .to_return(status: 401, body: { error: "Unauthorized" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(response.status).to eq(401)
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:credentials))
+    end
+
+    it "logs the upstream text it withheld from the seller" do
+      stub_upstream_error(status: 403, message: "Your key is not permitted")
+      allow(Rails.logger).to receive(:warn)
+
+      post_messages
+
+      expect(Rails.logger).to have_received(:warn).with(/status=403 Your key is not permitted/)
+    end
+
+    it "mints for an upstream body that is not JSON at all" do
+      stub_request(:post, messages_url).to_return(status: 502, body: "<html>Bad Gateway</html>")
+
+      post_messages
+
+      expect(response.status).to eq(502)
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:busy))
+      expect(response.body).not_to include("html")
+    end
+
+    it "leaves a successful reply untouched" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)["content"].first["text"]).to eq("Hello!")
+      expect(GumheadUsageEvent.count).to eq(1)
     end
   end
 

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -1033,15 +1033,26 @@ describe Api::V2::Gumhead::MessagesController do
       expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:credentials))
     end
 
-    # A guardrail or model allowlist also answers 403; calling that a
-    # rejected key would send ops looking at the wrong thing.
-    it "does not blame credentials for a 403 that is not about them" do
-      stub_upstream_error(status: 403, message: "Blocked by a guardrail policy")
+    # Guardrails, model allowlists, and budget caps all answer 403; calling
+    # those a rejected key would send ops looking at the wrong thing.
+    ["Blocked by a guardrail policy", "This model is not permitted", "Permission denied for this route"].each do |message|
+      it "does not blame credentials for a 403 saying #{message.inspect}" do
+        stub_upstream_error(status: 403, message:)
+
+        post_messages
+
+        expect(response.status).to eq(403)
+        expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:other))
+      end
+    end
+
+    it "reads OpenRouter's 403 workspace budget cap as out of budget" do
+      stub_upstream_error(status: 403, message: "Workspace monthly budget of $500.00 exceeded. Contact your org admin.")
 
       post_messages
 
       expect(response.status).to eq(403)
-      expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:other))
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:out_of_budget))
     end
 
     it "tells the runtime not to retry a spend limit it would otherwise retry" do

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -1077,6 +1077,19 @@ describe Api::V2::Gumhead::MessagesController do
       expect_forwarded_model(openrouter_messages_url, "x-ai/grok-4.6")
     end
 
+    it "warns on a stored empty value instead of treating it as unset" do
+      use_openrouter_base
+      $redis.set(RedisKey.gumhead_model_map, "")
+      stub_openrouter
+      allow(Rails.logger).to receive(:warn)
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect(Rails.logger).to have_received(:warn).with(/not a JSON object/).at_least(:once)
+      expect_forwarded_model(openrouter_messages_url, "x-ai/grok-4.6")
+    end
+
     it "serves the deployed map when Redis is unreachable" do
       use_openrouter_base
       # Other services read $redis on this path; only the map read fails.

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -1138,7 +1138,22 @@ describe Api::V2::Gumhead::MessagesController do
 
       post_messages
 
-      expect(Rails.logger).to have_received(:warn).with(/status=403 Your key is not permitted/)
+      expect(Rails.logger).to have_received(:warn).with(/status=403 .*Your key is not permitted/)
+    end
+
+    # The minted envelope replaces the body that carried this, and it is
+    # the only handle for finding the failure in the provider's logs.
+    it "logs the provider's request id alongside the withheld text" do
+      stub_request(:post, messages_url).to_return(
+        status: 429,
+        body: { type: "error", error: { type: "rate_limit_error", message: "Slow down" }, request_id: "req_018EeWyXxfu5" }.to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+      allow(Rails.logger).to receive(:warn)
+
+      post_messages
+
+      expect(Rails.logger).to have_received(:warn).with(/request_id=req_018EeWyXxfu5/)
     end
 
     it "mints for an upstream body that is not JSON at all" do

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -900,9 +900,7 @@ describe Api::V2::Gumhead::MessagesController do
 
     it "still rewrites Claude names when the configured map is empty" do
       use_openrouter_base
-      allow(GlobalConfig).to receive(:get)
-        .with("GUMHEAD_MODEL_MAP", described_class::DEFAULT_MODEL_MAP)
-        .and_return({})
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_MODEL_MAP").and_return("{}")
       stub_request(:post, openrouter_messages_url)
         .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
 
@@ -989,6 +987,135 @@ describe Api::V2::Gumhead::MessagesController do
 
       expect(response.status).to eq(502)
       expect(GumheadUsageEvent.sole.input_tokens).to eq(rewritten_payload_bytesize)
+    end
+  end
+
+  describe "live model map in Redis" do
+    let(:openrouter_messages_url) { "https://openrouter.ai/api/v1/messages" }
+
+    after { $redis.del(RedisKey.gumhead_model_map) }
+
+    def use_openrouter_base
+      allow(GlobalConfig).to receive(:get)
+        .with("GUMHEAD_UPSTREAM_API_BASE", described_class::DEFAULT_UPSTREAM_API_BASE)
+        .and_return("https://openrouter.ai/api/v1")
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_UPSTREAM_API_KEY").and_return("sk-or-test")
+    end
+
+    # Response without a model, so the ledger has to take the name from
+    # the rewritten body. A stub naming the mapped model would pass with
+    # the rewrite reverted.
+    def stub_openrouter
+      stub_request(:post, openrouter_messages_url)
+        .to_return(status: 200, body: anthropic_response.except(:model).to_json, headers: { "Content-Type" => "application/json" })
+    end
+
+    def expect_forwarded_model(url, model)
+      expect(WebMock).to have_requested(:post, url).with { |req|
+        JSON.parse(req.body)["model"] == model
+      }
+    end
+
+    it "serves the model a Redis write names, without a deploy" do
+      use_openrouter_base
+      $redis.set(RedisKey.gumhead_model_map, { "claude-sonnet-" => "openai/gpt-5.6-luna" }.to_json)
+      stub_openrouter
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect_forwarded_model(openrouter_messages_url, "openai/gpt-5.6-luna")
+      expect(GumheadUsageEvent.sole.model).to eq("openai/gpt-5.6-luna")
+    end
+
+    it "moves one role and leaves the rest on the built-in map" do
+      use_openrouter_base
+      $redis.set(RedisKey.gumhead_model_map, { "gumhead-status" => "openai/gpt-5.6-luna" }.to_json)
+      stub_openrouter
+
+      post_messages(request_payload.merge(model: "gumhead-status"))
+      post_messages(request_payload.merge(model: "gumhead-chat"))
+
+      expect_forwarded_model(openrouter_messages_url, "openai/gpt-5.6-luna")
+      expect_forwarded_model(openrouter_messages_url, "x-ai/grok-4.6")
+    end
+
+    it "outranks the deployed GUMHEAD_MODEL_MAP" do
+      use_openrouter_base
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_MODEL_MAP")
+        .and_return({ "claude-sonnet-" => "x-ai/grok-4.5" }.to_json)
+      $redis.set(RedisKey.gumhead_model_map, { "claude-sonnet-" => "openai/gpt-5.6-luna" }.to_json)
+      stub_openrouter
+
+      post_messages
+
+      expect_forwarded_model(openrouter_messages_url, "openai/gpt-5.6-luna")
+    end
+
+    it "falls back to the deployed map once the Redis key is deleted" do
+      use_openrouter_base
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_MODEL_MAP")
+        .and_return({ "claude-sonnet-" => "x-ai/grok-4.5" }.to_json)
+      $redis.del(RedisKey.gumhead_model_map)
+      stub_openrouter
+
+      post_messages
+
+      expect_forwarded_model(openrouter_messages_url, "x-ai/grok-4.5")
+    end
+
+    it "serves the deployed map and warns when the Redis value is not a JSON object" do
+      use_openrouter_base
+      $redis.set(RedisKey.gumhead_model_map, "x-ai/grok-4.5")
+      stub_openrouter
+      allow(Rails.logger).to receive(:warn)
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect(Rails.logger).to have_received(:warn).with(/not a JSON object/).at_least(:once)
+      expect_forwarded_model(openrouter_messages_url, "x-ai/grok-4.6")
+    end
+
+    it "serves the deployed map when Redis is unreachable" do
+      use_openrouter_base
+      # Other services read $redis on this path; only the map read fails.
+      allow($redis).to receive(:get).and_call_original
+      allow($redis).to receive(:get).with(RedisKey.gumhead_model_map).and_raise(Redis::CannotConnectError)
+      stub_openrouter
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect_forwarded_model(openrouter_messages_url, "x-ai/grok-4.6")
+    end
+
+    it "rewrites on an Anthropic upstream when only Redis names a map" do
+      $redis.set(RedisKey.gumhead_model_map, { "claude-sonnet-" => "claude-sonnet-4.5" }.to_json)
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect_forwarded_model(messages_url, "claude-sonnet-4.5")
+    end
+
+    it "records which source chose the model" do
+      use_openrouter_base
+      $redis.set(RedisKey.gumhead_model_map, { "claude-sonnet-" => "openai/gpt-5.6-luna" }.to_json)
+      stub_openrouter
+      sources = []
+      subscriber = ActiveSupport::Notifications.subscribe("process_action.action_controller") do |*, payload|
+        sources << payload[:gumhead_model_map_source]
+      end
+
+      begin
+        post_messages
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(sources).to include("redis")
     end
   end
 end

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -1024,13 +1024,42 @@ describe Api::V2::Gumhead::MessagesController do
       end
     end
 
-    it "mints a credentials error for an upstream 403" do
-      stub_upstream_error(status: 403, message: "Your key is not permitted")
+    it "mints a credentials error for an upstream 403 that names the key" do
+      stub_upstream_error(status: 403, message: "Your API key is not permitted")
 
       post_messages
 
       expect(response.status).to eq(403)
       expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:credentials))
+    end
+
+    # A guardrail or model allowlist also answers 403; calling that a
+    # rejected key would send ops looking at the wrong thing.
+    it "does not blame credentials for a 403 that is not about them" do
+      stub_upstream_error(status: 403, message: "Blocked by a guardrail policy")
+
+      post_messages
+
+      expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(minted(:other))
+    end
+
+    it "tells the runtime not to retry a spend limit it would otherwise retry" do
+      stub_upstream_error(status: 429, message: "You have reached your specified API usage limits.")
+
+      post_messages
+
+      expect(response.status).to eq(429)
+      expect(response.headers["x-should-retry"]).to eq("false")
+    end
+
+    it "leaves a real rate limit retryable" do
+      stub_upstream_error(status: 429, message: "Per-minute rate limit exceeded", headers: { "Retry-After" => "9" })
+
+      post_messages
+
+      expect(response.headers["x-should-retry"]).to be_nil
+      expect(response.headers["Retry-After"]).to eq("9")
     end
 
     it "mints a busy error for an upstream overload" do

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -1003,8 +1003,7 @@ describe Api::V2::Gumhead::MessagesController do
       )
     end
 
-    # The spend limit that took Gumhead chat down, in all three shapes the
-    # provider reports it. None may reach the pet as a transient retry.
+    # No spend-limit shape may be reported as a transient retry.
     [
       ["a self-set organization limit", 400, "You have reached your specified API usage limits. You will regain access on 2026-09-01 at 00:00 UTC."],
       ["a workspace limit", 400, "You have reached your specified workspace API usage limits."],


### PR DESCRIPTION
## What

An upstream **operational** failure now reaches the client as one of this gateway's own messages instead of the provider's text. Status and `Retry-After` still pass through, and the provider's text goes to the log.

| Class | Trigger | Minted message |
|---|---|---|
| out of budget | 402, the `enforced_spend_limit_reached` code, or a documented budget wording | The Gumhead model service is out of budget. |
| credentials | 401, or a 403 whose text is about credentials | The Gumhead model service rejected the gateway credentials. |
| rate limited | 429 without those markers | The Gumhead model service is rate limited. Please retry shortly. |
| busy | 5xx, including 529 | The Gumhead model service is busy. Please retry shortly. |

Anything else keeps the provider's message — a missing `max_tokens`, a bad tool history, a policy block. Those name a field this gateway can't, and `validate_max_tokens` already delegates them on purpose.

Two extras:

- A spend limit answers 429, which the SDK retries on status alone, so those responses carry `x-should-retry: false`. The bundled SDK checks that header before its 429 rule.
- A 403 alone is not a credential failure. Model allowlists, guardrails, and budget caps answer 403 too.

## Why

The pet picks its line by matching the message it receives. Forwarding provider text meant the client had to learn one vendor's exact wording — #17 needed three patterns for three phrasings of the same condition — and anything unmatched fell through to a one-minute retry line, wrong by up to a month during the August outage.

Now the client matches a fixed set of gateway strings, and adding a vendor is a gateway-side change with no client release.

Out of budget earns its own class because providers report it on 400, 402, and 429, so status alone can't separate it from a real rate limit.

## Known gap

Bytes already committed to a stream pass through untouched, so an error event sent mid-stream keeps its own wording. Minting that needs SSE re-framing across chunk boundaries and a scanner change (`GumheadStreamUsageScanner` is documented as scanning "without altering the pass-through bytes"), so it belongs in its own PR. Every failure that motivated this one is rejected before the stream commits. Marked in the code where the write loop is.

## Before/After

No user-visible surface in this app. Covered by specs rather than media, as in #7406 and #7409.

## Test Results

`DISABLE_SPRING=1 bin/rspec spec/controllers/api/v2/gumhead/messages_controller_spec.rb` — 108 examples, 0 failures. Rubocop clean.

New group `minted upstream errors` covers each class, all three provider shapes of the spend limit, OpenRouter's 403 workspace cap, a real rate limit on the same 429 status, three policy-shaped 403s that must *not* read as credentials, a client-correctable 400 kept verbatim, a bare-string `error` field, a non-JSON body, the retry header, and the log line with the provider's `request_id`.

Four existing examples moved to the new contract; each now asserts the minted message and the absence of the provider text, so reverting the minting fails them.

## Merge order

Stacked on #7409. **Merge and deploy antiwork/gumhead#18 first** — it teaches the pet these strings. Reversed, an out-of-budget failure falls back to the generic line until #18 ships.

---

AI disclosure: Claude Fable 5 (Claude Code) wrote this change.
