### PR TITLE
fix: don't 500 /v2/sales on a nested page param

### DIFF
--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -320,7 +320,8 @@ class Api::V2::SalesController < Api::V2::BaseController
     end
 
     def set_page # DEPRECATED
-      @page = (params[:page] || 1).to_i
+      page = params[:page]
+      @page = page.is_a?(Integer) || page.is_a?(String) ? page.to_i : 1
       error_400("Invalid page number. Page numbers start at 1.") unless @page > 0
     end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -362,10 +362,13 @@ class Rack::Attack
                      period: 60.seconds,
                      throttle_params: Proc.new { |req| req.json_params.is_a?(Hash) && req.json_params.dig("user", "email").presence }
 
-  # Throttle requests to Sales API with slow pagination
+  # Throttle requests to Sales API with slow pagination; a non-scalar `page`
+  # (JSON:API `page[size]=`) is treated as page 0 so it cannot crash with a 500.
   throttle("/api/v2/sales", limit: 10, period: 1.second) do |req|
-    req.remote_ip if req.path.ends_with?("/v2/sales") && req.params["page"].to_i > 10
-  rescue Rack::QueryParser::InvalidParameterError, TypeError, Rack::Multipart::EmptyContentError
+    page = req.params["page"]
+    page_number = page.is_a?(Integer) || page.is_a?(String) ? page.to_i : 0
+    req.remote_ip if req.path.ends_with?("/v2/sales") && page_number > 10
+  rescue Rack::QueryParser::InvalidParameterError, TypeError, Rack::Multipart::EmptyContentError, NoMethodError
     nil
   end
 

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -325,6 +325,14 @@ describe Api::V2::SalesController do
         }.as_json)
       end
 
+      it "treats a nested page param as the first deprecated page" do
+        get :index, params: @params.merge(page: { size: "100" })
+
+        sales_json = [@purchase.as_json(version: 2), @free_trial_purchase.as_json(version: 2)].map(&:as_json)
+        expect(response.code).to eq "200"
+        expect(response.parsed_body).to include({ success: true, sales: match_array(sales_json) })
+      end
+
       it "filters sales by product if one is specified" do
         matching_product = create(:product, user: @seller)
         matching_purchase = create(:purchase, purchaser: @purchaser, link: matching_product)

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -215,6 +215,54 @@ describe "Rack::Attack throttle", type: :request do
     end
   end
 
+  describe "GET /api/v2/sales throttle with a nested (JSON:API) page param" do
+    before { reset_rack_attack! }
+    after { reset_rack_attack! }
+
+    it "does not raise when page is a nested Hash (page[size]=100)" do
+      request = Rack::Attack::Request.new(
+        Rack::MockRequest.env_for(
+          "/api/v2/sales?page[size]=100",
+          method: "GET",
+          input: "",
+          "HTTP_CF_CONNECTING_IP" => "203.0.113.95"
+        )
+      )
+
+      expect do
+        Rack::Attack.configuration.throttled?(request)
+      end.not_to raise_error
+    end
+
+    it "still throttles a scalar page past the depth limit" do
+      travel_to(Time.current) do
+        10.times do |i|
+          request = Rack::Attack::Request.new(
+            Rack::MockRequest.env_for(
+              "/api/v2/sales?page=#{i + 11}",
+              method: "GET",
+              input: "",
+              "HTTP_CF_CONNECTING_IP" => "203.0.113.96"
+            )
+          )
+
+          expect(Rack::Attack.configuration.throttled?(request)).to be(false), "request #{i + 1} unexpectedly throttled"
+        end
+
+        over = Rack::Attack::Request.new(
+          Rack::MockRequest.env_for(
+            "/api/v2/sales?page=21",
+            method: "GET",
+            input: "",
+            "HTTP_CF_CONNECTING_IP" => "203.0.113.96"
+          )
+        )
+
+        expect(Rack::Attack.configuration.throttled?(over)).to be(true)
+      end
+    end
+  end
+
   describe "POST /oauth/device/code issuance throttle" do
     before { reset_rack_attack! }
     after { reset_rack_attack! }

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -229,9 +229,7 @@ describe "Rack::Attack throttle", type: :request do
         )
       )
 
-      expect do
-        Rack::Attack.configuration.throttled?(request)
-      end.not_to raise_error
+      expect(Rack::Attack.configuration.throttled?(request)).to be(false)
     end
 
     it "still throttles a scalar page past the depth limit" do


### PR DESCRIPTION
## What

Fix `GET /v2/sales` 500ing in production when the request sends a JSON:API-style nested `page` param (`page[size]=100`).

