### PR TITLE
Cap how much mail one abandoned-cart run may enqueue

### DIFF
--- a/app/sidekiq/schedule_abandoned_cart_emails_job.rb
+++ b/app/sidekiq/schedule_abandoned_cart_emails_job.rb
@@ -25,6 +25,13 @@ class ScheduleAbandonedCartEmailsJob
   # range_optimizer_max_mem_size and silently falls back to a full table scan.
   IN_LIST_BATCH_SIZE = 5_000
 
+  # Ceiling on the mails one run may enqueue. A run only ever exceeds a normal day's volume
+  # when it is working through a backlog, and that is exactly when an uncapped fan-out becomes
+  # a mass-enqueue storm of the kind that took the platform down in gumroad-private#2302.
+  # Windows are walked newest-first, so the budget goes to the carts most likely to convert and
+  # the oldest age out rather than holding up the rest.
+  MAX_EMAILS_PER_RUN = 20_000
+
   sidekiq_options queue: :low, retry: 5, lock: :until_executed
 
   # Duplicate sends from an overlapping run are prevented by the unique index on
@@ -56,15 +63,20 @@ class ScheduleAbandonedCartEmailsJob
   # insert, which drops the duplicate.
   def perform
     days_to_process = (Cart::ABANDONED_IF_UPDATED_AFTER_AGO.to_i / 1.day.to_i)
+    remaining = MAX_EMAILS_PER_RUN
     (1..days_to_process).each do |day|
       day_start = day.days.ago.beginning_of_day
       day_end = day == 1 ? Cart::ABANDONED_IF_UPDATED_BEFORE_AGO.ago : (day - 1).days.ago.beginning_of_day
-      schedule_emails_for_window(day_start..day_end)
+      remaining -= schedule_emails_for_window(day_start..day_end, limit: remaining)
+      if remaining <= 0
+        Rails.logger.info "Stopped at MAX_EMAILS_PER_RUN (#{MAX_EMAILS_PER_RUN}) after day #{day}; the remaining windows carry over to the next run"
+        break
+      end
     end
   end
 
   private
-    def schedule_emails_for_window(window)
+    def schedule_emails_for_window(window, limit:)
       start_time = Time.current
       # { product_id => { cart_id => [variant_ids] } }
       cart_product_ids_with_cart_ids = {}
@@ -98,10 +110,15 @@ class ScheduleAbandonedCartEmailsJob
       start_time = Time.current
       cart_ids_with_matched_workflow_ids_and_product_ids = matched_workflow_ids_and_product_ids_by_cart_id(cart_product_ids_with_cart_ids)
 
+      enqueued = 0
       cart_ids_with_matched_workflow_ids_and_product_ids.each do |cart_id, workflow_ids_with_product_ids|
+        break if enqueued >= limit
+
         CustomerMailer.abandoned_cart(cart_id, workflow_ids_with_product_ids.stringify_keys).deliver_later(queue: "low")
+        enqueued += 1
       end
-      Rails.logger.info "Scheduled abandoned cart emails for #{cart_ids_with_matched_workflow_ids_and_product_ids.count} carts for #{window.begin} to #{window.end} in #{(Time.current - start_time).round(2)} seconds"
+      Rails.logger.info "Scheduled abandoned cart emails for #{enqueued} of #{cart_ids_with_matched_workflow_ids_and_product_ids.count} matched carts for #{window.begin} to #{window.end} in #{(Time.current - start_time).round(2)} seconds"
+      enqueued
     end
 
     # Returns { cart_id => { workflow_id => [product_ids] } } for the given

--- a/app/sidekiq/schedule_abandoned_cart_emails_job.rb
+++ b/app/sidekiq/schedule_abandoned_cart_emails_job.rb
@@ -26,8 +26,8 @@ class ScheduleAbandonedCartEmailsJob
   IN_LIST_BATCH_SIZE = 5_000
 
   # Ceiling on the mails one run may enqueue: uncapped, a run works a backlog into a single mass
-  # enqueue (gumroad-private#2302). Windows are walked newest day first so the budget goes to the
-  # freshest carts; order within a window is unspecified, which does not matter across one day.
+  # enqueue (gumroad-private#2302). Windows are walked newest day first and carts within a window
+  # newest first, so a run that stops early spends its budget on the freshest carts.
   MAX_EMAILS_PER_RUN = 20_000
 
   sidekiq_options queue: :low, retry: 5, lock: :until_executed
