### PR TITLE
Resolve analytics widget product from signed script token

### DIFF
--- a/app/controllers/embedded_javascripts_controller.rb
+++ b/app/controllers/embedded_javascripts_controller.rb
@@ -17,9 +17,19 @@ class EmbeddedJavascriptsController < ApplicationController
   end
 
   def analytics
-    @product = Link.fetch(params[:id]) if params[:id].present?
-    @analytics_token = @product&.analytics_view_token(source_url: request.referrer) if request.referrer.present? && @product&.analytics_script_token?(params[:token])
+    @product = product_from_analytics_script_token(params[:token])
+    @analytics_token = @product.analytics_view_token(source_url: request.referrer) if @product && request.referrer.present?
     expires_now
     render :analytics, layout: false, content_type: "application/javascript"
   end
+
+  private
+    def product_from_analytics_script_token(token)
+      return if token.blank?
+
+      payload = Link.analytics_view_verifier.verified(token.to_s, purpose: Link::ANALYTICS_SCRIPT_TOKEN_PURPOSE)
+      return unless payload.is_a?(Hash)
+
+      Link.visible.find_by(id: payload["product_id"])
+    end
 end

--- a/app/views/embedded_javascripts/analytics.js.erb
+++ b/app/views/embedded_javascripts/analytics.js.erb
@@ -2,13 +2,13 @@
   var script = document.currentScript;
   if (!script || !script.src) return;
 
-  var id = script.getAttribute("data-gumroad-product");
+  var id = "<%= j @product&.unique_permalink.to_s %>";
   var token = "<%= j @analytics_token.to_s %>";
   var origin;
   try {
     var src = new URL(script.src);
     origin = src.origin;
-    if (!id) id = src.searchParams.get("id");
+    if (!id) id = script.getAttribute("data-gumroad-product") || src.searchParams.get("id");
   } catch (e) {
     return;
   }

--- a/spec/controllers/embedded_javascripts_controller_spec.rb
+++ b/spec/controllers/embedded_javascripts_controller_spec.rb
@@ -56,5 +56,33 @@ describe EmbeddedJavascriptsController do
 
       expect(response.body).to include('var token = "";')
     end
+
+    it "mints a view token when the widget id is the custom permalink" do
+      product.update!(custom_permalink: "from-nothing-to-sold-bundle")
+      expect(Link.fetch(product.custom_permalink)).to be_nil
+
+      request.env["HTTP_REFERER"] = "https://landing.example/post"
+      get :analytics, params: { id: product.custom_permalink, token: product.analytics_script_token }, format: :js
+
+      token = response.body.match(/var token = "([^"]*)";/)[1]
+      expect(token).not_to eq("")
+      expect(product.analytics_view_token?(token, source_url: "https://landing.example/post")).to eq(true)
+      expect(response.body).to include("var id = \"#{product.unique_permalink}\";")
+    end
+
+    it "resolves the signed-token product when another seller reuses the custom permalink" do
+      product.update!(custom_permalink: "shared-landing")
+      other = create(:product, custom_permalink: "shared-landing")
+      expect(other.custom_permalink).to eq(product.custom_permalink)
+      expect(other.id).not_to eq(product.id)
+
+      request.env["HTTP_REFERER"] = "https://landing.example/post"
+      get :analytics, params: { id: product.custom_permalink, token: product.analytics_script_token }, format: :js
+
+      token = response.body.match(/var token = "([^"]*)";/)[1]
+      expect(product.analytics_view_token?(token, source_url: "https://landing.example/post")).to eq(true)
+      expect(other.analytics_view_token?(token, source_url: "https://landing.example/post")).to eq(false)
+      expect(response.body).to include("var id = \"#{product.unique_permalink}\";")
+    end
   end
 end


### PR DESCRIPTION
# Resolve analytics widget product from the signed script token

Premerge review: clean @ 7c40e3e97b6935e03b3d1f13c993c7b65203bb25

## What

The external landing-page analytics script (`gumroad-analytics.js`) looks up the product from the **signed script token's `product_id`**, not from `Link.fetch` on the widget `id` query param. The served script bakes the product's **unique permalink** into the `increment_views.gif` URL so the GIF still hits `fetch_product`.

## Why

Widgets copied from the builder put the last path segment of the product URL in `id`. For a product with a custom permalink that is the custom slug, which `Link.fetch` does not match, so `@product` was nil, the view token was empty, and `increment_views` skipped every GET. Same-slug custom permalinks across sellers would also be wrong if we only switched to unscoped `fetch_leniently`. The token already names the product.

Ref antiwork/gumroad-private#2322.

## Before / after

- Before: `GET /js/gumroad-analytics.js?id=<custom-permalink>&token=<valid>` with a Referer minted `var token = ""`.
- After: the same request mints a source-bound view token for the token's product and sets `var id = "<unique_permalink>"` so the GIF can record the view.

## Checklist

- [x] Scope — analytics script endpoint + served JS only. Widget-builder `id` still uses the URL's last segment (covers already-pasted widgets). No view backfill (page views are not retroactive).
- [x] Design — token-first lookup; rejected unscoped `fetch_leniently` because custom permalinks are not globally unique.
- [x] Build — `7c40e3e97b` on `gumclaw/gp2322-analytics-widget-custom-permalink`
- [x] QA — local controller examples + hosted preview probe at `7c40e3e97b69` (custom `id` mints unique-permalink view token; GIF 200).
- [ ] Shipped
- [ ] Market — n/a, bugfix
- [ ] Sell — n/a; no backfill

## Test Results

```text
DISABLE_SPRING=1 bundle exec rspec spec/controllers/embedded_javascripts_controller_spec.rb
4 analytics examples, 0 failures (existing unique-permalink + no-token + two new custom-permalink examples)
overlay example red in this worktree: ViteRuby::MissingEntrypointError (missing node deps / vite manifest) — untouched by this diff; embed + all analytics examples green

Mutation: replaced product_from_analytics_script_token with Link.fetch(params[:id]); the two new examples failed (2 examples, 2 failures). Restored.
```

## QA

Local: custom-permalink widget id + valid script token + Referer mints a view token bound to that product; a colliding custom permalink on another seller still mints for the token's product; unique permalink baked into `var id`.

Hosted preview `https://gumclaw-gp2322-analytics-widget.apps.staging.gumroad.org` (`x-revision: 7c40e3e97b69`):

- `GET /js/gumroad-analytics.js?id=from-nothing-to-sold-bundle&token=<Beautiful widget script token>` with `Referer: https://landing.example/post` → `var id = "demo"` and a non-empty view token (token-first lookup; `Link.fetch` on that custom slug would miss).
- Same request with no/bogus token → `var id = ""`, `var token = ""`.
- `GET /links/demo/increment_views.gif?analytics_token=<view token>` → 200 `image/gif` 1×1.
- `ci/green` SUCCESS on this head.

---

AI disclosure: grok-4.6. Prompt/instructions: GitHub issues.opened on antiwork/gumroad-private#2322; autonomous-product-dev (draft PR early, evidence from captured output, no customer PII in public body).
