### PR TITLE
Return the product thumbnail in the mobile API, and allow a local HTTPS protocol

### DIFF
--- a/app/controllers/api/mobile/products_controller.rb
+++ b/app/controllers/api/mobile/products_controller.rb
@@ -53,7 +53,9 @@ class Api::Mobile::ProductsController < Api::Mobile::BaseController
         permalink: props["permalink"],
         price_formatted: props["price_formatted"],
         status: props["status"],
-        thumbnail_url: props.dig("thumbnail", "url"),
+        # `Thumbnail#as_json` returns symbol keys, unlike the string-keyed hash around it, so
+        # digging with "url" here silently returned nil for every product.
+        thumbnail_url: props["thumbnail"]&.dig(:url),
         can_edit: props["can_edit"],
         can_destroy: props["can_destroy"],
       }

--- a/config/domain.rb
+++ b/config/domain.rb
@@ -78,16 +78,17 @@ configuration_by_env = {
   }
 }
 
+# bin/vite requires this file before Rails boots, so ActiveSupport is not loaded here. Keep every
+# check below to plain Ruby: `present?` and `presence` raise NoMethodError in that path.
 custom_domain       = ENV["CUSTOM_DOMAIN"]
 custom_short_domain = ENV["CUSTOM_SHORT_DOMAIN"]
+custom_protocol     = ENV["CUSTOM_PROTOCOL"]
 environment         = ENV["RAILS_ENV"]&.to_sym || :development
 config              = configuration_by_env[environment]
 
-# CUSTOM_PROTOCOL pairs with CUSTOM_DOMAIN for local HTTPS work — running the mobile app against
-# a local backend, for example. Without it, CUSTOM_DOMAIN changes the host but development stays
-# on "http", so asset and redirect URLs point at http://app.localhost:3000 and every page the
-# mobile app embeds in an HTTPS WebView renders blank with no error on either side.
-PROTOCOL            = ENV["CUSTOM_PROTOCOL"] || config[:protocol]
+# CUSTOM_PROTOCOL pairs with CUSTOM_DOMAIN for local HTTPS. Without it the scheme stays "http", so
+# pages the mobile app embeds in an HTTPS WebView fail silently on their assets.
+PROTOCOL            = custom_protocol.to_s.empty? ? config[:protocol] : custom_protocol
 DOMAIN              = custom_domain || config[:domain]
 ASSET_DOMAIN        = ENV["ASSET_DOMAIN"] || config[:asset_domain]
 ROOT_DOMAIN         = custom_domain || config[:root_domain]
@@ -104,7 +105,7 @@ ANYCABLE_HOST           = config[:anycable_host]
 if custom_domain
   VALID_REQUEST_HOSTS << custom_domain
   VALID_API_REQUEST_HOSTS << "api.#{custom_domain}"
-  VALID_API_REQUEST_HOSTS << custom_domain if ENV["BRANCH_DEPLOYMENT"].present? # Allow CORS to preview app's root domain
+  VALID_API_REQUEST_HOSTS << custom_domain unless ENV["BRANCH_DEPLOYMENT"].to_s.empty? # Allow CORS to preview app's root domain
   VALID_CORS_ORIGINS << custom_domain
   DISCOVER_DOMAIN = custom_domain
   VALID_DISCOVER_REQUEST_HOST = custom_domain

