### PR TITLE
Fix stalled blast auto-resume skipping still-sending large sends

### DIFF
--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -10,11 +10,12 @@
 # (A hard-killed job itself is not the stranding mode: super_fetch resurrects it.)
 #
 # Auto-resume is deliberately conservative: only DEAD/UNACCOUNTED blasts still inside
-# AUTO_RESUME_WINDOW, at most once per blast, and never a non-opener resend while UNACCOUNTED —
-# its dedupe set is written only after delivery, so a duplicate racing a live sender the
-# snapshots missed would double-deliver. Older blasts may be time-boxed sale announcements worse
-# delivered late than not at all, and a blast that stalls AGAIN after a resume has something
-# wrong this job cannot see — all of these stay a human call and are reported as HELD.
+# AUTO_RESUME_WINDOW (unless recipients are still owed), not more than once per STALL_THRESHOLD,
+# and never a non-opener resend while UNACCOUNTED — its dedupe set is written only after
+# delivery, so a duplicate racing a live sender the snapshots missed would double-deliver.
+# A blast that emailed inside STALL_THRESHOLD is treated as running even when Sidekiq::Workers
+# does not list it — otherwise a still-sending large blast burns the resume marker and is
+# never tried again after the real death (gumroad-private#2338).
 #
 # The exception is a blast whose sender handed every recipient over and then died before
 # stamping `completed_at` (gumroad-private#2250). Resuming that one cannot double-send, so it
@@ -80,7 +81,7 @@ class AlertOnStalledPostEmailBlastsJob
 
       stalled = candidates.map do |blast|
         disposition =
-          if busy.include?(blast.id) then :running
+          if last_email_recent?(blast) || busy.include?(blast.id) then :running
           elsif queued.include?(blast.id) then :queued
           elsif retrying.include?(blast.id) then :retrying
           elsif @dead_entries.key?(blast.id) then :dead
@@ -124,7 +125,9 @@ class AlertOnStalledPostEmailBlastsJob
       # A DEAD entry proves its attempt chain ended; UNACCOUNTED can hide a live sender, and a
       # concurrent duplicate double-delivers a non-opener resend.
       return :held_non_opener if entry[:disposition] == :unaccounted && blast.to_non_openers?
-      return :held_past_window if blast.requested_at < AUTO_RESUME_WINDOW.ago
+      # Recipients still owed cannot double-send (SentPostEmail unique / per-blast sent set),
+      # so a late resume is the remaining delivery, not a time-boxed surprise.
+      return :held_past_window if blast.requested_at < AUTO_RESUME_WINDOW.ago && !recipients_still_owed?(blast)
       return :held_already_resumed if $redis.exists?(RedisKey.stalled_blast_auto_resumed(blast.id))
       return :would_resume unless live
       # Re-read the live sets at action time — the scan's snapshots are already stale by now.
@@ -137,6 +140,16 @@ class AlertOnStalledPostEmailBlastsJob
     # Three full Sidekiq scans per call, so memoize: `resolve_action` runs once per candidate and
     # the scan is bounded at MAX_CANDIDATES_SCANNED. One read per run is still "at action time" —
     # the point is that it is later than the dispositions taken in `scan_for_stalled_blasts`.
+    def last_email_recent?(blast)
+      emailed_at = blast.last_email_delivered_at
+      emailed_at.present? && emailed_at > STALL_THRESHOLD.ago
+    end
+
+    def recipients_still_owed?(blast)
+      pending = $redis.get(RedisKey.blast_pending_recipients(blast.id))
+      pending.present? && pending.to_i.positive?
+    end
+
     def sender_visible_now?(blast_id)
       @live_blast_ids ||= (busy_blast_ids + queued_blast_ids + retrying_blast_ids).to_set
       @live_blast_ids.include?(blast_id)
@@ -147,7 +160,9 @@ class AlertOnStalledPostEmailBlastsJob
       # Atomic NX claim, written before the resume: overlapping runs cannot both claim the same
       # blast, and a crash between claim and resume holds the blast for a human instead of risking
       # a second automated resume of a blast in an unknown state.
-      claimed = $redis.set(marker, Time.current.iso8601, nx: true, ex: LOOKBACK.to_i)
+      # TTL is the stall window, not the 14-day lookback: a resume that dies in minutes
+      # must be eligible again on the next scan instead of held for the rest of LOOKBACK.
+      claimed = $redis.set(marker, Time.current.iso8601, nx: true, ex: STALL_THRESHOLD.to_i)
       return false unless claimed
 
       if entry[:disposition] == :dead

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -76,6 +76,10 @@ class SendPostBlastEmailsJob
     # that an abandoned blast doesn't hold hundreds of thousands of entries forever.
     AUDIENCE_SNAPSHOT_TTL = 3.days
 
