### PR TITLE
Stop caching DynamoDB email engagement aggregates

### DIFF
--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -757,10 +757,11 @@ class Installment < ApplicationRecord
   end
 
   def unique_open_count
-    Rails.cache.fetch(key_for_cache(:unique_open_count)) do
-      if EmailEngagementDynamoStore.reads_enabled?
-        dynamo_engagement_summary[:open_count]
-      else
+    if EmailEngagementDynamoStore.reads_enabled?
+      # DDB GetItem is cheap; caching it pins a first-read zero while opens still stream in.
+      dynamo_engagement_summary[:open_count]
+    else
+      Rails.cache.fetch(key_for_cache(:unique_open_count)) do
         CreatorEmailOpenEvent.where(installment_id: id).count
       end
     end
@@ -857,10 +858,10 @@ class Installment < ApplicationRecord
   end
 
   def unique_click_count
-    Rails.cache.fetch(key_for_cache(:unique_click_count)) do
-      if EmailEngagementDynamoStore.reads_enabled?
-        dynamo_engagement_summary[:click_pair_count]
-      else
+    if EmailEngagementDynamoStore.reads_enabled?
+      dynamo_engagement_summary[:click_pair_count]
+    else
+      Rails.cache.fetch(key_for_cache(:unique_click_count)) do
         summary = CreatorEmailClickSummary.where(installment_id: id).last
         summary.present? ? summary[:total_unique_clicks] : 0
       end

--- a/app/modules/post/caching.rb
+++ b/app/modules/post/caching.rb
@@ -4,12 +4,16 @@ module Post::Caching
   # The _ddb namespace keeps legacy cached counters from surviving the read
   # flip (Memcached cannot bulk-delete): flipping email_engagement_dynamodb_reads
   # moves every fetch and every invalidation to fresh keys together.
-  def key_for_cache(key)
-    "#{key}_for_installment_#{id}#{EmailEngagementDynamoStore.reads_enabled? ? "_ddb" : ""}"
+  def key_for_cache(key, dynamodb_reads: EmailEngagementDynamoStore.reads_enabled?)
+    "#{key}_for_installment_#{id}#{dynamodb_reads ? "_ddb" : ""}"
   end
 
   def invalidate_cache(key)
     @dynamo_engagement_summary = nil
     Rails.cache.delete(key_for_cache(key))
+  end
+
+  def invalidate_legacy_engagement_cache(key)
+    Rails.cache.delete(key_for_cache(key, dynamodb_reads: false))
   end
 end

--- a/app/presenters/api/workflow_presenter.rb
+++ b/app/presenters/api/workflow_presenter.rb
@@ -121,7 +121,9 @@ class Api::WorkflowPresenter
       missing_ids = []
 
       keys_by_id.each do |id, keys|
-        if cached_counts.key?(keys.fetch(:event))
+        # The installment event key has no TTL. Under DynamoDB reads it can be a
+        # stale zero from the first dashboard hit; skip it and use the 5s API cache.
+        if !EmailEngagementDynamoStore.reads_enabled? && cached_counts.key?(keys.fetch(:event))
           counts[id] = cached_counts.fetch(keys.fetch(:event)).to_i
         elsif cached_counts.key?(keys.fetch(:api))
           counts[id] = cached_counts.fetch(keys.fetch(:api)).to_i

--- a/app/services/handle_email_event_info/for_abandoned_cart_email.rb
+++ b/app/services/handle_email_event_info/for_abandoned_cart_email.rb
@@ -100,7 +100,11 @@ class HandleEmailEventInfo::ForAbandonedCartEmail
     end
 
     def update_installment_cache(installment, key)
-      return if EmailEngagementDynamoStore.reads_enabled?
+      if EmailEngagementDynamoStore.reads_enabled?
+        installment.invalidate_cache(key)
+        installment.invalidate_legacy_engagement_cache(key)
+        return
+      end
 
       # Clear cache and precompute the result
       installment.invalidate_cache(key)

