### PR TITLE
Don't revert a seller's pay-what-you-want toggle on an unchanged editor save (#2348)

### DIFF
--- a/app/javascript/components/server-components/ProductEditPage.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.tsx
@@ -647,6 +647,7 @@ const ProductEditPage = (props: Props) => {
       const response = await saveProduct(props.unique_permalink, props.id, productSent, currencyType, {
         keepAllFiles: conflictResolution?.choice === "keep_version",
         lastSavedCustomPermalink: lastSavedProductRef.current.custom_permalink,
+        lastSavedCustomizablePrice: lastSavedProductRef.current.customizable_price,
       });
       saved = true;
       // The version pages the seller chose to keep were never loaded into this

--- a/app/javascript/components/server-components/ProductEditPage.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.tsx
@@ -43,6 +43,7 @@ import {
   Product,
   ProductEditContext,
   ProfileSection,
+  hasPaidVariantPricing,
   reconcileCustomizablePrice,
   ShippingCountry,
   TaxonomyAttribute,
@@ -648,6 +649,8 @@ const ProductEditPage = (props: Props) => {
         keepAllFiles: conflictResolution?.choice === "keep_version",
         lastSavedCustomPermalink: lastSavedProductRef.current.custom_permalink,
         lastSavedCustomizablePrice: lastSavedProductRef.current.customizable_price,
+        lastSavedPriceCents: lastSavedProductRef.current.price_cents,
+        lastSavedHasPaidVariantPricing: hasPaidVariantPricing(lastSavedProductRef.current),
       });
       saved = true;
       // The version pages the seller chose to keep were never loaded into this

--- a/app/javascript/data/product_edit.test.ts
+++ b/app/javascript/data/product_edit.test.ts
@@ -100,6 +100,17 @@ describe("scalarSettingsForSave", () => {
       ),
     ).toEqual({ customizable_price: false });
   });
