### PR TITLE
Stop the global-affiliate callback from halting the sale ping

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2140,7 +2140,11 @@ class Purchase < ApplicationRecord
   def create_product_affiliate
     return unless affiliate.present? && affiliate.global?
 
+    # Never return create_if_missing!'s "already assigned" false: state_machines terminates the
+    # after_transition chain on a callback returning exactly false, silently skipping every
+    # callback queued below this one — the sale ping included.
     ProductAffiliate.create_if_missing!(affiliate:, product: link)
+    nil
   end
 
   def create_url_redirect_for_failed_purchase

--- a/spec/models/purchase/product_affiliate_spec.rb
+++ b/spec/models/purchase/product_affiliate_spec.rb
@@ -3,13 +3,52 @@
 require "spec_helper"
 
 describe Purchase, "product affiliate assignment" do
+  let(:product) { create(:product) }
+  let(:affiliate) { create(:user).global_affiliate }
+
   it "keeps repeated global affiliate assignments idempotent" do
-    product = create(:product)
-    affiliate = create(:user).global_affiliate
     purchase = build(:purchase, link: product, affiliate:)
 
     2.times { purchase.send(:create_product_affiliate) }
 
     expect(ProductAffiliate.where(affiliate:, product:).count).to eq(1)
+  end
+
+  # state_machines terminates the after_transition chain on a callback that returns exactly
+  # false, so this one must never hand back create_if_missing!'s "already assigned" boolean.
+  # Everything queued after it — the sale ping included — is skipped silently otherwise.
+  it "does not return false when the assignment already exists" do
+    ProductAffiliate.create_if_missing!(affiliate:, product:)
+    purchase = build(:purchase, link: product, affiliate:)
+
+    expect(purchase.send(:create_product_affiliate)).not_to eq(false)
+  end
+
+  describe "callbacks queued after the assignment" do
+    it "sends the sale notification webhook when the assignment already exists" do
+      ProductAffiliate.create_if_missing!(affiliate:, product:)
+      purchase = create(:purchase, link: product, affiliate:, purchase_state: "in_progress")
+
+      purchase.mark_successful!
+
+      expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(purchase.id, nil)
+    end
+
+    it "sends the sale notification webhook when the assignment is created by this sale" do
+      purchase = create(:purchase, link: product, affiliate:, purchase_state: "in_progress")
+
+      purchase.mark_successful!
+
+      expect(PostToPingEndpointsWorker).to have_enqueued_sidekiq_job(purchase.id, nil)
+    end
+
+    it "indexes the sale when the assignment already exists" do
+      ProductAffiliate.create_if_missing!(affiliate:, product:)
+      purchase = create(:purchase, link: product, affiliate:, purchase_state: "in_progress")
+
+      expect(purchase).to receive(:update_product_search_index!)
+
+      purchase.mark_successful!
+    end
   end
 end


### PR DESCRIPTION
## What

`Purchase#create_product_affiliate` returned `ProductAffiliate.create_if_missing!`'s boolean.

`state_machines` terminates an `after_transition` chain on a callback that returns exactly `false` — the ActiveModel integration sets `callback_terminator` to `->(result) { result == false }`, and `Callback#call` does `throw :halt if @terminator.call(result)`. `create_if_missing!` returns `false` whenever the affiliate is already assigned to the product.

So a successful purchase carrying a **global affiliate with an existing assignment** halted the chain at that callback, and every callback queued below it was skipped:

- `queue_product_cache_invalidation`
- `touch_variants_if_limited_quantity`
- `update_product_search_index!`
- `delete_failed_purchases_count`
- `transcode_product_videos`
- **`send_notification_webhook`** — the sale Ping
- `block_fraudulent_free_purchases!`
- `schedule_order_review_reminder`
- `schedule_indian_card_mandate_registration_check`
- `log_transition`

The transition still succeeded, nothing raised and nothing was logged. This PR stops the callback from handing that boolean back to the state machine.

## Why