--- a/config/domain.rb
+++ b/config/domain.rb
@@ -82,13 +82,14 @@ configuration_by_env = {
 # check below to plain Ruby: `present?` and `presence` raise NoMethodError in that path.
 custom_domain       = ENV["CUSTOM_DOMAIN"]
 custom_short_domain = ENV["CUSTOM_SHORT_DOMAIN"]
-custom_protocol     = ENV["CUSTOM_PROTOCOL"]
+custom_protocol     = ENV["CUSTOM_PROTOCOL"].to_s.strip
 environment         = ENV["RAILS_ENV"]&.to_sym || :development
 config              = configuration_by_env[environment]
 
 # CUSTOM_PROTOCOL pairs with CUSTOM_DOMAIN for local HTTPS. Without it the scheme stays "http", so
-# pages the mobile app embeds in an HTTPS WebView fail silently on their assets.
-PROTOCOL            = custom_protocol.to_s.empty? ? config[:protocol] : custom_protocol
+# pages the mobile app embeds in an HTTPS WebView fail silently on their assets. Blank or
+# whitespace-only falls back: an empty scheme yields URLs like "://gumroad.com".
+PROTOCOL            = custom_protocol.empty? ? config[:protocol] : custom_protocol
 DOMAIN              = custom_domain || config[:domain]
 ASSET_DOMAIN        = ENV["ASSET_DOMAIN"] || config[:asset_domain]
 ROOT_DOMAIN         = custom_domain || config[:root_domain]

--- a/config/domain.rb
+++ b/config/domain.rb
@@ -83,7 +83,11 @@ custom_short_domain = ENV["CUSTOM_SHORT_DOMAIN"]
 environment         = ENV["RAILS_ENV"]&.to_sym || :development
 config              = configuration_by_env[environment]
 
-PROTOCOL            = config[:protocol]
+# CUSTOM_PROTOCOL pairs with CUSTOM_DOMAIN for local HTTPS work — running the mobile app against
+# a local backend, for example. Without it, CUSTOM_DOMAIN changes the host but development stays
+# on "http", so asset and redirect URLs point at http://app.localhost:3000 and every page the
+# mobile app embeds in an HTTPS WebView renders blank with no error on either side.
+PROTOCOL            = ENV["CUSTOM_PROTOCOL"] || config[:protocol]
 DOMAIN              = custom_domain || config[:domain]
 ASSET_DOMAIN        = ENV["ASSET_DOMAIN"] || config[:asset_domain]
 ROOT_DOMAIN         = custom_domain || config[:root_domain]

--- a/spec/config/domain_spec.rb
+++ b/spec/config/domain_spec.rb
@@ -60,4 +60,57 @@ RSpec.describe "config/domain.rb" do
       "MAILER_HOST" => "localhost:3001"
     )
   end
+
+  describe "PROTOCOL" do
+    # bin/vite requires config/domain.rb before Rails boots, so these load it the same way:
+    # bundler plus vite_ruby and nothing else. A `bin/rails runner` would pull in ActiveSupport
+    # and hide the constraint the examples below exist to protect.
+    PRE_RAILS_CMD = <<~'RUBY'
+      require "bundler/setup"
+      require "vite_ruby"
+      require File.expand_path("config/domain")
+      puts "PROTOCOL=#{PROTOCOL}"
+    RUBY
+
+    def pre_rails_protocol(env = {})
+      stdout, stderr, status = Open3.capture3(
+        env, "ruby", "-e", PRE_RAILS_CMD, chdir: Rails.root.to_s
+      )
+      [stdout[/^PROTOCOL=(.*)$/, 1], stderr, status]
+    end
+
+    it "falls back to the environment default when CUSTOM_PROTOCOL is unset" do
+      protocol, stderr, status = pre_rails_protocol("CUSTOM_PROTOCOL" => nil)
+
+      expect(status).to be_success, stderr
+      expect(protocol).to eq("http")
+    end
+
+    it "falls back to the environment default when CUSTOM_PROTOCOL is blank" do
+      # An empty string is truthy in Ruby, so a plain `||` would assign "" here and every
+      # absolute URL would come out as "://gumroad.dev".
+      protocol, stderr, status = pre_rails_protocol("CUSTOM_PROTOCOL" => "")
+
+      expect(status).to be_success, stderr
+      expect(protocol).to eq("http")
+    end
+
+    it "uses CUSTOM_PROTOCOL when it is set, so a local backend can serve the app over HTTPS" do
+      protocol, stderr, status = pre_rails_protocol("CUSTOM_PROTOCOL" => "https")
+
+      expect(status).to be_success, stderr
+      expect(protocol).to eq("https")
+    end
+
+    it "loads before Rails even with CUSTOM_DOMAIN set, without ActiveSupport predicates" do
+      # `present?`/`presence` raise NoMethodError in this path. CUSTOM_DOMAIN is what reaches the
+      # branch that used to call one, and it is exactly the setup CUSTOM_PROTOCOL pairs with.
+      protocol, stderr, status = pre_rails_protocol(
+        "CUSTOM_DOMAIN" => "gumroad.dev", "CUSTOM_PROTOCOL" => "https"
+      )
+
+      expect(status).to be_success, stderr
+      expect(protocol).to eq("https")
+    end
+  end
 end

