### PR TITLE
Run the reuse-full-suite self-test on every PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -185,6 +185,10 @@ jobs:
       - name: Self-test the branch-specs selector
         run: ruby spec/bin/branch_specs_test.rb
 
+      # Hosted here so a reuse-only PR cannot ship on the user_spec.rb floor.
+      - name: Self-test reuse-full-suite
+        run: bash script/test-reuse-full-suite
+
   build:
     name: Build images${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository && ' (internal PR noop)' || '' }}
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -392,7 +392,7 @@ changed.each do |path|
     # Same: standalone ruby (ruby spec/bin/classify_hung_checkout_test.rb), not rspec.
     next
   elsif path == "bin/reuse-full-suite" || path == "script/test-reuse-full-suite"
-    # Standalone bash + its test; lint/self-test jobs cover them.
+    # Standalone bash; script/test-reuse-full-suite runs on every PR.
     next
   elsif path == ".github/workflows/rerun-hung-checkout.yml"
     # Only invokes the classifier; the job `if` is asserted in that standalone

--- a/script/test-reuse-full-suite
+++ b/script/test-reuse-full-suite
@@ -100,7 +100,8 @@ write_jobs 18 50 "$FAKE/fix/jobs-full.json"
 printf '{"jobs":[{"name":"Test Fast 0 (internal PR noop)","conclusion":"success"},{"name":"Test Relevant 0","conclusion":"success"}]}\n' > "$FAKE/fix/jobs-noop.json"
 
 run() {
-  TESTS_WORKFLOW_PATH="$FAKE/tests.yml" REPO=antiwork/gumroad GH_FIXTURE_DIR="$FAKE/fix" GH="$FAKE/gh" "$SCRIPT" mainsha
+  env -u GITHUB_ACTIONS -u GITHUB_EVENT_NAME -u GITHUB_REF \
+    TESTS_WORKFLOW_PATH="$FAKE/tests.yml" REPO=antiwork/gumroad GH_FIXTURE_DIR="$FAKE/fix" GH="$FAKE/gh" "$SCRIPT" mainsha
 }
 
 out=$(run)
@@ -177,7 +178,8 @@ else echo "unexpected $path" >&2; exit 1
 fi
 EOF
 chmod +x "$FAKE/gh-fail-pull"
-out=$(TESTS_WORKFLOW_PATH="$FAKE/tests.yml" REPO=antiwork/gumroad GH="$FAKE/gh-fail-pull" "$SCRIPT" mainsha || true)
+out=$(env -u GITHUB_ACTIONS -u GITHUB_EVENT_NAME -u GITHUB_REF \
+  TESTS_WORKFLOW_PATH="$FAKE/tests.yml" REPO=antiwork/gumroad GH="$FAKE/gh-fail-pull" "$SCRIPT" mainsha || true)
 test "$out" = "reuse=false" || { echo "FAIL expected reuse=false on pulls 404 got [$out]"; exit 1; }
 echo "ok pulls 404 fail-closes"
 

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -615,6 +615,25 @@ check(
   expect_specs: %w[spec/models/widget_spec.rb],
 )
 
+check(
+  "reuse-full-suite-only change does not escalate",
+  base_files: {
+    "bin/reuse-full-suite" => "old",
+    "script/test-reuse-full-suite" => "old",
+  },
+  head_files: {
+    "bin/reuse-full-suite" => "new",
+    "script/test-reuse-full-suite" => "new",
+  },
+  expect_specs: [],
+)
+
+WORKFLOW = File.expand_path("../../.github/workflows/tests.yml", __dir__)
+$count += 1
+unless File.read(WORKFLOW).include?("bash script/test-reuse-full-suite")
+  $failures << "tests.yml does not run script/test-reuse-full-suite"
+end
+
 if $failures.empty?
 
   puts "#{$count} checks passed"

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -16,6 +16,7 @@
 require "tmpdir"
 require "fileutils"
 require "open3"
+require "yaml"
 
 SELECTOR = File.expand_path("../../bin/branch-specs", __dir__)
 
@@ -629,9 +630,14 @@ check(
 )
 
 WORKFLOW = File.expand_path("../../.github/workflows/tests.yml", __dir__)
+workflow = YAML.load_file(WORKFLOW)
+migration_versions = workflow.fetch("jobs").fetch("migration_versions")
+reuse_self_test = migration_versions.fetch("steps").find do |step|
+  step["name"] == "Self-test reuse-full-suite"
+end
 $count += 1
-unless File.read(WORKFLOW).include?("bash script/test-reuse-full-suite")
-  $failures << "tests.yml does not run script/test-reuse-full-suite"
+unless reuse_self_test && reuse_self_test["run"] == "bash script/test-reuse-full-suite" && !reuse_self_test.key?("if")
+  $failures << "tests.yml does not run script/test-reuse-full-suite as an ungated migration_versions step"
 end
 
 if $failures.empty?


### PR DESCRIPTION
## What

The Tests workflow's migration-versions job now runs `bash script/test-reuse-full-suite` on every PR. `bin/branch-specs` still skips `bin/reuse-full-suite` and `script/test-reuse-full-suite` so those diffs don't escalate to Fast/Slow.

Follow-up to #7419, which added the skip without invoking the dedicated test.

## Why

A PR that only changes the reuse script was treated as an empty rspec selection. CI then substituted `spec/models/user_spec.rb` and would merge a reuse regression untested. The selector self-test already lives in this job for the same reason (run-all-specs skips `relevant_specs`).

## Before / After

Before: reuse-only diff → empty selection → floor `spec/models/user_spec.rb`; the added self-test also failed under PR GitHub Actions env because the fixture cases inherited `GITHUB_ACTIONS` and the branch ref.

After: same skip, plus the bash self-test on every PR; the offline fixture cases clear ambient GitHub Actions env, while the explicit off-main/main-push cases still cover the production guard.

## Test Results

- `HOME=/tmp/githome-pr7420 GIT_CONFIG_NOSYSTEM=1 ruby spec/bin/branch_specs_test.rb` — 38 checks passed.
- `bash script/test-reuse-full-suite` — ALL_OK.
- `GITHUB_ACTIONS=true GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/ci/reuse-full-suite-self-test bash script/test-reuse-full-suite` — ALL_OK.
- `ruby -c spec/bin/branch_specs_test.rb` — Syntax OK.
- `bash -n script/test-reuse-full-suite` — OK.
- `bundle exec rubocop --force-exclusion spec/bin/branch_specs_test.rb` — 1 file inspected, no offenses detected.
- `pnpm format` — blocked before formatting: this project declares `packageManager: npm@10.8.2`.
- Mutation: removing the env clearing from the fixture runner fails under PR-like GitHub Actions env with `FAIL expected reuse=true got [reuse=false]`; changing the workflow step to a comment plus `run: echo skipped` fails the structured workflow pin; final restore re-ran the two green checks above.
- Sol review: `autoreview --mode branch --base origin/main --engine codex --max-priority P1` — clean at `9c9ba00c51d012517ed863244459886bbed6aaeb`.

Premerge review: clean @ 9c9ba00c51d012517ed863244459886bbed6aaeb

## QA steps

No rendered surface. After merge, open any PR's Tests → Migration versions and confirm the "Self-test reuse-full-suite" step ran.

- [x] Scope — skip stays; dedicated test is wired
- [x] Design — same job as the selector self-test, with fixture env isolated
- [x] Build — done
- [x] QA — no UI; self-test + mutation proof + Sol review above
- [ ] Shipped
- [ ] Market
- [ ] Sell

---

This pull request was written by an AI agent (grok-4.6 / xAI).
