### PR TITLE
Write sent_post_emails after the ESP accepts, and reschedule slices behind a held claim

### DIFF
--- a/app/sidekiq/concerns/post_blast_sending.rb
+++ b/app/sidekiq/concerns/post_blast_sending.rb
@@ -63,14 +63,10 @@ module PostBlastSending
   # The provider slice — not the mixed slice — is the retry unit: an ESP that has already
   # accepted its recipients is never handed them again because a later provider failed.
   #
-  # The sent_post_emails rows are written AFTER the provider accepts, never before. A
-  # rescue-and-delete around a pre-write cannot be made airtight — SIGKILL, OOM, and a
-  # rescue that itself raises all skip it — and every row it leaves behind is a recipient
-  # `remove_already_emailed_members` filters out of every retry as "already sent", so the
-  # blast completes with a hole nobody can see (gumroad-private#2366: ~1.7M recipients
-  # across 147 blasts). A kill between the ESP accepting and the write landing costs one
-  # duplicate email for that provider slice (<= 1,000); the pre-write ordering cost a
-  # silent non-delivery for the same slice. Duplicates are visible and bounded.
+  # sent_post_emails rows are written AFTER the provider accepts. Written before, any exit a
+  # rescue cannot see (SIGKILL, OOM) leaves rows that every retry then treats as sent, and the
+  # blast completes short with no signal. A kill between acceptance and the write costs at most
+  # one duplicate provider slice, which is visible and bounded.
   def send_provider_slice(provider:, members:, cache:)
     renew_chunk_claim! if respond_to?(:renew_chunk_claim!, true)
     owed = members.size
@@ -246,10 +242,9 @@ module PostBlastSending
                  RedisKey.blast_active_slice_partition(@blast.id), partition_chunks_key].compact)
   end
 
-  # Re-checked per provider slice, right before the send: the chunk-level filter ran once at
-  # the start of a slice that can take minutes, and a second publish or a concurrent sender
-  # may have emailed some of these addresses since. Non-opener resends dedupe through their
-  # per-blast Redis set instead (`remove_members_already_sent_in_this_blast`).
+  # Re-checked right before each provider call: the chunk-level filter ran once at the start
+  # of a slice that can take minutes, and another sender may have emailed some of these since.
+  # Non-opener resends dedupe through their per-blast Redis set instead.
   def drop_members_already_sent(members)
     return members if @blast.to_non_openers?
 
@@ -259,9 +254,7 @@ module PostBlastSending
     members.reject { already_sent.include?(_1.email) }
   end
 
-  # Records the slice as sent. Runs only after the provider accepted, so a row here always
-  # has an email behind it. A concurrent sender racing the same address just loses the
-  # unique-index race; the duplicate it already sent is the bounded cost.
+  # Only after the provider accepted, so a row here always has an email behind it.
   def store_recipients_as_sent(members)
     SentPostEmail.insert_all_emails(post: @post, emails: members.map(&:email))
   end

--- a/app/sidekiq/concerns/post_blast_sending.rb
+++ b/app/sidekiq/concerns/post_blast_sending.rb
@@ -21,6 +21,9 @@ module PostBlastSending
   # the monitor flags the blast via the (positive) pending count instead.
   SLICE_DONE_TTL = 3.days
 
+  # In-process attempts for the sent-row write that runs after the ESP accepted a slice.
+  POST_ACCEPT_WRITE_ATTEMPTS = 3
+
   SLICE_PARTITION_MUTATION_LOCK_TTL = 30.seconds
   SLICE_PARTITION_MUTATION_LOCK_WAIT = 5.seconds
   SLICE_PARTITION_MUTATION_LOCK_RETRY_INTERVAL = 0.05
@@ -254,9 +257,20 @@ module PostBlastSending
     members.reject { already_sent.include?(_1.email) }
   end
 
-  # Only after the provider accepted, so a row here always has an email behind it.
+  # Only after the provider accepted, so a row here always has an email behind it. A transient
+  # DB error now converts into a redelivered slice on the job retry, so absorb those in-process
+  # first; a persistent failure still raises — the retry's redelivery is bounded and visible,
+  # a swallowed write is a silent dedupe hole.
   def store_recipients_as_sent(members)
-    SentPostEmail.insert_all_emails(post: @post, emails: members.map(&:email))
+    attempts = 0
+    begin
+      SentPostEmail.insert_all_emails(post: @post, emails: members.map(&:email))
+    rescue StandardError
+      attempts += 1
+      raise if attempts >= POST_ACCEPT_WRITE_ATTEMPTS
+      sleep(attempts)
+      retry
+    end
   end
 
   def post_has_files?

