### PR TITLE
Pin download-page Watch app-bridge specs to resumeAt 0

### DIFF
--- a/spec/requests/download_page/rich_text_editor_spec.rb
+++ b/spec/requests/download_page/rich_text_editor_spec.rb
@@ -66,7 +66,7 @@ describe("Download Page – Rich Text Editor Content", type: :system, js: true) 
         expect(page.evaluate_script("window._messages[1]")).to eq(
           {
             type: "click",
-            payload: { resourceId: @video_file.external_id, isDownload: false, isPost: false, type: nil, isPlaying: nil, resumeAt: nil, contentLength: nil }
+            payload: { resourceId: @video_file.external_id, isDownload: false, isPost: false, type: nil, isPlaying: nil, resumeAt: "0", contentLength: nil }
           }.as_json
         )
         expect(page).not_to have_selector("[aria-label='Video Player']")
@@ -186,7 +186,7 @@ describe("Download Page – Rich Text Editor Content", type: :system, js: true) 
         expect(page.evaluate_script("window._messages[1]")).to eq(
           {
             type: "click",
-            payload: { resourceId: @video_file.external_id, isDownload: false, isPost: false, type: nil, isPlaying: nil, resumeAt: nil, contentLength: nil, extension: "MOV" }
+            payload: { resourceId: @video_file.external_id, isDownload: false, isPost: false, type: nil, isPlaying: nil, resumeAt: "0", contentLength: nil, extension: "MOV" }
           }.as_json
         )
         expect(page).not_to have_selector("[aria-label='Video Player']")


### PR DESCRIPTION
## What

Main is red on Test Slow 45 after [antiwork/gumroad#7435](https://github.com/antiwork/gumroad/pull/7435). Native Watch clicks now send `resumeAt: "0"`; the download-page rich-text embed specs still expected `nil`.

## Why

#7435 is the intended payload. Audio Watch examples already pin `resumeAt: "0"`. Video Watch examples did not, so iOS and React Native app-bridge examples fail on every main run (confirmed attempt 1 and the one allowed `--failed` rerun).

## Test Results

- Spec-only pin: two `resumeAt: nil` → `"0"` on the Watch (not Download) video examples.

## Status

- [x] Scope
- [x] Design
- [x] Build
- [ ] QA — CI on this head
- [ ] Ship
- [ ] Market
- [ ] Sell

Related: antiwork/gumroad#7435

---

AI disclosure: Authored by Gumclaw using Hermes Agent (grok-4.6).

Premerge review: clean @ 2a865ccd8813ee4b3e2d31c490b09d86a73d3f05
