### PR TITLE
Fix 500 when saving a checkout discount with a nil amount

### DIFF
--- a/app/controllers/checkout/discounts_controller.rb
+++ b/app/controllers/checkout/discounts_controller.rb
@@ -159,7 +159,10 @@ class Checkout::DiscountsController < Sellers::BaseController
         params[:amount_cents] = nil
         params[:currency_type] = nil
         params[:once_per_cart] = false
-      else
+      elsif params.key?(:amount_cents)
+        # Only nil the percentage when the client actually submitted a cents amount
+        # (a percent→cents conversion). A partial update that sends neither amount
+        # must leave the existing percentage untouched, or it silently wipes it.
         params[:amount_percentage] = nil
       end
     end

--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -113,6 +113,7 @@ class OfferCode < ApplicationRecord
 
   def amount_off(price_cents)
     return amount_cents if is_cents?
+    return 0 if amount_percentage.nil?
 
     (price_cents * (amount_percentage / 100.0)).round
   end
@@ -480,6 +481,7 @@ class OfferCode < ApplicationRecord
     def price_validation
       return if deleted_at.present?
       return errors.add(:base, "Please enter a positive discount amount.") if (is_percent? && amount_percentage.to_i < 0) || (is_cents? && amount_cents.to_i < 0)
+      return errors.add(:base, "Please enter a discount amount.") if !tiered? && !is_percent? && !is_cents?
 
       return errors.add(:base, "Please enter a discount amount that is 100% or less.") if is_percent? && amount_percentage > 100
 

--- a/spec/controllers/checkout/discounts_controller_spec.rb
+++ b/spec/controllers/checkout/discounts_controller_spec.rb
@@ -635,6 +635,23 @@ describe Checkout::DiscountsController do
       expect(offer_code.products).to eq([subject_product])
     end
 
+    it "preserves a percentage offer code's amount on a partial update that omits both amount keys" do
+      percent_code = create(:percentage_offer_code, user: seller, code: "CODE1")
+
+      put :update, params: {
+        id: percent_code.external_id,
+        name: "Renamed discount",
+      }, as: :json
+
+      expect(response).to be_successful
+      expect(response.parsed_body["success"]).to eq(true)
+
+      percent_code.reload
+      expect(percent_code.name).to eq("Renamed discount")
+      expect(percent_code.amount_percentage).to eq(50)
+      expect(percent_code.amount_cents).to eq(nil)
+    end
+
     it "returns an error and keeps the product list when removing a product whose default discount is the offer code" do
       subject_product = create(:product, user: seller, price_cents: 2000)
       offer_code.update!(universal: false, products: [subject_product])

--- a/spec/models/offer_code_spec.rb
+++ b/spec/models/offer_code_spec.rb
@@ -143,6 +143,14 @@ describe OfferCode do
       end
     end
 
+    describe "offer codes with neither a percentage nor a cents amount" do
+      it "rejects the code with a validation error instead of raising" do
+        expect { create(:offer_code, products: [@product], amount_percentage: nil, amount_cents: nil) }
+          .to raise_error(ActiveRecord::RecordInvalid, /Please enter a discount amount\./)
+        expect { create(:offer_code, products: [@product], amount_percentage: nil, amount_cents: nil) rescue nil }.to_not change { OfferCode.count }
+      end
+    end
+
     describe "universal offer codes" do
       before do
         create(:product, user: @product.user, price_cents: 1000, price_currency_type: "usd")
@@ -744,6 +752,10 @@ describe OfferCode do
         offer_code_3 = create(:offer_code, code: "2000_OFF", products: [@product], amount_cents: 2000)
         expect(offer_code_3.amount_off(@product.price_cents)).to eq 2000
       end
+    end
+
+    it "returns 0 when neither a cents amount nor a percentage is set" do
+      expect(OfferCode.new(amount_percentage: nil, amount_cents: nil).amount_off(@product.price_cents)).to eq 0
     end
   end
 


### PR DESCRIPTION
Premerge review: clean @ 0ebbda7ca500ee9cfedaefb6631c5a93e8165d2b

Sol (`gpt-5.6-sol`) money/risk lens at `0ebbda7ca500`. No P0/P1. Panel skipped: Fable-5 400 until 2026-09-01 (API usage limits).
## What

