### PR TITLE
Trim Purchase model comments to the IOF and tax-report traps

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -28,24 +28,11 @@ class Purchase < ApplicationRecord
   GUMROAD_FIXED_FEE_CENTS = 50
   PROCESSOR_FEE_PER_THOUSAND = 29
   PROCESSOR_FIXED_FEE_CENTS = 30
-  # IOF is a Brazilian consumer tax on any transaction that involves foreign exchange, currently
-  # 3.5% of the transaction value. It applies whenever the Pix payment leaves Brazil, which is
-  # every Pix charge except one created directly on a Brazilian seller's own Stripe account.
-  #
-  # This constant is the RECOVERY half, and it is narrower than the tax itself: it is billed only
-  # when Gumroad actually bore the cost. On a charge created on a Gumroad-held account, Gumroad
-  # tells Stripe to bill the buyer exactly the price they agreed to
-  # (`amount_includes_iof=always`, see Order::PreparePaymentIntentService#pix_payment_method_options)
-  # and Stripe deducts the IOF from what settles to us — so the cost has to be charged back to the
-  # seller as a fee component, or it would silently come out of Gumroad's own margin instead (the
-  # decision on gumroad-private#1305 was that the seller absorbs it).
-  #
-  # On a direct charge to a seller's own connected account the money never passes through a
-  # Gumroad-held balance, so there is no Gumroad cost to recover and this fee is not billed —
-  # whether or not the tax itself applied. That makes this gate deliberately DIFFERENT from
-  # Order::PreparePaymentIntentService#pix_iof_applies?, which decides whether the tax exists at
-  # all (a border question, keyed on the account's country) rather than who paid it. See the
-  # comment on that method.
+  # Brazilian IOF (3.5%) on Pix that leaves Brazil. This constant is the RECOVERY fee, billed
+  # only when Gumroad absorbed the tax (Gumroad-held account, amount_includes_iof=always).
+  # Direct charge to a connected account: no Gumroad cost, so no fee — whether or not IOF
+  # applied. Different question from PreparePaymentIntentService#pix_iof_applies? (tax exists
+  # vs who paid it). Seller absorbs it (gumroad-private#1305).
   PIX_IOF_FEE_PER_THOUSAND = 35
 
   MAX_PRICE_RANGE = (-2_147_483_647..2_147_483_647)
@@ -675,20 +662,10 @@ class Purchase < ApplicationRecord
   scope :successful, -> { where(purchase_state: "successful") }
   scope :test_successful, -> { where(purchase_state: "test_successful") }
   scope :in_progress, -> { where(purchase_state: "in_progress") }
-  # A payment that can still complete without the buyer returning to checkout, but hasn't
-  # settled yet. Two shapes reach this state: a payment the processor already confirmed and
-  # is clearing (e.g. an ACH bank debit, several business days), and a Pix payment where
-  # Stripe issued a QR code / copy-paste key the buyer can pay from their banking app for up
-  # to half an hour (Purchase::FinalizeConfirmedChargeService writes "requires_action" for
-  # that case). Both conditions matter: `stripe_status` is only ever written once Stripe has
-  # a live payment to report on, so an attempt the buyer dropped before reaching a payment
-  # method keeps it nil and is NOT settling. And a purchase must still be in_progress — once
-  # it reaches a terminal state (failed, successful), stripe_status remains set but the
-  # payment is no longer in flight.
-  #
-  # The Pix case is deliberately included: an outstanding QR key is exactly the window where
-  # a buyer could pay again by another method and end up paying twice, which is what the
-  # double-charge guards built on this scope exist to prevent.
+  # In-flight payment: ACH clearing, or a Pix QR still payable. stripe_status is set only
+  # once Stripe has a live payment, so a dropped attempt (nil) is not settling; a terminal
+  # purchase keeps stripe_status but is no longer in flight. Pix is included so double-charge
+  # guards catch a second payment while the QR is still live.
   scope :payment_settling, -> { in_progress.where.not(stripe_status: nil) }
   # Unconfirmed attempts hold a short lease; a processor status means the payment can still settle
   # after that lease expires.
@@ -757,19 +734,11 @@ class Purchase < ApplicationRecord
   }
   scope :paid, -> { successful.where("purchases.price_cents > 0").where("stripe_refunded is null OR stripe_refunded = 0") }
   scope :not_fully_refunded, -> { where("purchases.stripe_refunded IS NULL OR purchases.stripe_refunded = 0") }
