### PR TITLE
Only retry a DynamoDB cancellation explained entirely by contention

### DIFF
--- a/app/services/email_engagement_dynamo_store.rb
+++ b/app/services/email_engagement_dynamo_store.rb
@@ -21,6 +21,10 @@ class EmailEngagementDynamoStore
   BATCH_GET_MAX_ATTEMPTS = 5
   TRANSACT_CONFLICT_MAX_ATTEMPTS = 3
   TRANSACT_CONFLICT_BACKOFF = 0.02
+  # Reasons that leave a transaction worth retrying in place. A throttle or
+  # validation reason means DynamoDB is rejecting the transact for a reason a
+  # retry will not clear, so it must raise for Sidekiq's own backoff instead.
+  RETRYABLE_CANCELLATION_CODES = ["ConditionalCheckFailed", "TransactionConflict", "None"].freeze
 
   class << self
     attr_writer :client
@@ -295,10 +299,15 @@ class EmailEngagementDynamoStore
         codes.any? && codes.all? { |code| ["ConditionalCheckFailed", "None"].include?(code) }
       end
 
-      # A mixed [ConditionalCheckFailed, TransactionConflict] is worth retrying: the
-      # condition check settles as a duplicate once the contended write lands.
+      # A transaction is worth retrying in place only when its cancellation is
+      # explained entirely by contention and condition checks: the [ConditionalCheckFailed,
+      # TransactionConflict] mix settles as a duplicate once the contended write lands.
+      # A throttle or validation reason means DynamoDB is rejecting the transact for a
+      # reason a retry will not clear, so it must raise for Sidekiq's own backoff instead.
       def transaction_conflict?(error)
-        cancellation_codes(error).include?("TransactionConflict")
+        codes = cancellation_codes(error)
+        codes.include?("TransactionConflict") &&
+          codes.all? { |code| RETRYABLE_CANCELLATION_CODES.include?(code) }
       end
 
       # Stubbed clients raise with empty data, so fall back to the per-item reason

--- a/app/services/email_engagement_dynamo_store.rb
+++ b/app/services/email_engagement_dynamo_store.rb
@@ -299,11 +299,6 @@ class EmailEngagementDynamoStore
         codes.any? && codes.all? { |code| ["ConditionalCheckFailed", "None"].include?(code) }
       end
 
-      # A transaction is worth retrying in place only when its cancellation is
-      # explained entirely by contention and condition checks: the [ConditionalCheckFailed,
-      # TransactionConflict] mix settles as a duplicate once the contended write lands.
-      # A throttle or validation reason means DynamoDB is rejecting the transact for a
-      # reason a retry will not clear, so it must raise for Sidekiq's own backoff instead.
       def transaction_conflict?(error)
         codes = cancellation_codes(error)
         codes.include?("TransactionConflict") &&

--- a/spec/services/email_engagement_dynamo_store_spec.rb
+++ b/spec/services/email_engagement_dynamo_store_spec.rb
@@ -55,6 +55,11 @@ describe EmailEngagementDynamoStore do
           nil,
           "Transaction cancelled, please refer cancellation reasons for specific reasons [ConditionalCheckFailed, TransactionConflict]"
         )
+      when :conflict_and_throttle
+        raise Aws::DynamoDB::Errors::TransactionCanceledException.new(
+          nil,
+          "Transaction cancelled, please refer cancellation reasons for specific reasons [TransactionConflict, ProvisionedThroughputExceeded]"
+        )
       else
         step
       end
@@ -251,6 +256,16 @@ describe EmailEngagementDynamoStore do
       expect do
         described_class.record_open(installment_id: 123, mailer_method:, mailer_args:)
       end.to raise_error(Aws::Errors::ServiceError)
+
+      expect(requests.count { _1[:operation_name] == :transact_write_items }).to eq(1)
+    end
+
+    it "raises rather than retrying a mixed conflict-plus-throttle cancellation" do
+      stub_transact(:conflict_and_throttle)
+
+      expect do
+        described_class.record_open(installment_id: 123, mailer_method:, mailer_args:)
+      end.to raise_error(Aws::DynamoDB::Errors::TransactionCanceledException)
 
       expect(requests.count { _1[:operation_name] == :transact_write_items }).to eq(1)
     end


