### PR TITLE
Alert when buyer-currency wallet purchases stay at zero

### DIFF
--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -82,7 +82,6 @@ class RedisKey
     def long_running_jobs_in_flight = "deploy:long_running_jobs_in_flight"
     def stripe_balance_topup_needed = "stripe:balance_topup_needed"
     def min_successful_purchases_in_last_10_minutes = "healthcheck:min_successful_purchases_in_last_10_minutes"
-    def buyer_currency_wallet_presentment_zero_first_seen_at = "buyer_currency_wallet_presentment_zero:first_seen_at"
     def buyer_currency_wallet_presentment_zero_alerted_at = "buyer_currency_wallet_presentment_zero:alerted_at"
     def email_router_fallback(user_id) = "email_router_fallback:#{user_id}"
     def mobile_minimum_version = "mobile:minimum_version"

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -82,6 +82,8 @@ class RedisKey
     def long_running_jobs_in_flight = "deploy:long_running_jobs_in_flight"
     def stripe_balance_topup_needed = "stripe:balance_topup_needed"
     def min_successful_purchases_in_last_10_minutes = "healthcheck:min_successful_purchases_in_last_10_minutes"
+    def buyer_currency_wallet_presentment_zero_first_seen_at = "buyer_currency_wallet_presentment_zero:first_seen_at"
+    def buyer_currency_wallet_presentment_zero_alerted_at = "buyer_currency_wallet_presentment_zero:alerted_at"
     def email_router_fallback(user_id) = "email_router_fallback:#{user_id}"
     def mobile_minimum_version = "mobile:minimum_version"
     def mobile_minimum_update_created_at = "mobile:minimum_update_created_at"

--- a/app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb
+++ b/app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb
@@ -12,19 +12,25 @@ class AlertOnZeroBuyerCurrencyWalletPurchasesJob
   ALERT_ROOM = "agent_reports"
 
   def perform
-    return reset_alert_throttle unless buyer_currency_wallets_enabled?
+    return reset_alert_throttle unless wallet_lane_enabled?
     return reset_alert_throttle if recent_wallet_presentment_purchase_exists?
-    return if recently_alerted?
+    return unless claim_alert_throttle
 
     InternalNotificationWorker.perform_async(ALERT_ROOM, "Buyer-currency wallet purchases at zero", message_for(last_wallet_presentment_purchase_at))
-    record_alerted
   end
 
   private
-    def buyer_currency_wallets_enabled?
-      return true if Feature.active?(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+    # Checkout::BuyerCurrencyEligibility.wallets_enabled? ANDs both flags per seller. Either
+    # flag fully off means wallets are intentionally dark, so a zero-volume day is not an incident.
+    def wallet_lane_enabled?
+      feature_rollout_present?(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME) &&
+        feature_rollout_present?(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+    end
 
-      flipper_feature = Flipper[Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME]
+    def feature_rollout_present?(feature_name)
+      return true if Feature.active?(feature_name)
+
+      flipper_feature = Flipper[feature_name]
       flipper_value_present?(flipper_feature, :percentage_of_actors_value) ||
         flipper_value_present?(flipper_feature, :percentage_of_time_value) ||
         flipper_value_present?(flipper_feature, :actors_value) ||
@@ -58,27 +64,23 @@ class AlertOnZeroBuyerCurrencyWalletPurchasesJob
       $redis.del(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)
     end
 
-    def recently_alerted?
-      timestamp = $redis.get(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)
-      timestamp.present? && Time.at(timestamp.to_i) > ALERT_THROTTLE.ago
-    end
-
-    def record_alerted
-      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, Time.current.to_i, ex: ALERT_THROTTLE.to_i)
+    # Claim before enqueue so overlapping hourly (or manual) runs cannot both notify.
+    def claim_alert_throttle
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, Time.current.to_i, nx: true, ex: ALERT_THROTTLE.to_i)
     end
 
     def message_for(last_purchase_at)
       [
         headline(last_purchase_at),
         "",
-        "Expected baseline before the Aug 16 regression was about 370–420 wallet purchases with presentment rows per day. Check antiwork/gumroad-private#2326 and the buyer_currency_wallets flag before closing the incident.",
+        "Expected baseline before the Aug 16 regression was about 370–420 wallet purchases with presentment rows per day. Check antiwork/gumroad-private#2326 and the payment_element_wallets plus buyer_currency_wallets flags before closing the incident.",
       ].join("\n")
     end
 
     def headline(last_purchase_at)
-      return "No buyer-currency wallet purchase with a presentment row has ever been recorded while buyer_currency_wallets is enabled." if last_purchase_at.blank?
+      return "No buyer-currency wallet purchase with a presentment row has ever been recorded while the buyer-currency wallet lane is enabled." if last_purchase_at.blank?
 
       hours = ((Time.current - last_purchase_at) / 1.hour).floor
-      "No buyer-currency wallet purchase with a presentment row has been recorded in #{hours} hours while buyer_currency_wallets is enabled. The last one was at #{last_purchase_at.utc.strftime('%Y-%m-%d %H:%M UTC')}."
+      "No buyer-currency wallet purchase with a presentment row has been recorded in #{hours} hours while the buyer-currency wallet lane is enabled. The last one was at #{last_purchase_at.utc.strftime('%Y-%m-%d %H:%M UTC')}."
     end
 end

--- a/app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb
+++ b/app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb
@@ -8,6 +8,8 @@ class AlertOnZeroBuyerCurrencyWalletPurchasesJob
 
   WALLET_TYPES = %w[apple_pay google_pay].freeze
   ZERO_VOLUME_WINDOW = 24.hours
+  OVERLAP_LOOKBACK = 45.days
+  OVERLAP_SELLER_LIMIT = 100
   ALERT_THROTTLE = 24.hours
   ALERT_ROOM = "agent_reports"
 
@@ -16,32 +18,25 @@ class AlertOnZeroBuyerCurrencyWalletPurchasesJob
     return reset_alert_throttle if recent_wallet_presentment_purchase_exists?
     return unless claim_alert_throttle
 
