### PR TITLE
Alert when abandoned-cart email stops going out

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -94,7 +94,25 @@ class HealthcheckController < ApplicationController
     render plain: "Purchases: #{status}", status:
   end
 
+  # Abandoned-cart delivery freshness, as an endpoint and not only as a scheduled alert:
+  # AlertOnStalledAbandonedCartEmailsJob rides the same sidekiq-cron schedule as the sender it
+  # watches, so a scheduler-wide failure silences both. Polling this does not depend on Sidekiq at
+  # all (gumroad-private#2343).
+  def abandoned_cart_emails
+    last_sent_at = SentAbandonedCartEmail.order(id: :desc).limit(1).pick(:created_at)
+    healthy = last_sent_at.present? && last_sent_at > ABANDONED_CART_EMAIL_STALE_AFTER.ago
+    status = healthy ? :ok : :service_unavailable
+
+    render plain: "Abandoned cart emails: #{status}", status:
+  end
+
   SIDEKIQ_QUEUE_LIMITS = { critical: 12_000, default: 300_000 }
   SIDEKIQ_RETRIES_LIMIT = 20_000
-  private_constant :SIDEKIQ_QUEUE_LIMITS, :SIDEKIQ_RETRIES_LIMIT
+
+  # Wider than the job's own threshold because this is polled continuously: sends land in one daily
+  # burst, so a bare 24h window reads as stale for the few minutes each day between the 24h mark and
+  # that day's run landing.
+  ABANDONED_CART_EMAIL_STALE_AFTER = AlertOnStalledAbandonedCartEmailsJob::STALL_THRESHOLD + 2.hours
+
+  private_constant :SIDEKIQ_QUEUE_LIMITS, :SIDEKIQ_RETRIES_LIMIT, :ABANDONED_CART_EMAIL_STALE_AFTER
 end

