### PR TITLE
Record verified social-connect metadata for payout-hold risk reviews

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -131,6 +131,15 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
                                                      })
   end
 
+  def social_connections
+    user = find_internal_admin_user_for_read_or_render(include_deleted: true)
+    return unless user
+
+    render json: internal_admin_user_success_payload(user, {
+                                                       social_connections: user.social_connect_verifications.order(:platform).map { serialize_social_connect_verification(_1) },
+                                                     })
+  end
+
   def unpaid_balance
     user = find_internal_admin_user_for_read_or_render
     return unless user
@@ -996,6 +1005,19 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         reason: credit.reason,
         crediting_user_id: credit.crediting_user&.external_id,
         created_at: credit.created_at.iso8601
+      }
+    end
+
+    def serialize_social_connect_verification(verification)
+      {
+        platform: verification.platform,
+        handle: verification.handle,
+        account_created_at: verification.account_created_at&.iso8601,
+        follower_count: verification.follower_count,
+        post_count: verification.post_count,
+        last_posted_at: verification.last_posted_at&.iso8601,
+        last_verified_at: verification.last_verified_at.iso8601,
+        shared_identity_user_count: verification.shared_identity_user_ids.size,
       }
     end
 

--- a/app/models/social_connect_verification.rb
+++ b/app/models/social_connect_verification.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class SocialConnectVerification < ApplicationRecord
+  PLATFORMS = %w[twitter youtube instagram tiktok].freeze
+
+  belongs_to :user
+
+  validates :platform, presence: true, inclusion: { in: PLATFORMS }
+  validates :uid, presence: true
+  validates :last_verified_at, presence: true
+  validates :platform, uniqueness: { scope: :user_id }
+
+  # Other Gumroad accounts vouched for by the same social identity — the
+  # dedupe signal risk reviewers check (same precedent as bank/card fingerprints).
+  def shared_identity_user_ids
+    self.class.where(platform:, uid:).where.not(user_id:).pluck(:user_id)
+  end
+
+  # Twitter's OAuth 1.0a raw_info payload, from both the signup and the
+  # link-account callback paths.
+  def self.record_from_twitter!(user, raw_info)
+    uid = raw_info["id"].to_s
+    return if uid.blank? || raw_info["errors"].present?
+
+    verification = find_or_initialize_by(user:, platform: "twitter")
+    verification.update!(
+      uid:,
+      handle: raw_info["screen_name"],
+      account_created_at: parse_twitter_time(raw_info["created_at"]),
+      follower_count: raw_info["followers_count"],
+      post_count: raw_info["statuses_count"],
+      last_posted_at: parse_twitter_time(raw_info.dig("status", "created_at")),
+      last_verified_at: Time.current,
+    )
+    verification
+  end
+
+  def self.parse_twitter_time(value)
+    return if value.blank?
+
+    # Twitter's legacy format: "Sat Mar 21 16:47:01 +0000 2015"
+    DateTime.strptime(value, "%a %b %d %H:%M:%S %z %Y")
+  rescue Date::Error
+    nil
+  end
+  private_class_method :parse_twitter_time
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,7 @@ class User < ApplicationRecord
   include Purchase::Searchable::BuyerEmailCallbacks
 
   has_many :user_external_authentications, dependent: :destroy
+  has_many :social_connect_verifications, dependent: :destroy
 
   stripped_fields :name, :facebook_meta_tag, :google_analytics_id, :username, :email, :support_email
 

--- a/app/modules/user/social_twitter.rb
+++ b/app/modules/user/social_twitter.rb
@@ -65,6 +65,15 @@ module User::SocialTwitter
       user.twitter_user_id = data["id"]
       user.twitter_handle = data["screen_name"]
 
