### PR TITLE
Answer an empty reply as retryable instead of passing a blank turn through

### DIFF
--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -90,6 +90,17 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # equal to them would let the outer layers cut the client before the
   # rescue can render its error envelope.
   BUFFERED_TIMEOUT = 90
+  # How much of a stream may be held back, and for how long, while it has
+  # shown nothing the client can consume. Held bytes are thinking and
+  # framing; past either bound the stream commits anyway. The byte bound
+  # trades blank-turn detection for bounded memory. The time bound exists
+  # because an uncommitted response writes nothing to the client, and
+  # nginx and the Rack timeout cut a silent connection at 120s — a long
+  # thinking run used to stay alive on its own forwarded deltas. Every
+  # observed blank reply completed within seconds, so a short window
+  # catches them all.
+  MAX_HELD_STREAM_BYTES = 512.kilobytes
+  MAX_HELD_STREAM_SECONDS = 20
   # A buffered call is abandoned at BUFFERED_TIMEOUT, but Anthropic keeps
   # generating — and billing — until max_tokens. Clamping the forwarded
   # ceiling to what fits inside the timeout window keeps the elapsed-time
@@ -501,6 +512,15 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
 
         return render body:, content_type: "application/json", status: upstream.status.code
       end
+      # A 200 whose message carries no output at all: the loop upstream of
+      # the runtime would swallow it as a blank turn. Measured at 7 of 32
+      # calls across three models. A 502 makes the runtime retry instead;
+      # the reported input usage is still billed, so it is still metered.
+      if empty_reply?(parsed)
+        meter_buffered_usage(body) if meter
+        Rails.logger.warn("Gumhead gateway empty reply: model=#{loggable_upstream_field(parsed["model"])} provider=#{loggable_upstream_field(parsed["provider"])} request_id=#{upstream_request_id(parsed)}")
+        return render json: anthropic_error(*UPSTREAM_ERRORS.fetch(:busy)), status: :bad_gateway
+      end
       meter_buffered_usage(body) if meter
       copy_retry_after(upstream)
       render body:, content_type: "application/json", status: upstream.status.code
@@ -641,25 +661,45 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
         end
       end
 
-      response.headers["Content-Type"] = "text/event-stream"
-      response.headers["Cache-Control"] = "no-cache"
-      # Disable buffering at the proxy (nginx) layer so events flush to
-      # Gumhead as they are written.
-      response.headers["X-Accel-Buffering"] = "no"
-
       scanner = GumheadStreamUsageScanner.new
+      # Nothing is written until the stream shows something the client can
+      # consume, so a blank stream can still be answered as a retryable
+      # error instead of committed and passed through. The held bytes are
+      # thinking and framing; the cap bounds memory and fails open, since a
+      # stream that long is being generated, not stalling.
+      held = +""
+      committed = false
+      hold_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       begin
         last_renewal = Time.current
-        # Committed bytes pass through untouched, so an error event the
-        # provider sends after this point still carries its own wording —
+        # Once committed, bytes pass through untouched, so an error event
+        # the provider sends after that still carries its own wording —
         # the one failure this gateway does not mint. Rewriting it means
-        # re-framing SSE across chunk boundaries and teaching the scanner
-        # to separate an error ending from message_stop; that belongs in
-        # its own change, not in the middle of this loop.
+        # re-framing SSE across chunk boundaries; that belongs in its own
+        # change, not in the middle of this loop.
         while (chunk = upstream.body.readpartial)
           scanner << chunk
-          response.stream.write(chunk)
+          if committed
+            response.stream.write(chunk)
+          else
+            held << chunk
+            held_too_long = Process.clock_gettime(Process::CLOCK_MONOTONIC) - hold_started_at > MAX_HELD_STREAM_SECONDS
+            if scanner.substantive? || held.bytesize > MAX_HELD_STREAM_BYTES || held_too_long
+              committed = commit_stream!(held)
+            end
+          end
           last_renewal = renew_in_flight_lease(last_renewal)