-  # Purchase selection for the tax report jobs' sales leg. Pre-cutover purchases keep the
-  # historical exclusion of purchases fully refunded before the cutover (their netted amount
-  # would be zero, and dropping the row is how historical periods were filed). A purchase must
-  # stay in the report whenever any of its refunds is reported as its own refund-period row:
-  # post-cutover purchases always (they report gross amounts), and pre-cutover purchases that
-  # were fully refunded only on/after the cutover (they report amounts net of pre-cutover
-  # refunds, which is still positive — the post-cutover refund row is what offsets the rest).
-  # Dropping such a sale row would leave its refund row with nothing to subtract from,
-  # understating the period pair by the sale amount.
-  #
-  # The post-cutover refund test reuses Refund.effective (the same scope Refund.for_tax_period_reporting
-  # uses to build those refund rows), so a reversed-failure refund — which never gets a refund
-  # row — can't keep an otherwise fully-refunded sale in the report.
+  # Tax-report sales leg. Keep a sale whenever any of its refunds is reported as its own
+  # refund-period row (post-cutover always; pre-cutover only if fully refunded on/after
+  # cutover — net of pre-cutover refunds is still positive). Dropping the sale understates
+  # the period pair. Pre-cutover fully-refunded-before-cutover stays excluded (netted to 0).
+  # Uses Refund.effective so a reversed-failure refund cannot keep the sale in.
   # See Purchase::Reportable::REFUND_REPORTING_CUTOVER.
   scope :not_fully_refunded_for_tax_reporting, lambda {
     cutover = Purchase::Reportable::REFUND_REPORTING_CUTOVER.beginning_of_day
@@ -852,37 +821,20 @@ class Purchase < ApplicationRecord
       **chargeback_event_dated_bind_params
     )
   }
-  # Purchases whose chargeback (debit) leg lands in [starts_at, ends_at]: event-dated
-  # chargebacks (see CHARGEBACK_EVENT_DATED_SQL) whose dispute event date falls inside the
-  # window.
-  #
-  # We resolve the window through the disputes table rather than filtering purchases by
-  # purchases.chargeback_date directly: chargeback_date has no standalone index (only a
-  # seller_id-leading composite), so an all-sellers date range over it forces a full scan of
-  # the very large purchases table. chargeback_date mirrors the dispute's event_created_at
-  # (both are set from the same processor event when the dispute is formalized), so listing
-  # the disputes in the window and mapping them back to purchase ids yields the same set at a
-  # fraction of the cost. Any purchase the old chargeback_date predicate could return has a
-  # real charge — and therefore a Dispute row, its own or its Charge's for multi-item carts;
-  # the $0 gift/bundle child purchases that carry a chargeback_date without a Dispute row have
-  # no stripe_transaction_id and are excluded by every caller. The chargeback_date filter is
-  # kept as well so a purchase with several disputes is only selected when its own recorded
-  # chargeback_date is the one inside the window.
+  # Chargeback debit leg in [starts_at, ends_at]: event-dated disputes whose event date is
+  # in the window. Drive off disputes (indexed event_created_at), not purchases.chargeback_date
+  # (no standalone index — all-sellers range would scan purchases). Still filter
+  # chargeback_date so a purchase with several disputes is selected only when its own
+  # recorded date is in the window. $0 gift/bundle children with chargeback_date but no
+  # Dispute row have no stripe_transaction_id and are excluded by every caller.
   scope :chargebacks_for_tax_period_reporting, lambda { |starts_at, ends_at|
     where(id: purchase_ids_for_disputes_in_window(:event_created_at, starts_at, ends_at))
       .where(chargeback_date: starts_at..ends_at)
       .where(CHARGEBACK_EVENT_DATED_SQL, **chargeback_event_dated_bind_params)
   }