-    InternalNotificationWorker.perform_async(ALERT_ROOM, "Buyer-currency wallet purchases at zero", message_for(last_wallet_presentment_purchase_at))
+    enqueue_alert(last_wallet_presentment_purchase_at)
   end
 
   private
-    # Checkout::BuyerCurrencyEligibility.wallets_enabled? ANDs both flags per seller. Either
-    # flag fully off means wallets are intentionally dark, so a zero-volume day is not an incident.
     def wallet_lane_enabled?
-      feature_rollout_present?(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME) &&
-        feature_rollout_present?(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+      return true if Feature.active?(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME) &&
+        Feature.active?(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+
+      sellers_with_recent_wallet_presentment_history.any? do |seller|
+        Checkout::BuyerCurrencyEligibility.wallets_enabled?(seller)
+      end
     end
 
-    def feature_rollout_present?(feature_name)
-      return true if Feature.active?(feature_name)
-
-      flipper_feature = Flipper[feature_name]
-      flipper_value_present?(flipper_feature, :percentage_of_actors_value) ||
-        flipper_value_present?(flipper_feature, :percentage_of_time_value) ||
-        flipper_value_present?(flipper_feature, :actors_value) ||
-        flipper_value_present?(flipper_feature, :groups_value)
-    end
-
-    def flipper_value_present?(flipper_feature, method_name)
-      return false unless flipper_feature.respond_to?(method_name)
-
-      value = flipper_feature.public_send(method_name)
-      value.respond_to?(:any?) ? value.any? : value.to_i.positive?
+    def sellers_with_recent_wallet_presentment_history
+      User.where(id: wallet_presentment_purchases
+        .where("purchases.created_at >= ?", OVERLAP_LOOKBACK.ago)
+        .distinct
+        .limit(OVERLAP_SELLER_LIMIT)
+        .pluck(:seller_id))
     end
 
     def wallet_presentment_purchases
@@ -67,6 +62,13 @@ class AlertOnZeroBuyerCurrencyWalletPurchasesJob
     # Claim before enqueue so overlapping hourly (or manual) runs cannot both notify.
     def claim_alert_throttle
       $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, Time.current.to_i, nx: true, ex: ALERT_THROTTLE.to_i)
+    end
+
+    def enqueue_alert(last_purchase_at)
+      InternalNotificationWorker.perform_async(ALERT_ROOM, "Buyer-currency wallet purchases at zero", message_for(last_purchase_at))
+    rescue StandardError
+      reset_alert_throttle
+      raise
     end
 
     def message_for(last_purchase_at)

--- a/app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb
+++ b/app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Reports when the buyer-currency wallet lane is enabled but no Apple Pay / Google Pay purchase
-# lands with a presentment row for a full day (gumroad-private#2326).
+# Reports when the buyer-currency wallet lane is globally enabled but no Apple Pay / Google Pay
+# purchase lands with a non-USD presentment row for a full day (gumroad-private#2326).
 class AlertOnZeroBuyerCurrencyWalletPurchasesJob
   include Sidekiq::Job
   sidekiq_options retry: 2, queue: :low
@@ -12,7 +12,7 @@ class AlertOnZeroBuyerCurrencyWalletPurchasesJob
   ALERT_ROOM = "agent_reports"
 
   def perform
-    return reset_alert_throttle unless wallet_lane_enabled?
+    return reset_alert_throttle unless wallet_lane_fully_enabled?
     return reset_alert_throttle if recent_wallet_presentment_purchase_exists?
     return unless claim_alert_throttle
 
@@ -20,71 +20,23 @@ class AlertOnZeroBuyerCurrencyWalletPurchasesJob
   end
 
   private
-    def wallet_lane_enabled?
-      feature_rollouts_overlap?(
-        Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME,
-        Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME,
-      )
+    def wallet_lane_fully_enabled?
+      feature_fully_enabled?(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME) &&
+        feature_fully_enabled?(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
     end
 
-    def feature_rollouts_overlap?(first_feature_name, second_feature_name)
-      return false unless feature_rollout_present?(first_feature_name) && feature_rollout_present?(second_feature_name)
-      return true if broad_rollout?(first_feature_name) && broad_rollout?(second_feature_name)
-      return true if broad_rollout_covers_targeted_actors?(first_feature_name, second_feature_name)
-      return true if broad_rollout_covers_targeted_actors?(second_feature_name, first_feature_name)
+    def feature_fully_enabled?(feature_name)
+      return true if Feature.active?(feature_name)
 
-      targeted_rollouts_overlap?(first_feature_name, second_feature_name)
-    end
-
-    def feature_rollout_present?(feature_name)
-      broad_rollout?(feature_name) || targeted_actor_values(feature_name).any? || targeted_group_values(feature_name).any?
-    end
-
-    def broad_rollout?(feature_name)
-      Feature.active?(feature_name) || percentage_rollout?(feature_name)
-    end
-
-    def percentage_rollout?(feature_name)
       flipper_feature = Flipper[feature_name]
-      flipper_numeric_value(flipper_feature, :percentage_of_actors_value).positive? ||
-        flipper_numeric_value(flipper_feature, :percentage_of_time_value).positive?
+      flipper_percentage_value(flipper_feature, :percentage_of_actors_value) >= 100 ||
+        flipper_percentage_value(flipper_feature, :percentage_of_time_value) >= 100
     end
 
-    def flipper_numeric_value(flipper_feature, method_name)
+    def flipper_percentage_value(flipper_feature, method_name)
       return 0 unless flipper_feature.respond_to?(method_name)
 
       flipper_feature.public_send(method_name).to_i
-    end
-
-    def broad_rollout_covers_targeted_actors?(broad_feature_name, targeted_feature_name)
-      users_for_actor_values(targeted_actor_values(targeted_feature_name)).any? { Feature.active?(broad_feature_name, _1) } ||
-        targeted_group_values(targeted_feature_name).any?
-    end
-
-    def targeted_rollouts_overlap?(first_feature_name, second_feature_name)
-      users_for_actor_values(targeted_actor_values(first_feature_name) | targeted_actor_values(second_feature_name)).any? do |user|
-        Checkout::BuyerCurrencyEligibility.wallets_enabled?(user)
-      end || (targeted_group_values(first_feature_name) & targeted_group_values(second_feature_name)).any?
-    end
-
-    def targeted_actor_values(feature_name)
-      values_for(feature_name, :actors_value)
-    end
-
-    def targeted_group_values(feature_name)
-      values_for(feature_name, :groups_value)
-    end
-
-    def values_for(feature_name, method_name)
-      flipper_feature = Flipper[feature_name]
-      return [] unless flipper_feature.respond_to?(method_name)
-
-      Array(flipper_feature.public_send(method_name)).map(&:to_s)
-    end
-
-    def users_for_actor_values(actor_values)
-      user_ids = actor_values.filter_map { _1[/\AUser;(\d+)\z/, 1] }.map(&:to_i)
-      User.where(id: user_ids)
     end
 
     def wallet_presentment_purchases
@@ -129,9 +81,9 @@ class AlertOnZeroBuyerCurrencyWalletPurchasesJob
     end
 
     def headline(last_purchase_at)
-      return "No buyer-currency wallet purchase with a presentment row has ever been recorded while the buyer-currency wallet lane is enabled." if last_purchase_at.blank?
+      return "No buyer-currency wallet purchase with a non-USD presentment row has ever been recorded while the buyer-currency wallet lane is fully enabled." if last_purchase_at.blank?
 
       hours = ((Time.current - last_purchase_at) / 1.hour).floor
-      "No buyer-currency wallet purchase with a presentment row has been recorded in #{hours} hours while the buyer-currency wallet lane is enabled. The last one was at #{last_purchase_at.utc.strftime('%Y-%m-%d %H:%M UTC')}."
+      "No buyer-currency wallet purchase with a non-USD presentment row has been recorded in #{hours} hours while the buyer-currency wallet lane is fully enabled. The last one was at #{last_purchase_at.utc.strftime('%Y-%m-%d %H:%M UTC')}."
     end
 end

--- a/app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb
+++ b/app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Reports when the buyer-currency wallet lane is enabled but no Apple Pay / Google Pay purchase
+# lands with a presentment row for a full day (gumroad-private#2326).
+class AlertOnZeroBuyerCurrencyWalletPurchasesJob
+  include Sidekiq::Job
+  sidekiq_options retry: 2, queue: :low
+
+  WALLET_TYPES = %w[apple_pay google_pay].freeze
+  ZERO_VOLUME_WINDOW = 24.hours
+  ALERT_THROTTLE = 24.hours
+  ALERT_ROOM = "agent_reports"
+
+  def perform
+    return reset_zero_window unless buyer_currency_wallets_enabled?
+
+    recent_count = recent_wallet_presentment_purchase_count
+    return reset_zero_window if recent_count.positive?
+
+    first_seen_at = zero_volume_first_seen_at
+    if first_seen_at.blank?
+      record_zero_volume_started
+      return
+    end
+
+    return if first_seen_at > ZERO_VOLUME_WINDOW.ago
+    return if recently_alerted?
+
+    InternalNotificationWorker.perform_async(ALERT_ROOM, "Buyer-currency wallet purchases at zero", message_for(first_seen_at))
+    record_alerted
+  end
+
+  private
+    def buyer_currency_wallets_enabled?
+      return true if Feature.active?(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+
+      flipper_feature = Flipper[Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME]
+      flipper_value_present?(flipper_feature, :percentage_of_actors_value) ||
+        flipper_value_present?(flipper_feature, :percentage_of_time_value) ||
+        flipper_value_present?(flipper_feature, :actors_value) ||
+        flipper_value_present?(flipper_feature, :groups_value)
+    end
+
+    def flipper_value_present?(flipper_feature, method_name)
+      return false unless flipper_feature.respond_to?(method_name)
+
+      value = flipper_feature.public_send(method_name)
+      value.respond_to?(:any?) ? value.any? : value.to_i.positive?
+    end
+
+    def recent_wallet_presentment_purchase_count
+      Purchase.successful
+        .joins(:purchase_presentment, :purchase_wallet_type)
+        .where("purchases.created_at >= ?", ZERO_VOLUME_WINDOW.ago)
+        .where(purchase_wallet_types: { wallet_type: WALLET_TYPES })
+        .count
+    end
+
+    def zero_volume_first_seen_at
+      timestamp = $redis.get(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at)
+      Time.at(timestamp.to_i) if timestamp.present?
+    end
+
+    def record_zero_volume_started
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, Time.current.to_i)
+    end
+
+    def reset_zero_window
+      $redis.del(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at)
+      $redis.del(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)
+    end
+
+    def recently_alerted?
+      timestamp = $redis.get(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)
+      timestamp.present? && Time.at(timestamp.to_i) > ALERT_THROTTLE.ago
+    end
+
+    def record_alerted
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, Time.current.to_i, ex: ALERT_THROTTLE.to_i)
+    end
+
+    def message_for(first_seen_at)
+      [
+        "Buyer-currency wallet purchases have stayed at 0 for #{((Time.current - first_seen_at) / 1.hour).floor} hours while buyer_currency_wallets is enabled.",
+        "",
+        "Expected baseline before the Aug 16 regression was about 370–420 wallet purchases with presentment rows per day. Check antiwork/gumroad-private#2326 and the buyer_currency_wallets flag before closing the incident.",
+      ].join("\n")
+    end
+end

--- a/app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb
+++ b/app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb
@@ -8,8 +8,6 @@ class AlertOnZeroBuyerCurrencyWalletPurchasesJob
 
   WALLET_TYPES = %w[apple_pay google_pay].freeze
   ZERO_VOLUME_WINDOW = 24.hours
-  OVERLAP_LOOKBACK = 45.days
-  OVERLAP_SELLER_LIMIT = 100
   ALERT_THROTTLE = 24.hours
   ALERT_ROOM = "agent_reports"
 
@@ -23,26 +21,77 @@ class AlertOnZeroBuyerCurrencyWalletPurchasesJob
 
   private
     def wallet_lane_enabled?
-      return true if Feature.active?(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME) &&
-        Feature.active?(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
-
-      sellers_with_recent_wallet_presentment_history.any? do |seller|
-        Checkout::BuyerCurrencyEligibility.wallets_enabled?(seller)
-      end
+      feature_rollouts_overlap?(
+        Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME,
+        Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME,
+      )
     end
 
-    def sellers_with_recent_wallet_presentment_history
-      User.where(id: wallet_presentment_purchases
-        .where("purchases.created_at >= ?", OVERLAP_LOOKBACK.ago)
-        .distinct
-        .limit(OVERLAP_SELLER_LIMIT)
-        .pluck(:seller_id))
+    def feature_rollouts_overlap?(first_feature_name, second_feature_name)
+      return false unless feature_rollout_present?(first_feature_name) && feature_rollout_present?(second_feature_name)
+      return true if broad_rollout?(first_feature_name) && broad_rollout?(second_feature_name)
+      return true if broad_rollout_covers_targeted_actors?(first_feature_name, second_feature_name)
+      return true if broad_rollout_covers_targeted_actors?(second_feature_name, first_feature_name)
+
+      targeted_rollouts_overlap?(first_feature_name, second_feature_name)
+    end
+
+    def feature_rollout_present?(feature_name)
+      broad_rollout?(feature_name) || targeted_actor_values(feature_name).any? || targeted_group_values(feature_name).any?
+    end
+
+    def broad_rollout?(feature_name)
+      Feature.active?(feature_name) || percentage_rollout?(feature_name)
+    end
+
+    def percentage_rollout?(feature_name)
+      flipper_feature = Flipper[feature_name]
+      flipper_numeric_value(flipper_feature, :percentage_of_actors_value).positive? ||
+        flipper_numeric_value(flipper_feature, :percentage_of_time_value).positive?
+    end
+
+    def flipper_numeric_value(flipper_feature, method_name)
+      return 0 unless flipper_feature.respond_to?(method_name)
+
+      flipper_feature.public_send(method_name).to_i
+    end
+
+    def broad_rollout_covers_targeted_actors?(broad_feature_name, targeted_feature_name)
+      users_for_actor_values(targeted_actor_values(targeted_feature_name)).any? { Feature.active?(broad_feature_name, _1) } ||
+        targeted_group_values(targeted_feature_name).any?
+    end
+
+    def targeted_rollouts_overlap?(first_feature_name, second_feature_name)
+      users_for_actor_values(targeted_actor_values(first_feature_name) | targeted_actor_values(second_feature_name)).any? do |user|
+        Checkout::BuyerCurrencyEligibility.wallets_enabled?(user)
+      end || (targeted_group_values(first_feature_name) & targeted_group_values(second_feature_name)).any?
+    end
+
+    def targeted_actor_values(feature_name)
+      values_for(feature_name, :actors_value)
+    end
+
+    def targeted_group_values(feature_name)
+      values_for(feature_name, :groups_value)
+    end
+
+    def values_for(feature_name, method_name)
+      flipper_feature = Flipper[feature_name]
+      return [] unless flipper_feature.respond_to?(method_name)
+
+      Array(flipper_feature.public_send(method_name)).map(&:to_s)
+    end
+
+    def users_for_actor_values(actor_values)
+      user_ids = actor_values.filter_map { _1[/\AUser;(\d+)\z/, 1] }.map(&:to_i)
+      User.where(id: user_ids)
     end
 
     def wallet_presentment_purchases
       Purchase.successful
         .joins(:purchase_presentment, :purchase_wallet_type)
         .where(purchase_wallet_types: { wallet_type: WALLET_TYPES })
+        .where.not(purchase_presentments: { presentment_currency: Currency::USD })
     end
 
     def recent_wallet_presentment_purchase_exists?

--- a/app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb
+++ b/app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb
@@ -12,21 +12,11 @@ class AlertOnZeroBuyerCurrencyWalletPurchasesJob
   ALERT_ROOM = "agent_reports"
 
   def perform
-    return reset_zero_window unless buyer_currency_wallets_enabled?
-
-    recent_count = recent_wallet_presentment_purchase_count
-    return reset_zero_window if recent_count.positive?
-
-    first_seen_at = zero_volume_first_seen_at
-    if first_seen_at.blank?
-      record_zero_volume_started
-      return
-    end
-
-    return if first_seen_at > ZERO_VOLUME_WINDOW.ago
+    return reset_alert_throttle unless buyer_currency_wallets_enabled?
+    return reset_alert_throttle if recent_wallet_presentment_purchase_exists?
     return if recently_alerted?
 
-    InternalNotificationWorker.perform_async(ALERT_ROOM, "Buyer-currency wallet purchases at zero", message_for(first_seen_at))
+    InternalNotificationWorker.perform_async(ALERT_ROOM, "Buyer-currency wallet purchases at zero", message_for(last_wallet_presentment_purchase_at))
     record_alerted
   end
 
@@ -48,25 +38,23 @@ class AlertOnZeroBuyerCurrencyWalletPurchasesJob
       value.respond_to?(:any?) ? value.any? : value.to_i.positive?
     end
 
-    def recent_wallet_presentment_purchase_count
+    def wallet_presentment_purchases
       Purchase.successful
         .joins(:purchase_presentment, :purchase_wallet_type)
-        .where("purchases.created_at >= ?", ZERO_VOLUME_WINDOW.ago)
         .where(purchase_wallet_types: { wallet_type: WALLET_TYPES })
-        .count
     end
 
-    def zero_volume_first_seen_at
-      timestamp = $redis.get(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at)
-      Time.at(timestamp.to_i) if timestamp.present?
+    def recent_wallet_presentment_purchase_exists?
+      wallet_presentment_purchases.where("purchases.created_at >= ?", ZERO_VOLUME_WINDOW.ago).exists?
     end
 
-    def record_zero_volume_started
-      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, Time.current.to_i)
+    # Newest id rather than MAX(created_at), which has no supporting index and can scan the table.
+    # Rows are only inserted at checkout, so the newest id carries the newest timestamp.
+    def last_wallet_presentment_purchase_at
+      wallet_presentment_purchases.order(id: :desc).limit(1).pick(:created_at)
     end
 
-    def reset_zero_window
-      $redis.del(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at)
+    def reset_alert_throttle
       $redis.del(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)
     end
 
@@ -79,11 +67,18 @@ class AlertOnZeroBuyerCurrencyWalletPurchasesJob
       $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, Time.current.to_i, ex: ALERT_THROTTLE.to_i)
     end
 
