### PR TITLE
Replace n+1 queries in upsells presenter with 1 grouped query

### DIFF
--- a/app/presenters/checkout/upsells_presenter.rb
+++ b/app/presenters/checkout/upsells_presenter.rb
@@ -22,19 +22,29 @@ class Checkout::UpsellsPresenter
           upsell_variants: [:selected_variant, :offered_variant]
         ).map(&:as_json),
       pagination:,
-      products: pundit_user.seller.products
-        .visible_and_not_archived
-        .map { product_props(_1) }
+      products: product_props
     }
   end
 
   private
-    def product_props(product)
-      {
-        id: product.external_id,
-        name: product.name,
-        has_multiple_versions: product.alive_variants.limit(2).count > 1,
-        native_type: product.native_type
-      }
+    def product_props
+      products = pundit_user.seller.products.visible_and_not_archived.to_a
+      product_ids_with_multiple_versions = Variant.alive
+        .joins(:variant_category)
+        .merge(VariantCategory.alive)
+        .where(variant_categories: { link_id: products.map(&:id) })
+        .group("variant_categories.link_id")
+        .having("COUNT(base_variants.id) > 1")
+        .pluck("variant_categories.link_id")
+        .to_set
+
+      products.map do |product|
+        {
+          id: product.external_id,
+          name: product.name,
+          has_multiple_versions: product_ids_with_multiple_versions.include?(product.id),
+          native_type: product.native_type
+        }
+      end
     end
 end

--- a/spec/presenters/checkout/upsells_presenter_spec.rb
+++ b/spec/presenters/checkout/upsells_presenter_spec.rb
@@ -113,7 +113,10 @@ describe Checkout::UpsellsPresenter do
     end
 
     it "checks version counts for all products in one query" do
-      create_list(:product_with_digital_versions, 3, user: seller)
+      versioned_products = create_list(:product_with_digital_versions, 3, user: seller)
+      versionless_product = create(:product, user: seller)
+      single_version_product = create(:product, user: seller)
+      create(:variant, variant_category: create(:variant_category, link: single_version_product), name: "Untitled 1")
       variant_queries = []
       callback = lambda do |*, payload|
         sql = payload[:sql]
@@ -125,7 +128,11 @@ describe Checkout::UpsellsPresenter do
         props = presenter.upsells_props
       end
 
-      expect(props[:products]).to all(include(has_multiple_versions: true))
+      version_flags = props[:products].to_h { |product| [product[:id], product[:has_multiple_versions]] }
+      expect(version_flags.keys).to match_array([product1, product2, *versioned_products, versionless_product, single_version_product].map(&:external_id))
+      expect(version_flags.values_at(*[product1, product2, *versioned_products].map(&:external_id))).to all(be true)
+      expect(version_flags[versionless_product.external_id]).to be false
+      expect(version_flags[single_version_product.external_id]).to be false
       expect(variant_queries.size).to eq(1), variant_queries.join("\n")
     end
   end

--- a/spec/presenters/checkout/upsells_presenter_spec.rb
+++ b/spec/presenters/checkout/upsells_presenter_spec.rb
@@ -111,5 +111,22 @@ describe Checkout::UpsellsPresenter do
                  ]
                })
     end
+
+    it "checks version counts for all products in one query" do
+      create_list(:product_with_digital_versions, 3, user: seller)
+      variant_queries = []
+      callback = lambda do |*, payload|
+        sql = payload[:sql]
+        variant_queries << sql if sql.include?("FROM `base_variants`") && sql.include?("variant_categories")
+      end
+
+      props = nil
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        props = presenter.upsells_props
+      end
+
+      expect(props[:products]).to all(include(has_multiple_versions: true))
+      expect(variant_queries.size).to eq(1), variant_queries.join("\n")
+    end
   end
 end


### PR DESCRIPTION
## What

This PR removes an N+1 query from the checkout upsells dashboard. When serializing the seller's products, the presenter now determines which products have multiple live versions with one grouped query. It then uses the resulting product ID set to populate `has_multiple_versions` in memory. A regression spec verifies that version counts for all products are fetched with one query.

## Why

`Checkout::UpsellsPresenter` previously called this for every visible product:

```ruby
product.alive_variants.limit(2).count > 1
```

This issued one variant count query per product, even though the page needs the same boolean for every product in the collection. The new query groups live variants by product and returns only product IDs with more than one live variant. This preserves the existing response while keeping the number of variant queries constant.

## Verification

- Contributed regression spec ("checks version counts for all products in one query") passes with the fix, and fails-first (RED) against `origin/main` at `expect(variant_queries.size).to eq(1)` — confirming the N+1 is live and the fix is load-bearing.
- Full spec file: 2 examples, 0 failures (with fix).
- `rubocop` on changed files: no offenses.
- Autoreview Sol+Fable panel: clean, 0 findings.

## QA steps

1. Sign in as a seller with multiple visible products.
2. Ensure some products have more than one live version and some have one or none.
3. Create or edit an upsell.
4. Confirm products with multiple versions still expose the expected version-related options.
5. Confirm products without multiple versions continue to behave as before.

---

Premerge review: clean @ e74929132b4a9b1790925fca5e9a242c12b7d1b6

---

Based on https://github.com/haseebeqx/gumroad/pull/1 by @haseebeqx.

AI Disclosure: Hermes Agent was used to review the original PR and import the changes.

No before/after media: this is a backend query-optimization with a contributed regression spec; there is no user-visible UI surface, so the reviewable artifact is the diff plus the failing-first/green run output above.

<!-- gumclaw-ownership-sweep -->
_Ownership:_ Premerge Sol+Fable panel clean at `e74929132b4a9b1790925fca5e9a242c12b7d1b6`. Not money-path-capable (seller checkout-dashboard presenter query; no charges/payouts/fees). `working` removed; assignee stays gumclaw; squash auto-merge armed.
<!-- gumclaw-ownership-sweep -->

