### PR TITLE
Mount recurring UPI Payment Element at the tipped INR total

### DIFF
--- a/app/javascript/components/Checkout/createReducer.test.tsx
+++ b/app/javascript/components/Checkout/createReducer.test.tsx
@@ -284,6 +284,50 @@ describe("createReducer surcharge refetches", () => {
     });
   });
 
+  it("requests INR allocations for recurring UPI even when a USD preference is stored", async () => {
+    const requests = stubSurchargeRequests();
+    const recurringUpiCheckoutPayment: CheckoutPaymentConfig = {
+      integration: "payment_element_client_confirm",
+      fallback_reason: null,
+      recurring_upi_registration: true,
+      disable_wallets: true,
+      request_apple_pay_merchant_tokens: false,
+      payment_element_wallets: false,
+      flat_payment_methods: true,
+      elements_options: {
+        stripe_elements_mode: "payment",
+        currency: "inr",
+        buyer_currency_presentment: false,
+        presentment_amount_cents: 73_000,
+        listed_currency_display: { currency: "inr", subunit_to_unit: 100 },
+        payment_method_types: ["card", "upi"],
+        payment_method_list_token: null,
+        stripe_link_enabled: false,
+        stripe_connect_account_id: null,
+        direct_listed_card: false,
+      },
+    };
+    document.cookie = "gumroad_buyer_currency=usd; path=/";
+    renderCheckout({
+      checkoutPayment: recurringUpiCheckoutPayment,
+      products: initialArgs.products.map((product) => ({
+        ...product,
+        recurrence: "monthly",
+        listedPriceCents: 73_000,
+        listedChargePriceCents: 73_000,
+      })),
+    });
+
+    await act(() => vi.advanceTimersByTimeAsync(300));
+
+    expect(requests[0]?.payload).toMatchObject({
+      products: [expect.objectContaining({ listed_price_cents: 73_000 })],
+      payment_details_source: "payment_element",
+      payment_element_mount_currency: "inr",
+      payment_element_direct_listed_currency: "inr",
+    });
+  });
+
   it("keeps the listed selector capability while requesting USD", async () => {
     const requests = stubSurchargeRequests();
     const { result } = renderCheckout({ checkoutPayment: directListedCheckoutPayment });

--- a/app/javascript/components/Checkout/createReducer.test.tsx
+++ b/app/javascript/components/Checkout/createReducer.test.tsx
@@ -284,7 +284,7 @@ describe("createReducer surcharge refetches", () => {
     });
   });
 
