### PR TITLE
Resume a dead blast with a fresh jid instead of re-pushing its own

### DIFF
--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -165,14 +165,13 @@ class AlertOnStalledPostEmailBlastsJob
       claimed = $redis.set(marker, Time.current.iso8601, nx: true, ex: STALL_THRESHOLD.to_i)
       return false unless claimed
 
-      # Never `retry` the dead entry: it re-pushes the ORIGINAL jid, and super_fetch counts
-      # orphan recoveries per jid (`orphan-<jid>`, refreshed on every kill). A blast dead-set by
-      # its poison-pill guard has already blown that budget, so the retry runs, disappears at the
-      # next hourly orphan check, and leaves no failure metadata behind — the resume looks like it
-      # worked and delivers nothing (gumroad-private#2338). A fresh jid gets a fresh budget.
-      # Drop the dead entry first so a scan racing this one cannot resume the blast twice.
-      @dead_entries.fetch(blast.id).delete if entry[:disposition] == :dead
+      # `retry` would re-push the dead entry's own jid, and super_fetch counts orphan recoveries
+      # per jid: a blast its poison-pill guard already dead-set has no budget left, so that job is
+      # killed again before it delivers (gumroad-private#2338). Drop the entry only after the
+      # enqueue — losing it without a replacement leaves an UNACCOUNTED blast, which is never
+      # auto-resumed when it is a non-opener resend.
       SendPostBlastEmailsJob.perform_async(blast.id)
+      @dead_entries.fetch(blast.id).delete if entry[:disposition] == :dead
       true
     end
 

--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -165,11 +165,14 @@ class AlertOnStalledPostEmailBlastsJob
       claimed = $redis.set(marker, Time.current.iso8601, nx: true, ex: STALL_THRESHOLD.to_i)
       return false unless claimed
 
-      if entry[:disposition] == :dead
-        @dead_entries.fetch(blast.id).retry
-      else
-        SendPostBlastEmailsJob.perform_async(blast.id)
-      end
+      # Never `retry` the dead entry: it re-pushes the ORIGINAL jid, and super_fetch counts
+      # orphan recoveries per jid (`orphan-<jid>`, refreshed on every kill). A blast dead-set by
+      # its poison-pill guard has already blown that budget, so the retry runs, disappears at the
+      # next hourly orphan check, and leaves no failure metadata behind — the resume looks like it
+      # worked and delivers nothing (gumroad-private#2338). A fresh jid gets a fresh budget.
+      # Drop the dead entry first so a scan racing this one cannot resume the blast twice.
+      @dead_entries.fetch(blast.id).delete if entry[:disposition] == :dead
+      SendPostBlastEmailsJob.perform_async(blast.id)
       true
     end
 
@@ -227,8 +230,10 @@ class AlertOnStalledPostEmailBlastsJob
           "duplicate sender would double-deliver. UNACCOUNTED usually means a lost enqueue or a " \
           "post no longer sendable (super_fetch resurrects hard-killed jobs on its own). HELD " \
           "rows need a human: confirm with the seller (time-boxed blasts may be worse late than " \
-          "never), then `job.retry` a DEAD entry or `SendPostBlastEmailsJob.perform_async(blast_id)` " \
-          "for an UNACCOUNTED one. A blast whose sender finished delivering but died before the " \
+          "never), then `SendPostBlastEmailsJob.perform_async(blast_id)` — for a DEAD row too. " \
+          "Never `job.retry` a dead blast: it reuses the jid super_fetch has already spent its " \
+          "orphan budget on, so it is killed again before it delivers (gumroad-private#2338). " \
+          "A blast whose sender finished delivering but died before the " \
           "completion stamp is resumed regardless of those limits — the resumed job has nothing " \
           "left to send and just stamps it (gumroad-private#2250). See gumroad-private#1750 for " \
           "a worked run.",

--- a/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
+++ b/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
@@ -156,6 +156,18 @@ describe AlertOnStalledPostEmailBlastsJob do
         expect(SendPostBlastEmailsJob).to have_received(:perform_async).with(blast.id)
       end
 
+      # The reverse order can leave a blast with neither a dead entry nor a sender, and an
+      # UNACCOUNTED non-opener resend is held for a human indefinitely.
+      it "keeps the dead entry when the fresh enqueue fails" do
+        blast = stalled_blast(requested_hours_ago: 6)
+        stub_sidekiq(dead: [blast.id])
+        allow(SendPostBlastEmailsJob).to receive(:perform_async).and_raise(Redis::CannotConnectError)
+
+        expect { described_class.new.perform }.to raise_error(Redis::CannotConnectError)
+
+        expect(@dead_jobs.fetch(blast.id)).not_to have_received(:delete)
+      end
+
       it "re-enqueues an UNACCOUNTED blast inside the resume window" do
         blast = stalled_blast(requested_hours_ago: 6)
         stub_sidekiq

--- a/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
+++ b/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
@@ -42,7 +42,7 @@ describe AlertOnStalledPostEmailBlastsJob do
   end
 
   def fake_sidekiq_job(blast_id)
