### PR TITLE
Trim LinksController save-path comments

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -878,16 +878,10 @@ class LinksController < ApplicationController
       end
     end
 
-    # *** DO NOT USE THIS METHOD for actions that respond to non-subdomain URLs ***
-    #
-    # Used for actions where a product's general (custom or unique) permalink is used to identify the product.
-    # Usually these are public-facing URLs with permalink as part of the URL.
-    #
-    # Since custom permalinks aren't globally unique, this method is only guaranteed to fetch the unique product
-    # if the owner of the product can be identified by the URL's subdomain.
-    #
-    # To support legacy (non-subdomain) URLs, when no creator can be identify via subdomain, this method will fetch the
-    # oldest product with given unique or custom permalink.
+    # Do not use for actions that respond to non-subdomain URLs.
+    # Custom permalinks aren't globally unique — this is only unique when the
+    # owner is identified by the URL's subdomain. With no subdomain it fetches
+    # the oldest product with that unique or custom permalink (legacy URLs).
     def fetch_product_by_general_permalink
       custom_or_unique_permalink = params[:id] || params[:link_id]
       e404 if custom_or_unique_permalink.blank?
@@ -1229,35 +1223,18 @@ class LinksController < ApplicationController
       end
     end
 
-    # The editor only ever addresses the product's FIRST alive variant grouping
-    # — that is what the UI shows and what the payload's `variants` list means.
-    # Everything else the product owns (a second grouping left over from the
-    # older multi-category editor, or from the API) is simply not part of the
-    # request, so the save never visits it.
+    # The editor only addresses the first alive variant grouping; other
+    # groupings (legacy multi-category / API) are never in the payload, so the
+    # save never visits them. Under the contract a named deletion in an
+    # unvisited grouping is silently dropped (200, version still there).
     #
-    # That is fine while deletion is inferred from the payload, because a
-    # grouping nobody submitted has nothing to infer from. Under the save
-    # contract it stops being fine: the client can now name a specific variant
-    # id to delete, and if that variant lives in a grouping the save never
-    # visits, the deletion is silently dropped — the save returns success and
-    # the version is still there after a reload.
-    #
-    # So when (and only when) the contract is enforced and the request names ids
-    # or asks for a clear-all, the other alive groupings are appended as
-    # deletion-only entries (`options: nil`). Under the contract that route
-    # deletes exactly the named ids and nothing else
-    # (VariantCategoryUpdaterService#contract_scoped_category_deletions), so a
-    # grouping with no named ids is visited and left completely alone.
-    #
-    # Version-scoped deletions (a version's integrations) count as "names ids"
-    # for exactly the same reason: they name a version by its external id, and
-    # that version can live in any grouping. Without them in this condition a
-    # fresh, explicitly authorised request to disconnect an integration from a
-    # version outside the first grouping would return 200 with the integration
-    # still connected.
-    #
-    # Returns [] whenever the contract is off, which keeps the legacy single-
-    # grouping call byte-identical.
+    # When the contract is on and the request names variant ids, a clear-all,
+    # or version-scoped deletions (integrations name a version by external id,
+    # which can live in any grouping), append the other alive groupings as
+    # deletion-only (`options: nil`). That visits them so named ids apply, and
+    # a grouping with no named ids is left alone
+    # (VariantCategoryUpdaterService#contract_scoped_category_deletions).
+    # Returns [] when the contract is off (legacy single-grouping call).
     def deletion_only_category_params(alive_categories, except:)
       contract = product_save_contract
       return [] unless contract.enforced?
@@ -1272,34 +1249,19 @@ class LinksController < ApplicationController
         .map { { id: _1.external_id, options: nil } }
     end
 
-    # Who and which request is performing this save, for the deletion audit
-    # trail (ProductVariantDeletionAudit). `logged_in_user` rather than
-    # `current_seller`: on a collaborator or admin save those differ, and the
-    # audit wants the person who actually pressed save.
-    #
-    # `correlation_id` is a server-side digest, not the raw request id — Rails
-    # takes `X-Request-Id` from the client, so the raw value is caller-controlled
-    # (see AuditCorrelationId). `revision_token` is always nil today: the
-    # editor-scoped revision token proposed in gumroad-private#1379 does not
-    # exist yet, and the key is here so the audit shape doesn't change when it
-    # ships.
-    #
-    # The digest is computed here but NOT logged here: this context is built for
-    # every save, and most saves delete nothing. Logging at build time would emit
-    # a correlation line for saves that never produce an audit row, which is noise
-    # that makes the log useless for the one thing it exists for — finding the
-    # request behind an audit row. `ProductVariantDeletionAudit` logs the pair
-    # itself, at the point a row is actually scheduled.
+    # Deletion audit trail (ProductVariantDeletionAudit). `logged_in_user`, not
+    # `current_seller` — those differ on collaborator/admin saves.
+    # `correlation_id` is a server-side digest: Rails takes `X-Request-Id` from
+    # the client (see AuditCorrelationId). Do not log here — this runs on every
+    # save and most delete nothing; ProductVariantDeletionAudit logs when a row
+    # is actually scheduled.
     def deletion_audit_context
       @_deletion_audit_context ||= {
         actor_user_id: logged_in_user&.id,
         correlation_id: AuditCorrelationId.for(request.request_id),
         request_id: request.request_id,
-        # The snapshot token the client submitted, recorded so an audit row can
-        # be tied back to the editor session that asked for the deletion.
-        # Read straight from the params rather than from the contract: the audit
-        # must describe what the client actually sent even when the contract is
-        # disabled, and reading it here cannot start any revision work.
+        # Params, not the contract: describe what the client sent even when the
+        # contract is off, and don't start revision work.
         revision_token: params[:editor_revision].presence,
       }
     end
