### PR TITLE
Stop caching DynamoDB email engagement aggregates

### DIFF
--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -757,10 +757,11 @@ class Installment < ApplicationRecord
   end
 
   def unique_open_count
-    Rails.cache.fetch(key_for_cache(:unique_open_count)) do
-      if EmailEngagementDynamoStore.reads_enabled?
-        dynamo_engagement_summary[:open_count]
-      else
+    if EmailEngagementDynamoStore.reads_enabled?
+      # DDB GetItem is cheap; caching it pins a first-read zero while opens still stream in.
+      dynamo_engagement_summary[:open_count]
+    else
+      Rails.cache.fetch(key_for_cache(:unique_open_count)) do
         CreatorEmailOpenEvent.where(installment_id: id).count
       end
     end
@@ -857,10 +858,10 @@ class Installment < ApplicationRecord
   end
 
   def unique_click_count
-    Rails.cache.fetch(key_for_cache(:unique_click_count)) do
-      if EmailEngagementDynamoStore.reads_enabled?
-        dynamo_engagement_summary[:click_pair_count]
-      else
+    if EmailEngagementDynamoStore.reads_enabled?
+      dynamo_engagement_summary[:click_pair_count]
+    else
+      Rails.cache.fetch(key_for_cache(:unique_click_count)) do
         summary = CreatorEmailClickSummary.where(installment_id: id).last
         summary.present? ? summary[:total_unique_clicks] : 0
       end

--- a/app/presenters/api/workflow_presenter.rb
+++ b/app/presenters/api/workflow_presenter.rb
@@ -121,7 +121,9 @@ class Api::WorkflowPresenter
       missing_ids = []
 
       keys_by_id.each do |id, keys|
-        if cached_counts.key?(keys.fetch(:event))
+        # The installment event key has no TTL. Under DynamoDB reads it can be a
+        # stale zero from the first dashboard hit; skip it and use the 5s API cache.
+        if !EmailEngagementDynamoStore.reads_enabled? && cached_counts.key?(keys.fetch(:event))
           counts[id] = cached_counts.fetch(keys.fetch(:event)).to_i
         elsif cached_counts.key?(keys.fetch(:api))
           counts[id] = cached_counts.fetch(keys.fetch(:api)).to_i

--- a/spec/controllers/api/v2/workflows_controller_spec.rb
+++ b/spec/controllers/api/v2/workflows_controller_spec.rb
@@ -159,8 +159,8 @@ describe Api::V2::WorkflowsController do
         "send_emails" => true,
         "delay" => { "amount" => 2, "unit" => InstallmentRule::DAY },
         "sent_count" => 10,
-        "open_count" => 5,
-        "open_rate" => 50.0,
+        "open_count" => 4,
+        "open_rate" => 40.0,
         "click_count" => 2,
         "click_rate" => 20.0,
       )

--- a/spec/models/installment/installment_tracking_spec.rb
+++ b/spec/models/installment/installment_tracking_spec.rb
@@ -66,19 +66,15 @@ describe "InstallmentTracking"  do
       expect(@installment.unique_click_count).to eq 2
     end
 
-    it "does not hit DynamoDB once the cache is set" do
+    it "does not keep a stale cached zero after later DynamoDB writes" do
+      Rails.cache.write(@installment.key_for_cache(:unique_click_count), 0)
+
       record_click(@installment, recipient: "[1, 1]", url: "https://www&#46;gumroad&#46;com")
       record_click(@installment, recipient: "[1, 1]", url: "https://www&#46;google&#46;com")
       record_click(@installment, recipient: "[2, 2]", url: "https://www&#46;gumroad&#46;com")
       record_click(@installment, recipient: "[3, 3]", url: "https://www&#46;google&#46;com")
 
-      # Read once and set the cache
-      @installment.unique_click_count
-
-      expect(EmailEngagementDynamoStore).not_to receive(:summary)
-      unique_click_count = Installment.find(@installment.id).unique_click_count
-
-      expect(unique_click_count).to eq 4
+      expect(Installment.find(@installment.id).unique_click_count).to eq 4
     end
   end
 
@@ -87,20 +83,16 @@ describe "InstallmentTracking"  do
       @installment = create(:installment, customer_count: 4)
     end
 
-    it "does not hit DynamoDB once the cache is set" do
+    it "does not keep a stale cached zero after later DynamoDB writes" do
+      Rails.cache.write(@installment.key_for_cache(:unique_open_count), 0)
+
       3.times do |i|
         EmailEngagementDynamoStore.record_open(
           installment_id: @installment.id, mailer_method:, mailer_args: "[#{i}, #{i}]"
         )
       end
 