+      if user.persisted?
+        begin
+          SocialConnectVerification.record_from_twitter!(user, data)
+        rescue StandardError => e
+          # Verification metadata feeds risk reviews; it must never break signup/link.
+          Rails.logger.error("SocialConnectVerification twitter record failed for user #{user.id}: #{e.message}")
+        end
+      end
+
       # don't set these properties if they already have values
       if user.name.blank? && data["name"].present?
         user.name = data["name"].gsub(User::INVALID_NAME_FOR_EMAIL_DELIVERY_REGEX, "")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -469,6 +469,7 @@ Rails.application.routes.draw do
               get :purchases
               get :radar_stats
               get :related
+              get :social_connections
               get :suspension
               get :unpaid_balance
               get :credits

--- a/db/migrate/20261209041314_create_social_connect_verifications.rb
+++ b/db/migrate/20261209041314_create_social_connect_verifications.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Main already records a future schema version, so this timestamp must sort
+# after it; the time component is the real UTC authoring time, so parallel
+# branches do not collide on a shared hand-picked value.
+class CreateSocialConnectVerifications < ActiveRecord::Migration[7.1]
+  def change
+    create_table :social_connect_verifications do |t|
+      t.bigint :user_id, null: false
+      t.string :platform, null: false
+      t.string :uid, null: false
+      t.string :handle
+      t.datetime :account_created_at
+      t.bigint :follower_count
+      t.bigint :post_count
+      t.datetime :last_posted_at
+      t.datetime :last_verified_at, null: false
+      t.timestamps
+
+      t.index [:user_id, :platform], unique: true
+      # Deliberately non-unique: one social identity vouching for many Gumroad
+      # accounts is the abuse signal reviewers need to SEE, not a state to reject.
+      t.index [:platform, :uid]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_08_130000) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_09_041314) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -2486,6 +2486,22 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_08_130000) do
     t.integer "sku_id"
     t.index ["sku_id"], name: "index_skus_variants_on_sku_id"
     t.index ["variant_id"], name: "index_skus_variants_on_variant_id"
+  end
+
+  create_table "social_connect_verifications", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "platform", null: false
+    t.string "uid", null: false
+    t.string "handle"
+    t.datetime "account_created_at"
+    t.bigint "follower_count"
+    t.bigint "post_count"
+    t.datetime "last_posted_at"
+    t.datetime "last_verified_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["platform", "uid"], name: "index_social_connect_verifications_on_platform_and_uid"
+    t.index ["user_id", "platform"], name: "index_social_connect_verifications_on_user_id_and_platform", unique: true
   end
 
   create_table "staff_picked_products", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -2112,6 +2112,52 @@ describe Api::Internal::Admin::UsersController do
     include_examples "supports user lookup by user_id", :suspension, method: :get, build_user: -> { create(:compliant_user) }
   end
 
+  describe "GET social_connections" do
+    include_examples "admin api authorization required", :get, :social_connections
+
+    it "returns the user's verified social connections with the shared-identity count" do
+      user = create(:user, email: "seller@example.com")
+      verification = create(:social_connect_verification, user:, platform: "twitter", uid: "shared-uid", handle: "seller")
+      create(:social_connect_verification, platform: "twitter", uid: "shared-uid")
+
+      get :social_connections, params: { email: user.email }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({
+        success: true,
+        user_id: user.external_id,
+        social_connections: [
+          {
+            platform: "twitter",
+            handle: "seller",
+            account_created_at: verification.account_created_at.iso8601,
+            follower_count: verification.follower_count,
+            post_count: verification.post_count,
+            last_posted_at: verification.last_posted_at.iso8601,
+            last_verified_at: verification.last_verified_at.iso8601,
+            shared_identity_user_count: 1
+          }
+        ]
+      }.as_json)
+    end
+
+    it "returns an empty list for a user with no connections" do
+      user = create(:user, email: "seller@example.com")
+
+      get :social_connections, params: { email: user.email }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({ success: true, user_id: user.external_id, social_connections: [] }.as_json)
+    end
+
+    it "returns not found when the user does not exist" do
+      get :social_connections, params: { email: "missing@example.com" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ success: false, message: "User not found" }.as_json)
+    end
+  end
+
   describe "GET unpaid_balance" do
     include_examples "admin api authorization required", :get, :unpaid_balance
 

