### PR TITLE
Stop saying the sections editor is being phased out

### DIFF
--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -566,10 +566,9 @@ export default function SettingsPage() {
           ) : tab === "pages" && showPagesTab ? (
             <>
               <section className="grid gap-8 p-4! md:p-8!">
-                <Alert role="status" variant="warning">
-                  This sections editor is the old way to lay out your profile and is being phased out. It stays here
-                  while your profile still uses sections. Beyond it, your profile page is built to be updated by an AI
-                  agent — use your own agent, or Gumroad's built-in Agent tab. Open your{" "}
+                <Alert role="status" variant="info">
+                  Use this editor to lay out your profile with sections. You can also build a fully custom page with
+                  your own agent or Gumroad's Agent tab. Open your{" "}
                   <Link href={Routes.edit_page_path("profile")} className="underline">
                     Home page under Pages
                   </Link>{" "}

--- a/app/models/help_center/articles.yml
+++ b/app/models/help_center/articles.yml
@@ -157,7 +157,7 @@
 - id: 124
   slug: "124-your-gumroad-profile-page"
   title: "Build a website on Gumroad"
-  description: "In this article: Set up your profile Build your profile page with your agent Add standalone pages to your store Legacy pages and sections Your store's colors and font"
+  description: "In this article: Set up your profile Build your profile page with your agent Add standalone pages to your store The sections editor Your store's colors and font"
   category_id: <%= HelpCenter::Category::OPEN_AN_ACCOUNT.id %>
 - id: 125
   slug: "125-how-to-compress-a-video-using-handbrake"

--- a/app/views/help_center/articles/contents/_124-your-gumroad-profile-page.html.erb
+++ b/app/views/help_center/articles/contents/_124-your-gumroad-profile-page.html.erb
@@ -12,7 +12,7 @@
       </ul>
     </li>
     <li><a href="#Standalone-pages-Kw3xR" target="_self">Add standalone pages to your store</a></li>
-    <li><a href="#legacy-sections" target="_self">Legacy pages and sections</a></li>
+    <li><a href="#legacy-sections" target="_self">The sections editor</a></li>
     <li><a href="#theme-colors-fonts" target="_self">Your store's colors and font</a></li>
   </ul>
   <p>Your profile allows you to have your own website on Gumroad. You can use it to introduce yourself, <a href="170-audience">grow your following</a> by collecting email addresses, and showcase your products on a fully custom page.</p>
@@ -54,8 +54,8 @@
   <p>Live prices and your catalogue data are served with your profile page only, so a standalone page can't mark up a price. Link to the product instead and let its own page show the price.</p>
   <p>To delete a page, click the trash icon next to it in the list. Deleted pages are no longer reachable by visitors, and this can't be undone.</p>
   <p><i>Note:</i> Team members with the marketing or admin role can create and edit pages; support and accountant roles can view them.</p>
-  <h3 id="legacy-sections">Legacy pages and sections</h3>
-  <p>Profiles used to be laid out with pages of stacked sections (products, posts, subscribe, and text blocks). Sections are being phased out in favor of custom pages: they were confusing to arrange and not customizable enough. If your profile still uses them, the section editor remains available from your profile settings until you publish a custom page. Once your agent-built page is live, it replaces the sections layout entirely.</p>
+  <h3 id="legacy-sections">The sections editor</h3>
+  <p>You can lay out your profile with pages of stacked sections (products, posts, subscribe, and text blocks) from the section editor in profile settings. Publishing a custom page replaces the sections layout on your profile.</p>
   <p>If you have no custom page, no products, and no sections, your profile shows an email signup form.</p>
   <h3 id="theme-colors-fonts">Your store's colors and font</h3>
   <p>Your store has a theme: a background color, a highlight (accent) color, and a font. The theme applies across your whole store — your storefront profile page, <strong>every product page</strong>, <strong>the checkout page</strong>, the pages your buyers see for products they bought, your posts, and the emails you send to your audience. So the colors you see on your storefront are the same ones your product pages use. (Gumroad's own emails, like purchase receipts, keep Gumroad's styling.)</p>


### PR DESCRIPTION
# Stop saying the sections editor is being phased out

> Draft: copy is on the branch. Preview screenshots and walkthrough video still owed.

## What

Rewords the Profile > Pages sections-editor alert and the matching help-center section so they no longer call the editor the old way or say it is being phased out. The editor stays. A custom page still replaces the sections layout if a seller publishes one.

## Why

The old warning read as an AI-only workflow. The product decision is that the sections editor is not being removed. Refs antiwork/gumroad-private#2324.

Rejected alternative: delete the alert. Keep a short info note that names the custom-page path, without deprecation language.

## Before / After

| Surface | Before | After |
|---|---|---|
| Settings > Profile > Pages alert | "This sections editor is the old way to lay out your profile and is being phased out. … Beyond it, your profile page is built to be updated by an AI agent …" (`variant="warning"`) | "Use this editor to lay out your profile with sections. You can also build a fully custom page with your own agent or Gumroad's Agent tab. …" (`variant="info"`) |
| Help article `_124` "Legacy pages and sections" | "Sections are being phased out in favor of custom pages …" | Heading "The sections editor". "You can lay out your profile with pages of stacked sections … from the section editor in profile settings. Publishing a custom page replaces the sections layout on your profile." |

Visual evidence of the rendered alert and article is owed on the hosted preview (desktop + mobile, light + dark).

## Checklist

- [x] Scope — copy only on the settings alert, help article body, and article search description. No behavior change.
- [x] Design — info alert, not a deprecation warning. Custom-page replacement stays factual.
- [x] Build — `gumclaw/gp2324-sections-editor-copy`
- [ ] QA — preview screenshots and walkthrough video owed
- [ ] Shipped — draft
- [ ] Market — n/a, copy correction
- [ ] Sell — seller apology on the originating support thread, separate from this PR

## Test Results

- ERB compile of `_124-your-gumroad-profile-page.html.erb`: OK
- Repo grep for `being phased out` / `old way to lay` / `Legacy pages and sections` on the three touched files: 0 hits
- Help-center / profile specs: owed (no examples pinned the old strings)

## QA steps

Owed on the hosted preview once it serves this head:

1. Sign in as a seller whose profile still uses sections (no custom HTML).
2. Open Settings > Profile > Pages. Confirm the alert is info, not warning, and does not say "phased out" or "old way".
3. Open https://gumroad.com/help/article/124-your-gumroad-profile-page and confirm the sections heading/body match the After column.

---

AI disclosure: grok-4.6. Prompt/instructions: product-direction ruling that the sections editor is not being removed; update the misleading copy and apologize to the seller.

Premerge review: clean @ 93d630fdd31bd082453d8d3fd714413acc551378