-      # Read once and set the cache
-      @installment.unique_open_count
-
-      expect(EmailEngagementDynamoStore).not_to receive(:summary)
-      unique_open_count = Installment.find(@installment.id).unique_open_count
-
-      expect(unique_open_count).to eq 3
+      expect(Installment.find(@installment.id).unique_open_count).to eq 3
     end
   end
 end

--- a/spec/services/handle_email_event_info/for_abandoned_cart_email_spec.rb
+++ b/spec/services/handle_email_event_info/for_abandoned_cart_email_spec.rb
@@ -47,12 +47,12 @@ describe HandleEmailEventInfo::ForAbandonedCartEmail do
         end
       end
 
-      it "sets cache for open event" do
+      it "reads live unique open counts after an open event" do
         handler_class_for(email_provider).new.perform(params)
 
-        expect(Rails.cache.read("unique_open_count_for_installment_#{abandoned_cart_workflow_installment1.id}_ddb")).to eq(1)
-        expect(Rails.cache.read("unique_open_count_for_installment_#{abandoned_cart_workflow_installment2.id}_ddb")).to be_nil
-        expect(Rails.cache.read("unique_open_count_for_installment_#{abandoned_cart_workflow_installment3.id}_ddb")).to eq(1)
+        expect(Installment.find(abandoned_cart_workflow_installment1.id).unique_open_count).to eq(1)
+        expect(Installment.find(abandoned_cart_workflow_installment2.id).unique_open_count).to eq(0)
+        expect(Installment.find(abandoned_cart_workflow_installment3.id).unique_open_count).to eq(1)
       end
 
       it "tracks an open event and update it if there are 2 identical open events" do
@@ -104,18 +104,18 @@ describe HandleEmailEventInfo::ForAbandonedCartEmail do
         end
       end
 
-      it "sets cache on click event" do
+      it "reads live unique click and open counts after a click event" do
         handler_class_for(email_provider).new.perform(params1)
 
         [abandoned_cart_workflow_installment1.id, abandoned_cart_workflow_installment3.id].each do |installment_id|
-          expect(Rails.cache.read("unique_click_count_for_installment_#{installment_id}_ddb")).to eq(1)
-
-          # It should also cache unique_open_count
-          expect(Rails.cache.read("unique_open_count_for_installment_#{installment_id}_ddb")).to eq(1)
+          installment = Installment.find(installment_id)
+          expect(installment.unique_click_count).to eq(1)
+          expect(installment.unique_open_count).to eq(1)
         end
 
-        expect(Rails.cache.read("unique_click_count_for_installment_#{abandoned_cart_workflow_installment2.id}_ddb")).to be_nil
-        expect(Rails.cache.read("unique_open_count_for_installment_#{abandoned_cart_workflow_installment2.id}_ddb")).to be_nil
+        skipped = Installment.find(abandoned_cart_workflow_installment2.id)
+        expect(skipped.unique_click_count).to eq(0)
+        expect(skipped.unique_open_count).to eq(0)
       end
 
       it "tracks multiple click events and only one email click summary record for different URLs for an installment" do

--- a/spec/services/handle_email_event_info/for_installment_email_spec.rb
+++ b/spec/services/handle_email_event_info/for_installment_email_spec.rb
@@ -26,14 +26,13 @@ describe HandleEmailEventInfo::ForInstallmentEmail do
       expect(open_event.open_count).to eq 1
     end
 
-    it "sets cache for open event" do
+    it "reads live unique open counts after an open event" do
       params = { "_json" => [{ "event" => "open", "type" => "CreatorContactingCustomersMailer.purchase_installment",
                                "identifier" => @identifier, "installment_id" => @installment.id }] }
 
       HandleSendgridEventJob.new.perform(params)
 
-      unique_open_count = Rails.cache.read("unique_open_count_for_installment_#{@installment.id}_ddb")
-      expect(unique_open_count).to eq 1
+      expect(Installment.find(@installment.id).unique_open_count).to eq 1
     end
 
     it "creates a new CreatorEmailOpenEvent object and then update it if there are 2 identical open events" do
@@ -84,18 +83,15 @@ describe HandleEmailEventInfo::ForInstallmentEmail do
       expect(click_event.click_count).to eq 1
     end
 
-    it "sets cache on click event" do
+    it "reads live unique click and open counts after a click event" do
       params = { "_json" => [{ "event" => "click", "type" => "CreatorContactingCustomersMailer.purchase_installment",
                                "identifier" => @identifier, "installment_id" => @installment.id, "url" => "https://www&#46;gumroad&#46;com" }] }
 
       HandleSendgridEventJob.new.perform(params)
 