--- a/spec/config/domain_spec.rb
+++ b/spec/config/domain_spec.rb
@@ -95,6 +95,20 @@ RSpec.describe "config/domain.rb" do
       expect(protocol).to eq("http")
     end
 
+    it "falls back to the environment default when CUSTOM_PROTOCOL is only whitespace" do
+      protocol, stderr, status = pre_rails_protocol("CUSTOM_PROTOCOL" => "  ")
+
+      expect(status).to be_success, stderr
+      expect(protocol).to eq("http")
+    end
+
+    it "ignores surrounding whitespace in CUSTOM_PROTOCOL" do
+      protocol, stderr, status = pre_rails_protocol("CUSTOM_PROTOCOL" => " https ")
+
+      expect(status).to be_success, stderr
+      expect(protocol).to eq("https")
+    end
+
     it "uses CUSTOM_PROTOCOL when it is set, so a local backend can serve the app over HTTPS" do
       protocol, stderr, status = pre_rails_protocol("CUSTOM_PROTOCOL" => "https")
 

--- a/spec/controllers/api/mobile/products_controller_spec.rb
+++ b/spec/controllers/api/mobile/products_controller_spec.rb
@@ -37,6 +37,23 @@ describe Api::Mobile::ProductsController do
       expect(body["pagination"]).to eq("count" => 2, "page" => 1, "pages" => 1, "next" => nil)
     end
 
+    it "returns the thumbnail url when the product has a thumbnail" do
+      product = create(:product, user: @seller, name: "Brush pack")
+      thumbnail = create(:thumbnail, product:)
+
+      get :index, params: @params
+
+      expect(response.parsed_body["products"].first["thumbnail_url"]).to eq(thumbnail.url)
+    end
+
+    it "returns a nil thumbnail url when the product has no thumbnail" do
+      create(:product, user: @seller, name: "No cover")
+
+      get :index, params: @params
+
+      expect(response.parsed_body["products"].first["thumbnail_url"]).to be_nil
+    end
+
     it "filters products by name" do
       create(:product, user: @seller, name: "Photo pack")
       match = create(:product, user: @seller, name: "Writing guide")


### PR DESCRIPTION
## What

