### PR TITLE
Fix blank Apple Pay checkout for single-charge fixed-duration memberships

### DIFF
--- a/app/javascript/components/Checkout/applePayRecurringPaymentRequest.test.ts
+++ b/app/javascript/components/Checkout/applePayRecurringPaymentRequest.test.ts
@@ -112,21 +112,26 @@ describe("getApplePayRecurringPaymentRequest", () => {
     expect(request?.billingAgreement).toContain("for 4 payments");
   });
 
-  it("uses the singular 'payment' when the fixed duration fits in a single billing cycle", () => {
-    // A 12-month membership billed yearly makes exactly one payment (charged today), so the
-    // agreement text must not read "1 payments".
+  it("returns null for a single-charge fixed-duration membership so it is treated as a one-time purchase", () => {
+    // A 12-month membership billed yearly makes exactly one payment (charged today). Declaring a
+    // recurring payment request for it would hand Apple an auto-renewing agreement that never
+    // renews, and Stripe's `elements.create('payment')` rejects a `recurringPaymentEndDate` set to
+    // the current moment (a non-future date), which blank-screens the checkout. It falls back to a
+    // plain one-time request instead.
     const request = getApplePayRecurringPaymentRequest(
       [membership({ recurrence: "yearly", durationInMonths: 12 })],
       MANAGEMENT_URL,
     );
-    expect(request?.billingAgreement).toBe("$10 a year for 1 payment. Manage anytime from your Gumroad library.");
-    // The end date marks the final charge, and with one billing cycle the only charge is today's,
-    // so the agreement ends the same day it starts. This is display-only on the payment sheet.
-    const today = new Date();
+    expect(request).toBeNull();
+  });
+
+  it("still bounds a multi-cycle fixed-duration membership with an end date", () => {
+    // A 12-month membership billed monthly makes 12 payments; the first is charged today, so the
+    // agreement ends 11 months out.
+    const request = getApplePayRecurringPaymentRequest([membership({ durationInMonths: 12 })], MANAGEMENT_URL);
     const endDate = request?.regularBilling.recurringPaymentEndDate;
-    expect(endDate?.getFullYear()).toBe(today.getFullYear());
-    expect(endDate?.getMonth()).toBe(today.getMonth());
-    expect(endDate?.getDate()).toBe(today.getDate());
+    expect(endDate?.getTime()).toBeGreaterThan(new Date().getTime());
+    expect(request?.regularBilling.recurringPaymentIntervalCount).toBe(1);
   });
 
   it("leaves open-ended memberships without an end date", () => {

--- a/app/javascript/components/Checkout/applePayRecurringPaymentRequest.test.ts
+++ b/app/javascript/components/Checkout/applePayRecurringPaymentRequest.test.ts
@@ -113,16 +113,39 @@ describe("getApplePayRecurringPaymentRequest", () => {
   });
 
   it("returns null for a single-charge fixed-duration membership so it is treated as a one-time purchase", () => {
-    // A 12-month membership billed yearly makes exactly one payment (charged today). Declaring a
-    // recurring payment request for it would hand Apple an auto-renewing agreement that never
-    // renews, and Stripe's `elements.create('payment')` rejects a `recurringPaymentEndDate` set to
-    // the current moment (a non-future date), which blank-screens the checkout. It falls back to a
-    // plain one-time request instead.
     const request = getApplePayRecurringPaymentRequest(
       [membership({ recurrence: "yearly", durationInMonths: 12 })],
       MANAGEMENT_URL,
     );
     expect(request).toBeNull();
+  });
+
+  it("keeps a recurring request for a single-cycle free trial membership", () => {
+    const request = getApplePayRecurringPaymentRequest(
+      [
+        membership({
+          recurrence: "yearly",
+          durationInMonths: 12,
+          hasFreeTrial: true,
+          price: 0,
+          renewalPriceCents: 1_000,
+        }),
+      ],
+      MANAGEMENT_URL,
+    );
+    expect(request?.trialBilling).toEqual({ label: "Free trial", amount: 0 });
+    expect(request?.regularBilling.recurringPaymentEndDate).toBeUndefined();
+    expect(request?.billingAgreement).toBe("$10 a year for 1 payment. Manage anytime from your Gumroad library.");
+  });
+
+  it("keeps a recurring request for a subscription update with one fixed-duration charge remaining", () => {
+    const request = getApplePayRecurringPaymentRequest(
+      [membership({ subscription_id: "sub_123", durationInMonths: 1, price: 0, renewalPriceCents: 1_000 })],
+      MANAGEMENT_URL,
+    );
+    expect(request?.regularBilling.amount).toBe(1_000);
+    expect(request?.regularBilling.recurringPaymentEndDate).toBeUndefined();
+    expect(request?.billingAgreement).toBe("$10 a month for 1 payment. Manage anytime from your Gumroad library.");
   });
 
   it("still bounds a multi-cycle fixed-duration membership with an end date", () => {
@@ -209,6 +232,24 @@ describe("getApplePayRecurringPaymentRequest", () => {
     expect(request?.regularBilling.amount).toBe(2_500);
     expect(request?.paymentDescription).toBe("Product A (2 monthly installments)");
     expect(request?.billingAgreement).toBe("2 monthly installments of $25.");
+  });
+
+  it("omits the end date for an installment plan with one remaining charge", () => {
+    const request = getApplePayRecurringPaymentRequest(
+      [
+        product({
+          price: 0,
+          renewalPriceCents: 2_500,
+          payInInstallments: true,
+          installmentPlan: { numberOfInstallments: 4, remainingInstallments: 1 },
+        }),
+      ],
+      MANAGEMENT_URL,
+    );
+    expect(request?.regularBilling.amount).toBe(2_500);
+    expect(request?.regularBilling.recurringPaymentEndDate).toBeUndefined();
+    expect(request?.paymentDescription).toBe("Product A (1 monthly installment)");
+    expect(request?.billingAgreement).toBe("1 monthly installment of $25.");
   });
 
   it("returns null for an installment plan with no payments remaining", () => {

--- a/app/javascript/components/Checkout/applePayRecurringPaymentRequest.ts
+++ b/app/javascript/components/Checkout/applePayRecurringPaymentRequest.ts
@@ -82,14 +82,11 @@ const membershipRequest = (item: Product, managementURL: string): ApplePayRecurr
   // billing until the buyer cancels.
   const totalBillingCycles = item.durationInMonths != null ? Math.ceil(item.durationInMonths / months) : null;
 
-  // A fixed-duration membership whose duration fits in a single billing cycle (e.g. a 12-month
-  // membership billed yearly, or a 1-month membership billed monthly) charges the buyer exactly
-  // once. It is effectively a one-time purchase, so declaring a recurring payment request would
-  // be wrong: Apple would present an auto-renewing agreement that never renews, and Stripe's
-  // `elements.create('payment')` rejects a `recurringPaymentEndDate` set to the current moment
-  // (a non-future date), which this code previously produced as `addMonthsClamped(new Date(), 0)`.
-  // Fall back to a plain one-time request (a device token) instead.
-  if (totalBillingCycles !== null && totalBillingCycles <= 1) return null;
+  // Single-cycle purchases are one-time Apple Pay requests unless a later off-session charge
+  // still needs Apple's durable merchant token (free trials and subscription payment updates).
+  if (totalBillingCycles !== null && totalBillingCycles <= 1 && !item.hasFreeTrial && item.subscription_id == null) {
+    return null;
+  }
 
   let recurringPaymentEndDate: Date | undefined;
   if (totalBillingCycles != null && totalBillingCycles > 1) {
@@ -139,28 +136,21 @@ const installmentPlanRequest = (item: Product, managementURL: string): ApplePayR
   const remainingInstallments = item.installmentPlan?.remainingInstallments ?? numberOfInstallments;
   if (remainingInstallments < 1) return null;
   const baseInstallmentAmount = item.renewalPriceCents ?? Math.floor(item.price / numberOfInstallments);
-  // Installments are monthly; with `remainingInstallments` counting the plans left to charge, the
-  // last one lands `remainingInstallments - 1` months out. Floor at one month so a plan with a
-  // single remaining installment never hands Stripe a `recurringPaymentEndDate` in the past — a
-  // non-future date makes `elements.create('payment')` reject the whole checkout with a blank
-  // screen. (At checkout `remainingInstallments` defaults to the full plan count, so this is just
-  // the existing "last installment" date, guarded against the zero-month case.)
-  const endDate = addMonthsClamped(new Date(), Math.max(remainingInstallments - 1, 1));
+  const endDate = remainingInstallments > 1 ? addMonthsClamped(new Date(), remainingInstallments - 1) : undefined;
+  const installmentsLabel = `${remainingInstallments} monthly ${remainingInstallments === 1 ? "installment" : "installments"}`;
 
   return {
-    paymentDescription: `${item.name} (${remainingInstallments} monthly installments)`,
+    paymentDescription: `${item.name} (${installmentsLabel})`,
     managementURL,
     regularBilling: {
       label: item.name,
       amount: baseInstallmentAmount,
       recurringPaymentIntervalUnit: "month",
       recurringPaymentIntervalCount: 1,
-      recurringPaymentEndDate: endDate,
+      ...(endDate ? { recurringPaymentEndDate: endDate } : {}),
     },
-    billingAgreement: `${remainingInstallments} monthly installments of ${formatPriceCentsWithCurrencySymbol(
-      "usd",
-      baseInstallmentAmount,
-      { symbolFormat: "short" },
-    )}.`,
+    billingAgreement: `${installmentsLabel} of ${formatPriceCentsWithCurrencySymbol("usd", baseInstallmentAmount, {
+      symbolFormat: "short",
+    })}.`,
   };
 };

--- a/app/javascript/components/Checkout/applePayRecurringPaymentRequest.ts
+++ b/app/javascript/components/Checkout/applePayRecurringPaymentRequest.ts
@@ -70,11 +70,6 @@ export const getApplePayRecurringPaymentRequest = (
 const membershipRequest = (item: Product, managementURL: string): ApplePayRecurringPaymentRequest | null => {
   if (item.recurrence === null) return null;
 
-  // The renewal amount can differ from today's charge (e.g. a discount limited to the first
-  // billing cycle), so the caller computes it where discount details are available. Falling back
-  // to the current price keeps the declaration usable when no separate renewal price is known.
-  // Amounts are pre-tax, matching how prices are presented everywhere else at checkout; each
-  // renewal's tax is computed by the server when it is charged.
   const renewalAmount = item.renewalPriceCents ?? item.price;
   const months = numberOfMonthsInRecurrence(item.recurrence);
   const interval =
@@ -86,8 +81,18 @@ const membershipRequest = (item: Product, managementURL: string): ApplePayRecurr
   // months, so the agreement on the sheet is bounded by an end date rather than described as
   // billing until the buyer cancels.
   const totalBillingCycles = item.durationInMonths != null ? Math.ceil(item.durationInMonths / months) : null;
+
+  // A fixed-duration membership whose duration fits in a single billing cycle (e.g. a 12-month
+  // membership billed yearly, or a 1-month membership billed monthly) charges the buyer exactly
+  // once. It is effectively a one-time purchase, so declaring a recurring payment request would
+  // be wrong: Apple would present an auto-renewing agreement that never renews, and Stripe's
+  // `elements.create('payment')` rejects a `recurringPaymentEndDate` set to the current moment
+  // (a non-future date), which this code previously produced as `addMonthsClamped(new Date(), 0)`.
+  // Fall back to a plain one-time request (a device token) instead.
+  if (totalBillingCycles !== null && totalBillingCycles <= 1) return null;
+
   let recurringPaymentEndDate: Date | undefined;
-  if (totalBillingCycles != null) {
+  if (totalBillingCycles != null && totalBillingCycles > 1) {
     // The last charge happens one interval before the total duration elapses (the first charge is
     // today), so the agreement ends after (cycles - 1) further intervals.
     recurringPaymentEndDate = addMonthsClamped(new Date(), (totalBillingCycles - 1) * months);
@@ -134,7 +139,13 @@ const installmentPlanRequest = (item: Product, managementURL: string): ApplePayR
   const remainingInstallments = item.installmentPlan?.remainingInstallments ?? numberOfInstallments;
   if (remainingInstallments < 1) return null;
   const baseInstallmentAmount = item.renewalPriceCents ?? Math.floor(item.price / numberOfInstallments);
-  const endDate = addMonthsClamped(new Date(), remainingInstallments - 1);
+  // Installments are monthly; with `remainingInstallments` counting the plans left to charge, the
+  // last one lands `remainingInstallments - 1` months out. Floor at one month so a plan with a
+  // single remaining installment never hands Stripe a `recurringPaymentEndDate` in the past — a
+  // non-future date makes `elements.create('payment')` reject the whole checkout with a blank
+  // screen. (At checkout `remainingInstallments` defaults to the full plan count, so this is just
+  // the existing "last installment" date, guarded against the zero-month case.)
+  const endDate = addMonthsClamped(new Date(), Math.max(remainingInstallments - 1, 1));
 
   return {
     paymentDescription: `${item.name} (${remainingInstallments} monthly installments)`,


### PR DESCRIPTION
## Status

- [x] Scope — checkout Apple Pay recurring request helper only; no backend/schema/data changes.
- [x] Design — preserve one-time Apple Pay for charge-now single-cycle memberships, but keep merchant-token requests for deferred single charges.
- [x] Build — pushed follow-up commit `d30a579a6bdda126f400884862e531d1dfd470bd` addressing the Greptile P1/P2 findings.
- [x] QA — local unit, lint, typecheck, and mutation checks passed; preview checkout evidence is still owed before ready because this is a checkout money path.
- [ ] Shipped — draft PR; CI/Greptile rerun and preview checkout QA still pending.
- [ ] Market — not applicable.
- [ ] Sell — not applicable.
- [x] Ownership — draft with `working` label; unassigned until ready, then checkout money-path review goes to `nyomanjyotisa`.

## Problem

Buyers paying with **Apple Pay** on certain fixed-duration memberships hit a blank black checkout screen. The browser console shows:

```
Uncaught IntegrationError: Invalid value for elements.create('payment'):
applePay.recurringPaymentRequest.regularBilling.recurringPaymentEndDate
should be a future Date. You specified: "2026-08-29T09:41:22.753Z".
```

Reported live by the sell side of a UK healthy/compliant membership account (Amulet Editor, a 12-month membership billed yearly) whose customers in Japan, Japan, and Australia all hit a blank black checkout. Buyer 1 eventually got through via non-Apple-Pay; buyers 2 and 3 were stuck.

## Root Cause (confirmed)

`app/javascript/components/Checkout/applePayRecurringPaymentRequest.ts` builds the Apple Pay `recurringPaymentRequest` for a fixed-duration membership:

```ts
const totalBillingCycles = item.durationInMonths != null ? Math.ceil(item.durationInMonths / months) : null;
let recurringPaymentEndDate;
if (totalBillingCycles != null) {
  recurringPaymentEndDate = addMonthsClamped(new Date(), (totalBillingCycles - 1) * months);
}
```

For a **12-month membership billed yearly** (`recurrence: "yearly"` → `months = 12`, `durationInMonths = 12`):

- `totalBillingCycles = Math.ceil(12 / 12) = 1`
- `recurringPaymentEndDate = addMonthsClamped(new Date(), (1 - 1) * 12) = addMonthsClamped(new Date(), 0)` → **the current instant**.

Stripe requires `recurringPaymentEndDate` to be a *future* Date. When it's set to `now` (or any non-future value), `elements.create('payment')` throws, Stripe Elements never mounts, and the checkout renders blank/black — the exact symptom reported. The same non-future-date hazard exists in the installment path: a plan with a single remaining installment (`remainingInstallments - 1 = 0` months) computes `addMonthsClamped(new Date(), 0)` = now.

A 1-billing-cycle membership is really a **one-time purchase** (Apple's `isSingleChargeDuration` helper treats `durationInMonths === number_of_months_in_recurrence` as a single charge), so it should carry no recurring payment request at all.

## Fix

1. **`membershipRequest`** — single-cycle fixed-duration purchases still return `null` when the buyer is charged today, so Apple Pay treats them like one-time purchases and Stripe never receives a non-future `recurringPaymentEndDate`. The guard now preserves a recurring request when a later off-session charge still needs a durable merchant token: free trials and subscription payment-method updates with one charge remaining. Those single-future-charge paths omit `recurringPaymentEndDate` instead of setting it to `now`.
2. **`installmentPlanRequest`** — installment plans with more than one remaining charge keep their real `(remainingInstallments - 1)` month end date. A plan with exactly one remaining charge now keeps the recurring request for merchant-token capture but omits `recurringPaymentEndDate`, because the data passed to this helper does not include the exact due date and the prior one-month floor fabricated it.
3. **Review cleanup** — condensed the new production/test comments so they state the durable-token/date rationale without repeating the implementation narrative.

## Test Results

- `npx prettier --write app/javascript/components/Checkout/applePayRecurringPaymentRequest.ts app/javascript/components/Checkout/applePayRecurringPaymentRequest.test.ts`
- `npm run test -- app/javascript/components/Checkout/applePayRecurringPaymentRequest.test.ts` — 1 file, 28 tests passed
- `npm run lint-fast -- app/javascript/components/Checkout/applePayRecurringPaymentRequest.ts app/javascript/components/Checkout/applePayRecurringPaymentRequest.test.ts --max-warnings 0`
- `npm run typecheck -- --pretty false`
- Throwaway mutation harness — killed mutants for dropping the free-trial exception, dropping the subscription-update exception, and restoring the fabricated single-installment end date

## QA steps

- Backend/rendered-surface QA does not apply yet: this follow-up changes the Apple Pay request object helper and its unit coverage, with no screenshotable surface until checkout is exercised on the preview app. The PR stays draft while CI/Greptile re-run on the new head.

## Scope

This is a bounded, reversible frontend-only change to one decision file plus its test — no data migration, no backend, no schema. It restores the pre-rollout one-time-Apple-Pay behavior for the products that were broken, and keeps the merchant-token/MPAN rollout intact for future-charge paths (open-ended and multi-cycle memberships, free trials, subscription payment updates, and installment plans) without sending Stripe non-future or fabricated end dates.

---

AI use: Hermes Agent with grok-4.6 authored the follow-up and ran the checks listed above.

