### PR TITLE
Gate and nudge Gumhead builds by version

### DIFF
--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -41,15 +41,16 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   prepend_before_action { Sentry.get_current_scope.clear if defined?(Sentry) && Sentry.initialized? }
 
   before_action { doorkeeper_authorize! }
-  before_action :ensure_gateway_configured
+  before_action :ensure_gateway_configured, except: [:client_version]
   before_action :ensure_first_party_client
   before_action :ensure_gumhead_enabled
-  before_action :throttle_gateway_requests
-  before_action :load_body
-  before_action :validate_model
-  before_action :rewrite_upstream_model
-  before_action :validate_tools
-  before_action :validate_pricing_modifiers
+  before_action :enforce_minimum_client_version, except: [:client_version]
+  before_action :throttle_gateway_requests, except: [:client_version]
+  before_action :load_body, except: [:client_version]
+  before_action :validate_model, except: [:client_version]
+  before_action :rewrite_upstream_model, except: [:client_version]
+  before_action :validate_tools, except: [:client_version]
+  before_action :validate_pricing_modifiers, except: [:client_version]
   before_action :validate_max_tokens, only: [:create]
   before_action :enforce_daily_token_caps, only: [:create]
 
@@ -138,6 +139,14 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   # server-side, outside the ledger. Tune with GUMHEAD_DENIED_ANTHROPIC_BETAS.
   DEFAULT_DENIED_ANTHROPIC_BETAS = "fallback"
 
+  # The app has no auto-updater, so the gateway is the update channel: it
+  # is the one thing every install talks to. Both values live in Redis —
+  # unset means no gate and no nudge. "min" refuses builds the gateway can
+  # no longer serve safely; "current" lets the app tell the seller a newer
+  # build exists. The message is part of the client's error vocabulary.
+  #   $redis.set(RedisKey.gumhead_client_versions, { "min" => "0.1.0", "current" => "0.2.0" }.to_json)
+  UPDATE_REQUIRED_MESSAGE = "This Gumhead build is too old for the gateway. Download the update from your Gumroad dashboard."
+
   # One Gumhead turn is a whole tool loop of model calls, so the request
   # throttle is deliberately loose; the real spend control is the daily
   # token caps.
@@ -161,6 +170,14 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   IN_FLIGHT_TTL = 10.minutes
   IN_FLIGHT_RENEWAL_INTERVAL = 1.minute
 
+  # GET /v2/gumhead/client_version
+  # The launch-time check: the app compares itself to "current" and tells
+  # the seller when a newer build exists. Authenticated like everything
+  # else here, so the endpoint says nothing to the world at large.
+  def client_version
+    render json: client_versions
+  end
+
   # POST /v2/gumhead/v1/messages
   def create
     with_in_flight_slot do
@@ -183,6 +200,50 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   end
 
   private
+    # A build below "min" cannot be served safely — that is the only
+    # reason to set "min". Exactly one released build predates the
+    # X-Gumhead-Version header, so a missing header means that build:
+    # counting it as its real version keeps "min" honest at the boundary
+    # (min 0.1.0 serves it, min 0.2.0 gates it). That build predates the
+    # update vocabulary, so when gated it shows its generic try-again line
+    # instead of the update instruction — accepted: it has no installed
+    # base, and exempting it forever would defeat the gate. "dev" passes:
+    # cooperative, not a security boundary (the token is), and a
+    # development build runs code at least as new as any release.
+    PRE_HEADER_VERSION = "0.1.0"
+
+    def enforce_minimum_client_version
+      min = safe_version(client_versions["min"].to_s)
+      if min.nil?
+        # A typo in the policy must degrade to no gate, not fail every
+        # valid build's turns until an operator repairs the key.
+        Rails.logger.warn("Gumhead minimum client version is not a version; not gating.") if client_versions["min"].present?
+        return
+      end
+
+      reported = request.headers["X-Gumhead-Version"].to_s
+      return if reported == "dev"
+      reported = PRE_HEADER_VERSION if reported.blank?
+      return if safe_version(reported)&.>= min
+
+      render json: anthropic_error("invalid_request_error", UPDATE_REQUIRED_MESSAGE), status: :upgrade_required
+    end
+
+    def client_versions
+      raw = $redis.get(RedisKey.gumhead_client_versions)
+      parsed = safe_parse_json(raw.to_s)
+      versions = parsed.is_a?(Hash) ? parsed : {}
+      { "min" => versions["min"].to_s.presence, "current" => versions["current"].to_s.presence }.compact
+    rescue Redis::BaseError => e
+      # The gate is an ops policy read; losing Redis must not stop turns.
+      Rails.logger.warn("Gumhead client versions Redis read failed: #{e.class} #{e.message}")
+      {}
+    end
+
+    def safe_version(value)
+      Gem::Version.new(value) if value.match?(/\A\d+(\.\d+)*\z/)
+    end
+
     # Doorkeeper's defaults also authenticate `access_token`/`bearer_token`
     # request parameters. A token in the URL leaks into access logs, and a
     # token in the body would forward upstream — only the Authorization

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -200,24 +200,18 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
   end
 
   private
