### PR TITLE
Track mobile app product create, edit, and delete

### DIFF
--- a/app/controllers/api/mobile/products_controller.rb
+++ b/app/controllers/api/mobile/products_controller.rb
@@ -36,7 +36,7 @@ class Api::Mobile::ProductsController < Api::Mobile::BaseController
 
     @product = product
     product.delete!
-    create_user_event("delete_product_mobile_app", user_id: current_resource_owner.id)
+    create_user_event_without_raising("delete_product_mobile_app", user_id: current_resource_owner.id)
     render json: { success: true }
   end
 

--- a/app/controllers/api/mobile/products_controller.rb
+++ b/app/controllers/api/mobile/products_controller.rb
@@ -34,7 +34,9 @@ class Api::Mobile::ProductsController < Api::Mobile::BaseController
     return fetch_error("Product not found") if product.nil?
     return fetch_error("You cannot delete this product", status: :forbidden) unless Pundit.policy!(seller_context, product).destroy?
 
+    @product = product
     product.delete!
+    create_user_event("delete_product_mobile_app", user_id: current_resource_owner.id)
     render json: { success: true }
   end
 

--- a/app/controllers/concerns/events.rb
+++ b/app/controllers/concerns/events.rb
@@ -11,6 +11,12 @@ module Events
     )
   end
 
