### PR TITLE
Map JS trees that forced run-all-specs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: Tests
 
 on:
+  schedule:
+    # Daily full Fast/Slow on main (10:00 ET). Branch CI is trimmed, and
+    # squash-reuse can skip Fast/Slow on merge when a PR already ran them.
+    # This is the safety net so the full suite still runs every day.
+    - cron: "0 14 * * *"
   push:
     branches:
       - "**"
@@ -25,9 +30,9 @@ jobs:
 
   run_scope:
     # Decides whether this run gets the full Fast/Slow suite or the trimmed
-    # test_relevant job. Full suite: every push to main (deploy gate), or a
-    # PR carrying the run-all-specs label. Push events have no PR payload,
-    # so the label is looked up via the commit's PRs.
+    # test_relevant job. Full suite: the daily schedule, every push to main
+    # (deploy gate), or a PR carrying the run-all-specs label. Push events
+    # have no PR payload, so the label is looked up via the commit's PRs.
     #
     # Fork PRs hit this job via pull_request_target (token is the base repo).
     # No checkout here — only label lookup. Reuse of a prior Fast/Slow run
@@ -46,6 +51,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
         run: |
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
             echo "full=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,6 @@
 name: Tests
 
 on:
-  schedule:
-    # Daily full Fast/Slow on main (10:00 ET). Branch CI is trimmed, and
-    # squash-reuse can skip Fast/Slow on merge when a PR already ran them.
-    # This is the safety net so the full suite still runs every day.
-    - cron: "0 14 * * *"
   push:
     branches:
       - "**"
@@ -30,9 +25,9 @@ jobs:
 
   run_scope:
     # Decides whether this run gets the full Fast/Slow suite or the trimmed
-    # test_relevant job. Full suite: the daily schedule, every push to main
-    # (deploy gate), or a PR carrying the run-all-specs label. Push events
-    # have no PR payload, so the label is looked up via the commit's PRs.
+    # test_relevant job. Full suite: every push to main (deploy gate), or a
+    # PR carrying the run-all-specs label. Push events have no PR payload,
+    # so the label is looked up via the commit's PRs.
     #
     # Fork PRs hit this job via pull_request_target (token is the base repo).
     # No checkout here — only label lookup. Reuse of a prior Fast/Slow run
@@ -51,10 +46,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
         run: |
-          if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
-            echo "full=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
             echo "full=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -60,6 +60,24 @@ PROFILE_FLOW_SPECS = %w[
   spec/requests/profile_custom_html_spec.rb
 ].freeze
 
+# Harvested from PRs that had to carry run-all-specs because these JS
+# trees have no per-file spec (ProductEdit, Settings, API docs, etc.).
+PRODUCT_FLOW_SPECS = %w[spec/requests/products].freeze
+SETTINGS_FLOW_SPECS = %w[spec/requests/settings].freeze
+ANALYTICS_FLOW_SPECS = %w[
+  spec/requests/analytics
+  spec/requests/dashboard_spec.rb
+].freeze
+API_DOCS_SPECS = %w[
+  spec/requests/api
+  spec/requests/oauth_applications_pages_spec.rb
+].freeze
+BUNDLE_FLOW_SPECS = %w[spec/requests/bundles].freeze
+AUDIENCE_FLOW_SPECS = %w[
+  spec/requests/analytics/audience_spec.rb
+  spec/requests/customers
+].freeze
+
 FANOUT = {
   %r{\Aapp/presenters/checkout/} => CHECKOUT_FLOW_SPECS,
   %r{\Aapp/javascript/components/Checkout/} => CHECKOUT_FLOW_SPECS,
@@ -84,6 +102,24 @@ FANOUT = {
   # Help-center article partials render through the help_center request specs;
   # the per-article view glob finds nothing because specs aren't per-article.
   %r{\Aapp/views/help_center/} => %w[spec/requests/help_center_spec.rb spec/requests/help_center],
+  %r{\Aapp/javascript/components/HelpCenterPage} => %w[spec/requests/help_center_spec.rb spec/requests/help_center],
+  %r{\Aapp/javascript/pages/HelpCenter/} => %w[spec/requests/help_center_spec.rb spec/requests/help_center],
+  # Recurring run-all-specs gaps (ProductEdit, Settings, API docs, Analytics,
+  # Audience, Bundles, Dashboard). These trees have no co-located rspec.
+  %r{\Aapp/javascript/components/ProductEdit/} => PRODUCT_FLOW_SPECS,
+  %r{\Aapp/javascript/components/Product/} => PRODUCT_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/Products/} => PRODUCT_FLOW_SPECS,
+  %r{\Aapp/javascript/components/server-components/ProductEdit} => PRODUCT_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/Settings/} => SETTINGS_FLOW_SPECS,
+  %r{\Aapp/javascript/components/ApiDocumentation} => API_DOCS_SPECS,
+  %r{\Aapp/javascript/components/Analytics/} => ANALYTICS_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/Analytics/} => ANALYTICS_FLOW_SPECS,
+  %r{\Aapp/javascript/components/Audience/} => AUDIENCE_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/Bundles/} => BUNDLE_FLOW_SPECS,
+  %r{\Aapp/javascript/components/BundleEdit/} => BUNDLE_FLOW_SPECS,
+  %r{\Aapp/javascript/components/DashboardPage} => %w[spec/requests/dashboard_spec.rb],
+  %r{\Aapp/javascript/data/customer_surcharge} => CHECKOUT_FLOW_SPECS,
+  %r{\Aspec/support/dynamodb\.rb\z} => %w[spec/services/email_engagement_dynamo_store_spec.rb],
 }.freeze
 
 # Config files with dedicated request coverage. Everything else under