--- a/app/sidekiq/concerns/post_blast_sending.rb
+++ b/app/sidekiq/concerns/post_blast_sending.rb
@@ -60,35 +60,31 @@ module PostBlastSending
     end
   end
 
-  # The provider slice — not the mixed slice — is the retry unit. An ESP that has
-  # already accepted its recipients must not be handed them again because a later
-  # provider failed, so the cleanup below only rolls back the slice that raised.
+  # The provider slice — not the mixed slice — is the retry unit: an ESP that has already
+  # accepted its recipients is never handed them again because a later provider failed.
+  #
+  # The sent_post_emails rows are written AFTER the provider accepts, never before. A
+  # rescue-and-delete around a pre-write cannot be made airtight — SIGKILL, OOM, and a
+  # rescue that itself raises all skip it — and every row it leaves behind is a recipient
+  # `remove_already_emailed_members` filters out of every retry as "already sent", so the
+  # blast completes with a hole nobody can see (gumroad-private#2366: ~1.7M recipients
+  # across 147 blasts). A kill between the ESP accepting and the write landing costs one
+  # duplicate email for that provider slice (<= 1,000); the pre-write ordering cost a
+  # silent non-delivery for the same slice. Duplicates are visible and bounded.
   def send_provider_slice(provider:, members:, cache:)
     renew_chunk_claim! if respond_to?(:renew_chunk_claim!, true)
-    # Count the slice as handed over, not the post-dedupe remainder: anything
-    # `store_recipients_as_sent` drops was already emailed by someone else.
     owed = members.size
-    members = store_recipients_as_sent(members)
+    members = drop_members_already_sent(members)
+    return decrement_pending_recipients(owed) if members.empty?
 
-    begin
-      # Inside this rescue so a raise after store_recipients_as_sent cannot leave ghost rows.
-      recipients = prepare_recipients(members)
-      deliver_provider_slice(provider: provider, recipients: recipients, cache: cache)
-      mark_members_sent_in_this_blast(members) if @blast.to_non_openers?
-      decrement_pending_recipients(owed)
-    rescue Exception => e
-      # Delete the sent_post_emails records if there's an error with the provider send.
-      # We cannot use `transaction` here because it exceeds the lock timeout.
-      # Rescuing Exception, not StandardError: a deploy's hard shutdown raises
-      # Sidekiq::Shutdown (an Interrupt), and letting that skip the cleanup would leave
-      # these recipients marked sent but never emailed — the retry filters them out as
-      # already-emailed, so they are silently dropped from the blast.
-      unless @blast.to_non_openers?
-        emails = members.map(&:email)
-        SentPostEmail.where(post: @post, email: emails).delete_all
-      end
-      raise e
+    recipients = prepare_recipients(members)
+    deliver_provider_slice(provider: provider, recipients: recipients, cache: cache)
+    if @blast.to_non_openers?
+      mark_members_sent_in_this_blast(members)
+    else
+      store_recipients_as_sent(members)
     end
+    decrement_pending_recipients(owed)
   end
 
   def deliver_provider_slice(provider:, recipients:, cache:)
@@ -250,17 +246,24 @@ module PostBlastSending
                  RedisKey.blast_active_slice_partition(@blast.id), partition_chunks_key].compact)
   end
 
-  # Stores email addresses in SentPostEmail, just before sending the emails.
-  # In the very unlikely situation an email is already present there, its member won't be returned.
-  # "Unlikely situation" because we've already filtered the sent emails beforehand with `remove_already_emailed_members`,
-  # this behavior only helps if an email is sent by something else in parallel, between the start and the end of this job.
-  def store_recipients_as_sent(members)
+  # Re-checked per provider slice, right before the send: the chunk-level filter ran once at
+  # the start of a slice that can take minutes, and a second publish or a concurrent sender
+  # may have emailed some of these addresses since. Non-opener resends dedupe through their
+  # per-blast Redis set instead (`remove_members_already_sent_in_this_blast`).
+  def drop_members_already_sent(members)
     return members if @blast.to_non_openers?
 
-    emails = Set.new(SentPostEmail.insert_all_emails(post: @post, emails: members.map(&:email)))
-    return members if members.size == emails.size
+    already_sent = @post.sent_post_emails.where(email: members.map(&:email)).pluck(:email).to_set
+    return members if already_sent.empty?
 
-    members.select { _1.email.in?(emails) }
+    members.reject { already_sent.include?(_1.email) }
+  end
+
+  # Records the slice as sent. Runs only after the provider accepted, so a row here always
+  # has an email behind it. A concurrent sender racing the same address just loses the
+  # unique-index race; the duplicate it already sent is the bounded cost.
+  def store_recipients_as_sent(members)
+    SentPostEmail.insert_all_emails(post: @post, emails: members.map(&:email))
   end
 
   def post_has_files?