-    # A build below "min" cannot be served safely — that is the only
-    # reason to set "min". Exactly one released build predates the
-    # X-Gumhead-Version header, so a missing header means that build:
-    # counting it as its real version keeps "min" honest at the boundary
-    # (min 0.1.0 serves it, min 0.2.0 gates it). That build predates the
-    # update vocabulary, so when gated it shows its generic try-again line
-    # instead of the update instruction — accepted: it has no installed
-    # base, and exempting it forever would defeat the gate. "dev" passes:
-    # cooperative, not a security boundary (the token is), and a
-    # development build runs code at least as new as any release.
+    # A missing header is the one released pre-header build, 0.1.0: min
+    # 0.1.0 serves it, min 0.2.0 gates it — behind a stale generic error,
+    # accepted while it has no installed base. "dev" passes: the gate is
+    # cooperative, not a security boundary (the token is).
     PRE_HEADER_VERSION = "0.1.0"
 
     def enforce_minimum_client_version
-      min = safe_version(client_versions["min"].to_s)
+      versions = client_versions
+      min = safe_version(versions["min"].to_s)
       if min.nil?
-        # A typo in the policy must degrade to no gate, not fail every
-        # valid build's turns until an operator repairs the key.
-        Rails.logger.warn("Gumhead minimum client version is not a version; not gating.") if client_versions["min"].present?
+        # A policy typo degrades to no gate, not to failed turns.
+        Rails.logger.warn("Gumhead minimum client version is not a version; not gating.") if versions["min"].present?
         return
       end
 

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -30,6 +30,7 @@ class RedisKey
     def gumhead_gateway_throttle(user_id) = "gumhead_gateway_throttle:#{user_id}"
     def gumhead_gateway_in_flight(user_id) = "gumhead_gateway_in_flight:#{user_id}"
     def gumhead_model_map = "gumhead_model_map"
+    def gumhead_client_versions = "gumhead_client_versions"
     def agent_turn_status(user_id, client_turn_id) = "agent_turn_status:#{user_id}:#{client_turn_id}"
     def agent_custom_html_preview(user_id, token) = "agent_custom_html_preview:#{user_id}:#{token}"
     def agent_custom_html_preview_index(user_id) = "agent_custom_html_preview_index:#{user_id}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,6 +210,7 @@ Rails.application.routes.draw do
           post "messages", to: "messages#create"
           post "messages/count_tokens", to: "messages#count_tokens"
         end
+        get "client_version", to: "messages#client_version"
       end
     end
   end

--- a/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
+++ b/spec/controllers/api/v2/gumhead/messages_controller_spec.rb
@@ -1219,6 +1219,134 @@ describe Api::V2::Gumhead::MessagesController do
     end
   end
 