--- a/spec/factories/social_connect_verifications.rb
+++ b/spec/factories/social_connect_verifications.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :social_connect_verification do
+    user
+    platform { "twitter" }
+    sequence(:uid) { |n| "uid-#{n}" }
+    sequence(:handle) { |n| "handle#{n}" }
+    account_created_at { 5.years.ago }
+    follower_count { 1_000 }
+    post_count { 250 }
+    last_posted_at { 1.week.ago }
+    last_verified_at { Time.current }
+  end
+end

--- a/spec/models/social_connect_verification_spec.rb
+++ b/spec/models/social_connect_verification_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe SocialConnectVerification do
+  describe "validations" do
+    it "requires a supported platform" do
+      verification = build(:social_connect_verification, platform: "myspace")
+      expect(verification).not_to be_valid
+      expect(verification.errors[:platform]).to be_present
+    end
+
+    it "allows one record per platform per user" do
+      user = create(:user)
+      create(:social_connect_verification, user:, platform: "twitter", uid: "1")
+      duplicate = build(:social_connect_verification, user:, platform: "twitter", uid: "2")
+      expect(duplicate).not_to be_valid
+    end
+
+    it "allows the same social identity across different users" do
+      first = create(:social_connect_verification, platform: "twitter", uid: "shared")
+      second = build(:social_connect_verification, platform: "twitter", uid: "shared")
+      expect(second).to be_valid
+      expect(first).to be_valid
+    end
+  end
+
+  describe "#shared_identity_user_ids" do
+    it "returns other users vouched for by the same social identity" do
+      shared = create(:social_connect_verification, platform: "twitter", uid: "shared")
+      other = create(:social_connect_verification, platform: "twitter", uid: "shared")
+      create(:social_connect_verification, platform: "twitter", uid: "different")
+
+      expect(shared.shared_identity_user_ids).to eq([other.user_id])
+    end
+  end
+
+  describe ".record_from_twitter!" do
+    let(:user) { create(:user) }
+    let(:raw_info) { JSON.parse(File.read("#{Rails.root}/spec/support/fixtures/twitter_omniauth.json"))["extra"]["raw_info"] }
+
+    it "stores verified profile metadata from the OAuth payload" do
+      verification = described_class.record_from_twitter!(user, raw_info)
+
+      expect(verification.reload).to have_attributes(
+        platform: "twitter",
+        uid: "279418691",
+        handle: "squidarth",
+        follower_count: 183,
+        post_count: 170,
+      )
+      expect(verification.account_created_at).to eq(DateTime.parse("2011-04-09 06:50:16 UTC"))
+      expect(verification.last_posted_at).to eq(DateTime.parse("2013-03-06 23:21:06 UTC"))
+      expect(verification.last_verified_at).to be_present
+    end
+
+    it "updates the existing record on re-verify instead of creating a second one" do
+      described_class.record_from_twitter!(user, raw_info)
+      expect do
+        described_class.record_from_twitter!(user, raw_info.merge("followers_count" => 500))
+      end.not_to change { described_class.count }
+      expect(user.social_connect_verifications.sole.follower_count).to eq(500)
+    end
+
+    it "records nothing when the payload carries errors" do
+      expect do
+        described_class.record_from_twitter!(user, raw_info.merge("errors" => [{ "message" => "nope" }]))
+      end.not_to change { described_class.count }
+    end
+
+    it "records nothing when the uid is missing" do
+      expect do
+        described_class.record_from_twitter!(user, raw_info.except("id"))
+      end.not_to change { described_class.count }
+    end
+
+    it "tolerates unparseable timestamps" do
+      verification = described_class.record_from_twitter!(user, raw_info.merge("created_at" => "not a date"))
+      expect(verification.account_created_at).to be_nil
+    end
+  end
+end

