### PR TITLE
Erase social-connect PII on GDPR deletion and flag currently_linked after Twitter unlink

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -1011,7 +1011,9 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
     def serialize_social_connect_verification(verification)
       {
         platform: verification.platform,
+        uid: verification.uid,
         handle: verification.handle,
+        currently_linked: currently_linked?(verification),
         account_created_at: verification.account_created_at&.iso8601,
         follower_count: verification.follower_count,
         post_count: verification.post_count,
@@ -1019,6 +1021,17 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         last_verified_at: verification.last_verified_at.iso8601,
         shared_identity_user_count: verification.shared_identity_user_ids.size,
       }
+    end
+
+    # Unlinking clears the user's twitter columns but keeps the verification row as evidence,
+    # so the row alone cannot tell a reviewer whether the connection is still live.
+    def currently_linked?(verification)
+      case verification.platform
+      when "twitter"
+        verification.user.twitter_user_id.present? && verification.user.twitter_user_id.to_s == verification.uid.to_s
+      else
+        false
+      end
     end
 
     def build_admin_note(user, content)

--- a/app/services/gdpr_data_erasure_service.rb
+++ b/app/services/gdpr_data_erasure_service.rb
@@ -251,6 +251,10 @@ class GdprDataErasureService
         @user.save!(validate: false)
       end
 
+      # Erasure soft-deletes the user rather than destroying it, so the association's
+      # `dependent: :destroy` never runs and the platform uid/handle must be removed here.
+      @user.social_connect_verifications.destroy_all
+
       anonymized_email
     end
 

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -2129,7 +2129,9 @@ describe Api::Internal::Admin::UsersController do
         social_connections: [
           {
             platform: "twitter",
+            uid: "shared-uid",
             handle: "seller",
+            currently_linked: false,
             account_created_at: verification.account_created_at.iso8601,
             follower_count: verification.follower_count,
             post_count: verification.post_count,
@@ -2139,6 +2141,32 @@ describe Api::Internal::Admin::UsersController do
           }
         ]
       }.as_json)
+    end
+
+    it "reports currently_linked from the user's live twitter identity, not the retained verification row" do
+      user = create(:user, email: "seller@example.com", twitter_user_id: "12345")
+      create(:social_connect_verification, user:, platform: "twitter", uid: "12345", handle: "seller")
+
+      get :social_connections, params: { email: user.email }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["social_connections"].sole).to include("uid" => "12345", "currently_linked" => true)
+
+      user.update!(twitter_user_id: nil)
+
+      get :social_connections, params: { email: user.email }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["social_connections"].sole).to include("uid" => "12345", "currently_linked" => false)
+    end
+
+    it "reports currently_linked false when the user is linked to a different twitter account than the one verified" do
+      user = create(:user, email: "seller@example.com", twitter_user_id: "99999")
+      create(:social_connect_verification, user:, platform: "twitter", uid: "12345")
+
+      get :social_connections, params: { email: user.email }
+
+      expect(response.parsed_body["social_connections"].sole).to include("uid" => "12345", "currently_linked" => false)
     end
 
     it "returns an empty list for a user with no connections" do

--- a/spec/controllers/connections_controller_spec.rb
+++ b/spec/controllers/connections_controller_spec.rb
@@ -34,6 +34,17 @@ describe ConnectionsController do
       expect(response.body).to eq({ success: true }.to_json)
     end
 
+    it "keeps the social connect verification row while clearing the live twitter identity" do
+      verification = create(:social_connect_verification, user: seller, platform: "twitter", uid: "123", handle: "gumroad")
+
+      post :unlink_twitter
+
+      expect(response.body).to eq({ success: true }.to_json)
+      expect(seller.reload.twitter_user_id).to be_nil
+      expect(SocialConnectVerification.exists?(id: verification.id)).to be(true)
+      expect(verification.reload.uid).to eq("123")
+    end
+
     it "responds with an error message if the unlink fails" do
       allow_any_instance_of(User).to receive(:save!).and_raise("Failed to unlink Twitter")
 

--- a/spec/services/gdpr_data_erasure_service_spec.rb
+++ b/spec/services/gdpr_data_erasure_service_spec.rb
@@ -689,6 +689,19 @@ describe GdprDataErasureService do
       expect(purchase.browser_guid).to be_nil
     end
 
+    it "destroys the user's social connect verifications without touching other users' rows" do
+      user.update!(twitter_user_id: "12345", twitter_handle: "johndoe")
+      verification = create(:social_connect_verification, user:, platform: "twitter", uid: "12345", handle: "johndoe")
+      other_verification = create(:social_connect_verification, platform: "twitter", uid: "12345", handle: "johndoe")
+
+      described_class.new(user, performed_by: admin).perform!
+
+      expect(SocialConnectVerification.exists?(id: verification.id)).to be(false)
+      expect(SocialConnectVerification.where(user_id: user.id)).to be_empty
+      expect(SocialConnectVerification.where(uid: "12345").pluck(:user_id)).to eq([other_verification.user_id])
+      expect(user.reload.twitter_user_id).to be_nil
+    end
+
     it "anonymizes all of the user's carts and credit card records" do
       historical_cart = create(:cart, user:, email: user.email, ip_address: "127.0.0.2", browser_guid: "historical-browser-guid")
       historical_cart.mark_deleted!


### PR DESCRIPTION
## What

Risk reviewers still see a Twitter connection after a seller disconnects X. A deleted seller's Twitter uid and handle also stay in `social_connect_verifications` after GDPR erasure.

This follow-up to #7480 does two things:

- GDPR erasure now destroys that seller's `social_connect_verifications` next to the existing Twitter field nulling.
- The admin social-connections payload now includes `uid` and `currently_linked` (`user.twitter_user_id` equals the verification uid for Twitter).

Unlink still keeps the verification row. YouTube, Instagram, scoring, auto-release, and uid history are out of scope.

## Why

Erasure never destroys the user record, so `dependent: :destroy` on User does not run. The new table kept uid and handle after a deletion request.

Unlink already clears `TWITTER_PROPERTIES`. Reviewers need the payload to say whether that uid is still the live link.

## Before / After

Before: GDPR erasure nulls `twitter_user_id` and leaves the verification row. `GET /users/social_connections` lists handle and follower counts with no currently-linked flag, so a disconnected seller looks connected.

After: erasure removes that seller's verification rows. The same GET returns `uid` and `currently_linked`. After unlink, `currently_linked` is false and the row remains.

## Test Results

Ruby is not available in this environment, so these were not executed locally. CI will run:

- `bundle exec rspec spec/services/gdpr_data_erasure_service_spec.rb -e "destroys the user's social connect verifications"` — 1 example. Fails if the row or its uid survives `perform!`.
- `bundle exec rspec spec/controllers/api/internal/admin/users_controller_spec.rb -e "GET social_connections"` — 5 existing plus 2 new examples (7 total with auth shared examples still in that describe). The unlink presentation example fails if `currently_linked` stays true after `twitter_user_id` is cleared. The mismatch example fails if the flag is true whenever any Twitter id is present.
- `bundle exec rspec spec/controllers/connections_controller_spec.rb -e "keeps the social connect verification row"` — 1 example. Fails if unlink deletes the verification.

## QA

No seller-facing UI. The admin consumer is the internal API. The specs above are the proof. No extra QA steps were run.

---

Implemented by Claude Fable 5.1 (Claude Code).