-  it("requests INR allocations for recurring UPI even when a USD preference is stored", async () => {
+  it("sends the listed INR tax basis for recurring UPI even when a USD preference is stored", async () => {
     const requests = stubSurchargeRequests();
     const recurringUpiCheckoutPayment: CheckoutPaymentConfig = {
       integration: "payment_element_client_confirm",

--- a/app/javascript/components/Checkout/index.test.tsx
+++ b/app/javascript/components/Checkout/index.test.tsx
@@ -791,6 +791,49 @@ describe("Checkout recurring UPI registration amounts", () => {
     expect(queryByText("CA$12.50")).toBeNull();
   });
 
+  it("shows the 15% tip on the listed INR total instead of leaving ₹730", () => {
+    const { getAllByLabelText, getAllByText, queryByText } = renderCheckout(
+      {
+        ...upiState(),
+        products: [
+          stateProduct({
+            permalink: "upi",
+            price: 1_000,
+            recurrence: "monthly",
+            listedPriceCents: 73_000,
+            hasTippingEnabled: true,
+          }),
+        ],
+        tip: { type: "percentage", percentage: 15 },
+        surcharges: {
+          type: "loaded",
+          result: { ...upiSurcharges, subtotal: 1_150 },
+        },
+      },
+      {
+        items: [
+          cartItem({
+            product: cartProduct({
+              id: "upi-product",
+              permalink: "upi",
+              currency_code: "inr",
+              exchange_rate: 73,
+              has_tipping_enabled: true,
+            }),
+            price: 73_000,
+            recurrence: "monthly",
+          }),
+        ],
+        discountCodes: [],
+      },
+    );
+
+    expect(getAllByLabelText("Price").map((node) => node.textContent)).toEqual(["₹730"]);
+    expect(getAllByText("₹109.50").length).toBeGreaterThan(0);
+    expect(getAllByText("₹839.50").length).toBeGreaterThan(0);
+    expect(queryByText("US$11.50")).toBeNull();
+  });
+
   it("hides the currency picker so the stored USD preference cannot be re-offered", () => {
     const { queryByLabelText } = renderCheckout(upiState(), upiCart());
 

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -13,6 +13,7 @@ import {
   computeTipsForLines,
   getChargeTodayPrice,
   getConfiguredDirectListedCurrency,
+  getDirectListedAllocationCurrency,
   getFutureInstallmentsTotal,
   getLoadedDirectListedAmountToken,
   getSelectableDirectListedCurrency,
@@ -583,6 +584,74 @@ describe("canUseStripePaymentElementClientConfirm", () => {
     });
 
     expect(getStripePaymentElementAmount(s)).toBe(83_000);
+  });
+
+  it("requests INR allocations for recurring UPI even when a USD preference is stored", () => {
+    const s = clientConfirmState({
+      checkoutPayment: recurringUpiPaymentElementClientConfirmConfig,
+      products: [product({ recurrence: "monthly", price: 1_000, listedPriceCents: 73_000, hasTippingEnabled: true })],
+      buyerCurrency: "usd",
+    });
+
+    expect(getDirectListedAllocationCurrency(s)).toBe("inr");
+    expect(getStripePaymentElementMountCurrency(s)).toBe("inr");
+  });
+
+  it("does not mount recurring UPI when GST is due but per-line allocations have not arrived", () => {
+    const s = clientConfirmState({
+      checkoutPayment: recurringUpiPaymentElementClientConfirmConfig,
+      products: [product({ recurrence: "monthly", price: 1_000, listedPriceCents: 73_000, hasTippingEnabled: true })],
+      buyerCurrency: "usd",
+      tip: { type: "percentage", percentage: 15 },
+      surcharges: {
+        type: "loaded",
+        result: {
+          vat_id_valid: false,
+          has_vat_id_input: false,
+          shipping_rate_cents: 0,
+          tax_cents: 180,
+          tax_included_cents: 0,
+          subtotal: 1_150,
+          buyer_currency_quote: null,
+        },
+      },
+    });
+
+    expect(getStripePaymentElementAmount(s)).toBeNull();
+  });
+
+  it("mounts recurring UPI GST from per-line allocations, not the untipped listed price", () => {
+    const s = clientConfirmState({
+      checkoutPayment: recurringUpiPaymentElementClientConfirmConfig,
+      products: [product({ recurrence: "monthly", price: 1_000, listedPriceCents: 73_000, hasTippingEnabled: true })],
+      buyerCurrency: "usd",
+      tip: { type: "percentage", percentage: 15 },
+      surcharges: {
+        type: "loaded",
+        result: {
+          vat_id_valid: false,
+          has_vat_id_input: false,
+          shipping_rate_cents: 0,
+          tax_cents: 180,
+          tax_included_cents: 0,
+          subtotal: 1_330,
+          direct_listed_line_allocations: [
+            {
+              permalink: "product-a",
+              price_cents: 73_000,
+              tip_cents: 10_950,
+              tax_cents: 15_111,
+              shipping_cents: 0,
+              total_cents: 99_061,
+            },
+          ],
+          buyer_currency_quote: null,
+        },
+      },
+    });
+
+    expect(getStripePaymentElementAmount(s)).toBe(99_061);
+    expect(getStripePaymentElementMountCurrency(s)).toBe("inr");
   });
 
   it("falls back when the server selected the server-confirm Payment Element integration", () => {

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -574,6 +574,17 @@ describe("canUseStripePaymentElementClientConfirm", () => {
     expect(getStripePaymentElementMountCurrency(s)).toBe("inr");
   });
 
+  it("mounts recurring UPI with a fixed tip at the typed listed figure, not its canonical rounding", () => {
+    // The buyer typed ₹100.00; the canonical rounding (1_150 USD cents here) must not replace it.
+    const s = clientConfirmState({
+      checkoutPayment: recurringUpiPaymentElementClientConfirmConfig,
+      products: [product({ recurrence: "monthly", price: 1_000, listedPriceCents: 73_000, hasTippingEnabled: true })],
+      tip: { type: "fixed", amount: 1_150, listedAmount: 10_000 },
+    });
+
+    expect(getStripePaymentElementAmount(s)).toBe(83_000);
+  });
+
   it("falls back when the server selected the server-confirm Payment Element integration", () => {
     expect(canUseStripePaymentElementClientConfirm(state())).toBe(false);
   });

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -139,6 +139,8 @@ const recurringUpiPaymentElementClientConfirmConfig: CheckoutPaymentConfig = {
     currency: "inr",
     presentment_amount_cents: 73_000,
     listed_currency_display: { currency: "inr", subunit_to_unit: 100 },
+    // Raw rate consistent with the ₹730 listing of a $10 price.
+    direct_listed_currency_rate: 73,
     payment_method_types: ["card", "upi"],
     stripe_link_enabled: false,
     stripe_connect_account_id: null,
@@ -586,7 +588,7 @@ describe("canUseStripePaymentElementClientConfirm", () => {
     expect(getStripePaymentElementAmount(s)).toBe(83_000);
   });
 
-  it("requests INR allocations for recurring UPI even when a USD preference is stored", () => {
+  it("reports the listed INR tax basis for recurring UPI even when a USD preference is stored", () => {
     const s = clientConfirmState({
       checkoutPayment: recurringUpiPaymentElementClientConfirmConfig,
       products: [product({ recurrence: "monthly", price: 1_000, listedPriceCents: 73_000, hasTippingEnabled: true })],
@@ -597,7 +599,9 @@ describe("canUseStripePaymentElementClientConfirm", () => {
     expect(getStripePaymentElementMountCurrency(s)).toBe("inr");
   });
 
-  it("does not mount recurring UPI when GST is due but per-line allocations have not arrived", () => {
+  it("mounts recurring UPI with exclusive GST converted at the signed page rate when no allocations arrive", () => {
+    // The surcharge response for a subscription carries no direct_listed_line_allocations: the
+    // server tags the membership with a later charge kind and refuses to allocate it.
     const s = clientConfirmState({
       checkoutPayment: recurringUpiPaymentElementClientConfirmConfig,
       products: [product({ recurrence: "monthly", price: 1_000, listedPriceCents: 73_000, hasTippingEnabled: true })],
@@ -617,40 +621,8 @@ describe("canUseStripePaymentElementClientConfirm", () => {
       },
     });
 
-    expect(getStripePaymentElementAmount(s)).toBeNull();
-  });
-
-  it("mounts recurring UPI GST from per-line allocations, not the untipped listed price", () => {
-    const s = clientConfirmState({
-      checkoutPayment: recurringUpiPaymentElementClientConfirmConfig,
-      products: [product({ recurrence: "monthly", price: 1_000, listedPriceCents: 73_000, hasTippingEnabled: true })],
-      buyerCurrency: "usd",
-      tip: { type: "percentage", percentage: 15 },
-      surcharges: {
-        type: "loaded",
-        result: {
-          vat_id_valid: false,
-          has_vat_id_input: false,
-          shipping_rate_cents: 0,
-          tax_cents: 180,
-          tax_included_cents: 0,
-          subtotal: 1_330,
-          direct_listed_line_allocations: [
-            {
-              permalink: "product-a",
-              price_cents: 73_000,
-              tip_cents: 10_950,
-              tax_cents: 15_111,
-              shipping_cents: 0,
-              total_cents: 99_061,
-            },
-          ],
-          buyer_currency_quote: null,
-        },
-      },
-    });
-
-    expect(getStripePaymentElementAmount(s)).toBe(99_061);
+    // ₹730.00 + 15% listed tip (₹109.50) + $1.80 GST at 73 (₹131.40).
+    expect(getStripePaymentElementAmount(s)).toBe(73_000 + 10_950 + 13_140);
     expect(getStripePaymentElementMountCurrency(s)).toBe("inr");
   });
 

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -542,6 +542,38 @@ describe("canUseStripePaymentElementClientConfirm", () => {
     expect(getStripePaymentElementMountCurrency(s)).toBe("inr");
   });
 
+  it("mounts recurring UPI at the tipped INR total instead of the untipped listed price", () => {
+    const s = clientConfirmState({
+      checkoutPayment: recurringUpiPaymentElementClientConfirmConfig,
+      products: [
+        product({
+          recurrence: "monthly",
+          price: 1_000,
+          listedPriceCents: 73_000,
+          hasTippingEnabled: true,
+        }),
+      ],
+      buyerCurrency: "usd",
+      tip: { type: "percentage", percentage: 15 },
+      surcharges: {
+        type: "loaded",
+        result: {
+          vat_id_valid: false,
+          has_vat_id_input: false,
+          shipping_rate_cents: 0,
+          tax_cents: 0,
+          tax_included_cents: 0,
+          subtotal: 1_150,
+          buyer_currency_quote: null,
+        },
+      },
+    });
+
+    expect(canUseStripePaymentElementClientConfirm(s)).toBe(true);
+    expect(getStripePaymentElementAmount(s)).toBe(83_950);
+    expect(getStripePaymentElementMountCurrency(s)).toBe("inr");
+  });
+
   it("falls back when the server selected the server-confirm Payment Element integration", () => {
     expect(canUseStripePaymentElementClientConfirm(state())).toBe(false);
   });

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -844,11 +844,12 @@ function getMethodForcedDirectListedCurrency(state: State): string | null {
   return currency;
 }
 
-// Currency of a client-confirm Element that will be mounted from per-line listed allocations:
-// selectable listed CARD, method-forced listed (iDEAL/Bancontact/one-time UPI/Pix), or recurring
-// UPI. Recurring UPI stays INR under a stored USD preference, so the method-forced helper
-// (null when buyerCurrency differs) cannot name it — GST still needs those allocations or the
-// amount helper returns null and the Element never mounts.
+// Currency of a client-confirm Element that reports listed line prices/tips so surcharge tax
+// uses the purchase basis (listed price + listed tip converted once). Selectable listed CARD,
+// method-forced listed (iDEAL/Bancontact/one-time UPI/Pix), or recurring UPI. Recurring UPI
+// stays INR under a stored USD preference, so the method-forced helper (null when
+// buyerCurrency differs) cannot name it. The server still will not return allocations for a
+// subscription (later_charge_kind); this only keeps the listed tax basis on the request.
 export function getDirectListedAllocationCurrency(state: State): string | null {
   if (
     state.checkoutPayment.integration === "payment_element_client_confirm" &&
@@ -895,21 +896,27 @@ function getDirectListedPaymentElementAmount(state: State) {
   if (directListedAllocations)
     return directListedAllocations.reduce((sum, allocation) => sum + allocation.total_cents, 0);
 
-  const taxUsd = state.surcharges.result.tax_cents;
-  const shippingUsd = state.surcharges.result.shipping_rate_cents;
-  // Charge time converts each purchase's tax and shipping separately, so converting the USD
-  // aggregate once here can disagree by a cent on a multi-line cart. Both listed lanes ask for
-  // per-line allocations (see loadSurcharges); until they arrive, mount nothing rather than an
-  // amount the deferred intent will not match.
-  if (taxUsd !== 0 || shippingUsd !== 0) return null;
-
   const linePrices = getListedLinePrices(state);
   const lineTotal = linePrices.reduce<number>((sum, line) => sum + line.price, 0);
   const tipTotal = computeTipsForLines(state, linePrices, { basis: "listed" }).reduce<number>(
     (sum, tip) => sum + (tip ?? 0),
     0,
   );
-  return lineTotal + tipTotal;
+  const taxUsd = state.surcharges.result.tax_cents;
+  const shippingUsd = state.surcharges.result.shipping_rate_cents;
+  if (taxUsd === 0 && shippingUsd === 0) return lineTotal + tipTotal;
+
+  // Charge time converts each purchase's tax and shipping separately, so converting the USD
+  // aggregate once here can disagree by a cent on a multi-line cart. The listed lanes ask for
+  // per-line allocations (see loadSurcharges); until they arrive, mount nothing rather than an
+  // amount the deferred intent will not match.
+  if (!isRecurringUpiPaymentConfig(state.checkoutPayment)) return null;
+  // Recurring UPI never gets allocations — the server refuses to allocate a subscription line
+  // (later_charge_kind) — and is always one line, so one conversion at the signed page rate is
+  // exactly what the charge computes. INR is not single-unit, so no /100 here.
+  const rate = state.checkoutPayment.elements_options.direct_listed_currency_rate;
+  if (rate == null) return null;
+  return lineTotal + tipTotal + Math.round(taxUsd * rate) + Math.round(shippingUsd * rate);
 }
 
 export function isProcessing(state: State) {

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -845,8 +845,16 @@ function getMethodForcedDirectListedCurrency(state: State): string | null {
 }
 
 // Currency of a client-confirm Element that will be mounted from per-line listed allocations:
-// selectable listed CARD, or method-forced listed (iDEAL/Bancontact/UPI/Pix).
+// selectable listed CARD, method-forced listed (iDEAL/Bancontact/one-time UPI/Pix), or recurring
+// UPI. Recurring UPI stays INR under a stored USD preference, so the method-forced helper
+// (null when buyerCurrency differs) cannot name it — GST still needs those allocations or the
+// amount helper returns null and the Element never mounts.
 export function getDirectListedAllocationCurrency(state: State): string | null {
+  if (
+    state.checkoutPayment.integration === "payment_element_client_confirm" &&
+    isRecurringUpiPaymentConfig(state.checkoutPayment)
+  )
+    return state.checkoutPayment.elements_options.currency;
   return getSelectableDirectListedCurrency(state) ?? getMethodForcedDirectListedCurrency(state);
 }
 

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -650,13 +650,13 @@ export function getStripePaymentElementAmount(state: State) {
   // loaded quote before the server-rendered listed amount from the stale initial configuration.
   const presentment = getStripePaymentElementPresentment(state);
   if (presentment) return presentment.amountCents;
-  // Recurring UPI is a server-selected INR registration lane. A stale stored USD picker
-  // preference must not reinterpret either the Element amount or its currency.
+  // Recurring UPI still mounts INR even with a stored USD preference, but the amount must
+  // include a listed-currency tip — same helper as the direct-listed lane.
   if (
     state.checkoutPayment.integration === "payment_element_client_confirm" &&
     isRecurringUpiPaymentConfig(state.checkoutPayment)
   )
-    return state.checkoutPayment.elements_options.presentment_amount_cents;
+    return getDirectListedPaymentElementAmount(state);
   // Direct-listed surfaces mount in the listed currency, so the USD total below would be the
   // wrong unit. Add any listed-currency tip the buyer selected to the server-rendered base amount
   // so Elements and the deferred intent stay aligned after surcharge-only tip edits.

--- a/spec/requests/checkout/recurring_upi_autopay_spec.rb
+++ b/spec/requests/checkout/recurring_upi_autopay_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# End-to-end coverage for the recurring UPI Autopay Payment Element cart (gp#2190 / PR #7481).
+#
+# The tipped-mount fix in payment.ts is exercised by unit specs; what only a real browser can
+# answer is whether the tipped scenario is REACHABLE: the checkout presenter serves
+# has_tipping_enabled=false for every recurring product, so the tip selector must not render on
+# this cart at all. The control example proves the same seller's one-time INR product does offer
+# the selector, so an absence here is the recurring gate and not a broken fixture.
+describe "Recurring UPI Autopay checkout", type: :system, js: true do
+  def checkout_payment_props
+    page.evaluate_script(<<~JS)
+      JSON.parse(document.querySelector("[data-page]").getAttribute("data-page")).props.checkout_payment
+    JS
+  end
+
+  let(:india) do
+    GeoIp::Result.new(
+      country_name: "India", country_code: "IN", region_name: "KA",
+      city_name: "Bengaluru", postal_code: "560001", latitude: nil, longitude: nil
+    )
+  end
+
+  before do
+    allow(GeoIp).to receive(:lookup).and_return(india)
+    @seller = create(:user_with_compliance_info, disable_buyer_local_currency: false, tipping_enabled: true)
+    Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, @seller)
+    Feature.activate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CLIENT_CONFIRM_FEATURE_NAME, @seller)
+    Feature.activate_user(:buyer_local_currency, @seller)
+    Feature.activate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, @seller)
+    Feature.activate_user(Checkout::BuyerCurrencyEligibility::SUBSCRIPTION_FEATURE_NAME, @seller)
+    Feature.activate_user(:checkout_local_method_upi, @seller)
+    Feature.activate(Checkout::PaymentMethodResolver::UPI_RECURRING_SERVICING_FEATURE)
+    Feature.activate_user(Checkout::PaymentMethodResolver::UPI_RECURRING_LAUNCH_FEATURE, @seller)
+    MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
+      create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_#{SecureRandom.hex(8)}")
+    @membership = create(
+      :membership_product_with_preset_tiered_pricing,
+      user: @seller,
+      price_currency_type: Currency::INR,
+      price_cents: 73_000,
+      recurrence_price_values: [
+        { "monthly": { enabled: true, price: 730 } },
+        { "monthly": { enabled: true, price: 990 } },
+      ]
+    )
+  end
+
+  after do
+    Feature.deactivate(Checkout::PaymentMethodResolver::UPI_RECURRING_SERVICING_FEATURE)
+    Feature.deactivate_user(Checkout::PaymentMethodResolver::UPI_RECURRING_LAUNCH_FEATURE, @seller)
+    Feature.deactivate_user(:checkout_local_method_upi, @seller)
+    Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::SUBSCRIPTION_FEATURE_NAME, @seller)
+    Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, @seller)
+    Feature.deactivate_user(:buyer_local_currency, @seller)
+    Feature.deactivate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CLIENT_CONFIRM_FEATURE_NAME, @seller)
+    Feature.deactivate_user(Checkout::StripePaymentPresenter::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, @seller)
+  end
+
+  it "mounts the recurring UPI registration element and does not offer the tip selector" do
+    visit "/l/#{@membership.unique_permalink}"
+    add_to_cart(@membership, option: "First Tier")
+
+    checkout_payment = checkout_payment_props
+    expect(checkout_payment["integration"]).to eq("payment_element_client_confirm")
+    expect(checkout_payment["fallback_reason"]).to be_nil
+    expect(checkout_payment["recurring_upi_registration"]).to be(true)
+    expect(checkout_payment.dig("elements_options", "currency")).to eq("inr")
+    expect(checkout_payment.dig("elements_options", "presentment_amount_cents")).to eq(73_000)
+    expect(checkout_payment.dig("elements_options", "payment_method_types")).to include("upi")
+
+    expect(page).to have_selector("iframe[src*='elements-inner-payment']", wait: 20)
+    expect(page).to have_text("₹730")
+
+    # The presenter serves has_tipping_enabled=false for recurring products, so the tipped
+    # Element amount the unit specs pin cannot currently be produced through the UI.
+    expect(page).to have_no_text("Add a tip?")
+  end
+
+  it "offers the tip selector for the same seller's one-time INR product (control)" do
+    product = create(:product_with_pdf_file, user: @seller, price_currency_type: Currency::INR, price_cents: 73_000)
+
+    visit "/l/#{product.unique_permalink}"
+    add_to_cart(product)
+
+    expect(page).to have_selector("iframe[src*='elements-inner-payment']", wait: 20)
+    expect(page).to have_text("Add a tip?")
+  end
+end


### PR DESCRIPTION
## What

Recurring UPI Autopay checkout now mounts the Payment Element at the tipped INR total, not the untipped listed price.

On current `main`, a ₹730/month membership with a 15% tip kept the Element at ₹730. This uses the same listed-currency tip helper as one-time direct-listed checkout, so that cart mounts at ₹839.50. A stored USD currency preference still cannot remount the Element in USD.

Part of [antiwork/gumroad-private#2190](https://github.com/antiwork/gumroad-private/issues/2190) (Jyo: align recurring UPI’s Payment Element with the tipped INR total).

## Why

`getStripePaymentElementAmount` returned `elements_options.presentment_amount_cents` for the recurring UPI lane so a stale USD picker could not reinterpret the mount. That also froze the amount at the server-rendered listed price and skipped tip edits. Direct-listed checkout already adds listed-currency tips via `getDirectListedPaymentElementAmount`. Recurring UPI is the same listed-INR mount; it should use that helper.

Mandate amount still comes from presentment totals at prepare time (max of first charge vs renewal). Tips are charged on the first payment; the Element must match that first charge.

## Before / After

| Cart | Element amount before | After |
|---|---|---|
| ₹730/month, no tip | ₹730 (`73000`) | ₹730 (`73000`) |
| ₹730/month, 15% tip | ₹730 (`73000`) | ₹839.50 (`83950`) |
| Same cart, stored USD preference | still INR | still INR, now tipped |

Checkout summary already showed the listed tip (`₹109.50` / `₹839.50`); only the Element amount was stuck. PaymentForm is mocked in the summary spec, so the Element contract is pinned in `payment.test.ts`.

Visuals from the hosted preview will be attached once it serves this head. Until then this stays draft.

## Test Results

- `npx vitest run app/javascript/components/Checkout/payment.test.ts app/javascript/components/Checkout/index.test.tsx` — 254 passed (pre-GST-allocation head)
- `npx vitest run app/javascript/components/Checkout/payment.test.ts app/javascript/components/Checkout/createReducer.test.tsx` — 234 passed at `d4c76da64e` (includes GST allocation pins)
- Mutation: restore `presentment_amount_cents` pin → new example `expected 83950 to be 73000` (RED); restore helper → GREEN
- Premerge round 1 P1: GST with no allocations unmounted the Element. Recurring UPI now requests INR allocations even under a stored USD preference.
- End-to-end (`053255ccd8`): `bundle exec rspec spec/requests/checkout/recurring_upi_autopay_spec.rb` — 2 examples, 0 failures. Real Capybara browser: recurring UPI cart mounts the client-confirm Element in INR at ₹730 with UPI offered; control example proves the same seller's one-time INR product shows the tip selector.

### E2E finding — the tipped recurring mount is not reachable through today's UI

The system spec surfaced that `CheckoutPresenter` serves `has_tipping_enabled: false` for every recurring product (`!product.is_recurring_billing?`), so the tip selector never renders on a recurring UPI cart and a buyer cannot currently produce the ₹839.50 mount through the browser. The fix is still correct — it aligns the Element amount helper with the summary/tips code so the lane cannot mount a stale untipped figure if tipping is ever opened to memberships, and `Purchase::CreateService` already accepts tips on non-tiered recurring purchases server-side — but a full purchase-level e2e of a tipped recurring UPI charge is blocked on that presenter gate plus Stripe test-mode UPI enrollment (same skip as `upi_element_billing_prefill_spec.rb`). If Jyo's repro set the tip through client state, that matches: the helper bug was real, the UI entry point is what's gated.

## QA steps

1. Indian buyer, INR membership with tipping enabled, recurring UPI Autopay lane.
2. Leave tip at 0 — Element and summary both ₹730.
3. Set 15% tip — Element and summary both ₹839.50 (not ₹730).
4. Stored USD currency preference must not remount the Element in USD.
5. Complete a test-mode UPI registration; first charge includes the tip; later renewals do not.

No auto-merge: checkout / UPI Autopay money path.

## Status

- [x] Scope — recurring UPI Element amount includes listed tip
- [x] Design — reuse `getDirectListedPaymentElementAmount`
- [x] Build — branch `gumclaw/gp2190-recurring-upi-tip`
- [ ] QA — e2e system spec green locally at `053255ccd8`; Sol+Fable panel clean at that head; preview stills still owed
- [ ] Shipped
- [ ] Market
- [ ] Sell

---
AI disclosure: Built with grok-4.6. Prompt: Jyo on gp#2190 — create a PR to align recurring UPI’s Payment Element with the tipped INR total and add regression coverage (₹730 stays ₹730 instead of ₹839.50 with a 15% tip).

Premerge review: clean @ 053255ccd8d31374e200d2dc635065fcf3507d59

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (no human review requested/received yet — still mine to hand off), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->