-  # Purchases whose chargeback-reversal (dispute won) leg lands in [starts_at, ends_at]:
-  # event-dated chargebacks marked reversed, with a Dispute row — linked directly or through
-  # the purchase's Charge (multi-purchase carts) — recording a won_at inside the window.
-  #
-  # Same reasoning as the debit scope above: drive off the disputes table's won_at (now
-  # indexed) instead of a correlated EXISTS over every purchase. This matches the old EXISTS
-  # exactly — it already required a Dispute row with won_at in the window — while turning the
-  # per-purchase subquery into one small, date-indexed lookup. Callers emitting per-row output
-  # still date the leg with purchase.chargeback_reversal_reporting_date, which also resolves
-  # which dispute row wins when a purchase has several.
+  # Chargeback-reversal (dispute won) leg in [starts_at, ends_at]: same disputes-table
+  # lookup on won_at. Callers still date the row with chargeback_reversal_reporting_date
+  # when a purchase has several disputes.
   scope :chargeback_reversals_for_tax_period_reporting, lambda { |starts_at, ends_at|
     where(id: purchase_ids_for_disputes_in_window(:won_at, starts_at, ends_at))
       .where("purchases.chargeback_date >= ?", Purchase::Reportable::CHARGEBACK_REPORTING_CUTOVER.beginning_of_day)
@@ -1770,15 +1722,10 @@ class Purchase < ApplicationRecord
     refunds_that_moved_money.sum { |refund| refund.presentment_snapshot? ? refund.presentment_amount_cents.to_i : 0 }
   end
 
-  # True when this purchase has an effective refund that carries NO buyer-currency
-  # snapshot, which makes buyer_presentment_refunded_cents an incomplete total.
-  #
-  # Refunds issued before #6167 shipped have no presentment snapshot, so they contribute
-  # zero to the sum above. That is the right behaviour for the Sales API (it reports only
-  # what it can attest to), but a seller reading a CSV cannot tell an incomplete total from
-  # a real one — a plausible-looking low number next to a populated USD refund column is
-  # worse than an empty cell. Callers rendering the total for a human use this to blank the
-  # cell instead of publishing a number they'd have to caveat.
+  # True when an effective refund has no buyer-currency snapshot, so
+  # buyer_presentment_refunded_cents is incomplete (pre-#6167 refunds contribute 0).
+  # Sales API reports the partial sum; CSV callers blank the cell so a low number next
+  # to a populated USD refund column is not mistaken for a real total.
   def buyer_presentment_refunded_cents_incomplete?
     refunds_that_moved_money.any? { |refund| !refund.presentment_snapshot? }
   end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -32,7 +32,7 @@ class Purchase < ApplicationRecord
   # only when Gumroad absorbed the tax (Gumroad-held account, amount_includes_iof=always).
   # Direct charge to a connected account: no Gumroad cost, so no fee — whether or not IOF
   # applied. Different question from PreparePaymentIntentService#pix_iof_applies? (tax exists
-  # vs who paid it). Seller absorbs it (gumroad-private#1305).
+  # vs who paid it). Seller absorbs it.
   PIX_IOF_FEE_PER_THOUSAND = 35
 
   MAX_PRICE_RANGE = (-2_147_483_647..2_147_483_647)


### PR DESCRIPTION
## What

Comments only, no behaviour change. Docs-only — diff is the reviewable artifact.

Compress six essays in `Purchase` that restated the constant or scope below them. Facts a maintainer cannot re-derive stay, in fewer words. Sister cut to #7447 (PreparePaymentIntentService IOF). Follow-up commit drops the `gumroad-private#1305` citation from the IOF comment (company-history pointer; seller-absorbs constraint stays).

- `PIX_IOF_FEE_PER_THOUSAND` — keep: 3.5% IOF on Pix that leaves Brazil; this constant is the **recovery** fee, billed only when Gumroad absorbed it; connected-account direct charges bill no fee; different question from `#pix_iof_applies?`; seller absorbs it.
- `payment_settling` — keep: ACH clearing or live Pix QR; `stripe_status` nil is not settling; terminal purchases keep the status but are out of flight; Pix is in so double-charge guards catch a second pay.
- `not_fully_refunded_for_tax_reporting` — keep: keep a sale whenever any refund is its own period row; pre-cutover fully-refunded-before-cutover stays out; `Refund.effective` so reversed-failure refunds cannot keep the sale.
- `chargebacks_for_tax_period_reporting` — keep: drive off indexed `disputes.event_created_at`, not unindexed `purchases.chargeback_date`; still filter `chargeback_date` when a purchase has several disputes; $0 gift/bundle children with no Dispute row are excluded by every caller.
- `chargeback_reversals_for_tax_period_reporting` — keep: same disputes-table lookup on `won_at`; callers still date via `chargeback_reversal_reporting_date`.
- `buyer_presentment_refunded_cents_incomplete?` — keep: pre-#6167 refunds have no snapshot so the sum is incomplete; Sales API reports the partial; CSV blanks the cell.

## Why

Maintainers already know this file. An 18-line IOF essay next to a one-line constant (the shape #7447 already cut on the service) teaches people to skip the comments that matter.

## Line counts

`app/models/purchase.rb`: 6224 → 6171 (−53 net; 27 inserted, 80 deleted on the first commit; follow-up is comment-text only).

## Kept (on purpose)

- Purchase state-machine diagram (normal / test / preorder / gift / subscription) — hard to re-derive from the `state_machine` block.
- `as_json` version changelog (v1 vs v2 field shapes) — public API contract.
- `not_chargedback_for_tax_reporting` cutover note.
- `buyer_presentment_refunded_cents` (already short; points at `refunds_that_moved_money`).

## Not slop (left alone this run)

- `Order::PreparePaymentIntentService` — already trimmed in #7447 / #7463.
- `Checkout::BuyerCurrencyEligibility` — already trimmed in #7283 / #7333.
- `payment.ts` — already trimmed in #7373.
- `Checkout::BuyerCurrencyQuote` units/double-convert trap — load-bearing, not restatement.
- Purchase state-machine diagram and `as_json` TomDoc.

## Test Results

- `ruby -c app/models/purchase.rb` — Syntax OK
- `bundle exec rubocop app/models/purchase.rb` — no offenses
- `rails test test/models/purchase_test.rb -n "/payment_settling/"` — 3 runs, 8 assertions, 0 failures
- `bundle exec rspec spec/models/concerns/purchase/reportable_spec.rb` — 31 examples, 1 failure: `Validation failed: Charge processor merchant This account is already connected with another Gumroad account` on an unrelated multi-purchase-cart factory (`reportable_spec.rb:301`). Tax-report scopes this PR comments all passed. Environmental, not this diff.
- Branch CI `Tests` run 33530823594 — **success**, 0 pending, 0 failures (`ci/green` pass; Buildkite #22309 pass). Head `2507787c4c`.

Premerge review: exempt (comments-only, no behaviour change)

---
AI: Grok 4.6. Prompt: scheduled slop-reducer cron — cut AI comments in already-merged gumroad code, no behaviour change.