+  describe "client version gate" do
+    after { $redis.del(RedisKey.gumhead_client_versions) }
+
+    def stub_upstream
+      stub_request(:post, messages_url)
+        .to_return(status: 200, body: anthropic_response.to_json, headers: { "Content-Type" => "application/json" })
+    end
+
+    it "does nothing while no minimum is set" do
+      stub_upstream
+
+      post_messages
+
+      expect(response.status).to eq(200)
+    end
+
+    it "refuses a build below the minimum with the update message" do
+      $redis.set(RedisKey.gumhead_client_versions, { "min" => "0.2.0" }.to_json)
+      request.headers["X-Gumhead-Version"] = "0.1.0"
+
+      post_messages
+
+      expect(response.status).to eq(426)
+      expect(JSON.parse(response.body)["error"]["message"]).to eq(described_class::UPDATE_REQUIRED_MESSAGE)
+      expect(WebMock).not_to have_requested(:post, messages_url)
+    end
+
+    # A missing header means the one released pre-header build, 0.1.0.
+    it "gates the pre-header build once the minimum passes its version" do
+      $redis.set(RedisKey.gumhead_client_versions, { "min" => "0.2.0" }.to_json)
+
+      post_messages
+
+      expect(response.status).to eq(426)
+    end
+
+    it "serves a build at the minimum" do
+      $redis.set(RedisKey.gumhead_client_versions, { "min" => "0.2.0" }.to_json)
+      request.headers["X-Gumhead-Version"] = "0.2.0"
+      stub_upstream
+
+      post_messages
+
+      expect(response.status).to eq(200)
+    end
+
+    it "refuses a garbled version header once a minimum is set" do
+      $redis.set(RedisKey.gumhead_client_versions, { "min" => "0.2.0" }.to_json)
+      request.headers["X-Gumhead-Version"] = "not-a-version"
+
+      post_messages
+
+      expect(response.status).to eq(426)
+    end
+
+    it "serves the pre-header build while the minimum is its version" do
+      $redis.set(RedisKey.gumhead_client_versions, { "min" => "0.1.0" }.to_json)
+      stub_upstream
+
+      post_messages
+
+      expect(response.status).to eq(200)
+    end
+
+    it "serves a dev build regardless of the minimum" do
+      $redis.set(RedisKey.gumhead_client_versions, { "min" => "0.2.0" }.to_json)
+      request.headers["X-Gumhead-Version"] = "dev"
+      stub_upstream
+
+      post_messages
+
+      expect(response.status).to eq(200)
+    end
+
+    it "serves everyone when the configured minimum is not a version" do
+      $redis.set(RedisKey.gumhead_client_versions, { "min" => "0.2.x" }.to_json)
+      request.headers["X-Gumhead-Version"] = "0.1.0"
+      stub_upstream
+
+      post_messages
+
+      expect(response.status).to eq(200)
+    end
+
+    it "serves turns when the Redis read fails" do
+      allow($redis).to receive(:get).and_call_original
+      allow($redis).to receive(:get).with(RedisKey.gumhead_client_versions).and_raise(Redis::CannotConnectError)
+      stub_upstream
+
+      post_messages
+
+      expect(response.status).to eq(200)
+    end
+
+    it "reports the configured versions to an authenticated client" do
+      $redis.set(RedisKey.gumhead_client_versions, { "min" => "0.1.0", "current" => "0.2.0" }.to_json)
+
+      get :client_version
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq("min" => "0.1.0", "current" => "0.2.0")
+    end
+
+    it "reports an empty object while nothing is configured" do
+      get :client_version
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+
+    it "requires a token for the version endpoint" do
+      request.headers["Authorization"] = "Bearer nope"
+
+      get :client_version
+
+      expect(response.status).to eq(401)
+    end
+
+    it "answers the version endpoint even when the gateway key is unset" do
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_UPSTREAM_API_KEY").and_return(nil)
+      allow(GlobalConfig).to receive(:get).with("GUMHEAD_ANTHROPIC_API_KEY").and_return(nil)
+
+      get :client_version
+
+      expect(response.status).to eq(200)
+    end
+  end
+
   describe "live model map in Redis" do
     let(:openrouter_messages_url) { "https://openrouter.ai/api/v1/messages" }
 


### PR DESCRIPTION
Ref antiwork/gumroad-private#2331

## What

The gateway now gates Gumhead builds by version.

- New Redis key `gumhead_client_versions` holds `{"min": ..., "current": ...}`.
- A build below `min` gets 426 with a fixed update message. The app maps it to a friendly line.
- New authenticated `GET /v2/gumhead/client_version` reports the published versions. The app uses it to nudge about updates.
- No key, a malformed value, or a Redis failure serves everyone. The gate only ever fails open.
- A build that reports `dev` always passes. The gate is cooperative, not a security boundary; the token is.
- A missing header counts as `0.1.0`, the one released build that predates the header. So `min: 0.1.0` serves it, and `min: 0.2.0` gates it.

## Why

Shipped builds have no auto-updater yet. This gives operators a kill switch for broken old builds, and gives the app one place to learn a newer build exists. Both change live in Redis, with no deploy.

## Before/After

No behavior change until an operator sets the key. A gated build gets 426 instead of being served.

## Test Results

123 examples, 0 failures. Rubocop clean.

---

AI disclosure: Claude Fable 5 (Claude Code) wrote this change.