+  def create_user_event_without_raising(name, **kwargs)
+    create_user_event(name, **kwargs)
+  rescue StandardError => e
+    Rails.logger.error("Failed to record #{name}: #{e.class}: #{e.message}")
+  end
+
   def create_post_event(installment)
     @product = installment.try(:link)
     event = create_event(

--- a/app/controllers/concerns/events.rb
+++ b/app/controllers/concerns/events.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module Events
-  def create_user_event(name, seller_id: nil, on_custom_domain: false)
+  def create_user_event(name, seller_id: nil, on_custom_domain: false, user_id: nil)
     return if name.nil?
 
     create_event(
       event_name: name,
       on_custom_domain:,
-      user_id: logged_in_user&.id
+      user_id: user_id || logged_in_user&.id
     )
   end
 

--- a/app/controllers/concerns/mobile_app_web_view.rb
+++ b/app/controllers/concerns/mobile_app_web_view.rb
@@ -21,10 +21,18 @@ module MobileAppWebView
   end
 
   private
+    def mobile_app_web_view?
+      params[:display] == "mobile_app" || session[:mobile_app_web_view] == true
+    end
+
     def persist_mobile_app_web_view
       return unless params[:display] == "mobile_app" && user_signed_in?
 
       session[:mobile_app_web_view] = true
+    end
+
+    def create_mobile_app_user_event(name)
+      create_user_event(name) if mobile_app_web_view?
     end
 
     def authenticate_mobile_app_web_view!

--- a/app/controllers/concerns/mobile_app_web_view.rb
+++ b/app/controllers/concerns/mobile_app_web_view.rb
@@ -32,7 +32,7 @@ module MobileAppWebView
     end
 
     def create_mobile_app_user_event(name)
-      create_user_event(name) if mobile_app_web_view?
+      create_user_event_without_raising(name) if mobile_app_web_view?
     end
 
     def authenticate_mobile_app_web_view!

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -117,6 +117,7 @@ class LinksController < ApplicationController
     end
 
     create_user_event("add_product")
+    create_mobile_app_user_event("add_product_mobile_app")
     if ai_generated
       redirect_to edit_link_path(@product, ai_generated: true), status: :see_other
     else
@@ -685,6 +686,7 @@ class LinksController < ApplicationController
       ErrorNotifier.notify(e)
       return render json: { error_message: "Something went wrong while saving your changes. Please refresh the page and try again — if the problem continues, contact support." }, status: :unprocessable_entity
     end
+    create_mobile_app_user_event("edit_product_mobile_app")
     report_unapplied_deletions!
     report_unstated_confirmed_removals!
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,8 +8,11 @@ class Event < ApplicationRecord
   # We also create events that aren't in this list if they have a user_id (see Events#created_event),
   # but they're automatically deleted after a while (see DeleteOldUnusedEventsWorker).
   PERMITTED_NAMES = %w[
+    add_product_mobile_app
     audience_callout_dismissal
     chargeback
+    delete_product_mobile_app
+    edit_product_mobile_app
     first_purchase_on_profile_visit
     post_view
     product_refund_policy_fine_print_view

--- a/spec/controllers/api/mobile/products_controller_spec.rb
+++ b/spec/controllers/api/mobile/products_controller_spec.rb
@@ -69,17 +69,24 @@ describe Api::Mobile::ProductsController do
     it "deletes the seller's product" do
       product = create(:product, user: @seller, name: "To delete")
 
-      delete :destroy, params: @params.merge(id: product.unique_permalink)
+      expect do
+        delete :destroy, params: @params.merge(id: product.unique_permalink)
+      end.to change { Event.where(event_name: "delete_product_mobile_app").count }.by(1)
 
       expect(response).to be_successful
       expect(response.parsed_body["success"]).to eq(true)
       expect(product.reload.deleted?).to eq(true)
+      event = Event.where(event_name: "delete_product_mobile_app").last
+      expect(event.link_id).to eq(product.id)
+      expect(event.user_id).to eq(@seller.id)
     end
 
     it "does not delete another seller's product" do
       other = create(:product, name: "Not yours")
 
-      delete :destroy, params: @params.merge(id: other.unique_permalink)
+      expect do
+        delete :destroy, params: @params.merge(id: other.unique_permalink)
+      end.not_to change { Event.where(event_name: "delete_product_mobile_app").count }
 
       expect(response).to have_http_status(:not_found)
       expect(other.reload.deleted?).to eq(false)

--- a/spec/controllers/api/mobile/products_controller_spec.rb
+++ b/spec/controllers/api/mobile/products_controller_spec.rb
@@ -81,6 +81,17 @@ describe Api::Mobile::ProductsController do
       expect(event.user_id).to eq(@seller.id)
     end
 
+    it "still reports success if recording the delete event raises" do
+      product = create(:product, user: @seller, name: "To delete")
+      allow(controller).to receive(:create_user_event).and_raise(StandardError, "analytics down")
+
+      delete :destroy, params: @params.merge(id: product.unique_permalink)
+
+      expect(response).to be_successful
+      expect(response.parsed_body["success"]).to eq(true)
+      expect(product.reload.deleted?).to eq(true)
+    end
+
     it "does not delete another seller's product" do
       other = create(:product, name: "Not yours")
 

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -873,6 +873,27 @@ class LinksControllerSellerAreaTest < ActionController::TestCase
     assert_equal "UX design mastery using Figma", Link.last.name
   end
 
+  test "POST create records add_product_mobile_app when the request is from the mobile app" do
+    Rails.cache.clear
+    session[:mobile_app_web_view] = true
+
+    assert_difference -> { Event.where(event_name: "add_product_mobile_app").count }, 1 do
+      post :create, params: { link: { price_cents: 100, name: "from app" } }
+    end
+
+    event = Event.where(event_name: "add_product_mobile_app").last
+    assert_equal Link.last.id, event.link_id
+    assert_equal @logged_in_user.id, event.user_id
+  end
+
+  test "POST create does not record add_product_mobile_app for a web request" do
+    Rails.cache.clear
+
+    assert_no_difference -> { Event.where(event_name: "add_product_mobile_app").count } do
+      post :create, params: { link: { price_cents: 100, name: "from web" } }
+    end
+  end
+
   # --- POST release_preorder --------------------------------------------------
 
   def preorder_setup
@@ -1063,6 +1084,26 @@ class LinksControllerUpdateTest < ActionController::TestCase
 
   test "PUT update calls authorize" do
     assert_authorize_called(:put, :update, record: @product, params: @params)
+  end
+
+  test "PUT update records edit_product_mobile_app when the request is from the mobile app" do
+    session[:mobile_app_web_view] = true
+
+    assert_difference -> { Event.where(event_name: "edit_product_mobile_app").count }, 1 do
+      put :update, params: @params
+    end
+
+    assert_response :success
+    event = Event.where(event_name: "edit_product_mobile_app").last
+    assert_equal @product.id, event.link_id
+    assert_equal @logged_in_user.id, event.user_id
+  end
+
+  test "PUT update does not record edit_product_mobile_app for a web request" do
+    assert_no_difference -> { Event.where(event_name: "edit_product_mobile_app").count } do
+      put :update, params: @params
+    end
+    assert_response :success
   end
 
   test "PUT update allows a collaborator to access" do


### PR DESCRIPTION
Screen opens for create/edit in the app already show up in Google Analytics (`display=mobile_app`). Completions did not: `add_product` is not kept forever, and deletes via the mobile API logged nothing.

This records three durable `Event` names (added to `PERMITTED_NAMES` so they survive the 2-month unused-event cleanup):

- `add_product_mobile_app` — successful create while `session[:mobile_app_web_view]` or `display=mobile_app`
- `edit_product_mobile_app` — successful editor save in that same session
- `delete_product_mobile_app` — `DELETE /mobile/products/:id`

Web create/edit is unchanged (`add_product` still fires; no new web edit event). Deletes that fail (wrong product / 401) do not record an event. A failed analytics write after a successful delete does not 500 the client.

Local: 4 minitest + 8 rspec, 0 failures.

Premerge review: clean @ 2736028b2ab96d5fe541d50cb366de89f2475859