--- a/app/sidekiq/send_post_blast_emails_slice_job.rb
+++ b/app/sidekiq/send_post_blast_emails_slice_job.rb
@@ -25,6 +25,7 @@ class SendPostBlastEmailsSliceJob
 
       @filters = @post.audience_members_filter_params
       @members = load_chunk_members(member_ids)
+      renew_chunk_claim!
       # A retried slice re-runs its own chunk and must not double-decrement pending for
       # recipients its first attempt already handed off.
       @blast.to_non_openers? ? remove_members_already_sent_in_this_blast : remove_already_emailed_members
@@ -38,13 +39,13 @@ class SendPostBlastEmailsSliceJob
 
   private
     CHUNK_REVALIDATION_SLICE_SIZE = 1_000
-    # Renewed on every provider slice (seconds apart), so this only has to outlive the chunk's
-    # member load plus one provider call. The claim key is the sole record that another copy is
-    # sending; a hard-killed copy never releases it, and every second of TTL past that is a
-    # second the chunk cannot resume.
+    # The claim is renewed after the member load and on every provider slice, so it only has to
+    # outlive one of those steps. A hard-killed copy never releases it, and the chunk cannot
+    # resume until it lapses, so keep it short. Must stay above CHUNK_LOAD_TIMEOUT.
     CHUNK_CLAIM_TTL = 30.minutes
-    # A copy that finds the claim held waits this long past the claim's expiry before its next
-    # look, so a dead holder is noticed within a minute of the key lapsing.
+    # Statement cap for the member load. Below CHUNK_CLAIM_TTL so the claim cannot lapse mid-load.
+    CHUNK_LOAD_TIMEOUT = 20.minutes
+    # Wait this long past a held claim's expiry before looking again.
     CLAIM_RECHECK_SLACK = 1.minute
     RELEASE_CHUNK_CLAIM_IF_HELD = <<~LUA
       if redis.call("GET", KEYS[1]) == ARGV[1] then
@@ -73,11 +74,9 @@ class SendPostBlastEmailsSliceJob
       $redis.set(@chunk_claim_key, @chunk_claim_token, nx: true, ex: CHUNK_CLAIM_TTL.to_i)
     end
 
-    # A held claim is not an error, so it must not spend the job's retries: Sidekiq's backoff
-    # pushed every retry of a chunk whose first copy was hard-killed into that copy's still-held
-    # claim window, and the chunk landed in the dead set with its recipients never sent
-    # (gumroad-private#2366: 109 of 235 chunks on one blast). Come back once the claim can have
-    # lapsed; if the holder is alive and finishes, the completed-chunk check returns first.
+    # A held claim is not a failure, so it must not spend a retry: Sidekiq's backoff lands every
+    # retry inside the holder's window and the chunk dies with its recipients unsent. Come back
+    # once the claim can have lapsed; a holder that finished is caught by chunk_completed?.
     def reschedule_behind_claim(blast_id, partition_key, chunk_index, total_chunks, member_ids)
       ttl = $redis.ttl(@chunk_claim_key)
       delay = (ttl.positive? ? ttl : 0) + CLAIM_RECHECK_SLACK.to_i
@@ -100,7 +99,7 @@ class SendPostBlastEmailsSliceJob
 
       # The send phase needs filter-provided virtual columns (purchase_id/follower_id/affiliate_id).
       Makara::Context.release_all
-      members = WithMaxExecutionTime.timeout_queries(seconds: 1.hour) do
+      members = WithMaxExecutionTime.timeout_queries(seconds: CHUNK_LOAD_TIMEOUT) do
         member_ids.each_slice(CHUNK_REVALIDATION_SLICE_SIZE).flat_map do |ids_slice|
           AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true, ids: ids_slice)
             .select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a

--- a/app/sidekiq/send_post_blast_emails_slice_job.rb
+++ b/app/sidekiq/send_post_blast_emails_slice_job.rb
@@ -18,7 +18,7 @@ class SendPostBlastEmailsSliceJob
       finalize_partition_if_complete(partition_key, total_chunks)
       return
     end
-    claim_chunk!(partition_key, chunk_index)
+    return reschedule_behind_claim(blast_id, partition_key, chunk_index, total_chunks, member_ids) unless claim_chunk(partition_key, chunk_index)
 
     begin
       @blast.update!(started_at: Time.current) if @blast.started_at.nil?
@@ -38,7 +38,14 @@ class SendPostBlastEmailsSliceJob
 
   private
     CHUNK_REVALIDATION_SLICE_SIZE = 1_000