-    def message_for(first_seen_at)
+    def message_for(last_purchase_at)
       [
-        "Buyer-currency wallet purchases have stayed at 0 for #{((Time.current - first_seen_at) / 1.hour).floor} hours while buyer_currency_wallets is enabled.",
+        headline(last_purchase_at),
         "",
         "Expected baseline before the Aug 16 regression was about 370–420 wallet purchases with presentment rows per day. Check antiwork/gumroad-private#2326 and the buyer_currency_wallets flag before closing the incident.",
       ].join("\n")
+    end
+
+    def headline(last_purchase_at)
+      return "No buyer-currency wallet purchase with a presentment row has ever been recorded while buyer_currency_wallets is enabled." if last_purchase_at.blank?
+
+      hours = ((Time.current - last_purchase_at) / 1.hour).floor
+      "No buyer-currency wallet purchase with a presentment row has been recorded in #{hours} hours while buyer_currency_wallets is enabled. The last one was at #{last_purchase_at.utc.strftime('%Y-%m-%d %H:%M UTC')}."
     end
 end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -185,6 +185,11 @@ alert_on_stalled_abandoned_cart_emails:
   class: AlertOnStalledAbandonedCartEmailsJob
   queue: low
   description: Reports when no abandoned cart email has been sent in over a day