@@ -1344,17 +1306,12 @@ class LinksController < ApplicationController
       end
     end
 
-    # Descriptions of payload pages the server does NOT already know about.
-    # Editor sessions predating the id reconciliation in the save response keep
-    # their client-generated page ids across saves, so a resubmitted new page
-    # arrives under an unknown id: matching on content identifies it as a
-    # rewrite rather than a deletion. Pages submitted under an id the server
-    # already has are in-place updates of that page — their content must NOT
-    # unlock deleting a different stored page that happens to have the same
-    # content (two duplicate-content pages, an outdated payload omits one).
-    # NOTE: reads the RAW params, not the permitted ones — by the time the
-    # deletion guards run, the permitted variant params may have been
-    # consumed/mutated by earlier steps.
+    # Unknown-id pages (old editor sessions keep client-generated ids). Match
+    # on content to treat a resubmit as a rewrite, not a deletion. A known id
+    # is an in-place update — its content must not unlock deleting a different
+    # stored page that happens to have the same content.
+    # Reads RAW params: by the time deletion guards run, permitted variant
+    # params may have been consumed by earlier steps.
     def payload_page_descriptions
       @_payload_page_descriptions ||= begin
         pages = params[:rich_content].is_a?(Array) ? params[:rich_content].to_a : []
@@ -1429,20 +1386,9 @@ class LinksController < ApplicationController
       count + (params[:variants].is_a?(Array) ? params[:variants].sum { |variant| variant[:rich_content].is_a?(Array) ? variant[:rich_content].size : 0 } : 0)
     end
 
-    # A save that named deletions and applied fewer of them than it named is a
-    # success response the seller cannot tell apart from a real one
-    # (gumroad-private#1508). Under the save contract an unstated removal is a
-    # no-op by design, so the failure mode that used to be a wrong deletion is
-    # now a silent non-deletion: 200, nothing gone, nothing logged.
-    #
-    # Runs only on the success path, after the transaction committed, and only
-    # when the client actually stated deletions — so it costs one reload plus
-    # two id reads on the small minority of saves that delete something, and
-    # nothing at all on the rest.
-    #
-    # Never raises. This is a report, not a guard: the write already happened
-    # and failing the response here would tell the seller a committed save
-    # failed.
+    # Named-but-unapplied deletions look like a real 200 to the seller. After
+    # commit, and only when the client stated deletions. Report, not guard —
+    # never raise: the write already happened.
     def report_unapplied_deletions!
       contract = product_save_contract
       return unless contract.enforced?
@@ -1471,25 +1417,12 @@ class LinksController < ApplicationController
       ErrorNotifier.notify(e)
     end
 
-    # The blind spot in the report above: it is gated on `requested_deletion?`,
-    # so it cannot see a payload that named NO deletion at all. That is exactly
-    # the shape reported in gumroad-private#1508 — 200, nothing deleted, zero
-    # audit rows — and it is why the report has never fired.
-    #
-    # `confirmed_removed_variant_ids` is the witness. The editor sends it beside
-    # the deletion operations and both derive from the same in-session list, so a
+    # The report above is gated on `requested_deletion?`, so it misses a payload
+    # that named no deletion. `confirmed_removed_variant_ids` is the witness: a
     # contract-aware payload that confirms a removal while naming none of it is
-    # self-contradictory: the seller pressed "Yes, remove" and the request did
-    # not ask for it. Under Rule 1 the server correctly does nothing, which is
-    # what makes the failure silent.
-    #
-    # A current client cannot produce that contradiction — both lists come off
-    # one snapshot. This is a tripwire for the clients that can: a stale bundle,
-    # or a path nobody has found yet. It does NOT catch a row dropped from state
-    # with no confirmed id, which is undetectable here by contract design.
-    #
-    # Report, not guard: acting on the confirmed ids would delete rows through a
-    # route the contract deliberately closed.
+    # a contradiction (stale bundle / unknown path). Does not catch a row
+    # dropped from state with no confirmed id. Report, not guard — do not delete
+    # via the confirmed ids; that route is deliberately closed.
     def report_unstated_confirmed_removals!
       contract = product_save_contract
       return unless contract.enforced?
