### PR TITLE
Correct false super_fetch self-heal claim in blast alert copy

### DIFF
--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -7,7 +7,9 @@
 # enqueue never reached Redis — while the seller's dashboard shows a plausible non-zero delivered
 # count, so the only detection channel was a seller who knew their own audience size writing in.
 # 11 blasts / ~1.6M undelivered emails accrued that way over ten days before anyone noticed.
-# (A hard-killed job itself is not the stranding mode: super_fetch resurrects it.)
+# A hard-killed job is not reliable to resurrect: super_fetch's cleanup_the_dead can retire a
+# process while its private queue still holds jobs, stranding them in no Sidekiq set
+# (gumroad-private#2352).
 #
 # Auto-resume is deliberately conservative: only DEAD/UNACCOUNTED blasts still inside
 # AUTO_RESUME_WINDOW (unless recipients are still owed), not more than once per STALL_THRESHOLD,
@@ -226,8 +228,10 @@ class AlertOnStalledPostEmailBlastsJob
         "RUNNING/QUEUED may just be a very large blast mid-pass. DEAD/UNACCOUNTED blasts requested " \
           "within #{AUTO_RESUME_WINDOW.inspect} are resumed automatically, once per blast " \
           "(gumroad-private#2106) — except UNACCOUNTED non-opener resends, which a concurrent " \
-          "duplicate sender would double-deliver. UNACCOUNTED usually means a lost enqueue or a " \
-          "post no longer sendable (super_fetch resurrects hard-killed jobs on its own). HELD " \
+          "duplicate sender would double-deliver. UNACCOUNTED usually means a lost enqueue, a " \
+          "post no longer sendable, or a job stranded in a retired process's private queue that " \
+          "no resurrection pass has reached — super_fetch does not reliably resurrect hard-killed " \
+          "jobs (gumroad-private#2352). HELD " \
           "rows need a human: confirm with the seller (time-boxed blasts may be worse late than " \
           "never), then `SendPostBlastEmailsJob.perform_async(blast_id)` — for a DEAD row too. " \
           "Never `job.retry` a dead blast: it reuses the jid super_fetch has already spent its " \


### PR DESCRIPTION
# Correct false super_fetch self-heal claim in blast alert copy

> Copy-only fix: alert text and class comment. Specs green, CI green, premerge clean at head.

## What

Corrects the `AlertOnStalledPostEmailBlastsJob` comment and alert-body copy where they claim `super_fetch` "resurrects hard-killed jobs on its own." Unchanged: all disposition/scan/auto-resume logic.

## Why

The alert's runbook text and class comment told a reader/operator that a hard-killed job self-heals. It does not reliably: `super_fetch`'s `cleanup_the_dead` retires a process and deletes its tracking keys (`<identity>:super_queues`, membership in `super_processes`) while that process's private queue still holds jobs, stranding them in no Sidekiq set. Both recovery paths (`cleanup_the_dead`, `check_for_orphans`) run only at `startup`, so a stranded queue may never be seen again.

The false copy was a reassurance dead-end: it told the reader there was nothing to investigate, precisely when a job had vanished with no artifact anywhere. This is the third stall class from the blast saga (gumroad-private#2352), true for every job class on `super_fetch`. UNACCOUNTED now names three real causes (lost enqueue, no-longer-sendable post, or a job stranded in a retired process's private queue) instead of two plus a comforting falsehood.

## Before / after

- Before: "…super_fetch resurrects hard-killed jobs on its own" (alert body) and "(A hard-killed job itself is not the stranding mode: super_fetch resurrects it.)" (comment).
- After: the alert names the stranded-private-queue cause and states super_fetch does not reliably resurrect hard-killed jobs; the comment describes `cleanup_the_dead`'s stranding.

Backend job path, no user-visible surface beyond the alert text a human reads — nothing to screenshot. No behavioral logic change; the auto-resume hold logic, the fresh-jid enqueue ordering (#7457), and the blank-email filter (#7456) are untouched.

## Checklist

- [x] Scope — copy-only (alert text + class comment) in `app/sidekiq/alert_on_stalled_post_email_blasts_job.rb`. Structural fixes (changing `cleanup_the_dead` key-deletion semantics and adding a periodic resurrection pass / `orphan_handler`) are deliberately out of scope and remain open on gumroad-private#2352 for a human infra decision.
- [x] Design — the copy must not assert a mechanism that is unreliable; UNACCOUNTED now enumerates the real causes.
- [x] Build — branch `fix/gp2352-super-fetch-alert-copy`, one commit.
- [x] QA — see QA section.
- [ ] Shipped — ready for human review (alert text on a money-ish path → no auto-merge).
- [ ] Market — n/a.
- [ ] Sell — n/a.

## Tests

```text
$ ruby -c app/sidekiq/alert_on_stalled_post_email_blasts_job.rb   # Syntax OK
$ DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
# 31 examples, 0 failures
```

No spec pins the altered alert strings: `rg "resurrect|hard-killed|sendable" spec/ test/` returns no blast-alert copy hits.

## QA

- `ruby -c` clean and the full alert spec green at the pushed head.
- Read `message_for`'s long `[...].compact.join("\n")` block and confirm the UNACCOUNTED sentence lists the stranded-private-queue cause and no longer claims super_fetch self-heals.
- Confirm the class comment describes `cleanup_the_dead` stranding, not resurrection.
- Nothing to preview (no rendered UI); watch the alert text after deploy for a follow-on blast alert.

---

AI disclosure: grok-4.6. Prompt/instructions: fix the two alert-copy sites that assert super_fetch resurrects hard-killed jobs, per gumroad-private#2352.

Premerge review: clean @ 550534d2a76e2be7d1b0272c61f9eb02ce75067c