Root cause of gumroad-private#2155 — sale Ping webhooks not posted for successful purchases. That issue was closed against #7248 and #7354, which fixed real but different delivery-side bugs (an empty-DNS skip, and transient send-time failures). Drops continued after both shipped, because nothing was being enqueued in the first place: the ping's `after_transition` callback never ran. Sellers who drive licensing or fulfilment off Ping stop receiving notifications for a large share of their affiliate sales and have to re-ping each one by hand from the sale page.

The shape of the bug explains why it read as intermittent and resisted diagnosis:

- **Only global affiliates.** `create_product_affiliate` is the only callback gated on `affiliate.global?`, so direct-affiliate and collaborator sales are unaffected.
- **Only repeat sales.** The first sale for an affiliate/product pair creates the assignment, so `create_if_missing!` returns `true` and the ping fires normally. Every later sale on that pair returns `false` and halts.
- **The purchase looks healthy from every other angle.** `create_artifacts_and_send_receipt!`, the buyer receipt, the seller notification and the affiliate notification all run *before* the halt point, so the buyer gets the product and the seller gets the email.

Introduced in #7167, which replaced a `return unless … .none?` guard — returning `nil`, which does not terminate — with the boolean-returning call.

#7376 approached this from the other end, rescuing inside `notify_affiliate!`'s `after_commit`. That callback runs *before* the halt point and its mailer enqueue succeeds, so the rescue cannot affect this path; its regression spec uses a `DirectAffiliate`, which never reaches the halting callback at all. Left in place, with the new specs covering the global-affiliate path it misses.

### Why this fix

Returning `nil` from the callback is the smallest change that restores the chain, and it keeps the boolean where it is actually used — `Link#publish!` branches on it at `app/models/link.rb:553`, so changing `create_if_missing!`'s own return value was not an option. Reordering the callback below `send_notification_webhook` would fix the ping alone and leave the other nine skipped, and would leave the same trap for the next callback added above it.

## Before/After

No rendered surface — this is a state-machine callback, so there is no UI to capture and no video attached. The behaviour change is captured by the specs, which fail against the current `main` behaviour and pass with the fix.

**With the fix reverted (specs kept):**

```
5 examples, 3 failures

rspec ./spec/models/purchase/product_affiliate_spec.rb:20 # does not return false when the assignment already exists
rspec ./spec/models/purchase/product_affiliate_spec.rb:28 # sends the sale notification webhook when the assignment already exists
rspec ./spec/models/purchase/product_affiliate_spec.rb:45 # indexes the sale when the assignment already exists
```

**With the fix:**

```
5 examples, 0 failures
```

Note that `sends the sale notification webhook when the assignment is created by this sale` passes in both runs — that is the control, and it is exactly the split seen in production between an affiliate's first sale on a product and every sale after it.

## Test Results

- `bundle exec rspec spec/models/purchase/product_affiliate_spec.rb` — 5 examples, 0 failures. Reverting `app/models/purchase.rb` alone turns 3 of them red.
- `bundle exec rspec spec/models/purchase/purchase_notification_spec.rb` — 12 examples, 0 failures.
- `bundle exec rspec spec/services/purchase/create_service_spec.rb -e "affiliate notification"` — 4 examples, 0 failures (includes #7376's regression spec).
- `bundle exec rspec spec/models/product_affiliate_spec.rb spec/models/global_affiliate_spec.rb spec/models/product_affiliate_concurrency_spec.rb spec/models/purchase/` — 601 examples, 12 failures; the same 12 fail on the merge base (local environment, unrelated to this change).
- `bundle exec rubocop app/models/purchase.rb spec/models/purchase/product_affiliate_spec.rb` — 2 files inspected, no offenses.
- `bin/test-confidence` not run — no `ANTHROPIC_API_KEY` in this environment.

## Follow-ups

- Sales that halted since #7167 shipped did not have their ping sent, were not added to the purchases search index, and had no review reminder scheduled. The pings can be replayed per purchase via `send_notification_webhook`; worth a separate backfill task rather than folding it in here.
- The failure mode is completely silent, so an audit of the remaining `after_transition` callbacks for accidental `false` returns is worthwhile.

---

AI disclosure: investigated and implemented with Claude Opus 5.