@@ -121,6 +157,11 @@ IGNORED_PATTERNS = [
   %r{\.md\z},
   %r{\A\.agents/},
   %r{\A\.claude/},
+  # Static assets; rspec does not compile public/.
+  %r{\Apublic/},
+  # Other workflows are not the rspec suite. tests.yml still escalates via
+  # ESCALATE_PATTERNS (checked after this filter).
+  %r{\A\.github/workflows/(?!tests\.yml)},
   # Recorded HTTP, not helpers. A cassette-only diff must not force Slow;
   # the spec that plays the tape is already in the selection (or unchanged).
   %r{\Aspec/support/fixtures/vcr_cassettes/},
@@ -349,6 +390,9 @@ changed.each do |path|
     next
   elsif path == "bin/classify-hung-checkout" || path == "spec/bin/classify_hung_checkout_test.rb"
     # Same: standalone ruby (ruby spec/bin/classify_hung_checkout_test.rb), not rspec.
+    next
+  elsif path == "bin/reuse-full-suite" || path == "script/test-reuse-full-suite"
+    # Standalone bash + its test; lint/self-test jobs cover them.
     next
   elsif path == ".github/workflows/rerun-hung-checkout.yml"
     # Only invokes the classifier; the job `if` is asserted in that standalone

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -615,48 +615,6 @@ check(
   expect_specs: %w[spec/models/widget_spec.rb],
 )
 
-# The daily schedule must stay a full-suite run. Extract the live run_scope
-# step so this fails if someone deletes the schedule branch from tests.yml.
-WORKFLOW = File.expand_path("../../.github/workflows/tests.yml", __dir__)
-$count += 1
-workflow_text = File.read(WORKFLOW)
-unless workflow_text.include?('cron: "0 14 * * *"')
-  $failures << "tests.yml is missing the daily 0 14 * * * schedule"
-end
-unless workflow_text.include?('GITHUB_EVENT_NAME" = "schedule"')
-  $failures << "run_scope does not treat schedule events as full suite"
-end
-
-def run_scope_body
-  text = File.read(WORKFLOW)
-  chunk = text[/- id: scope\n.*?run: \|\n(.*?)(?:\n  [a-z_]+:|\n    permissions:)/m, 1]
-  raise "could not extract run_scope step" unless chunk
-  chunk.gsub(/^          /, "")
-end
-
-$count += 1
-Dir.mktmpdir do |dir|
-  out = File.join(dir, "github_output")
-  File.write(out, "")
-  env = {
-    "GITHUB_OUTPUT" => out,
-    "GITHUB_EVENT_NAME" => "schedule",
-    "GITHUB_REF" => "refs/heads/main",
-    "GH_TOKEN" => "none",
-    "SHA" => "deadbeef",
-    "GITHUB_REPOSITORY" => "antiwork/gumroad",
-  }
-  _stdout, stderr, status = Open3.capture3(env, "bash", "-c", run_scope_body)
-  unless status.success?
-    $failures << "run_scope schedule step failed: #{stderr}"
-  else
-    got = File.read(out)
-    unless got.include?("full=true")
-      $failures << "run_scope schedule did not set full=true (got #{got.inspect})"
-    end
-  end
-end
-
 if $failures.empty?
 
   puts "#{$count} checks passed"

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -541,7 +541,124 @@ check(
   expect_escalate: true,
 )
 
+
+# Recurring run-all-specs gaps: ProductEdit JS has no per-file rspec.
+check(
+  "ProductEdit component fans out to product request specs",
+  base_files: {
+    "spec/requests/products/edit/covers_spec.rb" => SPEC_STUB,
+    "app/javascript/components/ProductEdit/state.ts" => "old",
+  },
+  head_files: { "app/javascript/components/ProductEdit/state.ts" => "new" },
+  expect_specs: %w[spec/requests/products/edit/covers_spec.rb],
+)
+
+check(
+  "Settings page fans out to settings request specs",
+  base_files: {
+    "spec/requests/settings/main_spec.rb" => SPEC_STUB,
+    "app/javascript/pages/Settings/Main.tsx" => "old",
+  },
+  head_files: { "app/javascript/pages/Settings/Main.tsx" => "new" },
+  expect_specs: %w[spec/requests/settings/main_spec.rb],
+)
+
+check(
+  "dynamodb support file maps instead of escalating",
+  base_files: {
+    "spec/services/email_engagement_dynamo_store_spec.rb" => SPEC_STUB,
+    "spec/support/dynamodb.rb" => "old",
+  },
+  head_files: { "spec/support/dynamodb.rb" => "new" },
+  expect_specs: %w[spec/services/email_engagement_dynamo_store_spec.rb],
+)
+
+check(
+  "public image with a mapped spec does not escalate",
+  base_files: {
+    "app/models/widget.rb" => "old",
+    "spec/models/widget_spec.rb" => SPEC_STUB,
+    "public/images/help_center/foo.png" => "old",
+  },
+  head_files: {
+    "app/models/widget.rb" => "new",
+    "public/images/help_center/foo.png" => "new",
+  },
+  expect_specs: %w[spec/models/widget_spec.rb],
+)
+
+check(
+  "non-tests workflow with a mapped spec does not escalate",
+  base_files: {
+    "app/models/widget.rb" => "old",
+    "spec/models/widget_spec.rb" => SPEC_STUB,
+    ".github/workflows/e2e.yml" => "old",
+  },
+  head_files: {
+    "app/models/widget.rb" => "new",
+    ".github/workflows/e2e.yml" => "new",
+  },
+  expect_specs: %w[spec/models/widget_spec.rb],
+)
+
+check(
+  "reuse-full-suite script with a mapped spec does not escalate",
+  base_files: {
+    "app/models/widget.rb" => "old",
+    "spec/models/widget_spec.rb" => SPEC_STUB,
+    "bin/reuse-full-suite" => "old",
+  },
+  head_files: {
+    "app/models/widget.rb" => "new",
+    "bin/reuse-full-suite" => "new",
+  },
+  expect_specs: %w[spec/models/widget_spec.rb],
+)
+
+# The daily schedule must stay a full-suite run. Extract the live run_scope
+# step so this fails if someone deletes the schedule branch from tests.yml.
+WORKFLOW = File.expand_path("../../.github/workflows/tests.yml", __dir__)
+$count += 1
+workflow_text = File.read(WORKFLOW)
+unless workflow_text.include?('cron: "0 14 * * *"')
+  $failures << "tests.yml is missing the daily 0 14 * * * schedule"
+end
+unless workflow_text.include?('GITHUB_EVENT_NAME" = "schedule"')
+  $failures << "run_scope does not treat schedule events as full suite"
+end
+
+def run_scope_body
+  text = File.read(WORKFLOW)
+  chunk = text[/- id: scope\n.*?run: \|\n(.*?)(?:\n  [a-z_]+:|\n    permissions:)/m, 1]
+  raise "could not extract run_scope step" unless chunk
+  chunk.gsub(/^          /, "")
+end
+
+$count += 1
+Dir.mktmpdir do |dir|
+  out = File.join(dir, "github_output")
+  File.write(out, "")
+  env = {
+    "GITHUB_OUTPUT" => out,
+    "GITHUB_EVENT_NAME" => "schedule",
+    "GITHUB_REF" => "refs/heads/main",
+    "GH_TOKEN" => "none",
+    "SHA" => "deadbeef",
+    "GITHUB_REPOSITORY" => "antiwork/gumroad",
+  }
+  _stdout, stderr, status = Open3.capture3(env, "bash", "-c", run_scope_body)
+  unless status.success?
+    $failures << "run_scope schedule step failed: #{stderr}"
+  else
+    got = File.read(out)
+    unless got.include?("full=true")
+      $failures << "run_scope schedule did not set full=true (got #{got.inspect})"
+    end
+  end
+end
+
 if $failures.empty?
+
   puts "#{$count} checks passed"
 else
   $failures.each { |f| puts "FAIL: #{f}\n\n" }


### PR DESCRIPTION
## What

`bin/branch-specs` maps the JS trees that kept forcing the `run-all-specs` label: ProductEdit, Product, Products pages, Settings, API docs, Analytics, Audience, Bundles, Dashboard, Help Center pages, checkout surcharge data, and `spec/support/dynamodb.rb`.

Also ignores `public/` assets and non-`tests.yml` workflows so those diffs don't escalate.

No daily Tests schedule.

## Why

Those trees have no per-file rspec, so the selector escalated to the full suite. Mapping them means those PRs run the relevant request specs instead.

## Test Results

`ruby spec/bin/branch_specs_test.rb` — 36 checks passed.

Premerge review: clean @ 1bce289c752bcebf7ba9a5b8e480201eeed8ab24