### PR DESCRIPTION
## What

Follow-up to #7452. `transaction_conflict?` in `EmailEngagementDynamoStore` now retries a `TransactWriteItems` cancellation in place **only when every cancellation reason is contention/condition-check related** (`ConditionalCheckFailed`, `TransactionConflict`, `None`). A mixed cancellation where a throttle or validation reason accompanies a `TransactionConflict` now raises to Sidekiq's own backoff, matching the contract #7452 already stated ("Throttles and validation failures still raise").

## Why

#7452's predicate was `cancellation_codes(error).include?("TransactionConflict")`. That retried any transaction that contained a conflict, even one that *also* carried a throttle (`ProvisionedThroughputExceeded`) or validation reason — issuing up to three futile immediate DynamoDB attempts under throttling instead of letting Sidekiq back off. Greptile flagged it (P1, mixed-cancellation classification). Its suite couldn't catch it because the existing throttle test stubs a pure `ProvisionedThroughputExceededException` (a `ServiceError`, not a `TransactionCanceledException`), so a *mixed* cancellation reason set was never exercised.

## Before/After

No user-visible surface. Internal to the DynamoDB write path:

| Cancellation reasons | Before | After |
|---|---|---|
| `[TransactionConflict, None]` | retried in place | unchanged |
| `[ConditionalCheckFailed, TransactionConflict]` | retried, settles as duplicate | unchanged |
| `[TransactionConflict, ProvisionedThroughputExceeded]` (or validation) | retried in place up to 3× | **raises to Sidekiq immediately** (1 attempt) |
| Throttle / validation (pure) | raises to Sidekiq | unchanged |

Greptile's follow-up P2 on 2026-08-31 was valid: the method-level retry comment duplicated the constant-level rationale. Commit `37ea6380` removes that duplicate comment only; it does not change executable behavior.

## Test Results

```
bundle exec rspec spec/services/email_engagement_dynamo_store_spec.rb
29 examples, 0 failures

bundle exec rubocop app/services/email_engagement_dynamo_store.rb spec/services/email_engagement_dynamo_store_spec.rb
2 files inspected, no offenses detected

ruby -c app/services/email_engagement_dynamo_store.rb
Syntax OK
```

After the comment-only cleanup:

```
ruby -c app/services/email_engagement_dynamo_store.rb
Syntax OK

bundle exec rubocop app/services/email_engagement_dynamo_store.rb spec/services/email_engagement_dynamo_store_spec.rb
2 files inspected, no offenses detected
```

New example: "raises rather than retrying a mixed conflict-plus-throttle cancellation" (`stub_transact(:conflict_and_throttle)` → `[TransactionConflict, ProvisionedThroughputExceeded]`, expects raise + exactly 1 request). Mutation-proven: with the `all?` guard reverted to the old any-conflict predicate, that example fails — so the guard has teeth against regressing to #7452's over-broad retry.

## QA steps

Backend-only guard change, no rendered surface. Verified by the spec above (mixed throttle+conflict raises after one attempt; pure conflict and conditional+conflict still retry in place) against real cancellation-reason message shapes. The Greptile follow-up is a comment-only trim, verified by the diff and syntax/rubocop checks above.

## Status

- [x] Scope — narrow follow-up to the merged #7452 predicate
- [x] Design — predicate restricted to purely contention/condition-check cancellations
- [x] Build — committed `1892418d9`; comment-only cleanup committed `37ea6380`
- [x] QA — 29 examples green, rubocop clean, mutation-proven guard; comment cleanup rubocop/syntax clean
- [x] Shipped — merged `d4567a6bc724d6869599db463c05edf9b3448202` (not yet claiming deploy)
- [ ] Market — no
- [ ] Sell — no

Ownership: low-risk — not money-path-capable; Sol adversarial review clean; `working` removed; merged immediately because CI was already green (`d4567a6bc724d6869599db463c05edf9b3448202`).

Premerge review: clean @ 37ea638020a3ac773e5a26f0cb8d6b43b011d3fb

---

AI disclosure: authored with grok-4.6 (openrouter).