+    # Small counter key used by the stalled-blast monitor. Keep it for the full scan window;
+    # unlike the audience snapshot, it is tiny and is the only evidence for late safe resumes.
+    PENDING_RECIPIENTS_TTL = AlertOnStalledPostEmailBlastsJob::LOOKBACK
+
     # How many snapshotted member ids to revalidate per statement. Small on purpose:
     # MySQL's range optimizer silently drops the PK plan once an `IN (...)` list blows
     # its memory budget, and looks the rows up through (seller_id, email) instead —
@@ -339,10 +343,10 @@ class SendPostBlastEmailsJob
     # Publishes how many recipients this attempt still owes the ESPs, so a monitor can tell a
     # blast that died mid-send from one that died after the last handoff but before the stamp
     # below (gumroad-private#2250). Written per attempt, after filtering: a retry owes only
-    # what is left. The TTL matches the audience snapshot — past it the answer is "unknown"
-    # and the monitor falls back to resuming.
+    # what is left. The TTL matches the stalled-blast scan window so old incomplete blasts
+    # can still be distinguished from completed-but-unstamped ones.
     def start_pending_recipients
-      $redis.set(RedisKey.blast_pending_recipients(@blast.id), @members.size, ex: AUDIENCE_SNAPSHOT_TTL.to_i)
+      $redis.set(RedisKey.blast_pending_recipients(@blast.id), @members.size, ex: PENDING_RECIPIENTS_TTL.to_i)
     end
 
     def decrement_pending_recipients(count)

--- a/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
+++ b/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
@@ -7,8 +7,11 @@ describe AlertOnStalledPostEmailBlastsJob do
 
   def stalled_blast(requested_hours_ago: 6, post: self.post, delivery_count: 0, started: true)
     requested_at = requested_hours_ago.hours.ago
-    create(:post_email_blast, post:, requested_at:, started_at: started ? requested_at + 1.minute : nil,
-                              completed_at: nil, delivery_count:)
+    started_at = started ? requested_at + 1.minute : nil
+    # Factory default last_email is 10 minutes ago (still-sending). A stalled fixture must
+    # look idle or last_email_recent? would classify every candidate as running.
+    create(:post_email_blast, post:, requested_at:, started_at:, completed_at: nil, delivery_count:,
+                              first_email_delivered_at: started_at, last_email_delivered_at: started_at)
   end
 
   def stub_sidekiq(dead: [], retrying: [], busy: [], queued: [])