--- a/spec/modules/user/social_twitter_spec.rb
+++ b/spec/modules/user/social_twitter_spec.rb
@@ -75,5 +75,26 @@ describe User::SocialTwitter do
         expect(@user).to be_valid
       end
     end
+
+    describe "social connect verification" do
+      before do
+        @user = create(:user)
+      end
+
+      it "records a verification with the profile metadata", :vcr do
+        expect { User.query_twitter(@user, @data) }.to change { @user.social_connect_verifications.count }.by(1)
+
+        verification = @user.social_connect_verifications.sole
+        expect(verification).to have_attributes(platform: "twitter", uid: @data["id"].to_s, handle: @data["screen_name"])
+        expect(verification.follower_count).to eq(@data["followers_count"])
+      end
+
+      it "does not break the connect flow when recording fails", :vcr do
+        allow(SocialConnectVerification).to receive(:record_from_twitter!).and_raise(StandardError, "boom")
+
+        expect { User.query_twitter(@user, @data) }.not_to raise_error
+        expect(@user.reload.twitter_handle).to eq(@data["screen_name"])
+      end
+    end
   end
 end

--- a/spec/support/fixtures/vcr_cassettes/User_SocialTwitter/query_twitter/social_connect_verification/does_not_break_the_connect_flow_when_recording_fails.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_SocialTwitter/query_twitter/social_connect_verification/does_not_break_the_connect_flow_when_recording_fails.yml
@@ -1,0 +1,163 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.twitter.com/oauth2/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials
+    headers:
+      User-Agent:
+      - TwitterRubyGem/8.2.0
+      Accept:
+      - "*/*"
+      Authorization:
+      - Basic Og==
+      Connection:
+      - close
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Wed, 02 Sep 2026 04:20:33 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Ml:
+      - A
+      Perf:
+      - '7402827104'
+      Pragma:
+      - no-cache
+      Server:
+      - cloudflare envoy
+      Status:
+      - 403 Forbidden
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Set-Cookie:
+      - __cf_bm=QNAYzoHIdfW2v6EVXPqV3ocHafLWMUOscyvUSxJfeo8-1788322832.936508-1.0.1.1-71l7pg0QXUOc89LneDPAfrPqBuUXuKEJQceTCgj8zV7JHJod2x1Snmuyty8mIfFntqdIvmieY2XKZjhJ1m1sNfUMGpekrHcgC9Gh0HDnAnI8rVUhk9GFct_WB9X4yPc0;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=twitter.com; Expires=Wed,
+        02 Sep 2026 04:50:33 GMT
+      - guest_id=v1%3A178832283304323247; Max-Age=63072000; Expires=Fri, 01 Sep 2028
+        04:20:33 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id_ads=v1%3A178832283304323247; Max-Age=63072000; Expires=Fri, 01 Sep
+        2028 04:20:33 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id_marketing=v1%3A178832283304323247; Max-Age=63072000; Expires=Fri,
+        01 Sep 2028 04:20:33 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_N+Ko28SXxOydJrf8dIzWUg=="; Max-Age=63072000; Expires=Fri,
+        01 Sep 2028 04:20:33 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Last-Modified:
+      - Wed, 02 Sep 2026 04:20:33 GMT
+      X-Transaction:
+      - 2ca787b7e868bd4d
+      X-Frame-Options:
+      - DENY
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Vary:
+      - accept-encoding
+      X-Transaction-Id:
+      - 2ca787b7e868bd4d
+      X-Xss-Protection:
+      - '0'
+      Content-Disposition:
+      - attachment; filename=json.json
+      X-Content-Type-Options:
+      - nosniff
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Response-Time:
+      - '91'
+      Origin-Cf-Ray:
+      - a349b909de597095-EWR
+      Strict-Transport-Security:
+      - max-age=631138519; includeSubdomains
+      X-Served-By:
+      - t4_a
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - a349b909de597095-EWR
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":99,"message":"Unable to verify your credentials","label":"authenticity_token_error"}]}'
+  recorded_at: Wed, 02 Sep 2026 04:20:33 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/users/show.json?user_id=279418691
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      User-Agent:
+      - TwitterRubyGem/8.2.0
+      Authorization:
+      - 'Bearer '
+      Connection:
+      - close
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Wed, 02 Sep 2026 04:20:33 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Perf:
+      - '7402827104'
+      Server:
+      - cloudflare envoy
+      Set-Cookie:
+      - __cf_bm=Vp..qzqNe7u83jvLMrmi6b6ICDxkVc8u5RG8qw9yx0o-1788322833.2051377-1.0.1.1-7DmR3GM1n04.xtIyIEHlRaYkWsJ2RCh.Y2sLB51vob..WwX6twz3A_q5F236zfcNMHrxEIiYWzFnrE8IQUFF1a54o_ExoMXtyXp.G9oqBAhXCfnxsT38n2kQ50fTR4qM;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=twitter.com; Expires=Wed,
+        02 Sep 2026 04:50:33 GMT
+      - guest_id=v1%3A178832283322504097; Max-Age=63072000; Expires=Fri, 01 Sep 2028
+        04:20:33 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id_ads=v1%3A178832283322504097; Max-Age=63072000; Expires=Fri, 01 Sep
+        2028 04:20:33 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id_marketing=v1%3A178832283322504097; Max-Age=63072000; Expires=Fri,
+        01 Sep 2028 04:20:33 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_YvHBjvpahgM/8wh6Vr1C2g=="; Max-Age=63072000; Expires=Fri,
+        01 Sep 2028 04:20:33 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Vary:
+      - accept-encoding
+      X-Transaction-Id:
+      - e359164d0b85e48f
+      X-Response-Time:
+      - '7'
+      Origin-Cf-Ray:
+      - a349b90b8985431f-EWR
+      Strict-Transport-Security:
+      - max-age=631138519; includeSubdomains
+      X-Served-By:
+      - t4_a
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - a349b90b8985431f-EWR
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":215,"message":"Bad Authentication data."}]}'
+  recorded_at: Wed, 02 Sep 2026 04:20:33 GMT
+recorded_with: VCR 6.2.0

