### PR TITLE
Disable pay-what-you-want on /bin/bash products that have paid options

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/PriceEditor.test.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/PriceEditor.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { cleanup, render, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PriceEditor } from "$app/components/ProductEdit/ProductTab/PriceEditor";
+
+vi.mock("$app/components/ui/Alert", () => ({
+  Alert: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+afterEach(cleanup);
+
+const renderEditor = (overrides: Partial<React.ComponentProps<typeof PriceEditor>> = {}) => {
+  const setIsPWYW = vi.fn();
+  const view = render(
+    <PriceEditor
+      priceCents={0}
+      suggestedPriceCents={null}
+      isPWYW={false}
+      setPriceCents={() => {}}
+      setSuggestedPriceCents={() => {}}
+      setIsPWYW={setIsPWYW}
+      currencyType="usd"
+      eligibleForInstallmentPlans={false}
+      allowInstallmentPlan={false}
+      numberOfInstallments={null}
+      onAllowInstallmentPlanChange={() => {}}
+      onNumberOfInstallmentsChange={() => {}}
+      {...overrides}
+    />,
+  );
+  return { ...view, setIsPWYW };
+};
+
+const pwywSwitch = (view: ReturnType<typeof render>): HTMLInputElement => {
+  const toggle = view.getByRole("switch");
+  if (!(toggle instanceof HTMLInputElement)) throw new Error("expected checkbox");
+  return toggle;
+};
+
+describe("PriceEditor pay what you want toggle", () => {
+  it("forces pay what you want on for a $0 product with no paid options", () => {
+    const { setIsPWYW, ...view } = renderEditor({ isPWYW: true, hasPaidVariants: false });
+    const toggle = pwywSwitch(view);
+
+    expect(toggle.checked).toBe(true);
+    expect(toggle.disabled).toBe(true);
+    expect(view.getByText("Free products require a pay what they want price.")).toBeTruthy();
+    expect(setIsPWYW).not.toHaveBeenCalled();
+  });
+
+  it("disables pay what you want on a $0 product with paid pricing options", async () => {
+    const { setIsPWYW, ...view } = renderEditor({ isPWYW: true, hasPaidVariants: true });
+    const toggle = pwywSwitch(view);
+
+    expect(toggle.checked).toBe(false);
+    expect(toggle.disabled).toBe(true);
+    expect(view.getByText("Pay what you want isn't available on products with paid pricing options.")).toBeTruthy();
+    expect(view.queryByText("Free products require a pay what they want price.")).toBeNull();
+    await waitFor(() => expect(setIsPWYW).toHaveBeenCalledWith(false));
+  });
+
+  it("leaves the toggle enabled on a paid product that also has paid options", () => {
+    const { setIsPWYW, ...view } = renderEditor({
+      priceCents: 1000,
+      isPWYW: false,
+      hasPaidVariants: true,
+    });
+    const toggle = pwywSwitch(view);
+
+    expect(toggle.disabled).toBe(false);
+    expect(view.queryByText("Pay what you want isn't available on products with paid pricing options.")).toBeNull();
+    expect(setIsPWYW).not.toHaveBeenCalled();
+  });
+});

--- a/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
@@ -56,8 +56,17 @@ export const PriceEditor = ({
 }) => {
   const uid = React.useId();
   const isFreeProduct = priceCents === 0;
+  // Same split as Product::Prices#set_customizable_price: $0 with no paid options
+  // must be pay-what-you-want; $0 plus paid options cannot, or checkout would
+  // offer a $0 amount box for the paid tier.
+  const cannotBePWYW = isFreeProduct && !!hasPaidVariants;
   const mustBePWYW = isFreeProduct && !hasPaidVariants;
+  const pwywOn = isPWYW && !cannotBePWYW;
   const productEditContext = React.useContext(ProductEditContext);
+
+  React.useEffect(() => {
+    if (cannotBePWYW && isPWYW) setIsPWYW(false);
+  }, [cannotBePWYW, isPWYW, setIsPWYW]);
 
   // The regular product editor provides ProductEditContext; the bundle editor
   // passes the defaultOfferCode prop. Either way we can render the selector.
@@ -90,12 +99,17 @@ export const PriceEditor = ({
         currencyCodeSelector={currencyCodeSelector}
       />
       {mustBePWYW ? <Alert variant="info">Free products require a pay what they want price.</Alert> : null}
-      <Details open={isPWYW}>
+      {cannotBePWYW ? (
+        <Alert variant="info" role="status">
+          Pay what you want isn't available on products with paid pricing options.
+        </Alert>
+      ) : null}
+      <Details open={pwywOn}>
         <DetailsToggle chevronPosition="none" className="mb-0">
           <Switch
-            checked={isPWYW}
+            checked={pwywOn}
             onChange={(e) => setIsPWYW(e.target.checked)}
-            disabled={mustBePWYW}
+            disabled={mustBePWYW || cannotBePWYW}
             label={
               <a href="/help/article/133-pay-what-you-want-pricing" target="_blank" rel="noreferrer">
                 Allow customers to pay what they want

--- a/spec/requests/products/edit/edit_spec.rb
+++ b/spec/requests/products/edit/edit_spec.rb
@@ -576,7 +576,8 @@ describe("Product Edit Scenario", type: :system, js: true) do
     expect(product.customizable_price).to be false
 
     within_section "Pricing" do
-      expect(page).to have_unchecked_field("Allow customers to pay what they want", disabled: false)
+      expect(page).to have_unchecked_field("Allow customers to pay what they want", disabled: true)
+      expect(page).to have_content("Pay what you want isn't available on products with paid pricing options.")
       check "Allow customers to pay in installments"
       fill_in "Number of installments", with: 2
     end

--- a/spec/requests/products/edit/pwyw_spec.rb
+++ b/spec/requests/products/edit/pwyw_spec.rb
@@ -59,4 +59,23 @@ describe("Product Edit pay what you want setting", type: :system, js: true) do
     expect(pwyw_toggle).to be_checked
     expect(pwyw_toggle).not_to be_disabled
   end
+
+  it "disables the toggle on a $0 product that already has paid pricing options" do
+    variant_category = create(:variant_category, link: product, title: "Pack")
+    create(:variant, variant_category:, name: "Home Kit", price_difference_cents: 1500)
+
+    visit edit_link_path(product.unique_permalink)
+    fill_in "Amount", with: "0"
+
+    expect(page).to have_content("Pay what you want isn't available on products with paid pricing options.")
+    expect(page).not_to have_content("Free products require a pay what they want price.")
+    pwyw_toggle = find_field("Allow customers to pay what they want", disabled: true)
+    expect(pwyw_toggle).not_to be_checked
+
+    fill_in "Amount", with: "10"
+
+    expect(page).not_to have_content("Pay what you want isn't available on products with paid pricing options.")
+    pwyw_toggle = find_field("Allow customers to pay what they want")
+    expect(pwyw_toggle).not_to be_disabled
+  end
 end


### PR DESCRIPTION
# Disable pay-what-you-want on $0 products that have paid options

> Draft status: code is on the branch; hosted preview stills and walkthrough video are still owed.

## What

On a $0-base product that already has paid pricing options, the product editor no longer lets sellers turn on "Allow customers to pay what they want". The toggle is off and disabled, with an info note: "Pay what you want isn't available on products with paid pricing options." Raising the amount above $0 re-enables the toggle. Coffee products and paid-base products with options are unchanged.

## Why

Saving used to look like the toggle stuck, then the `Product::Prices#set_customizable_price` after-save hook wrote `customizable_price=false` with no editor feedback. That is the same guard that stops checkout from offering a $0 amount box next to a paid option (antiwork/gumroad-private#2342, antiwork/gumroad-private#1660). Matching the editor to that guard is the fix; forcing the flag true in the database would reopen the hole.

## Before / after

- Before: $0 amount + paid option → toggle still clickable; save silently turns it off.
- After: $0 amount + paid option → toggle off, disabled, with the reason. $10 amount + paid option → toggle stays editable.

Hosted preview stills will be committed to `qa-media/` once the branch preview is serving this head.

## Checklist

- [x] Scope — editor `PriceEditor` only; backend guard unchanged; no data repair
- [x] Design — disable + explain (do not hide); force local state off so save does not send `true`
- [x] Build — `gumclaw/pwyw-toggle-paid-variants`
- [ ] QA — preview stills and walkthrough owed
- [ ] Shipped
- [ ] Market — n/a, editor bugfix
- [ ] Sell — n/a

## Test Results

- `npx eslint --fix` on `PriceEditor.tsx` and `PriceEditor.test.tsx` — clean
- Vitest of `PriceEditor.test.tsx` — local run hung on Boxicons sourcemaps in a shared `node_modules` symlink; CI is the authoritative run
- New system example in `spec/requests/products/edit/pwyw_spec.rb`; inverted the stale pin in `edit_spec.rb` that expected the toggle enabled on this shape

## QA steps

1. Open a product with amount $0 and a paid pricing option.
2. Confirm the pay-what-you-want toggle is off, disabled, and the info note is visible.
3. Confirm you cannot turn it on.
4. Change amount to $10 and confirm the toggle is enabled again.
5. Save and confirm `customizable_price` stays false while amount is $0.

---

AI disclosure: grok-4.6. Prompt/instructions: handle gumroad-private#2342 — disable the product-editor pay-what-you-want toggle (with a reason) when a $0-base product has paid variant pricing, matching the existing backend guard.