--- a/app/sidekiq/alert_on_stalled_abandoned_cart_emails_job.rb
+++ b/app/sidekiq/alert_on_stalled_abandoned_cart_emails_job.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Reports that abandoned-cart email has stopped going out (gumroad-private#2343).
+#
+# This surface has died platform-wide three times (gumroad-private#1198, #1576, #2343) and was
+# never caught by monitoring: the job's own alerting reports failed *attempts*, so it says nothing
+# when a run half-succeeds, when the enqueue is silently dropped, or when the schedule stops firing.
+# Freshness is the one signal that covers all three, because it asks the only question that matters
+# — did anything reach a buyer.
+class AlertOnStalledAbandonedCartEmailsJob
+  include Sidekiq::Job
+  sidekiq_options retry: 2, queue: :low
+
+  # ScheduleAbandonedCartEmailsJob runs daily and has historically produced its first rows within
+  # ten minutes, so a full day of silence is a failure rather than a slow run. Paired with a cron
+  # a few hours after that run, this alerts the same day rather than the next.
+  STALL_THRESHOLD = 24.hours
+
+  def perform
+    last_sent_at = last_send_time
+    return if last_sent_at.present? && last_sent_at > STALL_THRESHOLD.ago
+
+    InternalNotificationWorker.perform_async("agent_reports", "Abandoned cart emails stalled", message_for(last_sent_at))
+  end
+
+  private
+    # Newest id rather than MAX(created_at): sent_abandoned_cart_emails has no index on created_at,
+    # so the aggregate is a full scan that grows with the table, while this reads one row off the
+    # primary key. Rows are only ever inserted at delivery, so the newest id carries the newest
+    # timestamp.
+    def last_send_time
+      SentAbandonedCartEmail.order(id: :desc).limit(1).pick(:created_at)
+    end
+
+    def message_for(last_sent_at)
+      [
+        headline(last_sent_at),
+        "",
+        "ScheduleAbandonedCartEmailsJob runs daily. A run that aborts partway still delivers the windows it finished, so total silence means it died before the first window's delivery, was never enqueued, or the schedule stopped firing — check the dead set and the cron's last_enqueue_time, not just Sentry.",
+        "",
+        "Carts stop being eligible once they age past Cart::ABANDONED_IF_UPDATED_AFTER_AGO, so every silent day permanently loses that day's carts. See gumroad-private#2343.",
+      ].join("\n")
+    end
+
+    def headline(last_sent_at)
+      return "No abandoned-cart email has ever been sent — sent_abandoned_cart_emails is empty." if last_sent_at.blank?
+
+      hours = ((Time.current - last_sent_at) / 1.hour).floor
+      "No abandoned-cart email has been sent in #{hours} hours. The last one went out at #{last_sent_at.utc.strftime('%Y-%m-%d %H:%M UTC')}."
+    end
+end

--- a/app/sidekiq/alert_on_stalled_abandoned_cart_emails_job.rb
+++ b/app/sidekiq/alert_on_stalled_abandoned_cart_emails_job.rb
@@ -6,8 +6,9 @@
 # lock, and this job's own schedule entry going away. Freshness covers all three: it asks whether
 # anything actually reached a buyer.
 #
-# Blind spot: it runs on the same sidekiq-cron schedule as the job it watches, so a total
-# scheduler failure silences both. Closing that needs an out-of-band check.
+# It rides the same sidekiq-cron schedule as the sender, so a scheduler-wide failure would silence
+# this too. /healthcheck/abandoned_cart_emails answers the same question over HTTP, which is what
+# covers that case.
 class AlertOnStalledAbandonedCartEmailsJob
   include Sidekiq::Job
   sidekiq_options retry: 2, queue: :low

--- a/app/sidekiq/alert_on_stalled_abandoned_cart_emails_job.rb
+++ b/app/sidekiq/alert_on_stalled_abandoned_cart_emails_job.rb
@@ -3,8 +3,11 @@
 # Reports that abandoned-cart email has stopped going out (gumroad-private#2343).
 #
 # Alerting on failed attempts misses a run that half-succeeds, an enqueue dropped by a stranded
-# lock, and a schedule that stops firing. Freshness covers all three: it asks whether anything
-# actually reached a buyer.
+# lock, and this job's own schedule entry going away. Freshness covers all three: it asks whether
+# anything actually reached a buyer.
+#
+# Blind spot: it runs on the same sidekiq-cron schedule as the job it watches, so a total
+# scheduler failure silences both. Closing that needs an out-of-band check.
 class AlertOnStalledAbandonedCartEmailsJob
   include Sidekiq::Job
   sidekiq_options retry: 2, queue: :low

--- a/app/sidekiq/alert_on_stalled_abandoned_cart_emails_job.rb
+++ b/app/sidekiq/alert_on_stalled_abandoned_cart_emails_job.rb
@@ -2,18 +2,15 @@
 
 # Reports that abandoned-cart email has stopped going out (gumroad-private#2343).
 #
-# This surface has died platform-wide three times (gumroad-private#1198, #1576, #2343) and was
-# never caught by monitoring: the job's own alerting reports failed *attempts*, so it says nothing
-# when a run half-succeeds, when the enqueue is silently dropped, or when the schedule stops firing.
-# Freshness is the one signal that covers all three, because it asks the only question that matters
-# — did anything reach a buyer.
+# Alerting on failed attempts misses a run that half-succeeds, an enqueue dropped by a stranded
+# lock, and a schedule that stops firing. Freshness covers all three: it asks whether anything
+# actually reached a buyer.
 class AlertOnStalledAbandonedCartEmailsJob
   include Sidekiq::Job
   sidekiq_options retry: 2, queue: :low
 
-  # ScheduleAbandonedCartEmailsJob runs daily and has historically produced its first rows within
-  # ten minutes, so a full day of silence is a failure rather than a slow run. Paired with a cron
-  # a few hours after that run, this alerts the same day rather than the next.
+  # The send job runs daily and produces its first rows within minutes, so a full day of silence is
+  # a failure rather than a slow run.
   STALL_THRESHOLD = 24.hours
 
   def perform
@@ -24,10 +21,8 @@ class AlertOnStalledAbandonedCartEmailsJob
   end
 
   private
-    # Newest id rather than MAX(created_at): sent_abandoned_cart_emails has no index on created_at,
-    # so the aggregate is a full scan that grows with the table, while this reads one row off the
-    # primary key. Rows are only ever inserted at delivery, so the newest id carries the newest
-    # timestamp.
+    # Newest id rather than MAX(created_at), which has no index and would scan the whole table.
+    # Rows are only inserted at delivery, so the newest id carries the newest timestamp.
     def last_send_time
       SentAbandonedCartEmail.order(id: :desc).limit(1).pick(:created_at)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   get "/healthcheck/stripe_balance" => "healthcheck#stripe_balance"
   get "/healthcheck/purchases" => "healthcheck#purchases"
   get "/healthcheck/apple_pay_domain" => "healthcheck#apple_pay_domain"
+  get "/healthcheck/abandoned_cart_emails" => "healthcheck#abandoned_cart_emails"
 
   # IndexNow key verification file (https://www.indexnow.org/documentation).
   # Deliberately unconstrained by host: the spec requires the key file to be

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -180,6 +180,11 @@ schedule_abandoned_cart_emails:
   cron: "0 14 * * *" # UTC 14:00
   class: ScheduleAbandonedCartEmailsJob
   description: Schedules abandoned cart emails for users who have not completed their purchase
+alert_on_stalled_abandoned_cart_emails:
+  cron: "0 17 * * *" # UTC 17:00, three hours after the send job starts
+  class: AlertOnStalledAbandonedCartEmailsJob
+  queue: low
+  description: Reports when no abandoned cart email has been sent in over a day
 memberships_price_update_emails:
   cron: "10 8 * * *" # UTC 08:10
   class: SendMembershipsPriceUpdateEmailsJob

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -272,6 +272,52 @@ describe HealthcheckController do
     end
   end
 
+  describe "GET 'abandoned_cart_emails'" do
+    # The action reads the newest row in the table, so rows leaked by other examples would read as
+    # fresh. Clearing inside the example's transaction makes each case deterministic.
+    before { SentAbandonedCartEmail.delete_all }
+
+    context "when a send landed recently" do
+      it "returns HTTP success" do
+        create(:sent_abandoned_cart_email, created_at: 2.hours.ago)
+
+        get :abandoned_cart_emails
+
+        expect(response.status).to eq(200)
+        expect(response.body).to eq("Abandoned cart emails: ok")
+      end
+    end
+
+    context "when the newest send is older than the stale window" do
+      it "returns HTTP service_unavailable" do
+        create(:sent_abandoned_cart_email, created_at: 3.days.ago)
+
+        get :abandoned_cart_emails
+
+        expect(response.status).to eq(503)
+        expect(response.body).to eq("Abandoned cart emails: service_unavailable")
+      end
+    end
+
+    context "when nothing has ever been sent" do
+      it "returns HTTP service_unavailable" do
+        get :abandoned_cart_emails
+
+        expect(response.status).to eq(503)
+      end
+    end
+
+    # The daily send lands in one burst, so a threshold equal to the job's own would read as stale
+    # for the minutes between the 24h mark and that day's run.
+    it "stays healthy just past the job's own stall threshold" do
+      create(:sent_abandoned_cart_email, created_at: AlertOnStalledAbandonedCartEmailsJob::STALL_THRESHOLD.ago - 30.minutes)
+
+      get :abandoned_cart_emails
+
+      expect(response.status).to eq(200)
+    end
+  end
+
   describe "GET 'purchases'" do
     let(:redis_key) { RedisKey.min_successful_purchases_in_last_10_minutes }
 

--- a/spec/sidekiq/alert_on_stalled_abandoned_cart_emails_job_spec.rb
+++ b/spec/sidekiq/alert_on_stalled_abandoned_cart_emails_job_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AlertOnStalledAbandonedCartEmailsJob do
+  before do
+    allow(InternalNotificationWorker).to receive(:perform_async)
+  end
+
+  def sent_email_at(time)
+    travel_to(time) { create(:sent_abandoned_cart_email) }
+  end
+
+  describe "#perform" do
+    it "stays quiet when a send landed inside the threshold" do
+      sent_email_at(2.hours.ago)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).not_to have_received(:perform_async)
+    end
+
+    it "stays quiet on the near side of the threshold" do
+      sent_email_at(described_class::STALL_THRESHOLD.ago + 1.hour)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).not_to have_received(:perform_async)
+    end
+
+    it "alerts once the newest send is older than the threshold" do
+      last_sent_at = described_class::STALL_THRESHOLD.ago - 1.hour
+      sent_email_at(last_sent_at)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).to have_received(:perform_async) do |room, _sender, message|
+        expect(room).to eq("agent_reports")
+        expect(message).to include(last_sent_at.utc.strftime("%Y-%m-%d %H:%M UTC"))
+        expect(message).to include("25 hours")
+      end
+    end
+
+    it "alerts when nothing has ever been sent" do
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _sender, message|
+        expect(message).to include("has ever been sent")
+      end
+    end
+
+    it "names the room and sender it reports to" do
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).to have_received(:perform_async)
+        .with("agent_reports", "Abandoned cart emails stalled", anything)
+    end
+
+    it "judges freshness on the newest send, not the oldest" do
+      # A stalled surface still has old rows; reading anything but the newest would report a
+      # platform-wide outage as healthy, which is the failure this job exists to catch.
+      sent_email_at(10.days.ago)
+      sent_email_at(1.hour.ago)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).not_to have_received(:perform_async)
+    end
+  end
+
+  describe "schedule" do
+    let(:schedule) { YAML.load_file(Rails.root.join("config", "sidekiq_schedule.yml")) }
+
+    def cron_for(job_class_name)
+      schedule.values.find { |entry| entry["class"] == job_class_name }&.fetch("cron")
+    end
+
+    it "is registered on the schedule so it actually runs" do
+      expect(schedule.values.map { |entry| entry["class"] }).to include(described_class.name)
+    end
+
+    # Reading freshness before the day's send has had a chance to write anything would report
+    # every healthy day as an outage, so the alert has to sit after the job it watches.
+    it "runs later in the day than the send job it watches" do
+      send_hour = cron_for("ScheduleAbandonedCartEmailsJob").split[1].to_i
+      alert_hour = cron_for(described_class.name).split[1].to_i
+
+      expect(alert_hour).to be > send_hour
+    end
+  end
+
+  # Every example above stubs the worker, so nothing else would notice the room going away —
+  # and InternalNotificationMailer#notify returns silently when the room has no recipient, which
+  # would leave this job permanently dark with all specs green.
+  it "sends to a room that resolves to a real recipient" do
+    mail = InternalNotificationMailer.notify(room_name: "agent_reports", sender: "spec", message_text: "hello")
+
+    expect(mail.to).to be_present
+  end
+end