--- a/spec/support/fixtures/vcr_cassettes/User_SocialTwitter/query_twitter/social_connect_verification/records_a_verification_with_the_profile_metadata.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_SocialTwitter/query_twitter/social_connect_verification/records_a_verification_with_the_profile_metadata.yml
@@ -1,0 +1,163 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.twitter.com/oauth2/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=client_credentials
+    headers:
+      User-Agent:
+      - TwitterRubyGem/8.2.0
+      Accept:
+      - "*/*"
+      Authorization:
+      - Basic Og==
+      Connection:
+      - close
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Wed, 02 Sep 2026 04:20:32 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Ml:
+      - A
+      Perf:
+      - '7402827104'
+      Pragma:
+      - no-cache
+      Server:
+      - cloudflare envoy
+      Status:
+      - 403 Forbidden
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Set-Cookie:
+      - __cf_bm=fG3CDFVSkqygVbEBcJQzDxOQTGrp7Mxkk3aXh8VUuE0-1788322832.4926722-1.0.1.1-ZoehEvcryqDcj0uqAWoX5zAD9W74QwwKrjrzasL76LLgI4hULe7FD0mi.WkOzHdjLS968N0W0kkYXWWYgWWfHiSzv.XvTrJkXzqzXRtESL6wkOJ2Dh3.33jMHotccSX9;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=twitter.com; Expires=Wed,
+        02 Sep 2026 04:50:32 GMT
+      - guest_id=v1%3A178832283251428081; Max-Age=63072000; Expires=Fri, 01 Sep 2028
+        04:20:32 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id_ads=v1%3A178832283251428081; Max-Age=63072000; Expires=Fri, 01 Sep
+        2028 04:20:32 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id_marketing=v1%3A178832283251428081; Max-Age=63072000; Expires=Fri,
+        01 Sep 2028 04:20:32 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_AHFA4uQcSMGiyadrUXTRNw=="; Max-Age=63072000; Expires=Fri,
+        01 Sep 2028 04:20:32 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Last-Modified:
+      - Wed, 02 Sep 2026 04:20:32 GMT
+      X-Transaction:
+      - b665664c34f9c2b4
+      X-Frame-Options:
+      - DENY
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Vary:
+      - accept-encoding
+      X-Transaction-Id:
+      - b665664c34f9c2b4
+      X-Xss-Protection:
+      - '0'
+      Content-Disposition:
+      - attachment; filename=json.json
+      X-Content-Type-Options:
+      - nosniff
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Response-Time:
+      - '8'
+      Origin-Cf-Ray:
+      - a349b9071f4dc8b9-EWR
+      Strict-Transport-Security:
+      - max-age=631138519; includeSubdomains
+      X-Served-By:
+      - t4_a
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - a349b9071f4dc8b9-EWR
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":99,"message":"Unable to verify your credentials","label":"authenticity_token_error"}]}'
+  recorded_at: Wed, 02 Sep 2026 04:20:32 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/users/show.json?user_id=279418691
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      User-Agent:
+      - TwitterRubyGem/8.2.0
+      Authorization:
+      - 'Bearer '
+      Connection:
+      - close
+      Host:
+      - api.twitter.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Wed, 02 Sep 2026 04:20:32 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Perf:
+      - '7402827104'
+      Server:
+      - cloudflare envoy
+      Set-Cookie:
+      - __cf_bm=7tvGXaNalEeCB8s4ffIQ4zWfW1LwEvcLFStL0NloWCo-1788322832.6486137-1.0.1.1-8JMDKvLOPSjudqKMkAqmCLUeX8cHx82.ZIn59xRsDKj6F3gzuZBX_VOq.PJxfoLsilkE2TD7atVAlvm9IyKR6gMy2s9n.vsQGh1wYtfCvEKT95ZQwx6Ky8P9lWhxSNLv;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=twitter.com; Expires=Wed,
+        02 Sep 2026 04:50:32 GMT
+      - guest_id=v1%3A178832283266508817; Max-Age=63072000; Expires=Fri, 01 Sep 2028
+        04:20:32 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id_ads=v1%3A178832283266508817; Max-Age=63072000; Expires=Fri, 01 Sep
+        2028 04:20:32 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - guest_id_marketing=v1%3A178832283266508817; Max-Age=63072000; Expires=Fri,
+        01 Sep 2028 04:20:32 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      - personalization_id="v1_sGmq/zSPO53ePq9Hxu4Ufg=="; Max-Age=63072000; Expires=Fri,
+        01 Sep 2028 04:20:32 GMT; Path=/; Domain=.twitter.com; Secure; SameSite=None
+      Cache-Control:
+      - no-cache, no-store, max-age=0
+      Vary:
+      - accept-encoding
+      X-Transaction-Id:
+      - db4e1ae4dc821f6c
+      X-Response-Time:
+      - '7'
+      Origin-Cf-Ray:
+      - a349b9080c67aa39-EWR
+      Strict-Transport-Security:
+      - max-age=631138519; includeSubdomains
+      X-Served-By:
+      - t4_a
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - a349b9080c67aa39-EWR
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":215,"message":"Bad Authentication data."}]}'
+  recorded_at: Wed, 02 Sep 2026 04:20:32 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## What