+alert_on_zero_buyer_currency_wallet_purchases:
+  cron: "5 * * * *" # hourly, with an in-job 24h zero-volume threshold
+  class: AlertOnZeroBuyerCurrencyWalletPurchasesJob
+  queue: low
+  description: Reports when buyer-currency wallet purchases stay at zero while the flag is enabled
 memberships_price_update_emails:
   cron: "10 8 * * *" # UTC 08:10
   class: SendMembershipsPriceUpdateEmailsJob

--- a/spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb
+++ b/spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
+  before do
+    allow(InternalNotificationWorker).to receive(:perform_async)
+    Feature.deactivate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+    Feature.deactivate_percentage(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+    $redis.del(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at)
+    $redis.del(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)
+  end
+
+  def create_presentment_for(purchase)
+    PurchasePresentment.create!(
+      purchase:,
+      processor: StripeChargeProcessor.charge_processor_id,
+      presentment_currency: Currency::CAD,
+      presentment_price_cents: 12_00,
+      presentment_tip_cents: 0,
+      presentment_seller_tax_cents: 0,
+      presentment_gumroad_tax_cents: 1_50,
+      presentment_shipping_cents: 0,
+      presentment_total_cents: 13_50,
+      presentment_gumroad_amount_cents: 1_35,
+    )
+  end
+
+  def create_wallet_presentment_purchase(created_at: Time.current, wallet_type: "apple_pay")
+    purchase = create(:purchase, purchase_state: "successful", created_at:)
+    create_presentment_for(purchase)
+    PurchaseWalletType.create!(purchase:, wallet_type:)
+    purchase
+  end
+
+  describe "#perform" do
+    it "stays quiet and clears the zero window while the wallet flag is off" do
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, 2.days.ago.to_i)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).not_to have_received(:perform_async)
+      expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at)).to be_nil
+    end
+
+    it "records the first zero-volume observation without alerting" do
+      Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).not_to have_received(:perform_async)
+      expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at)).to be_present
+    end
+
+    it "alerts when zero volume has lasted for a full day while the flag is enabled" do
+      Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+      first_seen_at = described_class::ZERO_VOLUME_WINDOW.ago - 1.hour
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, first_seen_at.to_i)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).to have_received(:perform_async) do |room, sender, message|
+        expect(room).to eq("agent_reports")
+        expect(sender).to eq("Buyer-currency wallet purchases at zero")
+        expect(message).to include("buyer_currency_wallets is enabled")
+        expect(message).to include("370–420")
+      end
+    end
+
+    it "treats a percentage rollout as enabled" do
+      Feature.activate_percentage(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME, 100)
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, 2.days.ago.to_i)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).to have_received(:perform_async)
+    end
+
+    it "throttles repeated alerts while the lane remains at zero" do
+      Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, 2.days.ago.to_i)
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, 1.hour.ago.to_i)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).not_to have_received(:perform_async)
+    end
+
+    it "stays quiet and clears the zero window when a recent wallet purchase has a presentment row" do
+      Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, 2.days.ago.to_i)
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, 2.days.ago.to_i)
+      create_wallet_presentment_purchase(created_at: 2.hours.ago)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).not_to have_received(:perform_async)
+      expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at)).to be_nil
+      expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)).to be_nil
+    end
+
+    it "ignores wallet purchases without a presentment row" do
+      Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, 2.days.ago.to_i)
+      purchase = create(:purchase, purchase_state: "successful", created_at: 2.hours.ago)
+      PurchaseWalletType.create!(purchase:, wallet_type: "apple_pay")
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).to have_received(:perform_async)
+    end
+
+    it "ignores presentment purchases that did not use a wallet" do
+      Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, 2.days.ago.to_i)
+      purchase = create(:purchase, purchase_state: "successful", created_at: 2.hours.ago)
+      create_presentment_for(purchase)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).to have_received(:perform_async)
+    end
+  end
+
+  describe "schedule" do
+    let(:schedule) { YAML.load_file(Rails.root.join("config", "sidekiq_schedule.yml")) }
+
+    it "is registered on the schedule so it actually runs" do
+      expect(schedule.values.map { |entry| entry["class"] }).to include(described_class.name)
+    end
+  end
+
+  # Every example above stubs the worker, so nothing else would notice the room going away —
+  # and InternalNotificationMailer#notify returns silently when the room has no recipient, which
+  # would leave this job permanently dark with all specs green.
+  it "sends to a room that resolves to a real recipient" do
+    mail = InternalNotificationMailer.notify(room_name: described_class::ALERT_ROOM, sender: "spec", message_text: "hello")
+
+    expect(mail.to).to be_present
+  end
+end