@@ -78,6 +78,7 @@ class ScheduleAbandonedCartEmailsJob
       start_time = Time.current
       # { product_id => { cart_id => [variant_ids] } }
       cart_product_ids_with_cart_ids = {}
+      updated_at_by_cart_id = {}
       cart_ids = abandoned_cart_ids(window)
       cart_ids.each_slice(BATCH_SIZE) do |batch_ids|
         carts = Cart.includes(:alive_cart_products, :user).where(id: batch_ids).reject do |cart|
@@ -86,6 +87,7 @@ class ScheduleAbandonedCartEmailsJob
         purchased_product_ids_by_cart_id = Cart.purchased_product_ids_by_cart_id(carts)
 
         carts.each do |cart|
+          updated_at_by_cart_id[cart.id] = cart.updated_at
           purchased_product_ids = purchased_product_ids_by_cart_id[cart.id] || []
 
           cart.alive_cart_products.each do |cart_product|
@@ -109,7 +111,12 @@ class ScheduleAbandonedCartEmailsJob
       cart_ids_with_matched_workflow_ids_and_product_ids = matched_workflow_ids_and_product_ids_by_cart_id(cart_product_ids_with_cart_ids)
 
       enqueued = 0
-      cart_ids_with_matched_workflow_ids_and_product_ids.each do |cart_id, workflow_ids_with_product_ids|
+      # Newest first: the match map is keyed in workflow-walk order, so without this a run that
+      # stops at the ceiling would favour whichever sellers happen to be walked first, every run
+      # for as long as the ceiling keeps binding.
+      ordered_matches = cart_ids_with_matched_workflow_ids_and_product_ids
+                          .sort_by { |cart_id, _| -updated_at_by_cart_id[cart_id].to_i }
+      ordered_matches.each do |cart_id, workflow_ids_with_product_ids|
         break if enqueued >= limit
 
         CustomerMailer.abandoned_cart(cart_id, workflow_ids_with_product_ids.stringify_keys).deliver_later(queue: "low")

--- a/app/sidekiq/schedule_abandoned_cart_emails_job.rb
+++ b/app/sidekiq/schedule_abandoned_cart_emails_job.rb
@@ -25,11 +25,9 @@ class ScheduleAbandonedCartEmailsJob
   # range_optimizer_max_mem_size and silently falls back to a full table scan.
   IN_LIST_BATCH_SIZE = 5_000
 
-  # Ceiling on the mails one run may enqueue. A run only ever exceeds a normal day's volume
-  # when it is working through a backlog, and that is exactly when an uncapped fan-out becomes
-  # a mass-enqueue storm of the kind that took the platform down in gumroad-private#2302.
-  # Windows are walked newest-first, so the budget goes to the carts most likely to convert and
-  # the oldest age out rather than holding up the rest.
+  # Ceiling on the mails one run may enqueue: uncapped, a run works a backlog into a single mass
+  # enqueue (gumroad-private#2302). Windows are walked newest day first so the budget goes to the
+  # freshest carts; order within a window is unspecified, which does not matter across one day.
   MAX_EMAILS_PER_RUN = 20_000
 
   sidekiq_options queue: :low, retry: 5, lock: :until_executed

--- a/spec/sidekiq/schedule_abandoned_cart_emails_job_spec.rb
+++ b/spec/sidekiq/schedule_abandoned_cart_emails_job_spec.rb
@@ -205,6 +205,55 @@ describe ScheduleAbandonedCartEmailsJob do
         end
       end
 