+        end
+        unless committed
+          # A completed blank stream is answered as retryable; anything
+          # else — a refusal the client handles, an unfinished ending —
+          # passes through as it arrived.
+          if scanner.terminal? && scanner.stop_reason == "end_turn"
+            Rails.logger.warn("Gumhead gateway empty reply: model=#{loggable_upstream_field(scanner.model)} stream=true")
+            render json: anthropic_error(*UPSTREAM_ERRORS.fetch(:busy)), status: :bad_gateway
+            return
+          end
+          committed = commit_stream!(held)
         end
         # A clean EOF without message_stop (or an upstream error event) is
         # an interruption the client would otherwise see as a silent close.
@@ -677,6 +717,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
         # an empty 200) would leave the client guessing. Anthropic delivers
         # mid-stream failures the same way: an error event on the open stream.
         Rails.logger.warn("Gumhead gateway upstream error: #{e.class} #{e.message}")
+        committed = commit_stream!(held) unless committed
         write_stream_error_frame
       ensure
         if scanner.usage?
@@ -687,7 +728,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
           # the exact prompt; no deltas arrived, so output stays zero.
           record_usage!(model: @body["model"], usage: synthetic_input_usage.merge("output_tokens" => 0))
         end
-        response.stream.close
+        response.stream.close if committed
       end
     rescue HTTP::ConnectTimeoutError => e
       # TCP connect failed; the request never reached Anthropic.
@@ -707,6 +748,20 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       # unwrapped, hence the explicit rescue.
       Rails.logger.warn("Gumhead gateway upstream error: #{e.class} #{e.message}")
       render json: anthropic_error("api_error", "Could not reach the model service."), status: :bad_gateway
+    end
+
+    # Commits the SSE response and flushes what was held back. From here
+    # on, bytes pass through as they arrive.
+    def commit_stream!(held)
+      response.headers["Content-Type"] = "text/event-stream"
+      response.headers["Cache-Control"] = "no-cache"
+      # Disable buffering at the proxy (nginx) layer so events flush to
+      # Gumhead as they are written.
+      response.headers["X-Accel-Buffering"] = "no"
+      # The stream buffer keeps a reference to what it is handed, so the
+      # held bytes must not be mutated after the write.
+      response.stream.write(held.dup) unless held.empty?
+      true
     end
 
     def write_stream_error_frame
@@ -837,8 +892,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
       # status alone; every attempt fails until the cap resets. The SDK
       # reads this header before it reaches that rule.
       response.set_header("x-should-retry", "false") if key == :out_of_budget
-      type, message = UPSTREAM_ERRORS.fetch(key)
-      anthropic_error(type, message)
+      anthropic_error(*UPSTREAM_ERRORS.fetch(key))
     end
 
     def upstream_error_key(status, parsed, detail)
@@ -882,6 +936,36 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
     def upstream_request_id(parsed)
       id = parsed.is_a?(Hash) ? parsed["request_id"].to_s : ""
       id[/\A[\w.-]{1,64}\z/] || "none"
+    end
+
+    # Deliberately narrow: a completed message that gives the client
+    # nothing to consume. Judged by the content, not the token count — a
+    # blank reply can bill a nonzero count. Substance is a tool_use block
+    # (a normal loop step) or non-blank text; a thinking block alone is
+    # not, because the client renders neither it nor the silence after it.
+    # Only end_turn counts: a refusal ships empty content the client
+    # handles and must never be retried, and other stop reasons mean the
+    # turn is not finished being answered.
+    def empty_reply?(parsed)
+      return false unless parsed.is_a?(Hash) && parsed["type"] == "message"
+      return false unless parsed["stop_reason"] == "end_turn"
+
+      blocks = parsed["content"]
+      return true if blocks.nil? || blocks == []
+      return false unless blocks.is_a?(Array)
+
+      blocks.none? do |b|
+        next false unless b.is_a?(Hash)
+
+        b["type"] == "tool_use" || (b["type"] == "text" && b["text"].to_s.strip.present?)
+      end
+    end
+
+    # Upstream-controlled and headed for one log line, so control
+    # characters are flattened and the length bounded — a newline would
+    # forge a second record.
+    def loggable_upstream_field(value)
+      value.to_s.gsub(/[[:cntrl:]]/, " ").strip.slice(0, 64).presence || "none"
     end
 
     def openrouter_error_envelope?(parsed)