--- a/spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb
+++ b/spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb
@@ -17,11 +17,11 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
     Feature.activate(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME)
   end
 
-  def create_presentment_for(purchase)
+  def create_presentment_for(purchase, presentment_currency: Currency::CAD)
     PurchasePresentment.create!(
       purchase:,
       processor: StripeChargeProcessor.charge_processor_id,
-      presentment_currency: Currency::CAD,
+      presentment_currency:,
       presentment_price_cents: 12_00,
       presentment_tip_cents: 0,
       presentment_seller_tax_cents: 0,
@@ -32,9 +32,9 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
     )
   end
 
-  def create_wallet_presentment_purchase(created_at: Time.current, wallet_type: "apple_pay")
+  def create_wallet_presentment_purchase(created_at: Time.current, wallet_type: "apple_pay", presentment_currency: Currency::CAD)
     purchase = create(:purchase, purchase_state: "successful", created_at:)
-    create_presentment_for(purchase)
+    create_presentment_for(purchase, presentment_currency:)
     PurchaseWalletType.create!(purchase:, wallet_type:)
     purchase
   end
@@ -175,6 +175,15 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
       enable_wallet_lane
       purchase = create(:purchase, purchase_state: "successful", created_at: 2.hours.ago)
       create_presentment_for(purchase)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).to have_received(:perform_async)