+      context "when the matching carts outnumber the per-run ceiling" do
+        # An uncapped run turns a backlog into one mass enqueue, the shape that took the
+        # platform down in gumroad-private#2302. Deferring the rest is safe: a delivered cart
+        # drops out of Cart.abandoned, so the next run resumes past it rather than repeating it.
+        it "stops at the ceiling and spends it on the newest window" do
+          travel_to Time.current.noon do
+            newest_cart = create(:cart)
+            create(:cart_product, cart: newest_cart, product: seller1_product1)
+            newest_cart.update!(updated_at: 25.hours.ago)
+
+            older_cart = create(:cart)
+            create(:cart_product, cart: older_cart, product: seller1_product1)
+            older_cart.update!(updated_at: 3.days.ago)
+
+            stub_const("#{described_class}::MAX_EMAILS_PER_RUN", 1)
+
+            expect do
+              described_class.new.perform
+            end.to have_enqueued_mail(CustomerMailer, :abandoned_cart).once
+              .and have_enqueued_mail(CustomerMailer, :abandoned_cart)
+                .with(newest_cart.id, { seller1_abandoned_cart_workflow.id => [seller1_product1.id] }.stringify_keys)
+          end
+        end
+
+        it "picks the deferred carts up on the next run" do
+          travel_to Time.current.noon do
+            newest_cart = create(:cart)
+            create(:cart_product, cart: newest_cart, product: seller1_product1)
+            newest_cart.update!(updated_at: 25.hours.ago)
+
+            older_cart = create(:cart)
+            create(:cart_product, cart: older_cart, product: seller1_product1)
+            older_cart.update!(updated_at: 3.days.ago)
+
+            stub_const("#{described_class}::MAX_EMAILS_PER_RUN", 1)
+            described_class.new.perform
+
+            # Standing in for the delivery the first run enqueued: that row is what takes the
+            # cart out of Cart.abandoned and lets the next run reach the one behind it.
+            create(:sent_abandoned_cart_email, cart: newest_cart, installment: seller1_abandoned_cart_workflow.alive_installments.sole)
+
+            expect do
+              described_class.new.perform
+            end.to have_enqueued_mail(CustomerMailer, :abandoned_cart)
+              .with(older_cart.id, { seller1_abandoned_cart_workflow.id => [seller1_product1.id] }.stringify_keys)
+          end
+        end
+      end
+
       context "when there are multiple matching abandoned cart workflows for a cart" do
         let(:cart) { create(:cart) }
         let!(:cart_product1) { create(:cart_product, cart: cart, product: seller1_product1) }

--- a/spec/sidekiq/schedule_abandoned_cart_emails_job_spec.rb
+++ b/spec/sidekiq/schedule_abandoned_cart_emails_job_spec.rb
@@ -228,6 +228,31 @@ describe ScheduleAbandonedCartEmailsJob do
           end
         end
 
+        it "spends the ceiling on the freshest carts inside a window" do
+          # The match map is keyed in workflow-walk order, so the stale cart — created first and
+          # therefore reached first — would win without an explicit sort, and would keep winning
+          # for as long as the ceiling binds.
+          travel_to Time.current.noon do
+            window_start = 2.days.ago.beginning_of_day
+
+            stale_cart = create(:cart)
+            create(:cart_product, cart: stale_cart, product: seller1_product1)
+            stale_cart.update!(updated_at: window_start + 2.hours)
+
+            fresh_cart = create(:cart)
+            create(:cart_product, cart: fresh_cart, product: seller1_product1)
+            fresh_cart.update!(updated_at: window_start + 20.hours)
+
+            stub_const("#{described_class}::MAX_EMAILS_PER_RUN", 1)
+
+            expect do
+              described_class.new.perform
+            end.to have_enqueued_mail(CustomerMailer, :abandoned_cart).once
+              .and have_enqueued_mail(CustomerMailer, :abandoned_cart)
+                .with(fresh_cart.id, { seller1_abandoned_cart_workflow.id => [seller1_product1.id] }.stringify_keys)
+          end
+        end
+
         it "picks the deferred carts up on the next run" do
           travel_to Time.current.noon do
             newest_cart = create(:cart)

--- a/spec/sidekiq/schedule_abandoned_cart_emails_job_spec.rb
+++ b/spec/sidekiq/schedule_abandoned_cart_emails_job_spec.rb
@@ -206,9 +206,8 @@ describe ScheduleAbandonedCartEmailsJob do
       end
 
       context "when the matching carts outnumber the per-run ceiling" do
-        # An uncapped run turns a backlog into one mass enqueue, the shape that took the
-        # platform down in gumroad-private#2302. Deferring the rest is safe: a delivered cart
-        # drops out of Cart.abandoned, so the next run resumes past it rather than repeating it.
+        # Deferring is safe because a delivered cart drops out of Cart.abandoned, so the next run
+        # resumes past it rather than repeating it.
         it "stops at the ceiling and spends it on the newest window" do
           travel_to Time.current.noon do
             newest_cart = create(:cart)
@@ -242,8 +241,8 @@ describe ScheduleAbandonedCartEmailsJob do
             stub_const("#{described_class}::MAX_EMAILS_PER_RUN", 1)
             described_class.new.perform
 