Saving a checkout discount 500s with `NoMethodError: undefined method '/' for nil` in `OfferCode#amount_off` when a discount has neither a cents amount nor a percentage. Sellers get a crash instead of a validation error. [GUMROAD-AR](https://gumroad-to.sentry.io/issues/7387839404/): 15 events / 4 users since 2026-04-05, last seen 2026-08-30 08:51Z. Production.

## Why

`amount_off` assumed `amount_percentage` is numeric whenever the code is not cents-based:

```ruby
def amount_off(price_cents)
  return amount_cents if is_cents?
  (price_cents * (amount_percentage / 100.0)).round
end
```

`price_validation` → `is_amount_valid?` calls this on every save. When both `amount_cents` and `amount_percentage` are nil it raised instead of adding an error.

Two triggers:

1. **`clean_params` invents a permitted nil.** Top-level `amount_percentage` absent → `clean_params` executes `params[:amount_percentage] = nil`, which `params.permit(:amount_percentage, …)` then includes, so `update` writes `amount_percentage = nil`. A percent offer code updated with a payload that sends neither amount (partial update, or a nested `offer_code:` payload the top-level-only permit ignores) has its percentage silently wiped → cents nil → `amount_off` 500s on the same save.

2. **No validation for a missing amount.** Even reaching `amount_off` with a nil percentage 500s rather than producing a validation error.

## Before-After

| Case | Before | After |
|---|---|---|
| Update a percent offer code sending neither amount (partial/nested update) | `clean_params` invents `amount_percentage=nil`, wipes the stored percentage, then `amount_off` 500s | Percentage preserved; update succeeds (the client submits the amount when it actually changes it) |
| Save a discount with neither a cents amount nor a percentage | `NoMethodError: undefined method '/' for nil` (500) | Validation error: `Please enter a discount amount.` |
| Percent→cents conversion via the dashboard (sends `amount_cents`) | works | still works (`params.key?(:amount_cents)` keeps the nill-out) |

Tiered offer codes (discount defined in `ownership_duration_tiers`) are exempt from the new missing-amount validation.

## Test Results

Local (dedicated worktree, lane 0 DB, ES `localhost:32768`, DynamoDB `localhost:32769`):

- `spec/models/offer_code_spec.rb:147` — new: rejects "neither amount" code with a validation error → **green**
- `spec/models/offer_code_spec.rb:757` — new: `amount_off` returns 0 for nil percentage → **green**
- `spec/controllers/checkout/discounts_controller_spec.rb:638` — new: partial update preserves a percent offer code's amount → **green**
- `spec/models/offer_code_spec.rb:102` — existing `#price_validation` block → **17 examples, 0 failures**
- `spec/models/offer_code_spec.rb:754` — existing `#amount_off` cents example → **green**
- `spec/controllers/checkout/discounts_controller_spec.rb` — full file → **43 examples, 1 failure; the single red is the pre-existing `GET index` Inertia render test failing on a fresh worktree's missing vite plugins (`@vitejs/plugin-react`, `@typia/unplugin/vite` absent from shared `node_modules`) — unrelated to this diff and reproduces on an untouched render path.**

**Red-proof (specs fail against the pre-fix code):**
- Both new model specs red with the exact `NoMethodError: undefined method '/' for nil` when `offer_code.rb` is reverted.
- The new controller spec red (`Expected false to eq true` — update returned `success: false`) when `discounts_controller.rb` is reverted.

## QA steps

- Open Checkout → Discounts, edit a percent-off code and save (dashboard posts flat keys with `amount_percentage` present). Confirmed no 500; still persists.
- Send a partial update to `PUT /checkout/discounts/:id` with neither amount key (e.g. a nested `offer_code:` payload): response is `success: true` and the stored `amount_percentage` is unchanged (previously `success: false` / 500 and the percentage wiped).
- Send an update creating a discount with neither amount: `success: false` with `error_message: "Please enter a discount amount."` instead of a 500.


Backend-only — no screenshotable surface; the reviewable artifact is the spec + controller path (a nil-amount save now 422s with a validation error instead of 500). Docs-only exemption does not apply; this is the adjacent-surface confirmation.

## AI disclosure

Built and tested by Hermes Agent (model `grok-4.6`).

---

## Status

- [x] Scope — Guard `amount_off` against nil; reject missing amount in `price_validation`; stop `clean_params` inventing a nil `amount_percentage`
- [x] Design — Exempt tiered codes; preserve percent→cents conversion; frontend posts flat top-level keys (verified in `app/javascript/data/offer_code.ts`), the nested `offer_code:` payload in the Sentry event comes from an external client — this diff makes that path safe too
- [x] Build — 4 files changed (2 app, 2 spec)
- [x] QA — new specs green + red-proven; full controller suite green except the environmental `GET index` vite failure
- [x] Ship — merged by nyomanjyotisa at 2026-08-30T16:04:28Z as `ad8d5dece406bb7b173533ff229615248ac41732`; production deploy verification remains tracked in antiwork/gumroad-private#2346
- [ ] Market — n/a (bug fix)
- [ ] Sell — n/a (bug fix)