--- a/app/services/handle_email_event_info/for_abandoned_cart_email.rb
+++ b/app/services/handle_email_event_info/for_abandoned_cart_email.rb
@@ -100,6 +100,8 @@ class HandleEmailEventInfo::ForAbandonedCartEmail
     end
 
     def update_installment_cache(installment, key)
+      return if EmailEngagementDynamoStore.reads_enabled?
+
       # Clear cache and precompute the result
       installment.invalidate_cache(key)
       installment.send(key)

--- a/app/services/handle_email_event_info/for_installment_email.rb
+++ b/app/services/handle_email_event_info/for_installment_email.rb
@@ -173,11 +173,15 @@ class HandleEmailEventInfo::ForInstallmentEmail
     end
 
     def update_installment_cache(installment_id, key)
-      # DDB aggregates are a live GetItem; precomputing them here only burns a
-      # read on a discarded Installment and cannot warm the dashboard.
-      return if EmailEngagementDynamoStore.reads_enabled?
-
       installment = Installment.find(installment_id)
+
+      if EmailEngagementDynamoStore.reads_enabled?
+        # DDB aggregates are live GetItem reads. Clear stale cache entries for
+        # this event, but do not precompute counters from the discarded instance.
+        installment.invalidate_cache(key)
+        installment.invalidate_legacy_engagement_cache(key)
+        return
+      end
 
       # Clear cache and precompute the result
       installment.invalidate_cache(key)

--- a/app/services/handle_email_event_info/for_installment_email.rb
+++ b/app/services/handle_email_event_info/for_installment_email.rb
@@ -173,6 +173,10 @@ class HandleEmailEventInfo::ForInstallmentEmail
     end
 
     def update_installment_cache(installment_id, key)
+      # DDB aggregates are a live GetItem; precomputing them here only burns a
+      # read on a discarded Installment and cannot warm the dashboard.
+      return if EmailEngagementDynamoStore.reads_enabled?
+
       installment = Installment.find(installment_id)
 
       # Clear cache and precompute the result

--- a/spec/controllers/api/v2/workflows_controller_spec.rb
+++ b/spec/controllers/api/v2/workflows_controller_spec.rb
@@ -159,8 +159,8 @@ describe Api::V2::WorkflowsController do
         "send_emails" => true,
         "delay" => { "amount" => 2, "unit" => InstallmentRule::DAY },
         "sent_count" => 10,
-        "open_count" => 5,
-        "open_rate" => 50.0,
+        "open_count" => 4,
+        "open_rate" => 40.0,
         "click_count" => 2,
         "click_rate" => 20.0,
       )

--- a/spec/models/installment/installment_tracking_spec.rb
+++ b/spec/models/installment/installment_tracking_spec.rb
@@ -66,19 +66,15 @@ describe "InstallmentTracking"  do
       expect(@installment.unique_click_count).to eq 2
     end
 
-    it "does not hit DynamoDB once the cache is set" do
+    it "does not keep a stale cached zero after later DynamoDB writes" do
+      Rails.cache.write(@installment.key_for_cache(:unique_click_count), 0)
+
       record_click(@installment, recipient: "[1, 1]", url: "https://www&#46;gumroad&#46;com")
       record_click(@installment, recipient: "[1, 1]", url: "https://www&#46;google&#46;com")
       record_click(@installment, recipient: "[2, 2]", url: "https://www&#46;gumroad&#46;com")
       record_click(@installment, recipient: "[3, 3]", url: "https://www&#46;google&#46;com")
 
-      # Read once and set the cache
-      @installment.unique_click_count
-
-      expect(EmailEngagementDynamoStore).not_to receive(:summary)
-      unique_click_count = Installment.find(@installment.id).unique_click_count
-
-      expect(unique_click_count).to eq 4
+      expect(Installment.find(@installment.id).unique_click_count).to eq 4
     end
   end
 