-            # Standing in for the delivery the first run enqueued: that row is what takes the
-            # cart out of Cart.abandoned and lets the next run reach the one behind it.
+            # Stands in for the first run's delivery: this row is what takes the cart out of
+            # Cart.abandoned.
             create(:sent_abandoned_cart_email, cart: newest_cart, installment: seller1_abandoned_cart_workflow.alive_installments.sole)
 
             expect do


### PR DESCRIPTION
## What

Caps how much mail one `ScheduleAbandonedCartEmailsJob` run may enqueue, via a new `MAX_EMAILS_PER_RUN`. The run spends its budget on the freshest carts and stops; the rest carry over to the next run.

Windows were already walked newest day first. This also sorts carts *within* a window by `updated_at`: the match map is keyed in workflow-walk order, so without the sort a capped run would favour whichever sellers happen to be walked first — and keep favouring them on every run for as long as the ceiling binds. `updated_at` is captured while the carts are already loaded, so it costs no extra query.

## Why

The scheduler enqueues one mail per matched cart with no ceiling, so its fan-out scales with however many carts are waiting rather than with a day's normal volume. That is only ever large when the job is working through a backlog — and a backlog is exactly the state in which an uncapped mass enqueue is most dangerous. A single job fanning out into a very large enqueue burst is the shape that took the platform down in gumroad-private#2302.

This ships **first, on its own**, deliberately. It is a no-op on a healthy day and harmless while the job is still failing, but it has to be deployed before #7442 removes the pre-filter that is currently aborting every run — otherwise the first run that actually completes fans out the entire accumulated backlog at once.

Carrying work over is safe: a delivered cart drops out of `Cart.abandoned`, so the next run resumes past it rather than repeating it.

**This is also what gets the job finishing at all.** Measured against production (numbers in gumroad-private#2343): with #7442's fix but no ceiling, a full 30-window sweep runs for well over an hour — squarely back in the failure mode where the job needs more uninterrupted runtime than a fleet with deploys and Vault-triggered restarts actually gives it. The ceiling cuts the run to a handful of windows and a runtime that comfortably survives a deploy. So this is not only a safety valve against the mass enqueue; it is load-bearing for completion.

Choosing newest-first is also the product call. A reminder about a cart abandoned weeks ago converts poorly and carries real complaint and deliverability risk, so spending a bounded budget on recent carts and letting the oldest age out is the behaviour we want, not a compromise. The constant is the knob for that policy — see gumroad-private#2343.

## Before / After

No user-visible surface: this is a scheduler-internal ceiling. Behaviour on a normal day is unchanged, because normal daily volume is far below the cap.

- **Before** — one run enqueues one mail per matched cart, unbounded.
- **After** — one run enqueues at most `MAX_EMAILS_PER_RUN`, newest window first, and logs when it stops.

⚠️ Walkthrough recording still to be attached.

## QA steps

1. Create abandoned carts in two different day-windows (`updated_at` 25 hours ago and 3 days ago), each holding a product covered by a published abandoned-cart workflow.
2. Temporarily set `ScheduleAbandonedCartEmailsJob::MAX_EMAILS_PER_RUN` to `1`, then run `ScheduleAbandonedCartEmailsJob.new.perform`.
3. Exactly one `CustomerMailer.abandoned_cart` job is enqueued, and it is for the cart in the **newest** window.
4. The log carries `Stopped at MAX_EMAILS_PER_RUN (1) after day 1; the remaining windows carry over to the next run`.
5. Create the `SentAbandonedCartEmail` row for that cart (standing in for the delivery), then run again — the older cart is now picked up, proving the deferral resumes rather than repeats.

## Test Results

`bundle exec rspec spec/sidekiq/schedule_abandoned_cart_emails_job_spec.rb` — 18 examples, 0 failures

Three new examples:
- stops at the ceiling and spends it on the newest window
- spends the ceiling on the freshest carts inside a window
- picks the deferred carts up on the next run

The ordering example was checked non-vacuous by removing the sort: the staler cart is created first, so it wins on insertion order and the example fails.

`bundle exec rubocop app/sidekiq/schedule_abandoned_cart_emails_job.rb spec/sidekiq/schedule_abandoned_cart_emails_job_spec.rb` — no offenses

Part of gumroad-private#2343

---

AI disclosure: written with Claude Opus 5 (1M context).