@@ -1794,18 +1727,6 @@ class LinksController < ApplicationController
         file_id_mappings: save_id_mappings[:files],
         rich_content_removed_file_embed_ids: save_id_mappings[:removed_file_embeds],
         **content_updated_at_response,
-        # The revision token for the state this save just committed
-        # (gumroad-private#1379). Every successful save moves the product's
-        # fingerprint, so the token the editor is holding — issued when the page
-        # loaded — is stale the moment the first save returns. Without handing
-        # back a fresh one, a seller who saves an ordinary edit and then deletes
-        # a version in the same session has the deletion silently refused as
-        # stale, and the row reappears on reload. The editor adopts this value
-        # and echoes it on the next save.
-        #
-        # Emitted only while the contract is enforced: with the flag off the
-        # token is meaningless and computing it would cost the fingerprint
-        # queries on every save for no benefit.
         **editor_revision_response,
       }
     end


### PR DESCRIPTION
## What

Comments only, no behaviour change.

In `LinksController`, compress essay-length product-save comments to the invariants a maintainer needs, and drop a duplicate `editor_revision` note that restated the method comment below it.

- `fetch_product_by_general_permalink` — keep subdomain uniqueness + oldest-permalink legacy fallback.
- `deletion_only_category_params` — keep first-grouping / silent-drop / `options: nil` / contract-off `[]`.
- `deletion_audit_context` — keep `logged_in_user` vs `current_seller`, digest `correlation_id`, don't log at build time; drop the stale "token is always nil / #1379" history.
- `payload_page_descriptions` — keep unknown-id rewrite vs known-id must not unlock a duplicate-content delete, and the RAW-params trap.
- `report_unapplied_deletions!` / `report_unstated_confirmed_removals!` — keep report-not-guard and the `requested_deletion?` blind spot; drop ticket narration.
- Hash-key comment on `**editor_revision_response` — deleted; the method comment already covers fingerprint staleness and "only when enforced".

## Why

Maintainers already know this file. A 29-line essay that restates the method below it, or a ticket-history paragraph, is noise that teaches people to skip the comments that matter.

## Line counts

`app/controllers/links_controller.rb`: 2313 → 2234 (−79 net; 37 inserted, 116 deleted).

## Kept (on purpose)

- `product_save_contract` — permitted-params shape, `deep_symbolize_keys` nested-key trap, inferred move from pre-provenance tabs.
- `variant_scoped_deletion_params` — variant external ids cannot be in a static `permit`; a bare String raises on a Symbol key.
- `page_rewrite_budget` — one budget for the whole save, not one per scope.
- `snapshot_variants_params` — pass the whole variant hash; sales also bump `updated_at`.
- `deletion_guard_diagnostics` — build before mutate; request body is not retained.
- `legacy_dead_file_embed_ids_by_rich_content_id` — named-source vs bounded legacy copy; locked pre-save ownership.
- `editor_revision_response` method comment — second save in a session would silently refuse deletions without a fresh token; skip fingerprint queries when the contract is off.
- Integrations baseline refresh — connect→save→disconnect would emit no deletion if the load-time baseline is never refreshed.
- Custom HTML sandbox / SEO / analytics comments — opaque origin, no `allow-top-navigation`, quote-escape of html_safe plaintext, wrapper vs iframe CSP.

## Not slop (left alone this run)

- `test/controllers/links_controller_test.rb` — July 21 incident shape, lock-ordering freshness check, default-off 409 with the 363-save production figure.
- `app/javascript/pages/Settings/Profile/Show.tsx` — Inertia prefetch/async/`preserveState` vs same-path remount.
- `spec/bin/branch_specs_test.rb` — throwaway-repo harness + ASCII-locale encoding.
- `CreatorHomePresenter` restated hashes — already trimmed in #7410.

## Test Results

- `ruby -c app/controllers/links_controller.rb` — Syntax OK
- `bundle exec rubocop app/controllers/links_controller.rb` — no offenses
- `bundle exec rails test test/controllers/links_controller_test.rb --name "/PUT update sets is_licensed/"` — 3 runs, 6 assertions, 0 failures
- Branch CI `Tests` run 33188382041 — **success**, 0 pending, 0 failures

Premerge review: exempt (comments-only, no behaviour change)

---
AI: Grok 4.6. Prompt: scheduled slop-reducer cron — cut AI comments in already-merged gumroad code, no behaviour change.