@@ -87,20 +83,16 @@ describe "InstallmentTracking"  do
       @installment = create(:installment, customer_count: 4)
     end
 
-    it "does not hit DynamoDB once the cache is set" do
+    it "does not keep a stale cached zero after later DynamoDB writes" do
+      Rails.cache.write(@installment.key_for_cache(:unique_open_count), 0)
+
       3.times do |i|
         EmailEngagementDynamoStore.record_open(
           installment_id: @installment.id, mailer_method:, mailer_args: "[#{i}, #{i}]"
         )
       end
 
-      # Read once and set the cache
-      @installment.unique_open_count
-
-      expect(EmailEngagementDynamoStore).not_to receive(:summary)
-      unique_open_count = Installment.find(@installment.id).unique_open_count
-
-      expect(unique_open_count).to eq 3
+      expect(Installment.find(@installment.id).unique_open_count).to eq 3
     end
   end
 end

--- a/spec/modules/post/caching_spec.rb
+++ b/spec/modules/post/caching_spec.rb
@@ -11,6 +11,7 @@ describe Post::Caching do
 
       Feature.activate(:email_engagement_dynamodb_reads)
       expect(installment.key_for_cache(:unique_open_count)).to eq("unique_open_count_for_installment_#{installment.id}_ddb")
+      expect(installment.key_for_cache(:unique_open_count, dynamodb_reads: false)).to eq("unique_open_count_for_installment_#{installment.id}")
     ensure
       Feature.deactivate(:email_engagement_dynamodb_reads)
     end
@@ -21,6 +22,14 @@ describe Post::Caching do
       expect(Rails.cache).to receive(:delete).with("unique_click_count_for_installment_#{installment.id}_ddb")
 
       installment.invalidate_cache(:unique_click_count)
+    end
+  end
+
+  describe "#invalidate_legacy_engagement_cache" do
+    it "deletes the unsuffixed key even while DynamoDB reads are enabled" do
+      expect(Rails.cache).to receive(:delete).with("unique_click_count_for_installment_#{installment.id}")
+
+      installment.invalidate_legacy_engagement_cache(:unique_click_count)
     end
   end
 end

--- a/spec/services/handle_email_event_info/for_abandoned_cart_email_spec.rb
+++ b/spec/services/handle_email_event_info/for_abandoned_cart_email_spec.rb
@@ -48,11 +48,18 @@ describe HandleEmailEventInfo::ForAbandonedCartEmail do
       end
 
       it "reads live unique open counts after an open event" do
+        [abandoned_cart_workflow_installment1, abandoned_cart_workflow_installment3].each do |installment|
+          Rails.cache.write(installment.key_for_cache(:unique_open_count, dynamodb_reads: false), 0)
+        end
+
         handler_class_for(email_provider).new.perform(params)
 
         expect(Installment.find(abandoned_cart_workflow_installment1.id).unique_open_count).to eq(1)
         expect(Installment.find(abandoned_cart_workflow_installment2.id).unique_open_count).to eq(0)
         expect(Installment.find(abandoned_cart_workflow_installment3.id).unique_open_count).to eq(1)
+        [abandoned_cart_workflow_installment1, abandoned_cart_workflow_installment3].each do |installment|
+          expect(Rails.cache.read(installment.key_for_cache(:unique_open_count, dynamodb_reads: false))).to be_nil
+        end
       end
 
       it "tracks an open event and update it if there are 2 identical open events" do
@@ -105,12 +112,19 @@ describe HandleEmailEventInfo::ForAbandonedCartEmail do
       end
 
       it "reads live unique click and open counts after a click event" do