First slice of antiwork/gumroad-private#2371 (social-connect verification to speed up payout-hold risk reviews): capture verified social profile metadata at the existing X/Twitter OAuth paths and expose it to risk reviewers via the internal admin API.

- New `social_connect_verifications` table + `SocialConnectVerification` model: platform, uid, handle, account-created-at, follower count, post count, last-posted-at, last-verified-at. One row per user+platform, updated on re-verify.
- `User.query_twitter` (the shared choke point for Twitter signup, sync link, and async link) now records/refreshes the verification. Failures are rescued and logged — verification metadata must never break signup or account linking.
- New internal admin endpoint `GET /users/social_connections` returning the verifications plus a `shared_identity_user_count` (other Gumroad accounts vouched for by the same social identity — the dedupe signal, same precedent as bank/card fingerprints). This is the surface the `gumroad admin` CLI consumes.

## Why

Payout holds are the largest source of review latency (Sahil, 2026-09-01). Most manual reviews answer "is this a real creator with a real audience?" — an OAuth-verified social account with history answers it directly, and established-creator linkage is already a required risk-review check (gp#1850) done by hand today with an unverified handle. This PR makes the verified evidence exist and be visible; scoring and shadow-mode auto-release build on it in follow-up PRs.

## Design notes

- Store-only, no gating: nothing in risk flow changes behavior yet. Unconnected users are unaffected.
- `[platform, uid]` index is deliberately non-unique: one social identity vouching for many Gumroad accounts is a signal reviewers need to SEE, not a state to reject at write time.
- Twitter first because its OAuth connect flow already exists end-to-end; YouTube/Instagram connect flows are follow-ups (issue "Done when" list).
- The OAuth grant is the existing read-profile scope; no new permissions requested.

## Before / After

Before: risk reviewers verify creator social presence by hand from a free-text `twitter_handle` (typed, unproven). After: `GET api/internal/admin/users/social_connections?user_id=…` returns OAuth-proven metadata:

```json
{
  "success": true,
  "user_id": "…",
  "social_connections": [
    {
      "platform": "twitter",
      "handle": "squidarth",
      "account_created_at": "2011-04-09T06:50:16Z",
      "follower_count": 183,
      "post_count": 170,
      "last_posted_at": "2013-03-06T23:21:06Z",
      "last_verified_at": "2026-09-02T04:20:00Z",
      "shared_identity_user_count": 0
    }
  ]
}
```

## Status

- [x] Scope — store verified Twitter metadata + admin API read (scoring/shadow-mode are follow-ups)
- [x] Design — OAuth-verified store-only slice; non-unique `[platform, uid]` index keeps the dedupe signal visible
- [x] Build — model, migration, query_twitter hook, admin endpoint, specs
- [x] QA — local specs green + mutation proof (see Test Results); endpoint payload pinned by controller spec
- [ ] Shipped
- [ ] Market — n/a until scoring/auto-release ships (internal tooling slice)
- [ ] Sell — n/a (internal risk tooling)

## Test Results

- `ruby -c` clean on all changed files.
- `spec/models/social_connect_verification_spec.rb`: 9 examples, 0 failures (4.14s, lane 0 env).
- `spec/controllers/api/internal/admin/users_controller_spec.rb -e "GET social_connections"`: 5 examples, 0 failures (incl. auth shared examples).
- `spec/modules/user/social_twitter_spec.rb`: 10 examples, 1 failure — the failure is the pre-existing `#twitter_picture_url` S3/avatar example (`undefined method 'key' for nil` at line 17), untouched by this diff and environmental (S3 attach in local env); all 4 `query_twitter` examples plus both new verification examples green.
- Mutation proof: deleted the `SocialConnectVerification.record_from_twitter!` call from `query_twitter` → "records a verification with the profile metadata" went RED (the rescue-path example stays green by design — it stubs the call). Restored, re-verified via `git checkout`.
- New VCR cassettes committed; grepped clean for live-key prefixes.

## QA steps

Backend-only slice, no rendered surface (admin UI is being deleted; the consumer is the internal API / `gumroad admin` CLI). Evidence will be the endpoint's real JSON response from a spec run or preview console probe, recorded before ready.

---

AI disclosure: built by Hermes Agent (claude-fable-5-1).

Premerge review: clean @ 57676539227b08b60fbccdbfed12ddbf33920f04