-    CHUNK_CLAIM_TTL = 4.hours
+    # Renewed on every provider slice (seconds apart), so this only has to outlive the chunk's
+    # member load plus one provider call. The claim key is the sole record that another copy is
+    # sending; a hard-killed copy never releases it, and every second of TTL past that is a
+    # second the chunk cannot resume.
+    CHUNK_CLAIM_TTL = 30.minutes
+    # A copy that finds the claim held waits this long past the claim's expiry before its next
+    # look, so a dead holder is noticed within a minute of the key lapsing.
+    CLAIM_RECHECK_SLACK = 1.minute
     RELEASE_CHUNK_CLAIM_IF_HELD = <<~LUA
       if redis.call("GET", KEYS[1]) == ARGV[1] then
         return redis.call("DEL", KEYS[1])
@@ -60,12 +67,22 @@ class SendPostBlastEmailsSliceJob
       $redis.sismember(RedisKey.blast_done_slices(@blast.id, partition_key), chunk_index)
     end
 
-    def claim_chunk!(partition_key, chunk_index)
+    def claim_chunk(partition_key, chunk_index)
       @chunk_claim_key = RedisKey.blast_slice_claim(@blast.id, partition_key, chunk_index)
       @chunk_claim_token = SecureRandom.uuid
-      return if $redis.set(@chunk_claim_key, @chunk_claim_token, nx: true, ex: CHUNK_CLAIM_TTL.to_i)
+      $redis.set(@chunk_claim_key, @chunk_claim_token, nx: true, ex: CHUNK_CLAIM_TTL.to_i)
+    end
 
-      raise "slice #{chunk_index} is already claimed for blast #{@blast.id}"
+    # A held claim is not an error, so it must not spend the job's retries: Sidekiq's backoff
+    # pushed every retry of a chunk whose first copy was hard-killed into that copy's still-held
+    # claim window, and the chunk landed in the dead set with its recipients never sent
+    # (gumroad-private#2366: 109 of 235 chunks on one blast). Come back once the claim can have
+    # lapsed; if the holder is alive and finishes, the completed-chunk check returns first.
+    def reschedule_behind_claim(blast_id, partition_key, chunk_index, total_chunks, member_ids)
+      ttl = $redis.ttl(@chunk_claim_key)
+      delay = (ttl.positive? ? ttl : 0) + CLAIM_RECHECK_SLACK.to_i
+      Rails.logger.info("[#{self.class.name}] blast_id=#{blast_id} chunk=#{chunk_index} claimed by another copy; rechecking in #{delay}s")
+      self.class.perform_in(delay, blast_id, partition_key, chunk_index, total_chunks, member_ids)
     end
 
     def renew_chunk_claim!

--- a/app/sidekiq/send_post_blast_emails_slice_job.rb
+++ b/app/sidekiq/send_post_blast_emails_slice_job.rb
@@ -39,9 +39,9 @@ class SendPostBlastEmailsSliceJob
 
   private
     CHUNK_REVALIDATION_SLICE_SIZE = 1_000
-    # The claim is renewed after the member load and on every provider slice, so it only has to
-    # outlive one of those steps. A hard-killed copy never releases it, and the chunk cannot
-    # resume until it lapses, so keep it short. Must stay above CHUNK_LOAD_TIMEOUT.
+    # Renewed on every member-load slice and every provider slice, so it only has to outlive
+    # one statement or one provider call. A hard-killed copy never releases it, and the chunk
+    # cannot resume until it lapses, so keep it short. Must stay above CHUNK_LOAD_TIMEOUT.
     CHUNK_CLAIM_TTL = 30.minutes
     # Statement cap for the member load. Below CHUNK_CLAIM_TTL so the claim cannot lapse mid-load.
     CHUNK_LOAD_TIMEOUT = 20.minutes
@@ -99,8 +99,11 @@ class SendPostBlastEmailsSliceJob
 
       # The send phase needs filter-provided virtual columns (purchase_id/follower_id/affiliate_id).
       Makara::Context.release_all
+      # CHUNK_LOAD_TIMEOUT caps each statement and the renewal below covers the gap between
+      # statements, so the claim cannot lapse mid-load however many slices run.
       members = WithMaxExecutionTime.timeout_queries(seconds: CHUNK_LOAD_TIMEOUT) do
         member_ids.each_slice(CHUNK_REVALIDATION_SLICE_SIZE).flat_map do |ids_slice|
+          renew_chunk_claim!
           AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true, ids: ids_slice)
             .select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
         end

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -841,8 +841,8 @@ describe SendPostBlastEmailsJob, :freeze_time do
 
       emails = [first_follower.email, second_follower.email]
       failed_email = (emails - [resend_email]).sole
