### PR TITLE
Retry a contended DynamoDB SUMMARY write in place

### DIFF
--- a/app/services/email_engagement_dynamo_store.rb
+++ b/app/services/email_engagement_dynamo_store.rb
@@ -19,6 +19,8 @@ class EmailEngagementDynamoStore
   SUMMARY_SORT_KEY = "SUMMARY"
   BATCH_GET_LIMIT = 100
   BATCH_GET_MAX_ATTEMPTS = 5
+  TRANSACT_CONFLICT_MAX_ATTEMPTS = 3
+  TRANSACT_CONFLICT_BACKOFF = 0.02
 
   class << self
     attr_writer :client
@@ -264,22 +266,47 @@ class EmailEngagementDynamoStore
         }
       end
 
+      # Every open and click for one post increments that post's single SUMMARY item, so a
+      # callback burst contends on it. Conflicts clear in milliseconds, but raising sends the
+      # whole event back to Sidekiq, which re-runs the MySQL half too and pushes the retry
+      # onto the queue depth that scales the worker fleet. Absorb them here instead.
       def transact_unless_exists(transact_items)
-        client.transact_write_items(transact_items:)
-        true
-      rescue Aws::DynamoDB::Errors::TransactionCanceledException => e
-        raise unless conditional_check_failed?(e)
-        false
+        attempts = 0
+        begin
+          client.transact_write_items(transact_items:)
+          true
+        rescue Aws::DynamoDB::Errors::TransactionCanceledException => e
+          return false if conditional_check_failed?(e)
+          raise unless transaction_conflict?(e)
+
+          attempts += 1
+          raise if attempts >= TRANSACT_CONFLICT_MAX_ATTEMPTS
+          # Jittered so contending writers don't line up again on the next attempt.
+          sleep(rand * TRANSACT_CONFLICT_BACKOFF * 2**(attempts - 1))
+          retry
+        end
       end
 
       # A cancellation is the expected duplicate only when fully explained by
-      # condition checks; anything else (conflict, throttle) raises so Sidekiq
-      # retries the event. Stubbed clients raise with empty data, so fall back
-      # to the per-item reason list the service embeds in the message.
+      # condition checks; a throttle or validation failure still raises so Sidekiq
+      # retries the event.
       def conditional_check_failed?(error)
-        codes = error.data.try(:cancellation_reasons).to_a.map(&:code)
-        codes = error.message.to_s[/\[([^\]]+)\]\z/, 1].to_s.split(",").map(&:strip) if codes.empty?
+        codes = cancellation_codes(error)
         codes.any? && codes.all? { |code| ["ConditionalCheckFailed", "None"].include?(code) }
+      end
+
+      # A mixed [ConditionalCheckFailed, TransactionConflict] is worth retrying: the
+      # condition check settles as a duplicate once the contended write lands.
+      def transaction_conflict?(error)
+        cancellation_codes(error).include?("TransactionConflict")
+      end
+
+      # Stubbed clients raise with empty data, so fall back to the per-item reason
+      # list the service embeds in the message.
+      def cancellation_codes(error)
+        codes = error.data.try(:cancellation_reasons).to_a.map(&:code)
+        return codes if codes.any?
+        error.message.to_s[/\[([^\]]+)\]\z/, 1].to_s.split(",").map(&:strip)
       end
 
       def item_key(installment_id, sort_key)

--- a/spec/services/email_engagement_dynamo_store_spec.rb
+++ b/spec/services/email_engagement_dynamo_store_spec.rb
@@ -10,6 +10,7 @@ describe EmailEngagementDynamoStore do
 
   before do
     described_class.client = client
+    allow(described_class).to receive(:sleep)
   end
 
   after do
@@ -48,6 +49,11 @@ describe EmailEngagementDynamoStore do
         raise Aws::DynamoDB::Errors::TransactionCanceledException.new(
           nil,
           "Transaction cancelled, please refer cancellation reasons for specific reasons [TransactionConflict, None, None]"
+        )
+      when :conditional_and_conflict
+        raise Aws::DynamoDB::Errors::TransactionCanceledException.new(
+          nil,
+          "Transaction cancelled, please refer cancellation reasons for specific reasons [ConditionalCheckFailed, TransactionConflict]"
         )
       else
         step
@@ -198,12 +204,55 @@ describe EmailEngagementDynamoStore do
       end.to raise_error(Aws::Errors::ServiceError)
     end
 
-    it "raises retryable transaction cancellations that are not conditional duplicates" do
+    it "raises a transaction conflict only after exhausting the in-process attempts" do
       stub_transact(:conflict)
 
       expect do
         described_class.record_click(installment_id: 123, mailer_method:, mailer_args:, click_url:)
       end.to raise_error(Aws::DynamoDB::Errors::TransactionCanceledException)
