### PR TITLE
Align recurring UPI Payment Element amount with the tipped INR total

### DIFF
--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -542,6 +542,30 @@ describe("canUseStripePaymentElementClientConfirm", () => {
     expect(getStripePaymentElementMountCurrency(s)).toBe("inr");
   });
 
+  it("adds a percentage tip to the recurring UPI Element amount in listed INR units", () => {
+    // gumroad-private#2190: ₹730 with a 15% tip must mount ₹839.50, not ₹730.
+    const s = clientConfirmState({
+      checkoutPayment: recurringUpiPaymentElementClientConfirmConfig,
+      products: [product({ recurrence: "monthly", price: 1_000, listedPriceCents: 73_000, hasTippingEnabled: true })],
+      tip: { type: "percentage", percentage: 15 },
+    });
+
+    expect(canUseStripePaymentElementClientConfirm(s)).toBe(true);
+    expect(getStripePaymentElementAmount(s)).toBe(83_950);
+    expect(getStripePaymentElementMountCurrency(s)).toBe("inr");
+  });
+
+  it("adds a fixed tip to the recurring UPI Element amount from the typed listed figure", () => {
+    // The buyer typed ₹100.00; the canonical rounding (1_150 USD cents here) must not replace it.
+    const s = clientConfirmState({
+      checkoutPayment: recurringUpiPaymentElementClientConfirmConfig,
+      products: [product({ recurrence: "monthly", price: 1_000, listedPriceCents: 73_000, hasTippingEnabled: true })],
+      tip: { type: "fixed", amount: 1_150, listedAmount: 10_000 },
+    });
+
+    expect(getStripePaymentElementAmount(s)).toBe(83_000);
+  });
+
   it("falls back when the server selected the server-confirm Payment Element integration", () => {
     expect(canUseStripePaymentElementClientConfirm(state())).toBe(false);
   });

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -651,12 +651,17 @@ export function getStripePaymentElementAmount(state: State) {
   const presentment = getStripePaymentElementPresentment(state);
   if (presentment) return presentment.amountCents;
   // Recurring UPI is a server-selected INR registration lane. A stale stored USD picker
-  // preference must not reinterpret either the Element amount or its currency.
+  // preference must not reinterpret either the Element amount or its currency. The buyer's tip
+  // is charged on top of the server-rendered base, allocated through the same listed-basis pass
+  // the summary and the submitted order use, so all three carry the identical INR total.
   if (
     state.checkoutPayment.integration === "payment_element_client_confirm" &&
     isRecurringUpiPaymentConfig(state.checkoutPayment)
-  )
-    return state.checkoutPayment.elements_options.presentment_amount_cents;
+  ) {
+    const baseAmountCents = state.checkoutPayment.elements_options.presentment_amount_cents;
+    if (baseAmountCents === null) return null;
+    return baseAmountCents + computeTipForListedLines(state, getListedLinePrices(state));
+  }
   // Direct-listed surfaces mount in the listed currency, so the USD total below would be the
   // wrong unit. Add any listed-currency tip the buyer selected to the server-rendered base amount
   // so Elements and the deferred intent stay aligned after surcharge-only tip edits.


### PR DESCRIPTION
- [x] Scope — recurring UPI Element amount ignores the tip (gumroad-private#2190, @nyomanjyotisa repro: ₹730 stays ₹730 with a 15% tip instead of ₹839.50)
- [x] Design — add the listed-basis tip (same `computeTipForListedLines` pass the summary and order submission use) to the recurring-UPI branch of `getStripePaymentElementAmount`
- [x] Build — `payment.ts` fix + 2 regression specs
- [x] QA — 214/214 in `payment.test.ts`; red proof: pre-fix code fails exactly the 2 new specs; full Checkout suite 508/508
- [ ] Shipped — pending review + merge + deploy
- [ ] Market — n/a (bug fix)
- [ ] Sell — n/a

## What

Recurring UPI (INR Autopay registration) checkouts now mount and update the Stripe Payment Element with the tipped listed total instead of the untipped server-rendered base. `getStripePaymentElementAmount` adds the buyer's tip — allocated through the same listed-basis pass (`computeTipForListedLines`) the order submission and the checkout summary already use — on top of `presentment_amount_cents`.

## Why

gumroad-private#2190 (report by @nyomanjyotisa, confirmed on current main): a ₹730/month membership with a 15% tip kept the Payment Element at ₹730 instead of ₹839.50. The recurring-UPI branch of `getStripePaymentElementAmount` returned the raw `presentment_amount_cents` and ignored `state.tip` entirely, while the summary (via `getCheckoutListedCurrencyAmounts`) and the charge path (`Charge::DirectListedPresentment`, where `displayed_price_cents` includes the tip) both carry the tipped total — so the Element the buyer confirmed on displayed/authorized a smaller amount than the intent charges.

## Before / After

Values from `getStripePaymentElementAmount` on the recurring-UPI lane, ₹730.00 listed monthly price (`presentment_amount_cents` 73_000):

| Tip | Before (main) | After (this branch) | Charge path |
| --- | --- | --- | --- |
| none | 73_000 | 73_000 | 73_000 |
| 15% | 73_000 | 83_950 | 83_950 |
| fixed, buyer typed ₹100.00 | 73_000 | 83_000 | 83_000 |

The fixed-tip case sums the typed listed figure (`tip.listedAmount`), not the canonical-USD rounding, matching the existing method-forced listed lane behavior.

## Test Results

- `npx vitest run app/javascript/components/Checkout/payment.test.ts` — 214 passed (includes the 2 new regression specs).
- Red proof: with the `payment.ts` fix stashed, exactly the 2 new specs fail (`expected 73000 to be 83950` / `to be 83000`); rest of the file stays green (212 passed).
- `npx vitest run app/javascript/components/Checkout/` — 20 files, 508 tests, all passed.

## QA steps

1. Cart: single INR-listed monthly membership with tipping enabled, buyer routed to the recurring UPI client-confirm lane (`recurring_upi_registration: true`).
2. Select a 15% tip: the Payment Element updates to ₹839.50 (the `elements.update({ amount })` effect in `PaymentElementInput.tsx` tracks `getStripePaymentElementAmount`), matching the summary total.
3. Type a fixed ₹100.00 tip: Element amount becomes ₹830.00.
4. Server-side alignment is pre-existing: `Charge::DirectListedPresentment` bills `displayed_price_cents` (tip included) and the UPI mandate maximum derives from the same tipped presentment total.

## Notes

- `canUseStripePaymentElementClientConfirm`'s lane-shape check compares `listedPriceCents` to `presentment_amount_cents` (base price, pre-tip), so tipping does not eject the cart from the lane — covered by the new percentage-tip spec asserting eligibility stays true.
- No screenshot: the changed surface is the amount inside the Stripe-hosted Payment Element iframe on the recurring UPI lane, which needs a seeded INR membership + Indian buyer routing on a preview app; the before/after value table above is the direct observable (the Element renders exactly this amount).

---

🤖 Generated with Hermes Agent (claude-fable-5-1)
