### PR TITLE
Don't clear a custom product URL on a later editor save

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -908,13 +908,17 @@ class LinksController < ApplicationController
       end
     end
 
-    # Null/blank custom_permalink is "not specified", not "clear the slug".
-    # The editor posts a full snapshot, so a content-tab save would otherwise
-    # wipe a URL set on an earlier Product-tab save.
+    # Blank custom_permalink is "not specified" unless the current editor marks
+    # it as a deliberate clear. Older tabs send the whole snapshot without that
+    # marker, so their stale blank must not wipe a slug another tab set.
     def omit_unspecified_product_scalars!
       permitted = product_permitted_params
-      permitted.delete(:custom_permalink) if permitted[:custom_permalink].blank?
+      permitted.delete(:custom_permalink) if permitted[:custom_permalink].blank? && !custom_permalink_clear_requested?
       permitted.delete(:customizable_price) if permitted[:customizable_price].nil?
+    end
+
+    def custom_permalink_clear_requested?
+      ActiveModel::Type::Boolean.new.cast(params[:custom_permalink_changed])
     end
 
     # Built from PERMITTED params so submitted? sees collections as strong

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -485,6 +485,8 @@ class LinksController < ApplicationController
           diagnostics: deletion_guard_diagnostics
         )
 
+        omit_unspecified_product_scalars!
+
         @product.assign_attributes(product_permitted_params.except(
           :products,
           :description,
@@ -904,6 +906,15 @@ class LinksController < ApplicationController
         permitted.delete(:custom_html) unless Feature.active?(:custom_html_pages, @product.user)
         permitted
       end
+    end
+
+    # Null/blank custom_permalink is "not specified", not "clear the slug".
+    # The editor posts a full snapshot, so a content-tab save would otherwise
+    # wipe a URL set on an earlier Product-tab save.
+    def omit_unspecified_product_scalars!
+      permitted = product_permitted_params
+      permitted.delete(:custom_permalink) if permitted[:custom_permalink].blank?
+      permitted.delete(:customizable_price) if permitted[:customizable_price].nil?
     end
 
     # Built from PERMITTED params so submitted? sees collections as strong

--- a/app/javascript/components/server-components/ProductEditPage.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.tsx
@@ -646,6 +646,7 @@ const ProductEditPage = (props: Props) => {
       setSaving(true);
       const response = await saveProduct(props.unique_permalink, props.id, productSent, currencyType, {
         keepAllFiles: conflictResolution?.choice === "keep_version",
+        lastSavedCustomPermalink: lastSavedProductRef.current.custom_permalink,
       });
       saved = true;
       // The version pages the seller chose to keep were never loaded into this

--- a/app/javascript/data/product_edit.test.ts
+++ b/app/javascript/data/product_edit.test.ts
@@ -48,13 +48,20 @@ describe("filesForSave", () => {
 });
 
 describe("scalarSettingsForSave", () => {
-  it("omits a null or empty custom permalink so a later save cannot clear it", () => {
-    expect(scalarSettingsForSave({ custom_permalink: null })).toEqual({});
-    expect(scalarSettingsForSave({ custom_permalink: "" })).toEqual({});
+  it("omits an unchanged blank custom permalink so a stale tab cannot clear it", () => {
+    expect(scalarSettingsForSave({ custom_permalink: null }, null)).toEqual({});
+    expect(scalarSettingsForSave({ custom_permalink: "" }, null)).toEqual({});
+  });
+
+  it("sends a marker when this session clears an existing custom permalink", () => {
+    expect(scalarSettingsForSave({ custom_permalink: null }, "kept-slug")).toEqual({
+      custom_permalink: null,
+      custom_permalink_changed: true,
+    });
   });
 
   it("sends a non-empty custom permalink", () => {
-    expect(scalarSettingsForSave({ custom_permalink: "my-custom-url" })).toEqual({
+    expect(scalarSettingsForSave({ custom_permalink: "my-custom-url" }, null)).toEqual({
       custom_permalink: "my-custom-url",
     });
   });

--- a/app/javascript/data/product_edit.test.ts
+++ b/app/javascript/data/product_edit.test.ts
@@ -19,6 +19,7 @@ import {
   resolveServerIdMapping,
   richContentMoveSourceIds,
   saveProductError,
+  scalarSettingsForSave,
   StaleContentConflictError,
   StaleDeletionConflictError,
 } from "$app/data/product_edit";
@@ -43,6 +44,19 @@ describe("filesForSave", () => {
     expect(filesForSave(editorFiles, new Set(), false)).toEqual([]);
     expect(editorFiles).toEqual([file]);
     expect(filesForSave(editorFiles, new Set(), true)).toEqual([file]);
+  });
+});
+
+describe("scalarSettingsForSave", () => {
+  it("omits a null or empty custom permalink so a later save cannot clear it", () => {
+    expect(scalarSettingsForSave({ custom_permalink: null })).toEqual({});
+    expect(scalarSettingsForSave({ custom_permalink: "" })).toEqual({});
+  });
+
+  it("sends a non-empty custom permalink", () => {
+    expect(scalarSettingsForSave({ custom_permalink: "my-custom-url" })).toEqual({
+      custom_permalink: "my-custom-url",
+    });
   });
 });
 

--- a/app/javascript/data/product_edit.ts
+++ b/app/javascript/data/product_edit.ts
@@ -425,6 +425,11 @@ export const reconcileMountedEditorFileEmbedIds = (editor: Editor, fileIdMapping
   if (transaction.docChanged) editor.view.dispatch(transaction);
 };
 
+// Omit a null/empty custom URL so a content-tab snapshot cannot clear a slug
+// the seller set on a previous save. A non-empty slug is still sent.
+export const scalarSettingsForSave = (product: { custom_permalink: string | null }) =>
+  product.custom_permalink ? { custom_permalink: product.custom_permalink } : {};
+
 export const saveProduct = async (
   permalink: string,
   id: string,
@@ -457,13 +462,14 @@ export const saveProduct = async (
   // would make "Keep version content" delete files embedded in the hidden
   // pages even though that retry asks us to preserve every file.
   const files = filesForSave(product.files, fileIds, options.keepAllFiles ?? false);
-  const { custom_html: _customHtml, ...productParams } = product;
+  const { custom_html: _customHtml, custom_permalink, ...productParams } = product;
   const response = await request({
     method: "POST",
     accept: "json",
     url: Routes.link_path(permalink),
     data: {
       ...productParams,
+      ...scalarSettingsForSave({ custom_permalink }),
       files,
       price_currency_type: currencyType,
       covers: product.covers.map(({ id }) => id),

--- a/app/javascript/data/product_edit.ts
+++ b/app/javascript/data/product_edit.ts
@@ -425,10 +425,16 @@ export const reconcileMountedEditorFileEmbedIds = (editor: Editor, fileIdMapping
   if (transaction.docChanged) editor.view.dispatch(transaction);
 };
 
-// Omit a null/empty custom URL so a content-tab snapshot cannot clear a slug
-// the seller set on a previous save. A non-empty slug is still sent.
-export const scalarSettingsForSave = (product: { custom_permalink: string | null }) =>
-  product.custom_permalink ? { custom_permalink: product.custom_permalink } : {};
+// Only send a blank custom URL when this session is clearing one it knows
+// about; an unchanged blank can be a stale tab snapshot from before another
+// tab set the slug.
+export const scalarSettingsForSave = (
+  product: { custom_permalink: string | null },
+  lastSavedCustomPermalink: string | null,
+) => {
+  if (product.custom_permalink) return { custom_permalink: product.custom_permalink };
+  return lastSavedCustomPermalink ? { custom_permalink: null, custom_permalink_changed: true } : {};
+};
 
 export const saveProduct = async (
   permalink: string,
@@ -439,7 +445,7 @@ export const saveProduct = async (
   // (the kept pages were never loaded into this session), so filtering files
   // by the file-embeds found in the submitted content would wrongly delete
   // every file — including the ones the kept pages embed. Skip the filter.
-  options: { keepAllFiles?: boolean } = {},
+  options: { keepAllFiles?: boolean; lastSavedCustomPermalink?: string | null } = {},
 ): Promise<SaveProductResponse> => {
   // TODO remove this once we have a better content uploader
   const editor = new Editor(baseEditorOptions(extensions(id)));
@@ -469,7 +475,7 @@ export const saveProduct = async (
     url: Routes.link_path(permalink),
     data: {
       ...productParams,
-      ...scalarSettingsForSave({ custom_permalink }),
+      ...scalarSettingsForSave({ custom_permalink }, options.lastSavedCustomPermalink ?? null),
       files,
       price_currency_type: currencyType,
       covers: product.covers.map(({ id }) => id),

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -1160,6 +1160,15 @@ class LinksControllerUpdateTest < ActionController::TestCase
     assert_equal "new-slug", @product.reload.custom_permalink
   end
 
+  test "PUT update clears a custom URL when the current editor marks the blank value as changed" do
+    @product.update!(custom_permalink: "kept-slug")
+
+    put :update, params: @params.merge(custom_permalink: nil, custom_permalink_changed: true), as: :json
+
+    assert_response :success
+    assert_nil @product.reload.custom_permalink
+  end
+
   test "PUT update returns the existing validation error when suggested price is set but the default price record is missing" do
     @product.prices.destroy_all
     @product.update_column(:customizable_price, true)

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -1139,6 +1139,27 @@ class LinksControllerUpdateTest < ActionController::TestCase
     assert_equal "kept-slug", @product.reload.custom_permalink
   end
 
+  test "PUT update does not clear a custom URL when the snapshot sends a blank permalink" do
+    @product.update!(custom_permalink: "kept-slug", price_cents: 500)
+    @product.update_column(:customizable_price, true)
+
+    put :update, params: @params.merge(custom_permalink: nil, customizable_price: nil), as: :json
+
+    assert_response :success
+    @product.reload
+    assert_equal "kept-slug", @product.custom_permalink
+    assert_equal true, @product.customizable_price
+  end
+
+  test "PUT update still writes a new custom URL when the snapshot sends one" do
+    @product.update!(custom_permalink: "kept-slug")
+
+    put :update, params: @params.merge(custom_permalink: "new-slug"), as: :json
+
+    assert_response :success
+    assert_equal "new-slug", @product.reload.custom_permalink
+  end
+
   test "PUT update returns the existing validation error when suggested price is set but the default price record is missing" do
     @product.prices.destroy_all
     @product.update_column(:customizable_price, true)


### PR DESCRIPTION
Premerge review: clean @ 26044af35b122df6aa9699127c53e2c9d91567fc

Don't clear a custom product URL on a later editor save

## What

A product-editor save that sends a blank `custom_permalink` as an unchanged snapshot no longer clears a URL the seller already set. A seller can still intentionally clear an existing custom URL from the current editor session: the client sends an explicit `custom_permalink_changed` marker and the controller honors that marked blank. A non-empty slug still writes. A nil `customizable_price` is likewise treated as unspecified.

## Why

The editor posts the whole product on every save. Empty URL input is `null` in that snapshot, and `assign_attributes` treated that as "clear the slug". Saving description/content after setting a custom URL wiped the URL. The Greptile review correctly caught that blindly omitting blank custom permalinks also removed the intentional-clear path, so the follow-up distinguishes an unchanged blank snapshot from a marked clear.

## Before / after

- Before: PUT with `custom_permalink: null` set the stored slug to nil. Proven: the original new example fails against `origin/main` (`Expected: "kept-slug"` / `Actual: nil`).
- After: an unmarked blank keeps `kept-slug`; a marked blank clears it; a non-empty slug still replaces it.

## Checklist

- [x] Scope — custom URL (and nil pay-what-you-want) on the editor save path. Does not change $0-base + paid-variant PWYW forcing.
- [x] Design — unchanged blank scalar = no change; marked custom URL blank = deliberate clear; present slug still writes. Rejected: inferring "content-only" saves from which keys appear.
- [x] Build — `gumclaw/gp2348-editor-scalar-revert` @ `26044af35b`
- [x] QA — focused controller examples, frontend payload tests, lint/typecheck, and Sol premerge (below). No visual surface.
- [ ] Shipped — ready; `ci/green` SUCCESS at `26044af35b`. Stays `working` (no review request until fable-5).
- [x] Market — n/a, editor save correctness
- [x] Sell — n/a

## Test Results

```text
./bin/bundle exec ruby -Itest test/controllers/links_controller_test.rb -n "/does not clear a custom URL|still writes a new custom URL|clears a custom URL/"
# at 26044af35b
3 runs, 7 assertions, 0 failures, 0 errors, 0 skips

npm test -- app/javascript/data/product_edit.test.ts
# at 26044af35b
Test Files  1 passed (1)
Tests  23 passed (23)

npm run lint-fast -- app/javascript/data/product_edit.ts app/javascript/data/product_edit.test.ts app/javascript/components/server-components/ProductEditPage.tsx --max-warnings 0 --no-warn-ignored
# at 26044af35b
exit 0

npm run typecheck -- --pretty false
# at 26044af35b
exit 0

./bin/bundle exec ruby -c app/controllers/links_controller.rb && ./bin/bundle exec ruby -c test/controllers/links_controller_test.rb
# at 26044af35b
Syntax OK / Syntax OK

Sol premerge review:
autoreview --mode branch --base origin/main --engine codex --max-priority P1
# at 26044af35b
autoreview clean: no accepted/actionable findings reported
```

`ci/green` SUCCESS and `buildkite/gumroad` SUCCESS at `26044af35b122df6aa9699127c53e2c9d91567fc`.

## QA steps

1. Create a draft product, set a custom URL, save.
2. Switch to the Content tab, edit the description, save.
3. Reload: the custom URL is still set.
4. From a current editor session with an existing custom URL, clear the URL field and save: the URL is cleared.

No rendered surface — the change is save-payload / assign_attributes. Specs are the reviewable artifact.

---

## AI disclosure

Generated with **grok-4.6** (xAI), running as Gumclaw. Prompts/instructions: GitHub issue-comment webhook; autonomous product-dev pipeline; handle Greptile's custom URL clear-path finding on the editor save PR.