-    instance_double(Sidekiq::SortedEntry, klass: "SendPostBlastEmailsJob", args: [blast_id], retry: nil)
+    instance_double(Sidekiq::SortedEntry, klass: "SendPostBlastEmailsJob", args: [blast_id], retry: nil, delete: nil)
   end
 
   before do
@@ -131,15 +131,29 @@ describe AlertOnStalledPostEmailBlastsJob do
       before { Feature.activate(:auto_resume_stalled_post_blasts) }
       after { Feature.deactivate(:auto_resume_stalled_post_blasts) }
 
-      it "retries a DEAD blast inside the resume window and marks it resumed once" do
+      it "re-enqueues a DEAD blast inside the resume window and marks it resumed once" do
         blast = stalled_blast(requested_hours_ago: 6)
         stub_sidekiq(dead: [blast.id])
 
         described_class.new.perform
 
-        expect(@dead_jobs.fetch(blast.id)).to have_received(:retry)
+        expect(SendPostBlastEmailsJob).to have_received(:perform_async).with(blast.id)
+        expect(@dead_jobs.fetch(blast.id)).to have_received(:delete)
         expect($redis.exists?(RedisKey.stalled_blast_auto_resumed(blast.id))).to be(true)
         expect(InternalNotificationWorker).not_to have_received(:perform_async)
+      end
+
+      # `retry` re-pushes the dead entry's ORIGINAL jid, and super_fetch's poison-pill guard
+      # counts orphan recoveries per jid — a blast it already killed is killed again before it
+      # delivers anything, silently (gumroad-private#2338).
+      it "never re-pushes the dead entry's own jid, which super_fetch would kill again" do
+        blast = stalled_blast(requested_hours_ago: 6)
+        stub_sidekiq(dead: [blast.id])
+
+        described_class.new.perform
+
+        expect(@dead_jobs.fetch(blast.id)).not_to have_received(:retry)
+        expect(SendPostBlastEmailsJob).to have_received(:perform_async).with(blast.id)
       end
 
       it "re-enqueues an UNACCOUNTED blast inside the resume window" do
@@ -158,7 +172,8 @@ describe AlertOnStalledPostEmailBlastsJob do
 
         described_class.new.perform
 