Rack::Attack's Sales-API pagination throttle calls `req.params["page"].to_i`. For a nested Hash (what `page[size]=` parses to, a `Rack::QueryParser::Params`), `to_i` raises `NoMethodError`, and the existing rescue didn't catch it — so the middleware 500s the request before the controller runs. Sentry `GUMROAD-WJ`: 10 events / 6 users since 2026-06-23, 5 on 2026-08-29.

## Why

The throttle is supposed to rate-limit deep pagination, not take the endpoint down. A client sending `page[size]` (common in HTTP clients) gets a 500 instead of a 200 or a 429.

## Before / After

Before (`config/initializers/rack_attack.rb`):
```ruby
req.remote_ip if req.path.ends_with?("/v2/sales") && req.params["page"].to_i > 10
rescue Rack::QueryParser::InvalidParameterError, TypeError, Rack::Multipart::EmptyContentError
```
`/api/v2/sales?page[size]=100` → `NoMethodError` → 500.

After:
```ruby
# Rack::Attack
page = req.params["page"]
page_number = page.is_a?(Integer) || page.is_a?(String) ? page.to_i : 0
req.remote_ip if req.path.ends_with?("/v2/sales") && page_number > 10

# Api::V2::SalesController#set_page
page = params[:page]
@page = page.is_a?(Integer) || page.is_a?(String) ? page.to_i : 1
```
A non-scalar `page` is not throttled by Rack::Attack and is normalized to the first deprecated Sales API page in the controller. A scalar deep page (`page=11+`) still throttles past the depth limit. `NoMethodError` is also added to the throttle rescue so a bad `page` can never take the API down before Rails handles it.

## Test Results

Ran focused checks on the pushed branch:
- `ruby -c app/controllers/api/v2/sales_controller.rb config/initializers/rack_attack.rb spec/requests/rack_attack_spec.rb spec/controllers/api/v2/sales_controller_spec.rb` — all 4 files syntax OK.
- `bundle exec rubocop --format simple app/controllers/api/v2/sales_controller.rb config/initializers/rack_attack.rb spec/requests/rack_attack_spec.rb spec/controllers/api/v2/sales_controller_spec.rb` — 4 files inspected, no offenses.
- `bundle exec rspec spec/requests/rack_attack_spec.rb:218 spec/controllers/api/v2/sales_controller_spec.rb:318 spec/controllers/api/v2/sales_controller_spec.rb:328` — 4 examples, 0 failures:
  - nested `page[size]=100` is not throttled by Rack::Attack (`false`, not just “no raise”)
  - scalar deep pages still throttle at the existing depth limit
  - invalid scalar page still returns 400
  - nested controller page param returns 200 and the first deprecated Sales API page.

**Mutation proof (spec has teeth):** temporarily reverted `Api::V2::SalesController#set_page` to `(params[:page] || 1).to_i` and re-ran `spec/controllers/api/v2/sales_controller_spec.rb:328`; it failed with `NoMethodError: undefined method 'to_i' for an instance of ActionController::Parameters`. Restored the fix afterward; branch diff is the intended three files only.

## QA steps

Backend-only change with no rendered surface (Rack::Attack middleware + Sales API controller guard), so no screenshot applies — verified in code + specs instead:
1. `GET /api/v2/sales?page[size]=100`: Rack::Attack returns `false` (not throttled), the controller treats the non-scalar `page` as page 1, and the endpoint returns 200 with the first Sales API page. Covered by the Rack::Attack and controller specs.
2. `GET /api/v2/sales?page=11` repeated 11× in 1s from one IP: 11th is 429. Covered by the scalar Rack::Attack spec.
3. `GET /api/v2/sales?page=e3`: still returns 400. Covered by the existing invalid-page controller spec.

---

## Status
- [x] Scope — Sales API pagination throttle must not 500 on a nested `page`
- [x] Design — coerce scalar `page` only in both Rack::Attack and the Sales controller; non-scalars cannot call `to_i`
- [x] Build — Rack::Attack guard, controller guard, and 3 focused spec examples; `ruby -c` and rubocop clean
- [x] QA — focused spec run green (4/0); controller mutation proof red against pre-fix code (see above)
- [ ] Shipped — not yet (draft; CI pending)
- [ ] Market — N/A (bug fix)
- [ ] Sell — N/A (bug fix)

---

AI disclosure: authored by Hermes Agent (model `grok-4.6`), reviewed per autonomous-product-dev.

Premerge review: clean @ 3b6fb6016a2905414e05a0e14939c045a0e89e3c
