### PR TITLE
Fix blast slice jobs crashing on strip_tags (full_sanitizer)

### DIFF
--- a/app/sidekiq/concerns/post_blast_sending.rb
+++ b/app/sidekiq/concerns/post_blast_sending.rb
@@ -2,7 +2,12 @@
 
 # Shared send phase for parent and slice jobs; callers set @blast, @post, and @members.
 module PostBlastSending
-  include ActionView::Helpers::SanitizeHelper
+  extend ActiveSupport::Concern
+
+  included do
+    # strip_tags calls self.class.full_sanitizer; ClassMethods must land on the job.
+    include ActionView::Helpers::SanitizeHelper
+  end
 
   # Small counter key used by the stalled-blast monitor. Keep it for the full scan window;
   # unlike the audience snapshot, it is tiny and is the only evidence for late safe resumes.
@@ -64,9 +69,10 @@ module PostBlastSending
     # `store_recipients_as_sent` drops was already emailed by someone else.
     owed = members.size
     members = store_recipients_as_sent(members)
-    recipients = prepare_recipients(members)
 
     begin
+      # Inside this rescue so a raise after store_recipients_as_sent cannot leave ghost rows.
+      recipients = prepare_recipients(members)
       deliver_provider_slice(provider: provider, recipients: recipients, cache: cache)
       mark_members_sent_in_this_blast(members) if @blast.to_non_openers?
       decrement_pending_recipients(owed)

--- a/app/sidekiq/send_post_blast_emails_slice_job.rb
+++ b/app/sidekiq/send_post_blast_emails_slice_job.rb
@@ -4,6 +4,7 @@
 # from one parent attempt from satisfying a later repartition of the same blast.
 class SendPostBlastEmailsSliceJob
   include Sidekiq::Job
+  include ActionView::Helpers::SanitizeHelper
   include PostBlastSending
   sidekiq_options retry: 10, queue: :default
 

--- a/spec/sidekiq/send_post_blast_emails_slice_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_slice_job_spec.rb
@@ -331,18 +331,24 @@ describe SendPostBlastEmailsSliceJob, :freeze_time do
       $redis.del(RedisKey.blast_sent_emails(blast.id), RedisKey.blast_done_slices(blast.id, partition_key))
     end
 
-    it "sends a product-post chunk whose product name contains tags" do
+    it "strips tags from purchase product names in prepare_recipients" do
       product = create(:product, user: @seller, name: "<b>Shattered</b> Samples")
       post = create(:product_post, :published, seller: @seller, link: product, bought_products: [product.unique_permalink])
       sale = create(:purchase, link: product, seller: @seller, email: "buyer@example.com")
       blast = create(:blast, :just_requested, post:)
-      activate_partition(blast)
-      member_ids = AudienceMember.where(seller_id: @seller).pluck(:id)
+      member = AudienceMember.filter(
+        seller_id: @seller.id,
+        params: post.audience_members_filter_params,
+        with_ids: true,
+        ids: AudienceMember.where(seller_id: @seller, email: sale.email).pluck(:id)
+      ).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
+      job = described_class.new
+      job.instance_variable_set(:@post, post)
+      job.instance_variable_set(:@blast, blast)
 
-      described_class.new.perform(blast.id, partition_key, 0, 1, member_ids)
+      recipients = job.send(:prepare_recipients, member)
 
-      expect(PostSendgridApi.mails.keys).to include(sale.email)
-      expect(blast.reload.completed_at).to be_present
+      expect(recipients.map { _1[:product_name] }).to eq(["Shattered Samples"])
     end
 
     it "does not leave SentPostEmail rows when preparing recipients raises" do

--- a/spec/sidekiq/send_post_blast_emails_slice_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_slice_job_spec.rb
@@ -331,6 +331,38 @@ describe SendPostBlastEmailsSliceJob, :freeze_time do
       $redis.del(RedisKey.blast_sent_emails(blast.id), RedisKey.blast_done_slices(blast.id, partition_key))
     end
 
+    it "sends a product-post chunk whose product name contains tags" do
+      product = create(:product, user: @seller, name: "<b>Shattered</b> Samples")
+      post = create(:product_post, :published, seller: @seller, link: product, bought_products: [product.unique_permalink])
+      sale = create(:purchase, link: product, seller: @seller, email: "buyer@example.com")
+      blast = create(:blast, :just_requested, post:)
+      activate_partition(blast)
+      member_ids = AudienceMember.where(seller_id: @seller).pluck(:id)
+
+      described_class.new.perform(blast.id, partition_key, 0, 1, member_ids)
+
+      expect(PostSendgridApi.mails.keys).to include(sale.email)
+      expect(blast.reload.completed_at).to be_present
+    end
+
+    it "does not leave SentPostEmail rows when preparing recipients raises" do
+      post = post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      activate_partition(blast)
+      allow_any_instance_of(described_class).to receive(:prepare_recipients).and_raise(NoMethodError, "undefined method 'full_sanitizer'")
+
+      expect {
+        described_class.new.perform(blast.id, partition_key, 0, 1, audience_ids)
+      }.to raise_error(NoMethodError, /full_sanitizer/)
+
+      expect(SentPostEmail.where(post:).count).to eq(0)
+    end
+
+    it "exposes SanitizeHelper class methods used by strip_tags" do
+      expect(described_class).to respond_to(:full_sanitizer)
+      expect(described_class.new.send(:strip_tags, "<b>Hi</b>")).to eq("Hi")
+    end
+
     it "records an empty chunk as done so the blast still completes" do
       blast = create(:blast, :just_requested, post: post_with_audience)
       activate_partition(blast)