-      # The provider that already accepted its slice keeps its rows; only the slice that
-      # raised is rolled back.
+      # The provider that already accepted its slice has its rows; the slice that raised
+      # never wrote any, so a retry re-sends exactly it.
       expect(SentPostEmail.where(post:, email: resend_email).count).to eq(1)
       expect(SentPostEmail.where(post:, email: failed_email).count).to eq(0)
       expect(blast.reload.completed_at).to be_blank
@@ -850,7 +850,7 @@ describe SendPostBlastEmailsJob, :freeze_time do
   end
 
   describe "error handling" do
-    it "deletes sent_post_emails records if a provider send raises an error" do
+    it "leaves no sent_post_emails records if a provider send raises an error" do
       # Setup post and blast
       post = create(:audience_post, :published, seller: @seller)
       create(:active_follower, user: @seller)
@@ -865,7 +865,7 @@ describe SendPostBlastEmailsJob, :freeze_time do
         described_class.new.perform(blast.id)
       end.to raise_error(StandardError, "API failure")
 
-      # Verify that no SentPostEmail records exist
+      # Rows are written only after the provider accepts, so a failed slice leaves none behind.
       expect(SentPostEmail.where(post: post).count).to eq(0)
     end
   end

--- a/spec/sidekiq/send_post_blast_emails_slice_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_slice_job_spec.rb
@@ -166,18 +166,38 @@ describe SendPostBlastEmailsSliceJob, :freeze_time do
       expect(blast.reload.completed_at).to be_present
     end
 
-    it "retries a chunk another copy is already sending" do
+    it "reschedules itself past the claim expiry instead of failing when another copy holds the chunk" do
       post = post_with_audience
       blast = create(:blast, :just_requested, post:, recipient_filter: PostEmailBlast::RECIPIENT_FILTER_UNOPENED)
       activate_partition(blast)
-      $redis.set(RedisKey.blast_slice_claim(blast.id, partition_key, 0), "live-copy-jid")
+      $redis.set(RedisKey.blast_slice_claim(blast.id, partition_key, 0), "live-copy-jid", ex: 600)
 
-      expect { described_class.new.perform(blast.id, partition_key, 0, 1, audience_ids.first(1)) }.to raise_error(/already claimed/)
+      expect { described_class.new.perform(blast.id, partition_key, 0, 1, audience_ids.first(1)) }.not_to raise_error
 
       expect_sent_count 0
       expect(blast.reload.completed_at).to be_blank
+      expect(described_class.jobs.size).to eq(1)
+      requeued = described_class.jobs.sole
+      expect(requeued["args"]).to eq([blast.id, partition_key, 0, 1, audience_ids.first(1)])
+      expect(requeued["at"]).to be_within(2).of((600 + described_class::CLAIM_RECHECK_SLACK.to_i).seconds.from_now.to_f)
+      # The held claim was left alone.
+      expect($redis.get(RedisKey.blast_slice_claim(blast.id, partition_key, 0))).to eq("live-copy-jid")
     ensure
       $redis.del(RedisKey.blast_slice_claim(blast.id, partition_key, 0), RedisKey.blast_active_slice_partition(blast.id)) if blast
+    end
+
+    it "sends the chunk once the previous copy's claim has lapsed" do
+      post = post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      activate_partition(blast)
+      # Redis expiry runs on wall-clock time, not the frozen test clock.
+      $redis.set(RedisKey.blast_slice_claim(blast.id, partition_key, 0), "killed-copy-token", px: 20)
+      sleep 0.05
+
+      described_class.new.perform(blast.id, partition_key, 0, 1, audience_ids)
+
+      expect_sent_count 3
+      expect(blast.reload.completed_at).to be_present
     end
 
     it "finalizes when retrying a chunk after every chunk was already recorded" do
@@ -233,10 +253,11 @@ describe SendPostBlastEmailsSliceJob, :freeze_time do
       job = described_class.new
       job.jid = "requeued-jid"
 
-      expect { job.perform(blast.id, partition_key, 0, 1, audience_ids) }.to raise_error(/already claimed/)
+      job.perform(blast.id, partition_key, 0, 1, audience_ids)
 
       expect_sent_count 0
       expect(blast.reload.completed_at).to be_blank
+      expect(described_class.jobs.size).to eq(1)
     ensure
       $redis.del(RedisKey.blast_slice_claim(blast.id, partition_key, 0), RedisKey.blast_active_slice_partition(blast.id)) if blast
     end