+    end
+
+    it "does not treat a USD wallet presentment as buyer-currency volume" do
+      enable_wallet_lane
+      create_wallet_presentment_purchase(created_at: 2.hours.ago, presentment_currency: Currency::USD)
 
       described_class.new.perform
 

--- a/spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb
+++ b/spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb
@@ -7,7 +7,6 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
     allow(InternalNotificationWorker).to receive(:perform_async)
     Feature.deactivate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
     Feature.deactivate_percentage(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
-    $redis.del(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at)
     $redis.del(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)
   end
 
@@ -34,42 +33,45 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
   end
 
   describe "#perform" do
-    it "stays quiet and clears the zero window while the wallet flag is off" do
-      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, 2.days.ago.to_i)
+    it "stays quiet and clears the alert throttle while the wallet flag is off" do
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, 1.hour.ago.to_i)
 
       described_class.new.perform
 
       expect(InternalNotificationWorker).not_to have_received(:perform_async)
-      expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at)).to be_nil
+      expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)).to be_nil
     end
 
-    it "records the first zero-volume observation without alerting" do
+    it "alerts as soon as the already-full 24-hour purchase window is empty" do
       Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
-
-      described_class.new.perform
-
-      expect(InternalNotificationWorker).not_to have_received(:perform_async)
-      expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at)).to be_present
-    end
-
-    it "alerts when zero volume has lasted for a full day while the flag is enabled" do
-      Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
-      first_seen_at = described_class::ZERO_VOLUME_WINDOW.ago - 1.hour
-      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, first_seen_at.to_i)
 
       described_class.new.perform
 
       expect(InternalNotificationWorker).to have_received(:perform_async) do |room, sender, message|
         expect(room).to eq("agent_reports")
         expect(sender).to eq("Buyer-currency wallet purchases at zero")
-        expect(message).to include("buyer_currency_wallets is enabled")
+        expect(message).to include("has ever been recorded")
         expect(message).to include("370–420")
+      end
+      expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)).to be_present
+    end
+
+    it "reports the newest wallet-presentment purchase when the drought is older than the threshold" do
+      Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+      last_purchase_at = 25.hours.ago
+      create_wallet_presentment_purchase(created_at: 3.days.ago)
+      create_wallet_presentment_purchase(created_at: last_purchase_at)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _sender, message|
+        expect(message).to include(last_purchase_at.utc.strftime("%Y-%m-%d %H:%M UTC"))
+        expect(message).to include("25 hours")
       end
     end
 
     it "treats a percentage rollout as enabled" do
       Feature.activate_percentage(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME, 100)
-      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, 2.days.ago.to_i)
 
       described_class.new.perform
 
@@ -78,7 +80,6 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
 
     it "throttles repeated alerts while the lane remains at zero" do
       Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
-      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, 2.days.ago.to_i)
       $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, 1.hour.ago.to_i)
 
       described_class.new.perform
@@ -86,22 +87,19 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
       expect(InternalNotificationWorker).not_to have_received(:perform_async)
     end
 
-    it "stays quiet and clears the zero window when a recent wallet purchase has a presentment row" do
+    it "stays quiet and clears the alert throttle when a recent wallet purchase has a presentment row" do
       Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
-      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, 2.days.ago.to_i)
       $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, 2.days.ago.to_i)
       create_wallet_presentment_purchase(created_at: 2.hours.ago)
 
       described_class.new.perform
 
       expect(InternalNotificationWorker).not_to have_received(:perform_async)
-      expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at)).to be_nil
       expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)).to be_nil
     end
 
     it "ignores wallet purchases without a presentment row" do
       Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
-      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, 2.days.ago.to_i)
       purchase = create(:purchase, purchase_state: "successful", created_at: 2.hours.ago)
       PurchaseWalletType.create!(purchase:, wallet_type: "apple_pay")
 