+        [abandoned_cart_workflow_installment1, abandoned_cart_workflow_installment3].each do |installment|
+          Rails.cache.write(installment.key_for_cache(:unique_click_count, dynamodb_reads: false), 0)
+          Rails.cache.write(installment.key_for_cache(:unique_open_count, dynamodb_reads: false), 0)
+        end
+
         handler_class_for(email_provider).new.perform(params1)
 
         [abandoned_cart_workflow_installment1.id, abandoned_cart_workflow_installment3.id].each do |installment_id|
           installment = Installment.find(installment_id)
           expect(installment.unique_click_count).to eq(1)
           expect(installment.unique_open_count).to eq(1)
+          expect(Rails.cache.read(installment.key_for_cache(:unique_click_count, dynamodb_reads: false))).to be_nil
+          expect(Rails.cache.read(installment.key_for_cache(:unique_open_count, dynamodb_reads: false))).to be_nil
         end
 
         skipped = Installment.find(abandoned_cart_workflow_installment2.id)

--- a/spec/services/handle_email_event_info/for_abandoned_cart_email_spec.rb
+++ b/spec/services/handle_email_event_info/for_abandoned_cart_email_spec.rb
@@ -47,12 +47,12 @@ describe HandleEmailEventInfo::ForAbandonedCartEmail do
         end
       end
 
-      it "sets cache for open event" do
+      it "reads live unique open counts after an open event" do
         handler_class_for(email_provider).new.perform(params)
 
-        expect(Rails.cache.read("unique_open_count_for_installment_#{abandoned_cart_workflow_installment1.id}_ddb")).to eq(1)
-        expect(Rails.cache.read("unique_open_count_for_installment_#{abandoned_cart_workflow_installment2.id}_ddb")).to be_nil
-        expect(Rails.cache.read("unique_open_count_for_installment_#{abandoned_cart_workflow_installment3.id}_ddb")).to eq(1)
+        expect(Installment.find(abandoned_cart_workflow_installment1.id).unique_open_count).to eq(1)
+        expect(Installment.find(abandoned_cart_workflow_installment2.id).unique_open_count).to eq(0)
+        expect(Installment.find(abandoned_cart_workflow_installment3.id).unique_open_count).to eq(1)
       end
 
       it "tracks an open event and update it if there are 2 identical open events" do
@@ -104,18 +104,18 @@ describe HandleEmailEventInfo::ForAbandonedCartEmail do
         end
       end
 
-      it "sets cache on click event" do
+      it "reads live unique click and open counts after a click event" do
         handler_class_for(email_provider).new.perform(params1)
 
         [abandoned_cart_workflow_installment1.id, abandoned_cart_workflow_installment3.id].each do |installment_id|
-          expect(Rails.cache.read("unique_click_count_for_installment_#{installment_id}_ddb")).to eq(1)
-
-          # It should also cache unique_open_count
-          expect(Rails.cache.read("unique_open_count_for_installment_#{installment_id}_ddb")).to eq(1)
+          installment = Installment.find(installment_id)
+          expect(installment.unique_click_count).to eq(1)
+          expect(installment.unique_open_count).to eq(1)
         end
 
-        expect(Rails.cache.read("unique_click_count_for_installment_#{abandoned_cart_workflow_installment2.id}_ddb")).to be_nil
-        expect(Rails.cache.read("unique_open_count_for_installment_#{abandoned_cart_workflow_installment2.id}_ddb")).to be_nil
+        skipped = Installment.find(abandoned_cart_workflow_installment2.id)
+        expect(skipped.unique_click_count).to eq(0)
+        expect(skipped.unique_open_count).to eq(0)
       end
 
       it "tracks multiple click events and only one email click summary record for different URLs for an installment" do

--- a/spec/services/handle_email_event_info/for_installment_email_spec.rb
+++ b/spec/services/handle_email_event_info/for_installment_email_spec.rb
@@ -37,12 +37,16 @@ describe HandleEmailEventInfo::ForInstallmentEmail do
 
     it "does not GetItem installment summaries while recording an open" do
       allow(EmailEngagementDynamoStore).to receive(:summary).and_call_original
