### PR TITLE
Resolve analytics widgets by custom permalink

### DIFF
--- a/app/controllers/embedded_javascripts_controller.rb
+++ b/app/controllers/embedded_javascripts_controller.rb
@@ -17,9 +17,21 @@ class EmbeddedJavascriptsController < ApplicationController
   end
 
   def analytics
-    @product = Link.fetch(params[:id]) if params[:id].present?
+    @product = analytics_widget_product
     @analytics_token = @product&.analytics_view_token(source_url: request.referrer) if request.referrer.present? && @product&.analytics_script_token?(params[:token])
     expires_now
     render :analytics, layout: false, content_type: "application/javascript"
+  end
+
+  private
+
+  # Widget `id` is the product URL's last segment (custom permalink when set).
+  # Link.fetch only matches unique_permalink; the signed token picks among collisions.
+  def analytics_widget_product
+    return if params[:id].blank?
+
+    unique = Link.fetch(params[:id])
+    candidates = [unique, *Link.visible.by_general_permalink(params[:id])].compact.uniq
+    candidates.find { |product| product.analytics_script_token?(params[:token]) } || unique
   end
 end

--- a/spec/controllers/embedded_javascripts_controller_spec.rb
+++ b/spec/controllers/embedded_javascripts_controller_spec.rb
@@ -56,5 +56,26 @@ describe EmbeddedJavascriptsController do
 
       expect(response.body).to include('var token = "";')
     end
+
+    it "mints a view token when the widget id is the custom permalink" do
+      product.update!(custom_permalink: "from-nothing-to-sold-bundle")
+      request.env["HTTP_REFERER"] = "https://landing.example/post"
+      get :analytics, params: { id: "from-nothing-to-sold-bundle", token: product.analytics_script_token }, format: :js
+
+      token = response.body.match(/var token = "([^"]+)";/)[1]
+      expect(token).not_to eq("")
+      expect(product.analytics_view_token?(token, source_url: "https://landing.example/post")).to eq(true)
+    end
+
+    it "mints the token-matching product when two custom permalinks collide" do
+      other = create(:product, custom_permalink: "shared-slug")
+      product.update!(custom_permalink: "shared-slug")
+      request.env["HTTP_REFERER"] = "https://landing.example/post"
+      get :analytics, params: { id: "shared-slug", token: product.analytics_script_token }, format: :js
+
+      token = response.body.match(/var token = "([^"]+)";/)[1]
+      expect(product.analytics_view_token?(token, source_url: "https://landing.example/post")).to eq(true)
+      expect(other.analytics_view_token?(token, source_url: "https://landing.example/post")).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
## What

The external landing-page analytics widget copies the product URL's last path segment as `id`. That segment is the custom permalink when one is set, but `EmbeddedJavascriptsController#analytics` only resolved `Link.fetch` (unique permalink). Custom-permalink widgets got an empty view token and recorded zero views.

Resolve unique or custom permalink, and let the signed script token pick the product when custom permalinks collide.

Fixes antiwork/gumroad-private#2322.

## Why

Seller widgets already pasted with custom permalinks (e.g. `from-nothing-to-sold-bundle`) cannot be rewritten after the fact. Server-side resolve is the fix that covers those.

## Test Results

`TEST_DATABASE_NAME=gumroad_test_pr2322analytics DISABLE_SPRING=1 bin/rspec spec/controllers/embedded_javascripts_controller_spec.rb:31`: 4 examples, 0 failures.

Mutation: replacing the resolver with `Link.fetch` only reddens the custom-permalink and collision examples.

## Status

- [x] Scope
- [x] Design
- [x] Build
- [ ] QA — preview widget still owed
- [ ] Shipped
- [ ] Market — n/a (widget recording)
- [ ] Sell — n/a

---
AI disclosure: authored by gumclaw using grok-4.6 (xAI).

Premerge review: clean @ 9fd7c924aaa843223ad5a3054dd1f863a13776db