@@ -249,10 +270,11 @@ describe SendPostBlastEmailsSliceJob, :freeze_time do
       job = described_class.new
       job.jid = "jid-b"
 
-      expect { job.perform(blast.id, partition_key, 0, 1, audience_ids) }.to raise_error(/already claimed/)
+      job.perform(blast.id, partition_key, 0, 1, audience_ids)
 
       expect_sent_count 0
       expect(blast.reload.completed_at).to be_blank
+      expect(described_class.jobs.size).to eq(1)
     ensure
       $redis.del(RedisKey.blast_slice_claim(blast.id, partition_key, 0), RedisKey.blast_active_slice_partition(blast.id)) if blast
     end
@@ -362,6 +384,67 @@ describe SendPostBlastEmailsSliceJob, :freeze_time do
       end.to raise_error(NoMethodError, /full_sanitizer/)
 
       expect(SentPostEmail.where(post:).count).to eq(0)
+    end
+
+    it "does not leave SentPostEmail rows when the worker is hard-killed before the provider accepts" do
+      post = post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      activate_partition(blast)
+      # A kill signal is not a StandardError and skips any rescue; the rows must simply not exist yet.
+      allow(PostSendgridApi).to receive(:process).and_raise(Sidekiq::Shutdown)
+
+      expect do
+        described_class.new.perform(blast.id, partition_key, 0, 1, audience_ids)
+      end.to raise_error(Sidekiq::Shutdown)
+
+      expect(SentPostEmail.where(post:).count).to eq(0)
+    end
+
+    it "records recipients as sent only after the provider accepted them" do
+      post = post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      activate_partition(blast)
+      rows_at_send = nil
+      allow(PostSendgridApi).to receive(:process).and_wrap_original do |original, **kwargs|
+        rows_at_send = SentPostEmail.where(post:).count
+        original.call(**kwargs)
+      end
+
+      described_class.new.perform(blast.id, partition_key, 0, 1, audience_ids)
+
+      expect(rows_at_send).to eq(0)
+      expect(SentPostEmail.where(post:).count).to eq(3)
+      expect_sent_count 3
+    end
+
+    it "re-sends recipients a killed copy left without a row, and skips the ones it recorded" do
+      post = post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      activate_partition(blast)
+      # First copy delivered alpha (row written) then died before bravo/charlie.
+      SentPostEmail.create!(post:, email: "alpha@example.com")
+
+      described_class.new.perform(blast.id, partition_key, 0, 1, audience_ids)
+
+      expect(PostSendgridApi.mails.keys).to contain_exactly("bravo@example.com", "charlie@example.com")
+      expect(SentPostEmail.where(post:).count).to eq(3)
+      expect(blast.reload.completed_at).to be_present
+    end
+
+    it "drops an address another sender recorded between the chunk filter and the provider call" do
+      post = post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      activate_partition(blast)
+      job = described_class.new
+      allow(job).to receive(:remove_already_emailed_members).and_wrap_original do |original|
+        original.call
+        SentPostEmail.create!(post:, email: "bravo@example.com")
+      end
+
+      job.perform(blast.id, partition_key, 0, 1, audience_ids)
+
+      expect(PostSendgridApi.mails.keys).to contain_exactly("alpha@example.com", "charlie@example.com")
+      expect(SentPostEmail.where(post:).count).to eq(3)
     end
 
     it "exposes SanitizeHelper class methods used by strip_tags" do

--- a/spec/sidekiq/send_post_blast_emails_slice_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_slice_job_spec.rb
@@ -186,6 +186,28 @@ describe SendPostBlastEmailsSliceJob, :freeze_time do
       $redis.del(RedisKey.blast_slice_claim(blast.id, partition_key, 0), RedisKey.blast_active_slice_partition(blast.id)) if blast
     end
 
+    it "renews its claim after loading the chunk members" do
+      post = post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      activate_partition(blast)
+      claim_key = RedisKey.blast_slice_claim(blast.id, partition_key, 0)
+      ttl_after_load = nil
+      allow_any_instance_of(described_class).to receive(:load_chunk_members).and_wrap_original do |original, *args|
+        # Pretend the load ran long enough for the claim to be close to lapsing.
+        $redis.expire(claim_key, 5)
+        original.call(*args)
+      end
+      allow_any_instance_of(described_class).to receive(:send_members) { ttl_after_load = $redis.ttl(claim_key) }
+
+      described_class.new.perform(blast.id, partition_key, 0, 1, audience_ids)
+
+      expect(ttl_after_load).to be > (described_class::CHUNK_CLAIM_TTL.to_i - 30)
+    end
+
+    it "keeps the member-load statement cap below the claim lifetime" do
+      expect(described_class::CHUNK_LOAD_TIMEOUT).to be < described_class::CHUNK_CLAIM_TTL
+    end
+
     it "sends the chunk once the previous copy's claim has lapsed" do
       post = post_with_audience
       blast = create(:blast, :just_requested, post:)