--- a/app/services/gumhead_stream_usage_scanner.rb
+++ b/app/services/gumhead_stream_usage_scanner.rb
@@ -21,6 +21,7 @@ class GumheadStreamUsageScanner
     @stop_reason = nil
     @saw_usage = false
     @terminal = false
+    @substantive = false
   end
 
   # True once the stream carried a proper ending — message_stop or a
@@ -32,6 +33,13 @@ class GumheadStreamUsageScanner
   def unbilled_refusal?
     @stop_reason == "refusal" && @content_delta_count.zero?
   end
+
+  attr_reader :stop_reason
+
+  # True once the stream carried something the client can consume: a tool
+  # call, or text with a non-space character. Thinking is not substance —
+  # the client renders neither it nor the silence after it.
+  def substantive? = @substantive
 
   def <<(chunk)
     @buffer << chunk
@@ -71,6 +79,9 @@ class GumheadStreamUsageScanner
         @terminal = true
       when "message_start"
         started(event)
+      when "content_block_start"
+        block = event["content_block"]
+        @substantive = true if block.is_a?(Hash) && block["type"] == "tool_use"
       when "content_block_delta"
         @content_delta_count += 1
         delta = event["delta"]
@@ -82,6 +93,8 @@ class GumheadStreamUsageScanner
           # every stream that completes.
           content = delta["text"] || delta["partial_json"] || delta["thinking"] || delta["data"]
           @streamed_output_bytes += content.bytesize if content.is_a?(String)
+          @substantive = true if delta["text"].is_a?(String) && delta["text"].match?(/\S/)
+          @substantive = true if delta["partial_json"].is_a?(String)
         end
       when "message_delta"
         delta = event["delta"]

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -1177,6 +1177,185 @@ describe Api::V2::Gumhead::MessagesController do
     end
   end
 