Two fixes, both found while capturing App Store screenshots for the mobile app ([antiwork/gumroad-mobile#358](https://github.com/antiwork/gumroad-mobile/pull/358)).

1. **Product thumbnails were missing from the mobile Products tab.** `thumbnail_url` came back `nil` for every product, so each row rendered a placeholder.
2. **Local WebViews rendered blank over HTTPS.** `PROTOCOL` had no override, so pointing the mobile app at a local backend broke every embedded page.

## Why

### The thumbnail was read with the wrong key type

`Api::Mobile::ProductsController#product_json` read `props.dig("thumbnail", "url")`. Every other key in that hash is a string, so this reads naturally — but `Thumbnail#as_json` returns **symbol** keys:

```ruby
def as_json(*)
  { url:,
    guid:
  }
end
```

The outer lookup succeeds, the inner one misses, and the result is always `nil`.

This is not environment-specific. The web dashboard reads the same hash, but only after Inertia serializes it to JSON, where symbol keys become strings — so only the mobile API, which dereferences it in Ruby, is affected.

No test caught it. The controller spec asserted `name`, `permalink`, `status`, `can_edit` and `can_destroy` but never `thumbnail_url`, and the product schema declares the field as `["string", "null"]`, so `nil` validated.

### PROTOCOL could not be overridden

`CUSTOM_DOMAIN` already exists to point a local backend at a registrable hostname, and the mobile app's dev config expects `https://gumroad.dev`. But `CUSTOM_DOMAIN` only changes the host — development stays on `http`, so Rails emits asset URLs like `http://app.localhost:3000/vite-dev/entrypoints/base.ts`.

Inside the app's HTTPS WebView those are unreachable. Every embedded page — sign-in, create product, settings — renders blank, with **no error in the app and none in the Rails log**. The page returns 200; only its assets fail.

This adds a `CUSTOM_PROTOCOL` override next to the existing `CUSTOM_DOMAIN` and `ASSET_DOMAIN` ones. Unset, `PROTOCOL` resolves exactly as before.

### A third bug, surfaced by review

Review suggested `ENV["CUSTOM_PROTOCOL"].presence`. That cannot be used here: `bin/vite` requires `config/domain.rb` before Rails boots, so ActiveSupport is not loaded and `presence` raises `NoMethodError`.

Line 108 already called `ENV["BRANCH_DEPLOYMENT"].present?`, which means `bin/vite` has been crashing whenever `CUSTOM_DOMAIN` is set — the exact configuration this override pairs with:

```
$ CUSTOM_DOMAIN=gumroad.dev ruby -e '... require_relative "config/domain"'
NoMethodError: undefined method 'present?' for nil
```

Both checks are now plain Ruby, with a comment recording the constraint so it is not reintroduced.

## Before / After

Not user-visible on the web. The mobile-side effect is in [antiwork/gumroad-mobile#358](https://github.com/antiwork/gumroad-mobile/pull/358): its frame 01 shows the Products tab with cover art, which required this fix — before it, every row showed a placeholder box.

## Test Results

- `bundle exec rspec spec/controllers/api/mobile/products_controller_spec.rb spec/config/domain_spec.rb` — 18 examples, 0 failures
- `bundle exec rubocop` on all changed files — no offenses
- Every new example was checked against its bug by reverting the fix and confirming the failure:
  - reverting the key type fails "returns the thumbnail url"
  - reverting the blank guard fails the blank-`CUSTOM_PROTOCOL` example
  - restoring `present?` fails the pre-Rails example with `NoMethodError`
  - reverting `strip` fails the whitespace example

New coverage in `spec/config/domain_spec.rb` loads the file the way `bin/vite` does — bundler and vite_ruby, nothing else — because a `bin/rails runner` boots Rails and would hide the ActiveSupport constraint.

These assert the resolved constant, not the URLs built from it. Confirming a WebView loads assets over HTTPS end to end needs a running backend, so that stays manual.

## QA steps

1. `bundle exec rspec spec/controllers/api/mobile/products_controller_spec.rb spec/config/domain_spec.rb`
2. Unset `CUSTOM_PROTOCOL` and confirm development still resolves `http`
3. For the WebView fix end to end: run this backend with `CUSTOM_DOMAIN=gumroad.dev CUSTOM_PROTOCOL=https ASSET_DOMAIN=gumroad.dev`, front it with an HTTPS proxy on 443, then open Products → New in the mobile app. The create-product page renders instead of coming up blank.

## Note on CI

`Compute relevant specs` escalates here: `bin/branch-specs` cannot attribute specs to `config/domain.rb`, so it asks for the full suite. The `run-all-specs` label is applied for that reason.

I tried mapping `config/domain.rb` into `CONFIG_SPEC_MAP` to avoid the label, then reverted it. That mapping would drop the full-suite guard for every future change to the file, and its constants fan out widely — `PROTOCOL` alone is referenced in 37 files — while `domain_spec.rb` exercises no consumer specs (CSP, CORS, WebAuthn origins, URL generation). Escalating is correct here; the label is the intended mechanism.

---

🤖 Written with **Claude Fable 5** (Claude Code).

The model investigated both bugs, wrote the fixes and specs, and verified each new example fails without its fix. Two of the three bugs were found by it while setting up a local backend to capture App Store screenshots; the whitespace and blank-value guards came from Greptile review feedback, which it evaluated before accepting. Its proposed `.presence` fix was rejected after testing showed it breaks `bin/vite`, and a self-inflicted change that would have weakened CI coverage was caught in review and reverted. All test results above were produced by real runs, not asserted.