+      Rails.cache.write(@installment.key_for_cache(:unique_open_count, dynamodb_reads: false), 0)
+      Rails.cache.write(@installment.key_for_cache(:unique_open_count), 0)
       params = { "_json" => [{ "event" => "open", "type" => "CreatorContactingCustomersMailer.purchase_installment",
                                "identifier" => @identifier, "installment_id" => @installment.id }] }
 
       HandleSendgridEventJob.new.perform(params)
 
       expect(EmailEngagementDynamoStore).not_to have_received(:summary)
+      expect(Rails.cache.read(@installment.key_for_cache(:unique_open_count, dynamodb_reads: false))).to be_nil
+      expect(Rails.cache.read(@installment.key_for_cache(:unique_open_count))).to be_nil
     end
 
     it "creates a new CreatorEmailOpenEvent object and then update it if there are 2 identical open events" do
@@ -96,12 +100,16 @@ describe HandleEmailEventInfo::ForInstallmentEmail do
     it "reads live unique click and open counts after a click event" do
       params = { "_json" => [{ "event" => "click", "type" => "CreatorContactingCustomersMailer.purchase_installment",
                                "identifier" => @identifier, "installment_id" => @installment.id, "url" => "https://www&#46;gumroad&#46;com" }] }
+      Rails.cache.write(@installment.key_for_cache(:unique_click_count, dynamodb_reads: false), 0)
+      Rails.cache.write(@installment.key_for_cache(:unique_open_count, dynamodb_reads: false), 0)
 
       HandleSendgridEventJob.new.perform(params)
 
       installment = Installment.find(@installment.id)
       expect(installment.unique_click_count).to eq 1
       expect(installment.unique_open_count).to eq 1
+      expect(Rails.cache.read(@installment.key_for_cache(:unique_click_count, dynamodb_reads: false))).to be_nil
+      expect(Rails.cache.read(@installment.key_for_cache(:unique_open_count, dynamodb_reads: false))).to be_nil
     end
 
     it "creates 1 new CreatorEmailClickSummary and 2 CreatorEmailClickEvent objects for different URLs, \

--- a/spec/services/handle_email_event_info/for_installment_email_spec.rb
+++ b/spec/services/handle_email_event_info/for_installment_email_spec.rb
@@ -26,14 +26,13 @@ describe HandleEmailEventInfo::ForInstallmentEmail do
       expect(open_event.open_count).to eq 1
     end
 
-    it "sets cache for open event" do
+    it "reads live unique open counts after an open event" do
       params = { "_json" => [{ "event" => "open", "type" => "CreatorContactingCustomersMailer.purchase_installment",
                                "identifier" => @identifier, "installment_id" => @installment.id }] }
 
       HandleSendgridEventJob.new.perform(params)
 
-      unique_open_count = Rails.cache.read("unique_open_count_for_installment_#{@installment.id}_ddb")
-      expect(unique_open_count).to eq 1
+      expect(Installment.find(@installment.id).unique_open_count).to eq 1
     end
 
     it "creates a new CreatorEmailOpenEvent object and then update it if there are 2 identical open events" do
@@ -84,18 +83,15 @@ describe HandleEmailEventInfo::ForInstallmentEmail do
       expect(click_event.click_count).to eq 1
     end
 
-    it "sets cache on click event" do
+    it "reads live unique click and open counts after a click event" do
       params = { "_json" => [{ "event" => "click", "type" => "CreatorContactingCustomersMailer.purchase_installment",
                                "identifier" => @identifier, "installment_id" => @installment.id, "url" => "https://www&#46;gumroad&#46;com" }] }
 
       HandleSendgridEventJob.new.perform(params)
 
-      unique_click_count = Rails.cache.read("unique_click_count_for_installment_#{@installment.id}_ddb")
-      expect(unique_click_count).to eq 1
-
-      # It should also cache unique_open_count
-      unique_open_count = Rails.cache.read("unique_open_count_for_installment_#{@installment.id}_ddb")
-      expect(unique_open_count).to eq 1
+      installment = Installment.find(@installment.id)
+      expect(installment.unique_click_count).to eq 1
+      expect(installment.unique_open_count).to eq 1
     end
 
     it "creates 1 new CreatorEmailClickSummary and 2 CreatorEmailClickEvent objects for different URLs, \

