### PR TITLE
Drop blank-email audience members so one bad row can't strand a blast

### DIFF
--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -34,10 +34,11 @@ class SendPostBlastEmailsJob
     # The filter query can be expensive to run, it's better to run it on the replica DB.
     Makara::Context.release_all
     @members = load_audience_members
+    remove_members_without_email
 
     if @blast.to_non_openers?
       keep_emails = load_non_opener_emails
-      @members.select! { _1.email.present? && keep_emails.include?(_1.email.downcase) }
+      @members.select! { keep_emails.include?(_1.email.downcase) }
       remove_members_already_sent_in_this_blast
     else
       # We will check each batch of emails to see if they were already messaged,
@@ -235,6 +236,16 @@ class SendPostBlastEmailsJob
       enrich_with_purchases_specifics(members_with_specifics)
       enrich_with_url_redirects(members_with_specifics)
       members_with_specifics.values
+    end
+
+    # A blank-email member reaches the provider slice and raises there, and every retry re-reads
+    # the same audience and dies on the same slice — ten retries later the blast is in the dead
+    # set with the rest of the audience never emailed (gumroad-private#2338).
+    def remove_members_without_email
+      before = @members.size
+      @members.select! { _1.email.present? }
+      dropped = before - @members.size
+      Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} dropped #{dropped} members without an email") if dropped > 0
     end
 
     def remove_already_emailed_members

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -785,6 +785,54 @@ describe SendPostBlastEmailsJob, :freeze_time do
     end
   end
 
+  describe "members without an email" do
+    # The provider raises on a blank recipient email, and every retry re-reads the same audience
+    # and dies on the same slice, so one such row strands the whole blast (gumroad-private#2338).
+    def blank_out_audience_email(email)
+      AudienceMember.find_by!(seller: @seller, email:).update_column(:email, "")
+    end
+
+    it "delivers to the rest of the audience instead of raising" do
+      post = create(:audience_post, :published, seller: @seller)
+      create(:active_follower, user: @seller, email: "reachable@example.com")
+      create(:active_follower, user: @seller, email: "blank@example.com")
+      blank_out_audience_email("blank@example.com")
+      blast = create(:blast, :just_requested, post:)
+
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 1
+      expect_sent_email "reachable@example.com"
+      expect(blast.reload.completed_at).to be_present
+    end
+
+    it "completes a blast whose entire audience has no email" do
+      post = create(:audience_post, :published, seller: @seller)
+      create(:active_follower, user: @seller, email: "blank@example.com")
+      blank_out_audience_email("blank@example.com")
+      blast = create(:blast, :just_requested, post:)
+
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 0
+      expect(blast.reload.completed_at).to be_present
+    end
+
+    it "drops them on a non-opener resend too" do
+      post = create(:audience_post, :published, seller: @seller)
+      create(:active_follower, user: @seller, email: "reachable@example.com")
+      create(:active_follower, user: @seller, email: "blank@example.com")
+      blank_out_audience_email("blank@example.com")
+      blast = create(:blast, :just_requested, post:, recipient_filter: PostEmailBlast::RECIPIENT_FILTER_UNOPENED)
+      allow_any_instance_of(Installment).to receive(:unopened_recipient_emails).and_return(["reachable@example.com", ""])
+
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 1
+      expect_sent_email "reachable@example.com"
+    end
+  end
+
   describe "one large blast per seller per day" do
     it "holds a second large blast until tomorrow" do
       blast = create(:blast, :just_requested, post: basic_post_with_audience)


### PR DESCRIPTION
## What

Drops audience members with a blank email before a blast hands anything to an ESP.

`SendPostBlastEmailsJob` filtered `email.present?` only on the `to_non_openers?` branch. On the regular path, a `audience_members` row with a blank email reached the provider slice, where `PostResendApi`/`PostSendgridApi` raise `"Recipients must have an email"`.

## Why

That raise is not recoverable by retrying. The rescue in `send_provider_slice` rolls the slice's `SentPostEmail` rows back, the job retries, and the retry re-reads the same audience and dies on the same slice — so it makes zero progress and burns all ten retries into the dead set. The net effect is that a single blank-email row **permanently strands every blast that seller sends**: the blast keeps `completed_at` nil, the dashboard shows a plausible partial delivered count, and the remainder of the audience is never emailed. Diagnosed while investigating https://github.com/antiwork/gumroad-private/issues/2338, where this accounted for a meaningful share of the dead `SendPostBlastEmailsJob` entries — a separate cause from the super_fetch one that issue is mainly about.

Filtering at load time rather than inside the provider classes keeps the fix in one place for both branches, and lets the now-redundant `email.present?` check come out of the non-opener `select!`. The provider-side `raise` stays: it is the invariant that catches a caller building recipients wrongly, and it should not be softened into a silent skip.

`AudienceMember` validates `presence: true` on email, so these rows can only pre-date the validation or have been written around it — the job still has to tolerate them rather than assume they cannot exist.

## Before/After

Backend job path with no user-visible surface, so there is nothing to screenshot. The observable change is that a blast with such a row now completes and emails everyone else, instead of dead-setting with the audience half-delivered.

Reverting `app/sidekiq/send_post_blast_emails_job.rb` and keeping the specs fails 2 of the 3 new examples with the exact production error:

```
Failure/Error: raise "Recipients must have an email" if recipient[:email].blank?
  Recipients must have an email
3 examples, 2 failures
```

(The third covers the non-opener branch, which already filtered blanks — it is there as a regression guard.)

## Test Results

```
bundle exec rspec spec/sidekiq/send_post_blast_emails_job_spec.rb
# 52 examples, 0 failures

bundle exec rubocop app/sidekiq/send_post_blast_emails_job.rb spec/sidekiq/send_post_blast_emails_job_spec.rb
# 2 files inspected, no offenses detected
```

## QA steps

1. Pick a seller with a small audience and give one of their `audience_members` rows a blank email (`update_column(:email, "")` — validation blocks the normal path).
2. Publish an email post to that audience.
3. Before: the blast raises, retries, and ends up in the dead set with `completed_at` nil and only the members ahead of the bad row emailed.
4. After: the blast completes, everyone with an email receives it, and the log carries `dropped 1 members without an email`.

---

Fixes part of https://github.com/antiwork/gumroad-private/issues/2338

🤖 Written with [Claude Code](https://claude.com/claude-code) using Claude Opus 5.
