### PR TITLE
Pass video resume positions to native app payloads

### DIFF
--- a/app/javascript/components/Download/FileList.test.tsx
+++ b/app/javascript/components/Download/FileList.test.tsx
@@ -37,7 +37,14 @@ vi.mock("$app/data/user_action_event", () => ({ trackUserActionEvent: vi.fn() })
 afterEach(() => {
   cleanup();
   createJWPlayer.mockReset();
+  delete window.ReactNativeWebView;
 });
+
+const mockReactNativeWebView = () => {
+  const postMessage = vi.fn();
+  window.ReactNativeWebView = { postMessage };
+  return postMessage;
+};
 
 const folder = (overrides: Partial<FolderItem> = {}): FolderItem => ({
   type: "folder",
@@ -71,16 +78,19 @@ const videoFile = (overrides: Partial<FileItem> = {}): FileItem => ({
 
 // Renders the embedded-video row the way the content page does, so the tests can
 // check the frame the buyer actually gets rather than only the style helper.
-const renderEmbeddedRow = (file: FileItem, mediaUrls: Record<string, string[]> = {}) =>
+const renderFileRow = (file: FileItem, mediaUrls: Record<string, string[]> = {}, isEmbed = false) =>
   render(
     <PurchaseInfoProvider value={{ purchaseId: "purchase-1", redirectId: "redirect-1", token: "token-1" }}>
       <MediaUrlsProvider value={[mediaUrls, () => undefined]}>
         <IsMobileAppViewProvider value={false}>
-          <FileRow file={file} playingAudioForId={null} setPlayingAudioForId={() => undefined} isEmbed />
+          <FileRow file={file} playingAudioForId={null} setPlayingAudioForId={() => undefined} isEmbed={isEmbed} />
         </IsMobileAppViewProvider>
       </MediaUrlsProvider>
     </PurchaseInfoProvider>,
   );
+
+const renderEmbeddedRow = (file: FileItem, mediaUrls: Record<string, string[]> = {}) =>
+  renderFileRow(file, mediaUrls, true);
 
 describe("FileList", () => {
   it("renders folders collapsed by default when the page has multiple folders", () => {
@@ -144,6 +154,43 @@ describe("FileList", () => {
       expect(videoFrameIsPortrait(videoFile({ width: 1920, height: 1080 }))).toBe(false);
       expect(videoFrameIsPortrait(videoFile({ width: 1080, height: 1080 }))).toBe(false);
       expect(videoFrameIsPortrait(videoFile())).toBe(false);
+    });
+  });
+
+  describe("native app video clicks", () => {
+    it("passes the saved position to the native stream player", () => {
+      const postMessage = mockReactNativeWebView();
+      const file = videoFile({
+        duration: 1800,
+        content_length: 1800,
+        latest_media_location: { location: 1209, timestamp: "2026-08-29T18:56:02Z" },
+      });
+
+      renderFileRow(file);
+      fireEvent.click(screen.getByRole("link", { name: "Watch" }));
+
+      expect(JSON.parse(String(postMessage.mock.calls[0]?.[0]))).toMatchObject({
+        type: "click",
+        payload: { resourceId: file.id, resumeAt: "1209", contentLength: "1800" },
+      });
+    });
+
+    it("passes the saved position to embedded-video native watch clicks", () => {
+      const postMessage = mockReactNativeWebView();
+      const file = videoFile({
+        duration: 5400,
+        content_length: 5400,
+        latest_media_location: { location: 3476, timestamp: "2026-08-29T18:25:20Z" },
+      });
+
+      renderEmbeddedRow(file, { [file.id]: ["https://example.test/index.m3u8"] });
+      fireEvent.click(screen.getByRole("button", { name: "Watch" }));
+
+      expect(JSON.parse(String(postMessage.mock.calls[0]?.[0]))).toMatchObject({
+        type: "click",
+        payload: { resourceId: file.id, resumeAt: "3476", contentLength: "5400" },
+      });
+      expect(createJWPlayer).not.toHaveBeenCalled();
     });
   });
 

--- a/app/javascript/components/Download/FileList.tsx
+++ b/app/javascript/components/Download/FileList.tsx
@@ -299,7 +299,7 @@ export const FileRow = ({
         {downloadButton}
 
         {!isEmbed && streamUrl != null ? (
-          <TrackClick eventName="stream_click" file={file}>
+          <TrackClick eventName="stream_click" file={file} resumeAt={resumeLocation || 0} contentLength={file.duration}>
             <NavigationButton color="primary" href={streamUrl} target="_blank">
               {file.latest_media_location != null && file.latest_media_location.location === file.content_length
                 ? "Watch again"
@@ -765,7 +765,7 @@ const VideoEmbedPreview = ({
           borderRadius: "var(--border-radius-1) var(--border-radius-1) 0 0",
         }}
       />
-      <TrackClick eventName="watch" file={file}>
+      <TrackClick eventName="watch" file={file} resumeAt={resumeLocation || 0} contentLength={file.duration}>
         <button
           className="cursor-pointer underline all-unset"
           style={{


### PR DESCRIPTION
Premerge review: clean @ 5765355ae25d7ccc828b7b0f98244d186b85f95c
## What

Passes a video's saved playback position and duration into the native-app click payloads for both purchase-page video entry points:

- the regular stream `Watch` button (`stream_click`)
- embedded content-page video `Watch` buttons (`watch`)

This is the Rails/web half left open by antiwork/gumroad-mobile#334 and now needed for antiwork/gumroad-mobile#359. The mobile app-side fallback from gumroad-mobile#336 is already in public iOS/Android releases, so this closes the remaining payload path where the WebView hands the app `resumeAt: null` even though the page has `latest_media_location`.

## Why

A buyer reinstalled the iOS app and still sees course videos reopen from the wrong position. Store-state checks rule out release lag: App Store Connect shows iOS `2026.08.24` as `READY_FOR_SALE`, Play production/internal are `2026.08.24` versionCode `363`, and gumroad-mobile#336 is an ancestor of the shipped 2026.08.03+ mobile version bumps.

The server-side rows are fresh and healthy, so the read gap is at launch. `FileList.tsx` already initializes `resumeLocation` from `file.latest_media_location` for web embedded playback and for the progress pie, but the two video `TrackClick` wrappers did not pass it through to `NativeAppLink`; only audio did. Native-app payloads therefore still carried `resumeAt: null` for video clicks unless the mobile API fallback saved the path.

## Before / After

Before: video native-app click payloads contained `resumeAt: null` and `contentLength: null` even when the page had a saved video location.

After: both standard and embedded video native-app click payloads include the saved position and duration, matching the audio payload contract.

No rendered UI changes. The observable artifact is the WebView-to-native JSON payload.

## Test Results

- `npx prettier --write app/javascript/components/Download/FileList.tsx app/javascript/components/Download/FileList.test.tsx` — completed, unchanged after formatting
- `npm run test -- app/javascript/components/Download/FileList.test.tsx app/javascript/components/Download/VideoEmbedPlayback.test.tsx` — 16 tests passed
- Mutation check: removing the two new `resumeAt`/`contentLength` props fails both new native-video payload tests with `resumeAt: null` and `contentLength: null`; restored afterward
- `npm run typecheck` — clean
- `npx eslint app/javascript/components/Download/FileList.tsx app/javascript/components/Download/FileList.test.tsx` — still reports the pre-existing generated-Routes errors in `FileList.tsx` lines 207 and 805; the new test assertions are lint-clean after removing the initial type assertions

## QA steps

1. Render `FileRow` for a video with `latest_media_location.location = 1209` and a `window.ReactNativeWebView` bridge.
2. Click the regular `Watch` link and verify the posted JSON payload includes `resumeAt: "1209"` and `contentLength: "1800"`.
3. Render the embedded video row with `latest_media_location.location = 3476` and the same bridge.
4. Click the embedded `Watch` button and verify the posted JSON payload includes `resumeAt: "3476"` and `contentLength: "5400"`, and that the in-page JWPlayer path is not started.

## Status

- [x] Scope — antiwork/gumroad-mobile#359 release-lag question answered; gumroad-mobile#336 is already in public store builds.
- [x] Design — close the payload path left open by #334 without changing the web playback path.
- [x] Build — video TrackClick payloads now carry resume position and duration.
- [x] QA — payload behavior covered by focused Vitest tests and mutation check.
- [x] Shipped — deployed in `v2026.08.31.1` (published 2026-08-31 02:30Z); no rendered UI (payload-only). Sol premerge clean at `5765355ae25d7ccc828b7b0f98244d186b85f95c`.
- [ ] Market — no public announcement needed.
- [ ] Sell — no sales copy needed.

---

AI disclosure: Generated with grok-4.6 running as a Hermes agent.