+
+      expect(requests.count { _1[:operation_name] == :transact_write_items })
+        .to eq(EmailEngagementDynamoStore::TRANSACT_CONFLICT_MAX_ATTEMPTS)
+    end
+  end
+
+  describe "SUMMARY item contention" do
+    it "retries a conflicted transaction in place rather than failing the event" do
+      stub_transact(:conflict, :ok)
+
+      expect do
+        described_class.record_open(installment_id: 123, mailer_method:, mailer_args:)
+      end.not_to raise_error
+
+      expect(requests.map { _1[:operation_name] }).to eq(%i[transact_write_items transact_write_items])
+    end
+
+    it "retries when a condition check and a conflict cancel the same transaction" do
+      stub_transact(:conditional_and_conflict, :conditional)
+
+      described_class.record_open(installment_id: 123, mailer_method:, mailer_args:)
+
+      # The retry settles as the duplicate it is, leaving the repeat-open update to bump
+      # last_open_at rather than the summary.
+      expect(requests.map { _1[:operation_name] }).to eq(%i[transact_write_items transact_write_items update_item])
+    end
+
+    it "backs off between attempts so contending writers do not line up again" do
+      stub_transact(:conflict, :ok)
+
+      expect(described_class).to receive(:sleep).once.with(a_value_between(0, EmailEngagementDynamoStore::TRANSACT_CONFLICT_BACKOFF))
+
+      described_class.record_open(installment_id: 123, mailer_method:, mailer_args:)
+    end
+
+    it "does not retry a throttle, which needs the job's own backoff" do
+      client.stub_responses(:transact_write_items, "ProvisionedThroughputExceededException")
+
+      expect do
+        described_class.record_open(installment_id: 123, mailer_method:, mailer_args:)
+      end.to raise_error(Aws::Errors::ServiceError)
+
+      expect(requests.count { _1[:operation_name] == :transact_write_items }).to eq(1)
     end
   end
 


### PR DESCRIPTION
## What

`EmailEngagementDynamoStore` now retries a `TransactWriteItems` cancelled by `TransactionConflict` in place, with a jittered backoff, instead of raising it to the caller. Throttles and validation failures still raise, and a cancellation fully explained by condition checks still settles as the duplicate it is.

A mixed `[ConditionalCheckFailed, TransactionConflict]` cancellation is retried too — the condition check resolves as a duplicate once the contended write lands.

## Why

The table keys on the installment id and keeps one `SUMMARY` item per post holding its open and click counters. Every open and click for that post increments that one item, so when a batch of delivery callbacks for a single send is processed concurrently, the writers contend on it and DynamoDB cancels with `TransactionConflict`.

Before this change, any cancellation that wasn't purely a condition check was raised so Sidekiq could retry the event. That is expensive out of proportion to the conflict:

- a cancelled transaction discards the per-recipient write **and** the MySQL read and update that ran alongside it, so the whole event is redone;
- the retry lands back on the `low` queue, whose depth is what the Sidekiq autoscaler reads to size the worker fleet — so contention feeds the same backlog that caused it;
- after five retries the event is dropped, losing the engagement record. `HandleResendEventJob` is currently the fifth-largest class in the dead set, and `TransactionCanceledException` is its live failure mode.

Contention on a single item clears in milliseconds, so absorbing it next to the write is both cheaper and more likely to succeed than a job retry minutes later. Three attempts with jitter, so contending writers don't line up again on the next pass.

Alternatives considered:

- **Take the counter out of the transaction.** Would remove the contention entirely, but the counters would no longer be atomic with the per-recipient write, so a mid-flight failure could leave unique opens undercounted — the exact property the transaction exists to protect.
- **Shard the `SUMMARY` item.** Correct at much larger scale, but it changes the key layout that a billion existing items were backfilled with, and reads would have to fan out and sum. Not worth it for contention that resolves in milliseconds.

## Before/After

No user-visible surface. Behaviour change is internal to the DynamoDB write path:

| Cancellation reasons | Before | After |
|---|---|---|
| `[ConditionalCheckFailed, None]` | treated as duplicate | unchanged |
| `[TransactionConflict, …]` | raised to Sidekiq, whole event redone | retried in place, up to 3 attempts |
| `[ConditionalCheckFailed, TransactionConflict]` | raised to Sidekiq | retried, then settles as duplicate |
| Throttle / validation | raised to Sidekiq | unchanged |

## Test Results

```
bundle exec rspec spec/services/email_engagement_dynamo_store_spec.rb
28 examples, 0 failures

bundle exec rubocop app/services/email_engagement_dynamo_store.rb spec/services/email_engagement_dynamo_store_spec.rb
2 files inspected, no offenses detected
```

Four of the new examples fail with the change reverted, covering: retrying a conflict rather than failing the event, the mixed condition-check-plus-conflict case, backing off between attempts, and raising only once the attempts are exhausted. A fifth asserts a throttle is *not* retried, guarding against the retry becoming too broad.

`spec/services/handle_email_event_info` also passes, except one pre-existing local failure unrelated to this change (`MerchantAccount.gumroad` is nil in this environment).

No video: this is a backend-only change to a DynamoDB write path with no user-visible surface. Happy to add a walkthrough if you'd like one.

Refs antiwork/gumroad-private#2273

---

Written with Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
