### PR TITLE
Defer client-confirm finalize until Stripe settlement data exists

### DIFF
--- a/app/services/purchase/finalize_confirmed_charge_service.rb
+++ b/app/services/purchase/finalize_confirmed_charge_service.rb
@@ -63,7 +63,18 @@ class Purchase::FinalizeConfirmedChargeService < Purchase::BaseService
     def finalize_successful_charge
       purchase.charge_intent = charge_intent
       assign_confirmed_card_presentation(charge_intent.charge)
-      purchase.save_charge_data(charge_intent.charge)
+      # Same missing-settlement deferral as Order::ChargeService / confirm_charge_intent!.
+      # Raising inside with_lock rolls back the stripe_transaction_id the retry jobs key on.
+      charge_data_saved = purchase.save_charge_data(
+        charge_intent.charge,
+        allow_missing_flow_of_funds: purchase.processor_settlement_deferrable?
+      )
+
+      if charge_data_saved == false
+        enqueue_processor_settlement_finalizer
+        return :pending
+      end
+
       persist_recurring_payment_method!
 
       if purchase.errors.present?
@@ -74,6 +85,15 @@ class Purchase::FinalizeConfirmedChargeService < Purchase::BaseService
 
       handle_purchase_success
       nil
+    end
+
+    def enqueue_processor_settlement_finalizer
+      charge = purchase.charge
+      if charge.present?
+        FinalizeBuyerPresentmentChargeJob.perform_in(FinalizeBuyerPresentmentChargeJob::INITIAL_DELAY, charge.id)
+      else
+        FinalizeBuyerPresentmentPurchaseJob.perform_in(FinalizeBuyerPresentmentPurchaseJob::INITIAL_DELAY, purchase.id)
+      end
     end
 
     # Persist the reusable method before creating the subscription. Any missing invariant rolls

--- a/spec/requests/checkout/returns_spec.rb
+++ b/spec/requests/checkout/returns_spec.rb
@@ -175,7 +175,7 @@ describe "Checkout return page", :vcr, type: :request do
       cart = create(:cart, :guest, browser_guid: order_params[:browser_guid])
       order, charge = build_client_confirmed_order
       Stripe::PaymentIntent.confirm(charge.stripe_payment_intent_id, { payment_method: "pm_card_visa" })
-      allow_any_instance_of(Purchase).to receive(:save_charge_data) do |purchase|
+      allow_any_instance_of(Purchase).to receive(:save_charge_data) do |purchase, *_args, **_kwargs|
         purchase.errors.add(:base, "Something went wrong.")
       end
 
@@ -195,12 +195,12 @@ describe "Checkout return page", :vcr, type: :request do
     it "renders the pending page instead of silently redirecting" do
       order, charge = build_client_confirmed_order(line_items: [line_item, second_line_item])
       Stripe::PaymentIntent.confirm(charge.stripe_payment_intent_id, { payment_method: "pm_card_visa" })
-      allow_any_instance_of(Purchase).to receive(:save_charge_data).and_wrap_original do |original, *args|
+      allow_any_instance_of(Purchase).to receive(:save_charge_data).and_wrap_original do |original, *args, **kwargs|
         purchase = original.receiver
         if purchase.link_id == second_product.id
           purchase.errors.add(:base, "Something went wrong.")
         else
-          original.call(*args)
+          original.call(*args, **kwargs)
         end
       end
 

--- a/spec/services/purchase/finalize_confirmed_charge_service_spec.rb
+++ b/spec/services/purchase/finalize_confirmed_charge_service_spec.rb
@@ -242,6 +242,61 @@ describe Purchase::FinalizeConfirmedChargeService do
       end
     end
 