+  describe "empty upstream replies" do
+    let(:blank_sse) do
+      [
+        %(event: message_start\ndata: {"type":"message_start","message":{"model":"x-ai/grok-4.6","usage":{"input_tokens":40,"output_tokens":0}}}\n\n),
+        %(event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":0,"input_tokens":40}}\n\n),
+        %(event: message_stop\ndata: {"type":"message_stop"}\n\n),
+      ].join
+    end
+
+    it "answers a completed blank stream as retryable instead of committing it" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: blank_sse, headers: { "Content-Type" => "text/event-stream" })
+
+      post_messages(request_payload.merge(stream: true))
+
+      expect(response.status).to eq(502)
+      expect(response.headers["Content-Type"]).not_to include("event-stream")
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(described_class::UPSTREAM_ERRORS.fetch(:busy).last)
+    end
+
+    it "answers a thinking-only completed stream as retryable" do
+      thinking_sse = [
+        %(event: message_start\ndata: {"type":"message_start","message":{"model":"x-ai/grok-4.6","usage":{"input_tokens":40,"output_tokens":0}}}\n\n),
+        %(event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"hm"}}\n\n),
+        %(event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":9,"input_tokens":40}}\n\n),
+        %(event: message_stop\ndata: {"type":"message_stop"}\n\n),
+      ].join
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: thinking_sse, headers: { "Content-Type" => "text/event-stream" })
+
+      post_messages(request_payload.merge(stream: true))
+
+      expect(response.status).to eq(502)
+    end
+
+    it "meters what a rejected blank stream reported" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: blank_sse, headers: { "Content-Type" => "text/event-stream" })
+
+      post_messages(request_payload.merge(stream: true))
+
+      expect(GumheadUsageEvent.sole.input_tokens).to eq(40)
+    end
+
+    it "passes a refusal stream through as it arrived" do
+      refusal_sse = [
+        %(event: message_start\ndata: {"type":"message_start","message":{"model":"x-ai/grok-4.6","usage":{"input_tokens":40,"output_tokens":0}}}\n\n),
+        %(event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"refusal"},"usage":{"output_tokens":0,"input_tokens":40}}\n\n),
+        %(event: message_stop\ndata: {"type":"message_stop"}\n\n),
+      ].join
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: refusal_sse, headers: { "Content-Type" => "text/event-stream" })
+
+      post_messages(request_payload.merge(stream: true))
+
+      expect(response.headers["Content-Type"]).to include("event-stream")
+      expect(response.body).to eq(refusal_sse)
+    end
+
+    it "streams a tool_use-only stream through byte for byte" do
+      tool_sse = [
+        %(event: message_start\ndata: {"type":"message_start","message":{"model":"x-ai/grok-4.6","usage":{"input_tokens":40,"output_tokens":0}}}\n\n),
+        %(event: content_block_start\ndata: {"type":"content_block_start","content_block":{"type":"tool_use","id":"t1","name":"read_folder"}}\n\n),
+        %(event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{}"}}\n\n),
+        %(event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":12,"input_tokens":40}}\n\n),
+        %(event: message_stop\ndata: {"type":"message_stop"}\n\n),
+      ].join
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: tool_sse, headers: { "Content-Type" => "text/event-stream" })
+
+      post_messages(request_payload.merge(stream: true))
+
+      expect(response.headers["Content-Type"]).to include("event-stream")
+      expect(response.body).to eq(tool_sse)
+    end
+
+    def empty_reply(content:, output_tokens: 0)
+      {
+        id: "msg_e", type: "message", role: "assistant", model: "x-ai/grok-4.6",
+        content:, stop_reason: "end_turn",
+        usage: { input_tokens: 40, output_tokens: },
+      }
+    end
+
+    it "answers a 200 with no output as retryable instead of passing a blank turn through" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: empty_reply(content: []).to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(response.status).to eq(502)
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(described_class::UPSTREAM_ERRORS.fetch(:busy).last)
+    end
+
+    it "still meters the input the empty reply reported" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: empty_reply(content: []).to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(GumheadUsageEvent.sole.input_tokens).to eq(40)
+    end
+
+    it "treats blank text blocks as no output" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: empty_reply(content: [{ type: "text", text: "  " }]).to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(response.status).to eq(502)
+    end
+
+    # Billing and substance are different facts: a blank reply can carry a
+    # nonzero output count, and it is still a blank turn.
+    it "catches a blank reply that billed output tokens" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: empty_reply(content: [], output_tokens: 1).to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(response.status).to eq(502)
+    end
+
+    # A refusal legitimately ships empty content; the client handles it,
+    # and retrying a refused prompt cannot succeed.
+    it "passes a refusal through untouched" do
+      body = empty_reply(content: []).merge(stop_reason: "refusal")
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)["stop_reason"]).to eq("refusal")
+    end
+
+    # A tool call is a normal loop step; converting it to an error would
+    # break every agentic turn.
+    it "passes a tool_use-only reply through untouched" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: empty_reply(content: [{ type: "tool_use", id: "t1", name: "read_folder", input: {} }], output_tokens: 0).to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)["content"].first["type"]).to eq("tool_use")
+    end
+
+    # The client renders neither the thinking nor the silence after it, so
+    # a completed turn of pure deliberation is a blank turn.
+    it "retries a thinking-only completed turn" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: empty_reply(content: [{ type: "thinking", thinking: "hm" }], output_tokens: 31).to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(response.status).to eq(502)
+    end
+
+    it "passes thinking through when text accompanies it" do
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: empty_reply(content: [{ type: "thinking", thinking: "hm" }, { type: "text", text: "Done." }], output_tokens: 40).to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(response.status).to eq(200)
+    end
+
+    it "leaves an unfinished stop reason alone even with no visible output" do
+      body = empty_reply(content: [{ type: "thinking", thinking: "hm" }]).merge(stop_reason: "max_tokens")
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
+
+      post_messages
+
+      expect(response.status).to eq(200)
+    end
+  end
+
   describe "live model map in Redis" do
     let(:openrouter_messages_url) { "https://openrouter.ai/api/v1/messages" }
 