@@ -112,7 +110,6 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
 
     it "ignores presentment purchases that did not use a wallet" do
       Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
-      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_first_seen_at, 2.days.ago.to_i)
       purchase = create(:purchase, purchase_state: "successful", created_at: 2.hours.ago)
       create_presentment_for(purchase)
 

--- a/spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb
+++ b/spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb
@@ -59,6 +59,15 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
       expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)).to be_nil
     end
 
+    it "stays quiet for partial percentage rollouts because the global count would not match the cohort" do
+      Feature.activate(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME)
+      Feature.activate_percentage(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME, 50)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).not_to have_received(:perform_async)
+    end
+
     it "alerts as soon as the already-full 24-hour purchase window is empty" do
       enable_wallet_lane
 
@@ -73,7 +82,7 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
       expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)).to be_present
     end
 
-    it "reports the newest wallet-presentment purchase when the drought is older than the threshold" do
+    it "reports the newest non-USD wallet-presentment purchase when the drought is older than the threshold" do
       enable_wallet_lane
       last_purchase_at = 25.hours.ago
       create_wallet_presentment_purchase(created_at: 3.days.ago)
@@ -87,35 +96,13 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
       end
     end
 
-    it "treats a percentage rollout as enabled when a historical seller is in both flags" do
-      create_wallet_presentment_purchase(created_at: 25.hours.ago)
+    it "treats a full percentage rollout as enabled" do
       Feature.activate(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME)
       Feature.activate_percentage(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME, 100)
 
       described_class.new.perform
 
       expect(InternalNotificationWorker).to have_received(:perform_async)
-    end
-
-    it "alerts on actor rollouts only when the same historical seller is in both flags" do
-      purchase = create_wallet_presentment_purchase(created_at: 25.hours.ago)
-      Feature.activate_user(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME, purchase.seller)
-      Feature.activate_user(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME, purchase.seller)
-
-      described_class.new.perform
-
-      expect(InternalNotificationWorker).to have_received(:perform_async)
-    end
-
-    it "stays quiet when the two actor rollouts do not overlap on a historical seller" do
-      payment_element_purchase = create_wallet_presentment_purchase(created_at: 25.hours.ago)
-      buyer_currency_purchase = create_wallet_presentment_purchase(created_at: 25.hours.ago)
-      Feature.activate_user(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME, payment_element_purchase.seller)
-      Feature.activate_user(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME, buyer_currency_purchase.seller)
-
-      described_class.new.perform
-
-      expect(InternalNotificationWorker).not_to have_received(:perform_async)
     end
 
     it "throttles repeated alerts while the lane remains at zero" do
@@ -150,7 +137,7 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
       expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)).to be_nil
     end
 
-    it "stays quiet and clears the alert throttle when a recent wallet purchase has a presentment row" do
+    it "stays quiet and clears the alert throttle when a recent wallet purchase has a non-USD presentment row" do
       enable_wallet_lane
       $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, 2.days.ago.to_i)
       create_wallet_presentment_purchase(created_at: 2.hours.ago)

--- a/spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb
+++ b/spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb
@@ -87,7 +87,8 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
       end
     end
 
-    it "treats a percentage rollout as enabled" do
+    it "treats a percentage rollout as enabled when a historical seller is in both flags" do
+      create_wallet_presentment_purchase(created_at: 25.hours.ago)
       Feature.activate(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME)
       Feature.activate_percentage(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME, 100)
 
@@ -96,13 +97,25 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
       expect(InternalNotificationWorker).to have_received(:perform_async)
     end
 
-    it "treats a payment_element_wallets percentage rollout as the prerequisite being on" do
-      Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
-      Feature.activate_percentage(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME, 100)
+    it "alerts on actor rollouts only when the same historical seller is in both flags" do
+      purchase = create_wallet_presentment_purchase(created_at: 25.hours.ago)
+      Feature.activate_user(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME, purchase.seller)
+      Feature.activate_user(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME, purchase.seller)
 
       described_class.new.perform
 
       expect(InternalNotificationWorker).to have_received(:perform_async)
+    end
+
+    it "stays quiet when the two actor rollouts do not overlap on a historical seller" do
+      payment_element_purchase = create_wallet_presentment_purchase(created_at: 25.hours.ago)
+      buyer_currency_purchase = create_wallet_presentment_purchase(created_at: 25.hours.ago)
+      Feature.activate_user(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME, payment_element_purchase.seller)
+      Feature.activate_user(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME, buyer_currency_purchase.seller)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).not_to have_received(:perform_async)
     end
 
     it "throttles repeated alerts while the lane remains at zero" do
@@ -126,6 +139,15 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
       described_class.new.perform
 
       expect(InternalNotificationWorker).not_to have_received(:perform_async)
+    end
+
+    it "releases the throttle when enqueue fails so Sidekiq retries can alert" do
+      enable_wallet_lane
+      allow(InternalNotificationWorker).to receive(:perform_async).and_raise(Redis::BaseError)
+
+      expect { described_class.new.perform }.to raise_error(Redis::BaseError)
+
+      expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)).to be_nil
     end
 
     it "stays quiet and clears the alert throttle when a recent wallet purchase has a presentment row" do

--- a/spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb
+++ b/spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb
@@ -7,7 +7,14 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
     allow(InternalNotificationWorker).to receive(:perform_async)
     Feature.deactivate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
     Feature.deactivate_percentage(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+    Feature.deactivate(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME)
+    Feature.deactivate_percentage(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME)
     $redis.del(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)
+  end
+
+  def enable_wallet_lane
+    Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+    Feature.activate(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME)
   end
 
   def create_presentment_for(purchase)
@@ -42,8 +49,18 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
       expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)).to be_nil
     end
 