--- a/spec/services/handle_email_event_info/for_installment_email_spec.rb
+++ b/spec/services/handle_email_event_info/for_installment_email_spec.rb
@@ -35,6 +35,16 @@ describe HandleEmailEventInfo::ForInstallmentEmail do
       expect(Installment.find(@installment.id).unique_open_count).to eq 1
     end
 
+    it "does not GetItem installment summaries while recording an open" do
+      allow(EmailEngagementDynamoStore).to receive(:summary).and_call_original
+      params = { "_json" => [{ "event" => "open", "type" => "CreatorContactingCustomersMailer.purchase_installment",
+                               "identifier" => @identifier, "installment_id" => @installment.id }] }
+
+      HandleSendgridEventJob.new.perform(params)
+
+      expect(EmailEngagementDynamoStore).not_to have_received(:summary)
+    end
+
     it "creates a new CreatorEmailOpenEvent object and then update it if there are 2 identical open events" do
       now = Time.current
       params = { "_json" => [{ "event" => "open", "type" => "CreatorContactingCustomersMailer.purchase_installment",

--- a/test/models/installment_test.rb
+++ b/test/models/installment_test.rb
@@ -780,7 +780,7 @@ const b = 2;</code></pre>
 
   # --- #invalidate_cache -----------------------------------------------------
 
-  test "invalidate_cache clears the cached value so the next read is fresh" do
+  test "unique_open_count reads live DynamoDB even if Rails.cache holds a stale zero" do
     installment = create_installment(customer_count: 4)
     record_open = lambda do |n|
       n.times do
@@ -793,10 +793,11 @@ const b = 2;</code></pre>
     end
     record_open.call(3)
 
-    assert_equal 3, installment.unique_open_count # reads and caches
+    assert_equal 3, installment.unique_open_count
 
     record_open.call(4)
-    assert_equal 3, installment.unique_open_count # still cached
+    Rails.cache.write(installment.key_for_cache(:unique_open_count), 0)
+    assert_equal 7, Installment.find(installment.id).unique_open_count
 
     installment.invalidate_cache(:unique_open_count)
     assert_equal 7, installment.unique_open_count


### PR DESCRIPTION
Premerge review: clean @ f18bc8682bb4d6967656d8f967aab566809cb83d

## What

Under DynamoDB engagement reads, `Installment#unique_open_count` and `#unique_click_count` no longer wrap `EmailEngagementDynamoStore.summary` in an infinite `Rails.cache.fetch`. The Emails list and workflow API now read the live SUMMARY item (request-memoized). Mongo reads still use the existing cache.

Event handlers now keep rollback safe too: when DynamoDB reads are on, they clear the active `_ddb` cache key and the legacy unsuffixed key without precomputing counters from a discarded `Installment`. The workflow presenter also ignores the no-TTL installment event key when DynamoDB reads are on, so a stale-zero there cannot override the 5-second API cache.

## Why

The Emails dashboard list showed 0% opened / 0 clicks on a freshly sent broadcast while the Clicked URLs modal (uncached `clicked_urls`) showed real activity. The first dashboard hit cached a genuine zero; later DynamoDB writes did not make that key catch up. Tracker: antiwork/gumroad-private#2333.

Greptile also correctly flagged the rollback case: if events land while DynamoDB reads are on, then reads are disabled later, the unsuffixed Mongo-backed cache must not still hold the pre-event count.

## Before / after

- Before: `Rails.cache.fetch` on the `_ddb` key pins the first read (often 0). `clicked_urls` stays live. List and modal disagree.
- Before the review fix: DynamoDB-read event handling skipped precompute, but could leave the unsuffixed legacy cache stale for a later read-flag rollback.
- After: list counters call `summary` every request. A poisoned `_ddb` cache key is ignored, and event handlers clear both cache namespaces without issuing discarded summary reads.

## Checklist

- [x] Scope — DDB-path aggregate reads only. Mongo cache path unchanged when reads are off. No flag/verify! change.
- [x] Design — skip the infinite cache on DDB GetItem rather than TTL or write-side recache (recache after invalidate can rewrite 0 under eventual consistency); invalidate legacy cache keys on DDB events so rollback cannot resurrect stale counts.
- [x] Build — `gumclaw/fix-stale-ddb-engagement-counts` @ f18bc8682bb4d6967656d8f967aab566809cb83d
- [x] QA — local specs + mutation proof at that SHA (see Test Results). Same markup; live numbers. No preview click-path.
- [x] Ship — merged 2026-08-28T21:54:59Z as a75d2421d2dbdc1f2229307ca1b2f570cf708dbd after CI green and Sol premerge clean at f18bc8682bb4d6967656d8f967aab566809cb83d.
- [ ] Market — n/a, dashboard correctness
- [ ] Sell — n/a

## Test Results

At f18bc8682bb4d6967656d8f967aab566809cb83d:

- `ruby -c app/modules/post/caching.rb && ruby -c app/services/handle_email_event_info/for_installment_email.rb && ruby -c app/services/handle_email_event_info/for_abandoned_cart_email.rb && ruby -c spec/modules/post/caching_spec.rb && ruby -c spec/services/handle_email_event_info/for_installment_email_spec.rb && ruby -c spec/services/handle_email_event_info/for_abandoned_cart_email_spec.rb` — all Syntax OK
- `DISABLE_SPRING=1 bundle exec rspec spec/models/installment/installment_tracking_spec.rb spec/controllers/api/v2/workflows_controller_spec.rb spec/services/handle_email_event_info/for_installment_email_spec.rb spec/services/handle_email_event_info/for_abandoned_cart_email_spec.rb spec/modules/post/caching_spec.rb` — 75 examples, 0 failures
- Mutation: remove `invalidate_legacy_engagement_cache(key)` from both DynamoDB-read event-handler branches — reddened 6 focused examples covering installment, abandoned-cart, open, click, SendGrid, and Resend paths
- `gh pr checks 7424 --repo antiwork/gumroad --watch --interval 30` — CI green at f18bc8682bb4d6967656d8f967aab566809cb83d after rerunning a cancelled `Test Minitest 1` job; Build images, Lint JS/TS, Lint Ruby, Typecheck TS, Test Minitest 0/1, Test Relevant 0–3, Buildkite, and preview deploy passed
- Autoreview vs origin/main (engine codex, max-priority P1) — clean; no accepted/actionable P0/P1 findings

## QA steps

1. Read `Installment#unique_open_count` / `#unique_click_count`: DDB branch has no `Rails.cache.fetch`.
2. Confirm `HandleEmailEventInfo::ForInstallmentEmail` and `ForAbandonedCartEmail` clear both the active `_ddb` cache key and the unsuffixed legacy key when `EmailEngagementDynamoStore.reads_enabled?`, then return before counter precompute.
3. Confirm `Api::WorkflowPresenter` skips the event cache key when `EmailEngagementDynamoStore.reads_enabled?`.
4. After deploy, the Emails list open/click counts should match `EmailEngagementDynamoStore.summary` for a live broadcast, including ones whose `_ddb` cache key is still 0. If DynamoDB reads are rolled back after events arrive, Mongo-backed readers should miss the cleared legacy cache and recompute.

No rendered markup change.

---

AI disclosure: Grok 4.6. Prompt/instructions: GitHub pull_request_review webhook for antiwork/gumroad#7424; autonomous-product-dev (draft PR early, bot findings are claims to verify, no PII in public body, DDB GetItem instead of infinite cache).