-      unique_click_count = Rails.cache.read("unique_click_count_for_installment_#{@installment.id}_ddb")
-      expect(unique_click_count).to eq 1
-
-      # It should also cache unique_open_count
-      unique_open_count = Rails.cache.read("unique_open_count_for_installment_#{@installment.id}_ddb")
-      expect(unique_open_count).to eq 1
+      installment = Installment.find(@installment.id)
+      expect(installment.unique_click_count).to eq 1
+      expect(installment.unique_open_count).to eq 1
     end
 
     it "creates 1 new CreatorEmailClickSummary and 2 CreatorEmailClickEvent objects for different URLs, \

--- a/test/models/installment_test.rb
+++ b/test/models/installment_test.rb
@@ -780,7 +780,7 @@ const b = 2;</code></pre>
 
   # --- #invalidate_cache -----------------------------------------------------
 
-  test "invalidate_cache clears the cached value so the next read is fresh" do
+  test "unique_open_count reads live DynamoDB even if Rails.cache holds a stale zero" do
     installment = create_installment(customer_count: 4)
     record_open = lambda do |n|
       n.times do
@@ -793,10 +793,11 @@ const b = 2;</code></pre>
     end
     record_open.call(3)
 
-    assert_equal 3, installment.unique_open_count # reads and caches
+    assert_equal 3, installment.unique_open_count
 
     record_open.call(4)
-    assert_equal 3, installment.unique_open_count # still cached
+    Rails.cache.write(installment.key_for_cache(:unique_open_count), 0)
+    assert_equal 7, Installment.find(installment.id).unique_open_count
 
     installment.invalidate_cache(:unique_open_count)
     assert_equal 7, installment.unique_open_count


### PR DESCRIPTION
> Draft status: local specs and mutation proof green; premerge review still owed.

## What

Under DynamoDB engagement reads, `Installment#unique_open_count` and `#unique_click_count` no longer wrap `EmailEngagementDynamoStore.summary` in an infinite `Rails.cache.fetch`. The Emails list and workflow API now read the live SUMMARY item (request-memoized). Mongo reads still use the existing cache. The workflow presenter also ignores the no-TTL installment event key when DynamoDB reads are on, so a stale-zero there cannot override the 5-second API cache.

## Why

The Emails dashboard list showed 0% opened / 0 clicks on a freshly sent broadcast while the Clicked URLs modal (uncached `clicked_urls`) showed real activity. The first dashboard hit cached a genuine zero; later DynamoDB writes did not make that key catch up. Tracker: antiwork/gumroad-private#2333.

## Before / after

- Before: `Rails.cache.fetch` on the `_ddb` key pins the first read (often 0). `clicked_urls` stays live. List and modal disagree.
- After: list counters call `summary` every request. A poisoned `_ddb` cache key is ignored.

## Checklist

- [x] Scope — DDB-path aggregate reads only. Mongo cache path unchanged. No flag/verify! change.
- [x] Design — skip the infinite cache on DDB GetItem rather than TTL or write-side recache (recache after invalidate can rewrite 0 under eventual consistency).
- [x] Build — `gumclaw/fix-stale-ddb-engagement-counts` @ faa08eec1e23d34dab41b4060e7da24cd1f4d59d
- [x] QA — local specs + mutation proof at that SHA (see Test Results). Same markup; live numbers. No preview click-path.
- [ ] Shipped — draft until premerge
- [ ] Market — n/a, dashboard correctness
- [ ] Sell — n/a

## Test Results

At faa08eec1e23d34dab41b4060e7da24cd1f4d59d:

- `bundle exec rspec spec/models/installment/installment_tracking_spec.rb spec/controllers/api/v2/workflows_controller_spec.rb spec/services/handle_email_event_info/for_installment_email_spec.rb spec/services/handle_email_event_info/for_abandoned_cart_email_spec.rb spec/modules/post/caching_spec.rb` — 73 examples, 0 failures
- `bundle exec rails test test/models/installment_test.rb -n "/unique_open_count reads live DynamoDB/"` — 1 run, 3 assertions, 0 failures
- Mutation: re-wrap `unique_open_count` in `Rails.cache.fetch` — reddened `InstallmentTracking #unique_open_count does not keep a stale cached zero after later DynamoDB writes`

## QA steps

1. Read `Installment#unique_open_count` / `#unique_click_count`: DDB branch has no `Rails.cache.fetch`.
2. Confirm `Api::WorkflowPresenter` skips the event cache key when `EmailEngagementDynamoStore.reads_enabled?`.
3. After deploy, the Emails list open/click counts should match `EmailEngagementDynamoStore.summary` for a live broadcast, including ones whose `_ddb` cache key is still 0.

No rendered markup change.

---

AI disclosure: Grok 4.6. Prompt/instructions: GitHub issues webhook for antiwork/gumroad-private#2333; autonomous-product-dev (draft PR early, no PII in public body, DDB GetItem instead of infinite cache).
