### PR TITLE
Drop untracked Resend events before they reach the queue

### DIFF
--- a/app/controllers/foreign_webhooks_controller.rb
+++ b/app/controllers/foreign_webhooks_controller.rb
@@ -77,7 +77,8 @@ class ForeignWebhooksController < ApplicationController
   end
 
   def resend
-    HandleResendEventJob.perform_async(params.to_unsafe_hash.to_hash)
+    event_json = params.to_unsafe_hash.to_hash
+    HandleResendEventJob.perform_async(event_json) if trackable_resend_event?(event_json)
 
     render json: { success: true }
   end
@@ -112,6 +113,18 @@ class ForeignWebhooksController < ApplicationController
   end
 
   private
+    # Resend sends a callback per event for every message we send, and a large send arrives
+    # as a burst. Events we don't track no-op inside the job anyway, so discard them before
+    # they cost a Redis write and a worker cycle each — and before they count toward the
+    # `low` queue depth that scales the Sidekiq fleet. This is header parsing only, no I/O.
+    # Anything we can't parse is still enqueued, leaving the job the one place that decides
+    # what an event means.
+    def trackable_resend_event?(event_json)
+      !ResendEventInfo.new(event_json).invalid?
+    rescue StandardError
+      true
+    end
+
     def validate_sns_webhook
       return if Aws::SNS::MessageVerifier.new.authentic?(request.raw_post)
 

--- a/spec/controllers/foreign_webhooks_controller_spec.rb
+++ b/spec/controllers/foreign_webhooks_controller_spec.rb
@@ -401,6 +401,76 @@ describe ForeignWebhooksController do
         expect(HandleResendEventJob.jobs.size).to eq(0)
       end
     end
+
+    # A large send arrives as one callback per event, so anything the job would discard is
+    # worth discarding before it reaches the queue.
+    describe "discarding events the job would no-op on" do
+      before do
+        # The outer stub is scoped to one key, which makes header encryption raise.
+        allow(GlobalConfig).to receive(:get).and_call_original
+        allow(GlobalConfig).to receive(:get).with("RESEND_WEBHOOK_SECRET").and_return(secret)
+      end
+
+      def gum_header(name, value)
+        { "name" => MailerInfo.header_name(name), "value" => MailerInfo.encrypt(value) }
+      end
+
+      def sign_and_post(event)
+        json = event.to_json
+        signature = Base64.strict_encode64(
+          OpenSSL::HMAC.digest("SHA256", secret_bytes, "#{message_id}.#{timestamp}.#{json}")
+        )
+        request.headers["svix-signature"] = "v1,#{signature}"
+        post :resend, body: json, as: :json
+      end
+
+      let(:tracked_headers) do
+        [
+          gum_header(:mailer_class, "CustomerMailer"),
+          gum_header(:mailer_method, "receipt"),
+        ]
+      end
+
+      def event(type:, headers: tracked_headers)
+        {
+          "created_at" => "2025-01-02T00:14:12.391Z",
+          "type" => type,
+          "data" => {
+            "created_at" => "2025-01-02 00:14:11.140106+00",
+            "to" => ["buyer@example.com"],
+            "headers" => headers,
+          },
+        }
+      end
+
+      it "enqueues an event type we track" do
+        sign_and_post(event(type: "email.delivered"))
+
+        expect(response).to be_successful
+        expect(HandleResendEventJob.jobs.size).to eq(1)
+      end
+
+      it "does not enqueue an event type we do not track" do
+        sign_and_post(event(type: "email.sent"))
+
+        expect(response).to be_successful
+        expect(HandleResendEventJob.jobs.size).to eq(0)
+      end
+
+      it "does not enqueue mail sent without our mailer headers" do
+        sign_and_post(event(type: "email.delivered", headers: []))
+
+        expect(response).to be_successful
+        expect(HandleResendEventJob.jobs.size).to eq(0)
+      end
+
+      it "enqueues a payload it cannot parse, leaving the job to decide" do
+        sign_and_post({ "type" => "email.delivered" })
+
+        expect(response).to be_successful
+        expect(HandleResendEventJob.jobs.size).to eq(1)
+      end
+    end
   end
 
   describe "POST sns" do


### PR DESCRIPTION
## What

`ForeignWebhooksController#resend` now checks `ResendEventInfo#invalid?` before enqueuing, so a callback the job would immediately discard never becomes a job.

A payload that can't be parsed is still enqueued, leaving `HandleResendEventJob` the single place that decides what an event means.

## Why

Resend sends one callback per event for every message we send, so a large send arrives as a burst of them. Today every callback is enqueued unconditionally — and a substantial share of them return immediately, because the job only acts on five event types (`bounced`, `delivered`, `opened`, `clicked`, `complained`) carrying our own `X-Gum-Mailer-*` headers. Everything else — other Resend event types, and mail sent without those headers — is parsed and thrown away inside the worker.

Those discards aren't free:

- each costs a Redis write, a worker fetch, and a job cycle;
- each counts toward the `low` queue depth, which is what the Sidekiq autoscaler reads to decide how many worker instances to run. Discarded events inflate that signal exactly as much as real work does.

`ResendEventInfo#invalid?` is header parsing with no I/O — no database, no DynamoDB, no network — so it's cheap enough to run in the request and decide there.

Deliberately **not** doing two adjacent things:

- **Not rejecting the request.** We still return `200`. Svix retries on non-2xx, so a rejection would bring the same callback back rather than settle it.
- **Not moving parsing wholesale into the controller.** The job re-parses independently, so anything already queued, or enqueued by another path, behaves exactly as before.

The narrower alternative — matching on `type` alone and skipping the header check — avoids the parse entirely but only catches untracked event types, not mail without our headers. The parse is microseconds against an AES-GCM header, so it isn't worth giving up half the filtering for.

## Before/After

No user-visible surface; this changes which callbacks become background jobs.

| Callback | Before | After |
|---|---|---|
| Tracked type, our headers present | enqueued → processed | unchanged |
| Untracked event type | enqueued → discarded in worker | not enqueued |
| Tracked type, no `X-Gum-Mailer-*` headers | enqueued → discarded in worker | not enqueued |
| Unparseable payload | enqueued | unchanged (still enqueued) |

Response is `200` in every row, before and after.

## Test Results

```
bundle exec rspec spec/controllers/foreign_webhooks_controller_spec.rb
45 examples, 0 failures

bundle exec rubocop app/controllers/foreign_webhooks_controller.rb spec/controllers/foreign_webhooks_controller_spec.rb
2 files inspected, no offenses detected
```

Four new examples cover the table above. The two "does not enqueue" rows fail with the change reverted; the two preserved-behaviour rows pass either way, which is the point of including them.

The pre-existing `#resend` examples are unchanged and still pass — including the one whose payload isn't a real Resend event, which is what exercises the unparseable-payload fallback.

No video: this is a backend-only change to a webhook ingest path with no user-visible surface. Happy to add a walkthrough if you'd like one.

Refs antiwork/gumroad-private#2273

---

Written with Claude Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