-    it "alerts as soon as the already-full 24-hour purchase window is empty" do
+    it "stays quiet when payment_element_wallets is off even if buyer_currency_wallets is on" do
       Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+      $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, 1.hour.ago.to_i)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).not_to have_received(:perform_async)
+      expect($redis.get(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at)).to be_nil
+    end
+
+    it "alerts as soon as the already-full 24-hour purchase window is empty" do
+      enable_wallet_lane
 
       described_class.new.perform
 
@@ -57,7 +74,7 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
     end
 
     it "reports the newest wallet-presentment purchase when the drought is older than the threshold" do
-      Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+      enable_wallet_lane
       last_purchase_at = 25.hours.ago
       create_wallet_presentment_purchase(created_at: 3.days.ago)
       create_wallet_presentment_purchase(created_at: last_purchase_at)
@@ -71,6 +88,7 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
     end
 
     it "treats a percentage rollout as enabled" do
+      Feature.activate(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME)
       Feature.activate_percentage(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME, 100)
 
       described_class.new.perform
@@ -78,8 +96,17 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
       expect(InternalNotificationWorker).to have_received(:perform_async)
     end
 
-    it "throttles repeated alerts while the lane remains at zero" do
+    it "treats a payment_element_wallets percentage rollout as the prerequisite being on" do
       Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+      Feature.activate_percentage(Checkout::BuyerCurrencyEligibility::PAYMENT_ELEMENT_WALLETS_FEATURE_NAME, 100)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).to have_received(:perform_async)
+    end
+
+    it "throttles repeated alerts while the lane remains at zero" do
+      enable_wallet_lane
       $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, 1.hour.ago.to_i)
 
       described_class.new.perform
@@ -87,8 +114,22 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
       expect(InternalNotificationWorker).not_to have_received(:perform_async)
     end
 
+    it "does not enqueue when a concurrent run already claimed the throttle" do
+      enable_wallet_lane
+      allow($redis).to receive(:set).and_call_original
+      allow($redis).to receive(:set).with(
+        RedisKey.buyer_currency_wallet_presentment_zero_alerted_at,
+        anything,
+        hash_including(nx: true)
+      ).and_return(false)
+
+      described_class.new.perform
+
+      expect(InternalNotificationWorker).not_to have_received(:perform_async)
+    end
+
     it "stays quiet and clears the alert throttle when a recent wallet purchase has a presentment row" do
-      Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+      enable_wallet_lane
       $redis.set(RedisKey.buyer_currency_wallet_presentment_zero_alerted_at, 2.days.ago.to_i)
       create_wallet_presentment_purchase(created_at: 2.hours.ago)
 
@@ -99,7 +140,7 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
     end
 
     it "ignores wallet purchases without a presentment row" do
-      Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+      enable_wallet_lane
       purchase = create(:purchase, purchase_state: "successful", created_at: 2.hours.ago)
       PurchaseWalletType.create!(purchase:, wallet_type: "apple_pay")
 
@@ -109,7 +150,7 @@ describe AlertOnZeroBuyerCurrencyWalletPurchasesJob do
     end
 
     it "ignores presentment purchases that did not use a wallet" do
-      Feature.activate(Checkout::BuyerCurrencyEligibility::WALLETS_FEATURE_NAME)
+      enable_wallet_lane
       purchase = create(:purchase, purchase_state: "successful", created_at: 2.hours.ago)
       create_presentment_for(purchase)
 


### PR DESCRIPTION
## What

Adds a scheduled alert for the buyer-currency wallet lane: when `payment_element_wallets` and `buyer_currency_wallets` are fully enabled and successful Apple Pay / Google Pay purchases with non-USD `PurchasePresentment` rows are absent for the previous 24 hours, the job notifies `agent_reports`.

Private tracker: antiwork/gumroad-private#2326

## Why

The wallet-presentment regression produced a clean zero-volume cliff: the lane was expected to run at hundreds of purchases per day, but after the Aug 16 deploy it stayed at zero. The fix PR restores the checkout behavior; this PR adds the missing backstop so the same silent cliff is reported automatically instead of waiting for a seller to notice.

## Before / After

Before: there was no recurring check for wallet purchases that carried buyer-currency presentment rows, so a live flag plus zero completed wallet-presentment purchases could stay silent.

After: the hourly job alerts once the already-complete 24-hour purchase window is empty while both wallet flags are fully enabled, includes the last observed non-USD wallet-presentment purchase timestamp when one exists, throttles repeat alerts to once per day, releases the throttle if enqueue fails, and clears its throttle when either the lane is off or a qualifying purchase lands.

## Test Results

- `ruby -c app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb` — Syntax OK
- `ruby -c spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb` — Syntax OK
- `DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb` — 15 examples, 0 failures
- `bundle exec rubocop app/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job.rb spec/sidekiq/alert_on_zero_buyer_currency_wallet_purchases_job_spec.rb app/services/redis_key.rb` — 3 files inspected, no offenses detected
- `pnpm format` — not run: this checkout is configured to use npm and has no `format` script
- Autoreview round 1 at `94fa9203612c54cfeb63d710c9b0afaef554ad7e` found a P1 double-window delay; fixed in `c21a3cb402` by alerting on the first already-empty 24-hour window.
- Autoreview round 2 at `a72e0bf10df4da38e246060415d4ffdcbbf1e757` found P1s around enqueue-failure throttle release and non-overlapping targeted rollout gates; fixed through `649ad6e31a` by releasing the throttle on enqueue failure and only monitoring the fully enabled global lane.

Premerge review: clean @ 649ad6e31a95fa5b24673bb2da8c47add453014e

## QA steps

No rendered surface applies. I verified the scheduled job behavior with specs covering flag-off reset, full-lane gating, partial-rollout silence, immediate alert once the full 24-hour window is empty, last-purchase timestamp reporting, full percentage rollout detection, repeat-alert throttling, concurrent throttle claims, enqueue-failure recovery, recovery after a recent non-USD wallet-presentment purchase, USD-presentment exclusion, and the schedule registration.

---

AI disclosure: written with grok-4.6.