--- a/spec/sidekiq/send_post_blast_emails_slice_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_slice_job_spec.rb
@@ -439,6 +439,59 @@ describe SendPostBlastEmailsSliceJob, :freeze_time do
       expect_sent_count 3
     end
 
+    it "renews the chunk claim on every member-load slice" do
+      post = post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      activate_partition(blast)
+      job = described_class.new
+      renewals_during_load = 0
+      allow(job).to receive(:renew_chunk_claim!).and_wrap_original do |original|
+        renewals_during_load += 1 if PostSendgridApi.mails.empty?
+        original.call
+      end
+      stub_const("#{described_class}::CHUNK_REVALIDATION_SLICE_SIZE", 1)
+
+      job.perform(blast.id, partition_key, 0, 1, audience_ids)
+
+      # One renewal per 1-member load slice, before any provider renewal.
+      expect(renewals_during_load).to be >= 3
+      expect_sent_count 3
+    end
+
+    it "retries the post-acceptance sent-row write in-process instead of re-sending the slice" do
+      post = post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      activate_partition(blast)
+      calls = 0
+      allow(SentPostEmail).to receive(:insert_all_emails).and_wrap_original do |original, **kwargs|
+        calls += 1
+        raise ActiveRecord::Deadlocked if calls == 1
+        original.call(**kwargs)
+      end
+      allow_any_instance_of(described_class).to receive(:sleep)
+
+      described_class.new.perform(blast.id, partition_key, 0, 1, audience_ids)
+
+      # The provider was handed the slice exactly once; the write landed on the second try.
+      expect_sent_count 3
+      expect(SentPostEmail.where(post:).count).to eq(3)
+      expect(blast.reload.completed_at).to be_present
+    end
+
+    it "raises after the post-acceptance write attempts are exhausted" do
+      post = post_with_audience
+      blast = create(:blast, :just_requested, post:)
+      activate_partition(blast)
+      allow(SentPostEmail).to receive(:insert_all_emails).and_raise(ActiveRecord::Deadlocked)
+      allow_any_instance_of(described_class).to receive(:sleep)
+
+      expect do
+        described_class.new.perform(blast.id, partition_key, 0, 1, audience_ids)
+      end.to raise_error(ActiveRecord::Deadlocked)
+
+      expect(SentPostEmail).to have_received(:insert_all_emails).exactly(PostBlastSending::POST_ACCEPT_WRITE_ATTEMPTS).times
+    end
+
     it "re-sends recipients a killed copy left without a row, and skips the ones it recorded" do
       post = post_with_audience
       blast = create(:blast, :just_requested, post:)


### PR DESCRIPTION
# Write `sent_post_emails` after the ESP accepts, and reschedule slices behind a held claim

## What

Two changes to the blast send path, both from live production forensics on gumroad-private#2366:

1. **`SentPostEmail` rows are written after the provider accepts, not before.** `store_recipients_as_sent` used to run before `PostResendApi/PostSendgridApi.process` and rely on a `rescue Exception` to delete the rows on failure. The rescue cannot cover hard kills (SIGKILL/OOM/pod recycle), a rescue that itself raises, or a death mid-cleanup. Every row it leaves behind is a recipient `remove_already_emailed_members` filters out of every later retry as "already sent". The blast then stamps `completed_at` with a hole nobody can see. A per-provider-slice dedupe re-check (`drop_members_already_sent`) replaces the old "insert and keep only the new emails" race guard.
2. **A held chunk claim reschedules instead of raising.** `claim_chunk!` raised `slice N is already claimed`, which spent one of the slice job's 10 retries. With a 4h claim TTL and Sidekiq's exponential backoff, every retry of a chunk whose first copy was hard-killed landed inside that copy's still-held window, and after 10 misses the chunk was dead-set with its recipients unsent. Now the slice `perform_in`s itself for claim-TTL + 60s and the TTL drops to 30 minutes (renewed after the member load, whose statement cap is now 20 minutes, and on every provider slice).

## Why

Live audited read (`20260902T023112Z-ee90659a`): **147 blasts since the #7461 slice-split deploy have `SentPostEmail.count > delivery_count`, total gap 1,706,794 recipients.** 53 of them are stuck (`completed_at` nil) and 78 stamped complete with the hole. Per-batch classification on blast 461506 (Remo De Vico, the ticket that opened this issue): 218 insert batches, 160 with purchasers and **zero** matching `EmailInfo` rows (ghosts, 11,100 recipients), 58 fully confirmed (3,634), 0 partial. Same shape on 461535 (504 ghost batches / 38,080). #7476 fixed the `full_sanitizer` crash and moved `prepare_recipients` inside the rescue, but pre-write ordering is unsound under any exit the rescue does not see.