--- a/spec/services/gumhead_stream_usage_scanner_spec.rb
+++ b/spec/services/gumhead_stream_usage_scanner_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GumheadStreamUsageScanner do
+  def feed(scanner, events)
+    events.each { |e| scanner << "event: #{e["type"]}\ndata: #{e.to_json}\n\n" }
+    scanner
+  end
+
+  def message_start(model: "x-ai/grok-4.6", input: 40)
+    { "type" => "message_start", "message" => { "model" => model, "usage" => { "input_tokens" => input, "output_tokens" => 0 } } }
+  end
+
+  def message_delta(stop_reason:, output: 0)
+    { "type" => "message_delta", "delta" => { "stop_reason" => stop_reason }, "usage" => { "output_tokens" => output, "input_tokens" => 40 } }
+  end
+
+  describe "#substantive?" do
+    it "is false for a stream of framing and thinking alone" do
+      scanner = feed(described_class.new, [
+                       message_start,
+                       { "type" => "content_block_delta", "delta" => { "type" => "thinking_delta", "thinking" => "hm" } },
+                       message_delta(stop_reason: "end_turn", output: 9),
+                       { "type" => "message_stop" },
+                     ])
+
+      expect(scanner.substantive?).to eq(false)
+      expect(scanner.terminal?).to eq(true)
+      expect(scanner.stop_reason).to eq("end_turn")
+    end
+
+    it "turns true on text with a non-space character" do
+      scanner = feed(described_class.new, [
+                       message_start,
+                       { "type" => "content_block_delta", "delta" => { "type" => "text_delta", "text" => "Hi" } },
+                     ])
+
+      expect(scanner.substantive?).to eq(true)
+    end
+
+    it "stays false for whitespace-only text" do
+      scanner = feed(described_class.new, [
+                       message_start,
+                       { "type" => "content_block_delta", "delta" => { "type" => "text_delta", "text" => "  \n" } },
+                     ])
+
+      expect(scanner.substantive?).to eq(false)
+    end
+
+    it "turns true when a tool_use block starts" do
+      scanner = feed(described_class.new, [
+                       message_start,
+                       { "type" => "content_block_start", "content_block" => { "type" => "tool_use", "id" => "t1", "name" => "read_folder" } },
+                     ])
+
+      expect(scanner.substantive?).to eq(true)
+    end
+
+    it "turns true on tool input json" do
+      scanner = feed(described_class.new, [
+                       message_start,
+                       { "type" => "content_block_delta", "delta" => { "type" => "input_json_delta", "partial_json" => "{}" } },
+                     ])
+
+      expect(scanner.substantive?).to eq(true)
+    end
+  end
+
+  describe "#stop_reason" do
+    it "exposes the last stop reason the stream carried" do
+      scanner = feed(described_class.new, [message_start, message_delta(stop_reason: "refusal")])
+
+      expect(scanner.stop_reason).to eq("refusal")
+    end
+
+    it "is nil for a stream that never finished" do
+      scanner = feed(described_class.new, [message_start])
+
+      expect(scanner.stop_reason).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## What

Some model replies come back as HTTP 200 with nothing in them — no text, no tool call. Today the gateway passes those through and Gumhead shows a blank turn.

Now the gateway answers them as a 502 with its existing busy message. The runtime retries 5xx automatically, so the turn recovers on its own.

Works on both paths:

- **Buffered**: an empty completed message becomes the 502.
- **Streamed** (what the runtime actually uses): nothing is committed to the response until the stream shows text or a tool call. A stream that completes blank gets the 502. The hold is capped at 512KB and 20s — past either, the stream commits and passes through as before.

Left alone, each with a spec: tool calls, thinking followed by text, refusals (client-handled, must never retry), unfinished turns, and committed stream bytes. Input usage of a rejected reply is still metered.

## Why

Benchmarking chat models found 7 of 32 calls blank: grok-4.6 3/8, gpt-5.6-sol 3/8, gpt-5.6-terra 1/8. A real turn is tens of calls, so most turns would hit one. The runtime has no reason to retry a well-formed empty success — turning it into a 5xx is the whole fix.

## Before/After

No change on the happy path. Before: an occasional blank turn. After: the runtime retries and the seller sees a normal answer.

## Test Results

129 examples, 0 failures (`bin/rspec spec/controllers/api/v2/gumhead/messages_controller_spec.rb spec/services/gumhead_stream_usage_scanner_spec.rb`). Rubocop clean. The scanner gets its own unit spec for the substance rules.

---

AI disclosure: Claude Fable 5 (Claude Code) wrote this change.