### PR DESCRIPTION
## What

Two ways to find out that abandoned-cart email has stopped:

1. **`AlertOnStalledAbandonedCartEmailsJob`** — a daily check reporting when nothing has been sent in over a day. Scheduled at 17:00 UTC, a few hours after the send job.
2. **`GET /healthcheck/abandoned_cart_emails`** — the same question over HTTP, following the existing `/healthcheck/purchases` pattern.

The second exists because the first rides the same sidekiq-cron schedule as the sender it watches, so a scheduler-wide failure silences the monitor and the thing it monitors together. HTTP polling depends on nginx and Puma, not on Sidekiq. Only `#index` gates the blue/green deploy, so a 503 on this action holds nothing up.

⚠️ The endpoint only alerts once something polls it — that half is ops config, same as `/healthcheck/purchases`.

Independent of #7441 and #7442 — it can merge in any order.

## Why

Abandoned-cart email has died platform-wide three times (gumroad-private#1198, #1576, #2343). None of them was caught by monitoring; the first two were reported by sellers.

The existing alerting is a `sidekiq_retries_exhausted` hook, which reports a failed *attempt*. That covers one of the three ways this surface goes dark and misses the others:

- a run that half-succeeds and delivers only its first window never exhausts retries
- an enqueue silently dropped by a stranded unique-job lock produces no attempt at all
- a schedule that stops firing produces no attempt either

It also reports via `ErrorNotifier.notify` with a string, which becomes `Sentry.capture_message` — a message rather than an exception, with no paging path. In the most recent outage that hook's trigger condition was met on roughly twenty separate days and nobody saw it.

Send freshness covers all three failure modes at once, because it asks the only question that matters: did anything actually reach a buyer.

## Implementation notes

Reads the newest row off the primary key rather than `MAX(created_at)`. `sent_abandoned_cart_emails` has no index on `created_at`, so the aggregate is a full scan that grows with the table; rows are only ever inserted at delivery, so the newest id carries the newest timestamp.

Threshold is 24h and the cron sits three hours after the send job, so a stalled day is reported the same day rather than the next.

The endpoint's window is deliberately wider than the job's threshold. Sends land in one daily burst, so a bare 24h window would read as stale for the few minutes each day between the 24h mark and that day's run landing — fine for a once-a-day job, a flapping 503 for something polled continuously.

## Before / After

No user-visible surface — this is internal alerting.

- **Before** — the surface can be dead for weeks with every spec green and no signal anyone reads.
- **After** — a day with no delivery reports to `agent_reports` the same afternoon, and `/healthcheck/abandoned_cart_emails` returns 503 for anything polling it.

⚠️ Walkthrough recording still to be attached.

## QA steps

1. With a `SentAbandonedCartEmail` row created in the last few hours, run `AlertOnStalledAbandonedCartEmailsJob.new.perform`. Nothing is sent.
2. Backdate the newest row past `STALL_THRESHOLD` and run again. A notification goes to `agent_reports` naming the last send time and how many hours have passed.
3. On an empty `sent_abandoned_cart_emails`, it alerts with the "has ever been sent" wording rather than a bogus hour count.
4. Confirm the room resolves: `InternalNotificationMailer.notify(room_name: "agent_reports", sender: "spec", message_text: "hello").to` is present.
5. `curl -i /healthcheck/abandoned_cart_emails` — 200 with a recent send, 503 once the newest row is backdated past the window, 503 on an empty table.

## Test Results

`bundle exec rspec spec/sidekiq/alert_on_stalled_abandoned_cart_emails_job_spec.rb spec/controllers/healthcheck_controller_spec.rb spec/models/concerns/recurring_lock_ttl_spec.rb` — 193 examples, 0 failures, 6 pending

`bundle exec rubocop app/sidekiq/alert_on_stalled_abandoned_cart_emails_job.rb spec/sidekiq/alert_on_stalled_abandoned_cart_emails_job_spec.rb` — no offenses

Covered: quiet inside the threshold, quiet on the near side of it, alerts past it, alerts on an empty table, judges freshness on the newest send rather than the oldest, is registered on the schedule, runs later in the day than the job it watches, and reports to a room that resolves to a real recipient — that last one because every other example stubs the worker, and `InternalNotificationMailer#notify` returns silently on a room with no recipient, which would leave the job permanently dark with all specs green.

Part of gumroad-private#2343

---

AI disclosure: written with Claude Opus 5 (1M context).