--- a/spec/sidekiq/send_post_blast_emails_slice_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_slice_job_spec.rb
@@ -357,9 +357,9 @@ describe SendPostBlastEmailsSliceJob, :freeze_time do
       activate_partition(blast)
       allow_any_instance_of(described_class).to receive(:prepare_recipients).and_raise(NoMethodError, "undefined method 'full_sanitizer'")
 
-      expect {
+      expect do
         described_class.new.perform(blast.id, partition_key, 0, 1, audience_ids)
-      }.to raise_error(NoMethodError, /full_sanitizer/)
+      end.to raise_error(NoMethodError, /full_sanitizer/)
 
       expect(SentPostEmail.where(post:).count).to eq(0)
     end


### PR DESCRIPTION
# Fix blast slice jobs crashing on strip_tags (full_sanitizer)

## What

Give `SendPostBlastEmailsSliceJob` (and any job that includes `PostBlastSending`) SanitizeHelper class methods so `strip_tags` can call `self.class.full_sanitizer`. Move `prepare_recipients` inside the existing SentPostEmail cleanup rescue so a raise after `store_recipients_as_sent` cannot leave ghost rows that a retry then skips.

## Why

antiwork/gumroad-private#2366. After the slice-job split (PR #7461), every large post blast dies in `send_members` with `NoMethodError: undefined method 'full_sanitizer' for class SendPostBlastEmailsSliceJob`. No mail reaches the ESP. The parent job still worked because it included SanitizeHelper directly; the slice job only included `PostBlastSending`, whose module-level include left ClassMethods on the module.

## Before / after

- Before: a slice that hits `strip_tags` (any purchaser in the chunk) raises immediately. `SentPostEmail` rows written before `prepare_recipients` stay, so a retry treats those recipients as already sent.
- After: slice jobs have `full_sanitizer`. A raise during prepare deletes the just-written rows (except `to_non_openers`, which already uses a Redis set).

## Checklist

- [x] Scope — sanitizer ClassMethods + prepare-inside-rescue. Ghost-row cleanup for already-stuck blasts is a post-deploy data step, not this PR.
- [x] Design — `PostBlastSending` is a Concern so ClassMethods land on the including class; slice job also includes SanitizeHelper the same way the parent does.
- [x] Build — `7e9e9b335eb7c41883157d21db27f6b6f5da459d` on `gumclaw/gp2366-slice-job-full-sanitizer` (code at `4c4143957e`, rubocop `do/end` after).
- [x] QA — Sol+Fable panel clean (0 findings) at this head; Tests `push` SUCCESS; `ci/green` pass. No rendered surface (Sidekiq send path) — screenshot gate does not apply.
- [ ] Shipped
- [ ] Market — n/a, delivery bug
- [ ] Sell — n/a

## Test Results

At `4c4143957e`, `DISABLE_SPRING=1 VITE_RUBY_AUTO_BUILD=false bundle exec rspec spec/sidekiq/send_post_blast_emails_slice_job_spec.rb` with `-e` on the three new examples:

```text
3 examples, 0 failures
```

Full-file run of that spec was 24 examples, 6 failures. The 6 were all `Vite Ruby can't find entrypoints/email.ts` on examples that render mail (including one first version of a new example, since rewritten to call `prepare_recipients` only). The two new non-mailer examples passed in that full-file run too.

CI at `7e9e9b335eb7c41883157d21db27f6b6f5da459d`: Tests `push` success, Lint Ruby/JS/TS, Typecheck TS, Migration versions, Test Minitest 0/1, Test Relevant 0–3, `ci/green` pass.

## QA steps

No rendered surface (Sidekiq send path). After deploy: confirm a new slice job no longer logs `undefined method 'full_sanitizer'`, then separately clean leftover `SentPostEmail` rows for blasts that died with `first_email_delivered_at` nil so retries do not skip those recipients.

Walkthrough video omitted for velocity on a live blast outage — the diff is three backend files and the panel/CI evidence above is the reviewable artifact.

---

AI disclosure: grok-4.6. Prompt/instructions: GitHub webhook on antiwork/gumroad-private#2366; autonomous-product-dev build of the confirmed slice-job sanitizer regression.

Premerge review: clean @ 7e9e9b335eb7c41883157d21db27f6b6f5da459d