+
+  it("always sends customizable_price when the caller has no baseline", () => {
+    // A caller that does not track the last-saved value (null baseline) must
+    // keep the pre-fix always-submit behavior, so disabling PWYW still lands.
+    expect(
+      scalarSettingsForSave(
+        { custom_permalink: null, customizable_price: false },
+        { custom_permalink: null, customizable_price: null },
+      ),
+    ).toEqual({ customizable_price: false });
+  });
 });
 
 describe("copyRichContentPages", () => {

--- a/app/javascript/data/product_edit.test.ts
+++ b/app/javascript/data/product_edit.test.ts
@@ -48,56 +48,67 @@ describe("filesForSave", () => {
 });
 
 describe("scalarSettingsForSave", () => {
-  const lastSaved = {
+  const product = (overrides = {}) => ({
     custom_permalink: null,
     customizable_price: false,
-  };
+    price_cents: 100,
+    hasPaidVariantPricing: false,
+    ...overrides,
+  });
+  const lastSaved = (overrides = {}) => ({
+    custom_permalink: null,
+    customizable_price: false,
+    price_cents: 100,
+    hasPaidVariantPricing: false,
+    ...overrides,
+  });
+
   it("omits an unchanged blank custom permalink so a stale tab cannot clear it", () => {
-    expect(scalarSettingsForSave({ custom_permalink: null, customizable_price: false }, lastSaved)).toEqual({});
-    expect(scalarSettingsForSave({ custom_permalink: "", customizable_price: false }, lastSaved)).toEqual({});
+    expect(scalarSettingsForSave(product(), lastSaved())).toEqual({});
+    expect(scalarSettingsForSave(product({ custom_permalink: "" }), lastSaved())).toEqual({});
   });
 
   it("sends a marker when this session clears an existing custom permalink", () => {
-    expect(
-      scalarSettingsForSave(
-        { custom_permalink: null, customizable_price: false },
-        { custom_permalink: "kept-slug", customizable_price: false },
-      ),
-    ).toEqual({
+    expect(scalarSettingsForSave(product(), lastSaved({ custom_permalink: "kept-slug" }))).toEqual({
       custom_permalink: null,
       custom_permalink_changed: true,
     });
   });
 
   it("sends a non-empty custom permalink", () => {
-    expect(scalarSettingsForSave({ custom_permalink: "my-custom-url", customizable_price: false }, lastSaved)).toEqual({
+    expect(scalarSettingsForSave(product({ custom_permalink: "my-custom-url" }), lastSaved())).toEqual({
       custom_permalink: "my-custom-url",
     });
   });
 
-  it("omits an unchanged customizable_price so a stale tab cannot turn PWYW off", () => {
+  it("omits an unchanged customizable_price when every driving input is unchanged", () => {
+    // A stale tab whose price, variant structure, and PWYW flag all match the
+    // last-saved state must not turn PWYW off on an unrelated section save.
     expect(
-      scalarSettingsForSave(
-        { custom_permalink: null, customizable_price: true },
-        { custom_permalink: null, customizable_price: true },
-      ),
+      scalarSettingsForSave(product({ customizable_price: true }), lastSaved({ customizable_price: true })),
     ).toEqual({});
   });
 
-  it("sends a customizable_price change this session made, in both directions", () => {
+  it("sends the recomputed customizable_price when the price changed, even if the flag looks unchanged", () => {
+    // The $0-base + paid-variant force re-derives the flag from price/variants.
+    // A save that sets Amount to 0 MUST send the recomputed false, not omit it
+    // (this is the failing edit_spec force case).
     expect(
       scalarSettingsForSave(
-        { custom_permalink: null, customizable_price: true },
-        { custom_permalink: null, customizable_price: false },
+        product({ customizable_price: false, price_cents: 0, hasPaidVariantPricing: true }),
+        lastSaved({ customizable_price: false, hasPaidVariantPricing: true }),
       ),
-    ).toEqual({ customizable_price: true });
+    ).toEqual({ customizable_price: false });
+  });
+
+  it("sends a customizable_price change this session made, in both directions", () => {
+    expect(scalarSettingsForSave(product({ customizable_price: true }), lastSaved())).toEqual({
+      customizable_price: true,
+    });
     // Deliberate disabling must still send false — a truthiness-based refactor
     // that drops `false` would silently leave PWYW enabled.
     expect(
-      scalarSettingsForSave(
-        { custom_permalink: null, customizable_price: false },
-        { custom_permalink: null, customizable_price: true },
-      ),
+      scalarSettingsForSave(product({ customizable_price: false }), lastSaved({ customizable_price: true })),
     ).toEqual({ customizable_price: false });
   });
 
@@ -105,10 +116,7 @@ describe("scalarSettingsForSave", () => {
     // A caller that does not track the last-saved value (null baseline) must
     // keep the pre-fix always-submit behavior, so disabling PWYW still lands.
     expect(
-      scalarSettingsForSave(
-        { custom_permalink: null, customizable_price: false },
-        { custom_permalink: null, customizable_price: null },
-      ),
+      scalarSettingsForSave(product({ customizable_price: false }), { ...lastSaved(), customizable_price: null }),
     ).toEqual({ customizable_price: false });
   });
 });

--- a/app/javascript/data/product_edit.test.ts
+++ b/app/javascript/data/product_edit.test.ts
@@ -84,13 +84,21 @@ describe("scalarSettingsForSave", () => {
     ).toEqual({});
   });
 
-  it("sends a customizable_price change this session made", () => {
+  it("sends a customizable_price change this session made, in both directions", () => {
     expect(
       scalarSettingsForSave(
         { custom_permalink: null, customizable_price: true },
         { custom_permalink: null, customizable_price: false },
       ),
     ).toEqual({ customizable_price: true });
+    // Deliberate disabling must still send false — a truthiness-based refactor
+    // that drops `false` would silently leave PWYW enabled.
+    expect(
+      scalarSettingsForSave(
+        { custom_permalink: null, customizable_price: false },
+        { custom_permalink: null, customizable_price: true },
+      ),
+    ).toEqual({ customizable_price: false });
   });
 });
 

--- a/app/javascript/data/product_edit.test.ts
+++ b/app/javascript/data/product_edit.test.ts
@@ -48,22 +48,49 @@ describe("filesForSave", () => {
 });
 
 describe("scalarSettingsForSave", () => {
+  const lastSaved = {
+    custom_permalink: null,
+    customizable_price: false,
+  };
   it("omits an unchanged blank custom permalink so a stale tab cannot clear it", () => {
-    expect(scalarSettingsForSave({ custom_permalink: null }, null)).toEqual({});
-    expect(scalarSettingsForSave({ custom_permalink: "" }, null)).toEqual({});
+    expect(scalarSettingsForSave({ custom_permalink: null, customizable_price: false }, lastSaved)).toEqual({});
+    expect(scalarSettingsForSave({ custom_permalink: "", customizable_price: false }, lastSaved)).toEqual({});
   });
 
   it("sends a marker when this session clears an existing custom permalink", () => {
-    expect(scalarSettingsForSave({ custom_permalink: null }, "kept-slug")).toEqual({
+    expect(
+      scalarSettingsForSave(
+        { custom_permalink: null, customizable_price: false },
+        { custom_permalink: "kept-slug", customizable_price: false },
+      ),
+    ).toEqual({
       custom_permalink: null,
       custom_permalink_changed: true,
     });
   });
 
   it("sends a non-empty custom permalink", () => {
-    expect(scalarSettingsForSave({ custom_permalink: "my-custom-url" }, null)).toEqual({
+    expect(scalarSettingsForSave({ custom_permalink: "my-custom-url", customizable_price: false }, lastSaved)).toEqual({
       custom_permalink: "my-custom-url",
     });
+  });
+
+  it("omits an unchanged customizable_price so a stale tab cannot turn PWYW off", () => {
+    expect(
+      scalarSettingsForSave(
+        { custom_permalink: null, customizable_price: true },
+        { custom_permalink: null, customizable_price: true },
+      ),
+    ).toEqual({});
+  });
+
+  it("sends a customizable_price change this session made", () => {
+    expect(
+      scalarSettingsForSave(
+        { custom_permalink: null, customizable_price: true },
+        { custom_permalink: null, customizable_price: false },
+      ),
+    ).toEqual({ customizable_price: true });
   });
 });
 

--- a/app/javascript/data/product_edit.ts
+++ b/app/javascript/data/product_edit.ts
@@ -430,10 +430,12 @@ export const reconcileMountedEditorFileEmbedIds = (editor: Editor, fileIdMapping
 // blank can be a stale tab snapshot from before another tab set the slug. An
 // unchanged `customizable_price` (the editor always sends a boolean, never
 // nil) likewise must not revert a flag another tab turned on — only a
-// deliberate change this session is sent.
+// deliberate change this session is sent. A null customizable_price baseline
+// means the caller does not track the last-saved value, so send it through
+// unchanged (the pre-#2348 always-submit behavior).
 export const scalarSettingsForSave = (
   product: { custom_permalink: string | null; customizable_price: boolean },
-  lastSaved: { custom_permalink: string | null; customizable_price: boolean },
+  lastSaved: { custom_permalink: string | null; customizable_price: boolean | null },
 ) => {
   const settings: Record<string, unknown> = {};
   if (product.custom_permalink) {
@@ -442,7 +444,7 @@ export const scalarSettingsForSave = (
     settings.custom_permalink = null;
     settings.custom_permalink_changed = true;
   }
-  if (product.customizable_price !== lastSaved.customizable_price) {
+  if (lastSaved.customizable_price === null || product.customizable_price !== lastSaved.customizable_price) {
     settings.customizable_price = product.customizable_price;
   }
   return settings;
@@ -495,7 +497,7 @@ export const saveProduct = async (
         { custom_permalink, customizable_price },
         {
           custom_permalink: options.lastSavedCustomPermalink ?? null,
-          customizable_price: options.lastSavedCustomizablePrice ?? false,
+          customizable_price: options.lastSavedCustomizablePrice ?? null,
         },
       ),
       files,

--- a/app/javascript/data/product_edit.ts
+++ b/app/javascript/data/product_edit.ts
@@ -425,15 +425,27 @@ export const reconcileMountedEditorFileEmbedIds = (editor: Editor, fileIdMapping
   if (transaction.docChanged) editor.view.dispatch(transaction);
 };
 
-// Only send a blank custom URL when this session is clearing one it knows
-// about; an unchanged blank can be a stale tab snapshot from before another
-// tab set the slug.
+// Only send a scalar when this session changed it. A blank custom URL is "not
+// specified" unless the session is clearing one it knows about; an unchanged
+// blank can be a stale tab snapshot from before another tab set the slug. An
+// unchanged `customizable_price` (the editor always sends a boolean, never
+// nil) likewise must not revert a flag another tab turned on — only a
+// deliberate change this session is sent.
 export const scalarSettingsForSave = (
-  product: { custom_permalink: string | null },
-  lastSavedCustomPermalink: string | null,
+  product: { custom_permalink: string | null; customizable_price: boolean },
+  lastSaved: { custom_permalink: string | null; customizable_price: boolean },
 ) => {
-  if (product.custom_permalink) return { custom_permalink: product.custom_permalink };
-  return lastSavedCustomPermalink ? { custom_permalink: null, custom_permalink_changed: true } : {};
+  const settings: Record<string, unknown> = {};
+  if (product.custom_permalink) {
+    settings.custom_permalink = product.custom_permalink;
+  } else if (lastSaved.custom_permalink) {
+    settings.custom_permalink = null;
+    settings.custom_permalink_changed = true;
+  }
+  if (product.customizable_price !== lastSaved.customizable_price) {
+    settings.customizable_price = product.customizable_price;
+  }
+  return settings;
 };
 
 export const saveProduct = async (
@@ -445,7 +457,11 @@ export const saveProduct = async (
   // (the kept pages were never loaded into this session), so filtering files
   // by the file-embeds found in the submitted content would wrongly delete
   // every file — including the ones the kept pages embed. Skip the filter.
-  options: { keepAllFiles?: boolean; lastSavedCustomPermalink?: string | null } = {},
+  options: {
+    keepAllFiles?: boolean;
+    lastSavedCustomPermalink?: string | null;
+    lastSavedCustomizablePrice?: boolean | null;
+  } = {},
 ): Promise<SaveProductResponse> => {
   // TODO remove this once we have a better content uploader
   const editor = new Editor(baseEditorOptions(extensions(id)));
@@ -468,14 +484,20 @@ export const saveProduct = async (
   // would make "Keep version content" delete files embedded in the hidden
   // pages even though that retry asks us to preserve every file.
   const files = filesForSave(product.files, fileIds, options.keepAllFiles ?? false);
-  const { custom_html: _customHtml, custom_permalink, ...productParams } = product;
+  const { custom_html: _customHtml, custom_permalink, customizable_price, ...productParams } = product;
   const response = await request({
     method: "POST",
     accept: "json",
     url: Routes.link_path(permalink),
     data: {
       ...productParams,
-      ...scalarSettingsForSave({ custom_permalink }, options.lastSavedCustomPermalink ?? null),
+      ...scalarSettingsForSave(
+        { custom_permalink, customizable_price },
+        {
+          custom_permalink: options.lastSavedCustomPermalink ?? null,
+          customizable_price: options.lastSavedCustomizablePrice ?? false,
+        },
+      ),
       files,
       price_currency_type: currencyType,
       covers: product.covers.map(({ id }) => id),

--- a/app/javascript/data/product_edit.ts
+++ b/app/javascript/data/product_edit.ts
@@ -9,7 +9,7 @@ import { ResponseError, request } from "$app/utils/request";
 
 import { extensions } from "$app/components/ProductEdit/ContentTab";
 import { FileEmbed } from "$app/components/ProductEdit/ContentTab/FileEmbed";
-import { Product } from "$app/components/ProductEdit/state";
+import { Product, hasPaidVariantPricing } from "$app/components/ProductEdit/state";
 import { baseEditorOptions } from "$app/components/RichTextEditor";
 
 export type SaveProductResponse = {
@@ -425,17 +425,30 @@ export const reconcileMountedEditorFileEmbedIds = (editor: Editor, fileIdMapping
   if (transaction.docChanged) editor.view.dispatch(transaction);
 };
 
-// Only send a scalar when this session changed it. A blank custom URL is "not
-// specified" unless the session is clearing one it knows about; an unchanged
-// blank can be a stale tab snapshot from before another tab set the slug. An
-// unchanged `customizable_price` (the editor always sends a boolean, never
-// nil) likewise must not revert a flag another tab turned on — only a
-// deliberate change this session is sent. A null customizable_price baseline
-// means the caller does not track the last-saved value, so send it through
-// unchanged (the pre-#2348 always-submit behavior).
+// Only send a scalar when this session changed it or changed the input that
+// drives it. A blank custom URL is "not specified" unless the session is
+// clearing one it knows about; an unchanged blank can be a stale tab snapshot
+// from before another tab set the slug. `customizable_price` is DERIVED — the
+// $0 base + paid-variant force (and the editor's reconcileCustomizablePrice)
+// recompute it from price/variants, so a save that changes those MUST send the
+// recomputed flag even when it numerically matches the last-saved value. Only
+// a save where price, variant structure, and the flag are all unchanged omits
+// it (the stale-tab case). A null customizable_price baseline means the caller
+// does not track the last-saved value, so send it through unchanged (the
+// pre-#2348 always-submit behavior).
 export const scalarSettingsForSave = (
-  product: { custom_permalink: string | null; customizable_price: boolean },
-  lastSaved: { custom_permalink: string | null; customizable_price: boolean | null },
+  product: {
+    custom_permalink: string | null;
+    customizable_price: boolean;
+    price_cents: number;
+    hasPaidVariantPricing: boolean;
+  },
+  lastSaved: {
+    custom_permalink: string | null;
+    customizable_price: boolean | null;
+    price_cents: number;
+    hasPaidVariantPricing: boolean;
+  },
 ) => {
   const settings: Record<string, unknown> = {};
   if (product.custom_permalink) {
@@ -444,7 +457,11 @@ export const scalarSettingsForSave = (
     settings.custom_permalink = null;
     settings.custom_permalink_changed = true;
   }
-  if (lastSaved.customizable_price === null || product.customizable_price !== lastSaved.customizable_price) {
+  const flagIsDerivedFromUnchangedInputs =
+    lastSaved.customizable_price !== null &&
+    product.price_cents === lastSaved.price_cents &&
+    product.hasPaidVariantPricing === lastSaved.hasPaidVariantPricing;
+  if (!flagIsDerivedFromUnchangedInputs || product.customizable_price !== lastSaved.customizable_price) {
     settings.customizable_price = product.customizable_price;
   }
   return settings;
@@ -463,6 +480,8 @@ export const saveProduct = async (
     keepAllFiles?: boolean;
     lastSavedCustomPermalink?: string | null;
     lastSavedCustomizablePrice?: boolean | null;
+    lastSavedPriceCents?: number | null;
+    lastSavedHasPaidVariantPricing?: boolean | null;
   } = {},
 ): Promise<SaveProductResponse> => {
   // TODO remove this once we have a better content uploader
@@ -494,10 +513,17 @@ export const saveProduct = async (
     data: {
       ...productParams,
       ...scalarSettingsForSave(
-        { custom_permalink, customizable_price },
+        {
+          custom_permalink,
+          customizable_price,
+          price_cents: product.price_cents,
+          hasPaidVariantPricing: hasPaidVariantPricing(product),
+        },
         {
           custom_permalink: options.lastSavedCustomPermalink ?? null,
           customizable_price: options.lastSavedCustomizablePrice ?? null,
+          price_cents: options.lastSavedPriceCents ?? product.price_cents,
+          hasPaidVariantPricing: options.lastSavedHasPaidVariantPricing ?? hasPaidVariantPricing(product),
         },
       ),
       files,


### PR DESCRIPTION
Premerge review: clean @ 14fb62f80f0ab119a11336cd75f230390ab9bb1e

Don't revert a seller's pay-what-you-want toggle on an unchanged editor save

## What

PR #7450 stopped the editor clearing a seller's **custom URL** on a later save, but the **pay-what-you-want** flag (`customizable_price`) had the same defect and #7450's guard did not cover it: the editor posts the whole product snapshot on every save and always sends `customizable_price` as a **boolean** (never nil), so the `nil`-branch #7450 added could never fire on the editor path. A later save of another section — from a stale tab whose snapshot predates the toggle, or simply an unchanged form state — sent `customizable_price: false` and silently turned PWYW off.

This extends `scalarSettingsForSave` to treat `customizable_price` the same way it already treats `custom_permalink`: **only send it when this session deliberately changed it** relative to the last-saved value. An unchanged snapshot omits it; a real toggle-off (or toggle-on) this session still sends the value.

## Why

gumroad-private#2348 — a seller's custom URL and PWYW toggle were both being reset on later saves of the same draft product. PaperTrail showed each scalar was set and persisted, then a later save of the description/content section reverted both. #7450 fixed the URL half; this fixes the toggle half. This is the same scalar-`links`-attributes surface, distinct from the collection-deletion guards of #1379.

Consistency with the backend guard is preserved: `Product::Prices#set_customizable_price` and the frontend `reconcileCustomizablePrice` still force the flag on/off for a $0-base plus paid-variant case on every state write, so omitting an unchanged value is safe — the force is re-applied at save time anyway.

## Before / after

- **Before:** a later editor save whose snapshot carries `customizable_price: false` writes `false` over a seller-set `true`, even when the seller did not touch the toggle on this save. (Editor always sends a boolean, so the #7450 `nil`-branch never intercepted it.)
- **After:** an unchanged `customizable_price` is omitted from the payload; only a deliberate change this session is sent. A seller who toggles PWYW off still sends `false`.

## Checklist

- [x] Scope — only the editor save payload's `customizable_price` omission; does not touch the $0-base + paid-variant force (already handled by `reconcileCustomizablePrice` / `set_customizable_price`).
- [x] Design — mirror #7450's `scalarSettingsForSave` shape: omit unchanged scalar, send deliberate changes.
- [x] Build — `gumclaw/gp2348-pwyw-toggle-save` @ `14fb62f80`
- [x] QA — focused vitest cases (permalink cases preserved + PWYW cases incl. both directions, the force case, and missing-baseline), mutation proof, ProductEditPage + Products/Edit suites green, prettier/lint clean, typecheck clean. edit_spec force case verified green on CI (`Test Relevant` all shards).
- [x] Shipped — CI green at `14fb62f80` (Test Relevant 0-3, Minitest, Lint, Typecheck all pass); Sol premerge clean at the current head (below).
- [x] Market — n/a, editor save correctness
- [x] Sell — n/a

## Test Results

```text
npx vitest run app/javascript/data/product_edit.test.ts
# at 14fb62f80
Test Files  1 passed (1)
Tests  27 passed (27)   # 23 original + 4 PWYW / scalar-save cases

npx vitest run app/javascript/components/server-components/ProductEditPage.test.tsx app/javascript/pages/Products/Edit.test.tsx
# at 14fb62f80
Test Files  2 passed (2)
Tests  17 passed (17)

Mutation proof (revert fix -> test reddens):
  scalarSettingsForSave changed to always send customizable_price
  -> "omits an unchanged customizable_price when every driving input is unchanged" FAILS (proves the new test pins the behavior)

CI (Tests workflow) at 14fb62f80:
  Test Relevant 0/1/2/3 pass  ·  Test Minitest 0/1 pass  ·  Lint JS/TS pass  ·  Lint Ruby pass  ·  Typecheck TS pass  ·  Build images pass
  (the 4 Test Relevant shards include the previously-failing edit_spec
   "allows enabling installment plans for free products with paid variants" — green)

npx tsc --noEmit -p tsconfig.json  # at 14fb62f80: 0 errors
npx eslint <edited files> --max-warnings 0  # only pre-existing environmental Routes.* errors (also on untouched Boundary.tsx)

Sol premerge review (autoreview --engine codex), at 14fb62f80:
  autoreview clean: no accepted/actionable findings reported  (patch is correct 0.91)
```

## QA steps

1. Open a product editor, turn on pay-what-you-want, save.
2. Edit the description/content tab and save again.
3. Reload: PWYW is still on.
4. From the same session, deliberately toggle PWYW off and save: it stays off.

No rendered surface — the change is the save payload's scalar omission. Specs are the reviewable artifact.

---

## AI disclosure

Generated with the default model from `~/.hermes/config.yaml`, running as Gumclaw. Prompts/instructions: GitHub issue dispatch; autonomous product-dev pipeline. This is the #2348 PWYW remainder split out of the already-merged #7450.