-        expect(@dead_jobs.fetch(blast.id)).not_to have_received(:retry)
+        expect(@dead_jobs.fetch(blast.id)).not_to have_received(:delete)
+        expect(SendPostBlastEmailsJob).not_to have_received(:perform_async)
         expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|
           expect(message).to match(/blast #{blast.id}.*HELD \(past/)
         end
@@ -221,7 +236,8 @@ describe AlertOnStalledPostEmailBlastsJob do
 
         described_class.new.perform
 
-        expect(@dead_jobs.fetch(blast.id)).to have_received(:retry)
+        expect(SendPostBlastEmailsJob).to have_received(:perform_async).with(blast.id)
+        expect(@dead_jobs.fetch(blast.id)).to have_received(:delete)
         expect(InternalNotificationWorker).not_to have_received(:perform_async)
       end
 
@@ -254,14 +270,15 @@ describe AlertOnStalledPostEmailBlastsJob do
         end
       end
 
-      it "still retries a DEAD non-opener resend, since its dead entry proves no sender is running" do
+      it "still resumes a DEAD non-opener resend, since its dead entry proves no sender is running" do
         blast = stalled_blast(requested_hours_ago: 6)
         blast.update!(recipient_filter: PostEmailBlast::RECIPIENT_FILTER_UNOPENED)
         stub_sidekiq(dead: [blast.id])
 
         described_class.new.perform
 
-        expect(@dead_jobs.fetch(blast.id)).to have_received(:retry)
+        expect(SendPostBlastEmailsJob).to have_received(:perform_async).with(blast.id)
+        expect(@dead_jobs.fetch(blast.id)).to have_received(:delete)
         expect(InternalNotificationWorker).not_to have_received(:perform_async)
       end
 
@@ -307,7 +324,8 @@ describe AlertOnStalledPostEmailBlastsJob do
 
         described_class.new.perform
 
-        expect(@dead_jobs.fetch(blast.id)).to have_received(:retry)
+        expect(SendPostBlastEmailsJob).to have_received(:perform_async).with(blast.id)
+        expect(@dead_jobs.fetch(blast.id)).to have_received(:delete)
         expect(InternalNotificationWorker).not_to have_received(:perform_async)
       end
 
@@ -410,7 +428,7 @@ describe AlertOnStalledPostEmailBlastsJob do
 
         described_class.new.perform
 
-        expect(@dead_jobs.fetch(blast.id)).not_to have_received(:retry)
+        expect(@dead_jobs.fetch(blast.id)).not_to have_received(:delete)
         expect(SendPostBlastEmailsJob).not_to have_received(:perform_async)
         expect($redis.exists?(RedisKey.stalled_blast_auto_resumed(blast.id))).to be(false)
         expect(InternalNotificationWorker).to have_received(:perform_async) do |_room, _subject, message|


### PR DESCRIPTION
## What

`AlertOnStalledPostEmailBlastsJob` resumes a DEAD blast by enqueuing a fresh `SendPostBlastEmailsJob` and dropping the dead-set entry, instead of calling `retry` on that entry.

Also fixes the runbook text in the alert body, which told humans to do the thing that cannot work.

## Why

`Sidekiq::SortedEntry#retry` is `Sidekiq::Client.push(msg)` — it re-pushes the entry's **original jid**. That matters because of how a long blast actually dies.

We run Sidekiq Pro with `config.super_fetch!` on defaults: `max_recoveries: 3`, `recovery_window: 72h`, orphan check at most once an hour. Its `recover_orphan` Lua script does, per orphan event:

```lua
count = INCR 'orphan-'..jid ; EXPIRE 'orphan-'..jid 72h   -- TTL refreshed on EVERY event
count <= 3 ? LMOVE back to the queue                       -- requeue
           : RPOP + ZADD 'dead' <raw payload>              -- straight to dead
```

Worker processes are replaced routinely (deploys, autoscaling, config-driven restarts), and each replacement orphans whatever is in flight. A six-figure blast runs long enough to be caught by several of those, so it accumulates recoveries — and because the counter's TTL is refreshed on every event, the budget never resets while churn continues. Past the limit, super_fetch pushes the raw payload straight into the dead set: **no `error_class`, no `failed_at`, no `retry_count`**, no Sentry, and no `orphan_handler` configured to report it.

`retry` on such an entry is therefore guaranteed futile. The jid's counter is already over the limit, so the job starts, appears in `Sidekiq::Workers`, and is killed again at the next orphan check — leaving no failure metadata and delivering nothing. From the outside the resume looks like it worked. This is what made the documented recovery for https://github.com/antiwork/gumroad-private/issues/2338 a no-op every time it was attempted, and the same shape as the stranded-digest problem in gumroad-private#1816: a recovery path that silently does nothing is worse than one that errors.

A fresh `perform_async` gets a fresh jid and a fresh budget. Losing the entry's `retry_count` and backtrace is not a cost worth protecting here — a resumed blast wants its full retry budget, and the poison-pilled entry has no backtrace to keep.

The enqueue happens **before** the dead entry is dropped. The reverse order looks tidier but a `perform_async` that raises, or a process killed between the two calls, would leave the blast with neither a dead entry nor a sender: the NX marker holds it for the stall window, and once it reads as UNACCOUNTED a non-opener resend is never auto-resumed at all, so a recoverable state becomes one that waits for a human. The marker claim already prevents two runs resuming the same blast, so this ordering costs nothing — worst case is a stale dead entry alongside a live job, and `scan_for_stalled_blasts` ranks QUEUED above DEAD anyway.

Note this does not stop blasts being orphaned; it makes recovery actually recover. Chunking the send so no attempt outlives a worker restart is the structural fix and is deliberately not in this PR.

## Before/After

Backend job path with no user-visible surface. The behavioural change is that a resumed DEAD blast now runs to completion instead of silently disappearing.

Reverting `app/sidekiq/alert_on_stalled_post_email_blasts_job.rb` and keeping the specs fails 5 examples, including the dedicated guard:

```
1) ... re-enqueues a DEAD blast inside the resume window and marks it resumed once
2) ... never re-pushes the dead entry's own jid, which super_fetch would kill again
3) ... resumes a blast past the window when recipients are still owed
4) ... still resumes a DEAD non-opener resend, since its dead entry proves no sender is running
5) ... resumes a DEAD blast so the send job stamps it
31 examples, 5 failures
```

The ordering above has its own guard — `keeps the dead entry when the fresh enqueue fails` fails if the delete is moved back in front of the enqueue.

## Test Results

```
bundle exec rspec spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
# 31 examples, 0 failures

bundle exec rubocop app/sidekiq/alert_on_stalled_post_email_blasts_job.rb spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
# 2 files inspected, no offenses detected
```

## QA steps

1. Find an incomplete blast whose job was dead-set by the poison-pill guard — a dead entry with `error_class` / `failed_at` / `retry_count` all nil, and `GET orphan-<jid>` above 3.
2. Before: `Sidekiq::DeadSet` entry `.retry` → the job appears in `Sidekiq::Workers`, then vanishes at the next `HH:04`-ish orphan check with `delivery_count` unmoved and a new metadata-less dead entry. Grep worker logs for `Killed poison pill`.
3. After: the hourly scan drops the dead entry and enqueues a fresh jid; `GET orphan-<newjid>` is empty, and `delivery_count` climbs until the blast stamps `completed_at`.

Verified out-of-band on the two stranded blasts from the issue: enqueuing a fresh jid by hand (the same thing this PR automates) resumed delivery immediately after every `.retry` had failed.

---

Fixes part of https://github.com/antiwork/gumroad-private/issues/2338

🤖 Written with [Claude Code](https://claude.com/claude-code) using Claude Opus 5.