Dead set at the same read: 1,027 dead `SendPostBlastEmails*` jobs across 126 blasts. For 461602 (342k audience) 109 of 235 chunks are dead with `slice N is already claimed`, their claims still held (TTL ~1100s at read time) and no live worker. `undone_minus_dead=0` on every stuck blast inspected: the dead chunks are exactly the unsent ones.

**Trade-off, stated plainly:** a hard kill between the ESP accepting a slice and the row write landing now costs at most one duplicate provider slice (≤100 Resend / ≤1,000 SendGrid recipients). Before, the same kill cost a silent non-delivery of the same slice. Duplicates are visible and bounded; missing mail is neither.

## Before / after

- Before: kill during `deliver_provider_slice` → rows stay → recipients dropped from every retry → blast completes short.
- After: kill during `deliver_provider_slice` → no rows → retry re-sends that slice.
- Before: retry lands on a held claim → `RuntimeError` → retry consumed → dead set after 10.
- After: retry lands on a held claim → `perform_in(ttl + 60s)` → picks up when the claim lapses, or exits on `chunk_completed?` if the holder finished.

## Checklist

- [x] Scope — send-order + claim backoff only. Recovery of the 147 already-affected blasts is a separate audited console run under gumroad-private#2366 (ghost rows deleted per frozen id range, blast un-completed, re-enqueued), not this PR.
- [x] Design — no schema change; `SentPostEmail` unique index and `insert_all_emails` unchanged.
- [x] Build — `114ec4c43d` on `gumclaw/gp2366-ghost-free-blast-sends`.
- [x] QA — Sol+Fable panel clean (0 findings each) at `114ec4c43d`. Greptile P1 #1 fixed, P1 #2 mitigated with an in-process write retry, P2 fixed. No rendered surface (Sidekiq send path). CI: awaiting green at head (`ci_watch` armed).
- [ ] Shipped
- [ ] Market — n/a
- [ ] Sell — n/a

## Test Results

Local, `DISABLE_SPRING=1 VITE_RUBY_AUTO_BUILD=false bundle exec rspec`:

```text
spec/sidekiq/send_post_blast_emails_slice_job_spec.rb  34 examples, 0 failures
spec/sidekiq/send_post_blast_emails_job_spec.rb        69 examples, 0 failures
```

New examples: rows absent when the provider raises `Sidekiq::Shutdown` (not a StandardError); rows written only after the provider accepted; a killed copy's unrecorded recipients are re-sent while its recorded ones are skipped; an address recorded by another sender between the chunk filter and the provider call is dropped; a held claim reschedules with the right delay and leaves the claim alone; a lapsed claim lets the chunk send. Rubocop clean on the four files.

## Review triage (Greptile, round 1)

1. **Claim expires before renewal (P1) — accepted, fixed.** The claim is renewed on every member-load slice (each <=1,000 ids) and again after the full load, and the load's statement cap is `CHUNK_LOAD_TIMEOUT = 20.minutes`, pinned below `CHUNK_CLAIM_TTL` by a spec — no statement and no gap between statements can outlive the claim.
2. **Post-send write raising replays delivery (P1) — mitigated; residual is the designed trade-off.** `store_recipients_as_sent` absorbs transient DB errors in-process (`POST_ACCEPT_WRITE_ATTEMPTS = 3`, spec-pinned both ways) so a deadlock no longer converts into a redelivered slice. A persistent failure still raises and costs at most one visible, bounded duplicate provider slice on retry — the pre-write alternative is the silent-non-delivery failure this PR removes. Neither ESP batch endpoint offers an idempotency key today.
3. **Comments embed incident history (P2) — accepted, trimmed.** Counts and issue attribution live here and in gumroad-private#2366; the code comments keep only the ordering constraint and the why.

## QA steps

Sidekiq send path, no rendered surface. After deploy: `SentPostEmail.where(post_id:).count - blast.delivery_count` on fresh blasts should be 0 (or a small positive from other-blast rows on a republished post), and `Sidekiq::DeadSet` should stop accruing `slice N is already claimed` entries.

---

AI disclosure: claude-fable-5-1. Prompt: "Fix properly. https://github.com/antiwork/gumroad-private/issues/2366" (Sahil, Telegram).

Premerge review: clean @ 114ec4c43d5b17ffb79411bc1395329e32b4d7e9