+    context "when a buyer-presentment charge succeeded without Stripe settlement data" do
+      let(:seller) { create(:user) }
+      let(:product) { create(:product, user: seller) }
+      let(:merchant_account) do
+        MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
+          create(:merchant_account, user: nil, charge_processor_id: StripeChargeProcessor.charge_processor_id)
+      end
+      let(:charge) { create(:charge, seller:, merchant_account:) }
+      let(:purchase) do
+        create(:purchase_in_progress,
+               link: product,
+               seller:,
+               merchant_account:,
+               charge_processor_id: StripeChargeProcessor.charge_processor_id,
+               flow_of_funds: nil,
+               stripe_transaction_id: nil)
+      end
+      let(:processor_charge) do
+        BaseProcessorCharge.new.tap do |processor_charge|
+          processor_charge.charge_processor_id = StripeChargeProcessor.charge_processor_id
+          processor_charge.id = "ch_presentment_missing_settlement"
+          processor_charge.refunded = false
+          processor_charge.fee = 59
+          processor_charge.fee_currency = Currency::USD
+          processor_charge.card_fingerprint = "card_fp"
+          processor_charge.card_type = "visa"
+          processor_charge.card_country = "US"
+        end
+      end
+      let(:charge_intent) do
+        instance_double(StripeChargeIntent, succeeded?: true, processing?: false, charge: processor_charge)
+      end
+
+      before do
+        charge.purchases << purchase
+        charge_presentment = create(:charge_presentment, charge:)
+        create(:purchase_presentment, purchase:, charge_presentment:)
+      end
+
+      it "persists charge ids, stays in progress, and enqueues settlement finalization instead of rolling back" do
+        expect(ErrorNotifier).not_to receive(:notify)
+
+        result = described_class.new(purchase:, charge_intent:).perform
+
+        expect(result).to eq(:pending)
+        expect(purchase.reload).to be_in_progress
+        expect(purchase.stripe_transaction_id).to eq("ch_presentment_missing_settlement")
+        expect(purchase.flow_of_funds).to be_nil
+        expect(purchase.balance_transactions).to be_empty
+        expect(purchase).to be_pending_buyer_presentment_settlement
+        expect(FinalizeBuyerPresentmentChargeJob.jobs.size).to eq(1)
+        expect(FinalizeBuyerPresentmentChargeJob.jobs.first["args"]).to eq([charge.id])
+      end
+    end
+
     context "when the purchase is already successful" do
       let(:purchase) { create(:purchase_in_progress).tap { _1.update_column(:purchase_state, "successful") } }
 


### PR DESCRIPTION
## Status

- [x] Scope — client-confirm finalize must defer presentment/seller-held Stripe charges when settlement data is missing, same as `Order::ChargeService` / `confirm_charge_intent!`
- [x] Design — pass `allow_missing_flow_of_funds:` and enqueue `FinalizeBuyerPresentmentChargeJob` instead of booking balances from a nil flow of funds
- [x] Build
- [ ] QA — backend-only; no rendered surface
- [ ] Shipped
- [ ] Market
- [ ] Sell

## What

`Purchase::FinalizeConfirmedChargeService` now uses the same missing-settlement deferral as the server-confirm charge path.

When Stripe has captured the PaymentIntent but has not yet produced a balance transaction, finalize persists charge ids, leaves the purchase `in_progress`, and enqueues `FinalizeBuyerPresentmentChargeJob` (or the purchase-level job if there is no Charge row). It does not call `increment_sellers_balance!` on a nil `flow_of_funds`.

## Why

After tips on buyer-currency listings (#7367), those purchases skip the Gumroad-held USD fallback in `load_flow_of_funds`. Client-confirm finalize (`OrdersController#finalize` / the return page) still called `save_charge_data` without `allow_missing_flow_of_funds`. `create_holding_amount_for_seller` then raised `NoMethodError` on nil (`GUMROAD-1E5`). The raise ran inside `with_lock`, so the charge ids rolled back and the settlement retry jobs could not see `stripe_transaction_id`.

Server-confirm checkout already deferred this case in #7368. Client-confirm did not.

## Before / after

| Path | Before | After |
|---|---|---|
| Client-confirm presentment/seller-held, Stripe captured, no balance txn | Raise → Sentry → `in_progress` with **no** `stripe_transaction_id` | Persist charge ids, return `:pending`, enqueue settlement job |
| Same path once Stripe exposes settlement | Unreachable via the job (no txn id) | Job/sync retrieves flow of funds and fulfills |
| Gumroad-held non-presentment (USD fallback) | Unchanged | Unchanged |

## Test results

- `DISABLE_SPRING=1 bundle exec rspec spec/services/purchase/finalize_confirmed_charge_service_spec.rb` — 13 examples, 0 failures
- Mutant: drop `allow_missing_flow_of_funds` → the new example red with `undefined method 'merchant_account_gross_amount' for nil` at `balance_transaction.rb:59` (the production exception)

## QA steps

No rendered surface. Probe is the spec above: presentment purchase + blank processor `flow_of_funds` must stay `in_progress` with a persisted `stripe_transaction_id` and an enqueued `FinalizeBuyerPresentmentChargeJob`, and must not notify Sentry.

Residual in-progress rows that already lost their `stripe_transaction_id` need a separate recovery pass after this ships; this PR stops new rows from entering that state and lets `SyncStatusWithChargeProcessorService` (client-confirm branch) succeed on retry once settlement exists.

Related: antiwork/gumroad-private#2349, #7367, #7368

---

AI disclosure: Authored by Gumclaw using Hermes Agent (grok-4.6).

Premerge review: clean @ 5aa0706482c49291c2f49e6092e922bf008554f3