@@ -172,6 +175,54 @@ describe AlertOnStalledPostEmailBlastsJob do
         expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
           expect(message).to match(/blast #{blast.id}.*HELD \(already auto-resumed/)
         end
+      end
+
+      it "retries again after the resume marker expires" do
+        blast = stalled_blast(requested_hours_ago: 6)
+        stub_sidekiq
+
+        described_class.new.perform
+        expect(SendPostBlastEmailsJob).to have_received(:perform_async).with(blast.id).once
+
+        $redis.del(RedisKey.stalled_blast_auto_resumed(blast.id))
+        described_class.new.perform
+        expect(SendPostBlastEmailsJob).to have_received(:perform_async).with(blast.id).twice
+      end
+
+      it "expires the resume marker after the stall threshold, not the lookback" do
+        blast = stalled_blast(requested_hours_ago: 6)
+        stub_sidekiq
+        allow($redis).to receive(:set).and_call_original
+        expect($redis).to receive(:set).with(
+          RedisKey.stalled_blast_auto_resumed(blast.id),
+          anything,
+          hash_including(nx: true, ex: described_class::STALL_THRESHOLD.to_i)
+        ).and_call_original
+
+        described_class.new.perform
+      end
+
+      it "treats a blast that emailed inside the stall threshold as running even without a Sidekiq worker" do
+        blast = stalled_blast(requested_hours_ago: 6)
+        blast.update!(last_email_delivered_at: 30.minutes.ago)
+        stub_sidekiq
+
+        described_class.new.perform
+
+        expect(SendPostBlastEmailsJob).not_to have_received(:perform_async)
+        expect($redis.exists?(RedisKey.stalled_blast_auto_resumed(blast.id))).to be(false)
+        expect(InternalNotificationWorker).not_to have_received(:perform_async)
+      end
+
+      it "resumes a blast past the window when recipients are still owed" do
+        blast = stalled_blast(requested_hours_ago: 30)
+        $redis.set(RedisKey.blast_pending_recipients(blast.id), 12)
+        stub_sidekiq(dead: [blast.id])
+
+        described_class.new.perform
+
+        expect(@dead_jobs.fetch(blast.id)).to have_received(:retry)
+        expect(InternalNotificationWorker).not_to have_received(:perform_async)
       end
 
       it "holds the blast when a concurrent run wins the NX claim between the check and the resume" do

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -78,13 +78,15 @@ describe SendPostBlastEmailsJob, :freeze_time do
       expect($redis.exists?(pending_key)).to be(false)
     end
 
-    it "leaves the owed count positive when the send dies before the provider call" do
+    it "leaves the owed count positive through the stalled-blast scan window when the send dies before the provider call" do
       blast = create(:blast, :just_requested, post: basic_post_with_audience)
+      pending_key = RedisKey.blast_pending_recipients(blast.id)
       expect(PostSendgridApi).to receive(:process).and_raise(StandardError.new("API failure"))
 
       expect { described_class.new.perform(blast.id) }.to raise_error(StandardError, "API failure")
 
-      expect($redis.get(RedisKey.blast_pending_recipients(blast.id)).to_i).to eq(1)
+      expect($redis.get(pending_key).to_i).to eq(1)
+      expect($redis.ttl(pending_key)).to be_between(13.days.to_i, AlertOnStalledPostEmailBlastsJob::LOOKBACK.to_i).inclusive
       expect(described_class.fully_delivered?(blast.reload)).to be(false)
     end
 


### PR DESCRIPTION
## What

`AlertOnStalledPostEmailBlastsJob` no longer treats a still-sending large blast as stalled, and no longer burns a 14-day resume marker on that false stall.

- A blast whose last email is inside `STALL_THRESHOLD` is `RUNNING`, even when Sidekiq lists no worker.
- The auto-resume marker TTL is the stall window (4 hours), not the 14-day lookback, so a resume that dies can be tried again on the next scan.
- A blast still owing recipients (`blast_pending_recipients` > 0) is resumed past the 24-hour window. `SentPostEmail` uniqueness already prevents double-sends.
- The pending-recipient counter now lives for the full 14-day stalled-blast scan window, so the safe-resume evidence does not expire after three days.

## Why

Large audience sends run longer than four hours. The scanner keys stall on `requested_at`, misses the live worker, claims the once-per-blast marker, and then never retries after the real death. The July statement-cap raise (PR #5862) is not this failure class: member load completes and the snapshot is the full audience; the send dies mid-pass and auto-resume refuses to continue it.

## Before / After

Backend-only; there is no rendered surface.

| | Before | After |
|---|---|---|
| Last email 30 minutes ago, no Sidekiq worker | UNACCOUNTED → auto-resume, marker held 14 days | RUNNING, no enqueue, no marker |
| Resume dies minutes later | HELD (already auto-resumed) for 14 days | Marker expires after 4 hours; next scan retries |
| Recipients still owed, requested 30h ago | HELD (past 24h window) | Resumed (cannot double-send) |
| Recipients still owed, requested 5d ago | Evidence expired after 3d → HELD | Counter still exists through the 14d lookback → resumed |

## Test Results

- `ruby -c app/sidekiq/send_post_blast_emails_job.rb && ruby -c app/sidekiq/alert_on_stalled_post_email_blasts_job.rb && ruby -c spec/sidekiq/send_post_blast_emails_job_spec.rb && ruby -c spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb` — all four syntax checks OK.
- `DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb` — 29 examples, 0 failures (completed during the combined run).
- `DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/send_post_blast_emails_job_spec.rb:81` — 1 example, 0 failures for the new pending-recipient TTL assertion.
- Mutation proof: changing `PENDING_RECIPIENTS_TTL` back to `AUDIENCE_SNAPSHOT_TTL` made `spec/sidekiq/send_post_blast_emails_job_spec.rb:81` fail with Redis TTL 259200 seconds vs the expected 13–14 day window; restored branch passes the same example.
- `DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/send_post_blast_emails_job_spec.rb spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb` — alert spec file completed green; the full send-post-blast spec file hit the local Vite manifest/node-dependency failure (`Vite Ruby can't find entrypoints/email.ts`, missing `@typia/unplugin`, `@vitejs/plugin-react`, `vite`, etc.) on existing email-render examples before reaching a full-file verdict.

## QA steps

1. Confirm a blast with `last_email_delivered_at` inside 4 hours and no Sidekiq worker is not enqueued and does not write `stalled_blast_auto_resumed`.
2. Confirm `$redis.ttl(RedisKey.stalled_blast_auto_resumed(id))` after a resume is ~4 hours, not 14 days.
3. Confirm a dead blast with `blast_pending_recipients` > 0 and `requested_at` 30 hours ago is retried.
4. Confirm a sender that dies before the provider call leaves `blast_pending_recipients` with a TTL near the 14-day lookback, not the 3-day audience snapshot.

No preview app applies.

## Status

- [x] Scope
- [x] Design
- [x] Build
- [x] QA — spec file green locally; no UI
- [ ] Shipped
- [ ] Market
- [ ] Sell

Fixes antiwork/gumroad-private#2338

---

AI disclosure: grok-4.6


Premerge review: clean @ 9a63c6785eeb255c514fe6c913569cc828f33438
