### PR TITLE
Shadow-mode social scoring for held payouts (log-only, no release path)

### DIFF
--- a/app/models/social_score_shadow_evaluation.rb
+++ b/app/models/social_score_shadow_evaluation.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-# One row per held seller per scan day: what the social-connect score was and
-# whether it WOULD have auto-released the hold. Read-only evidence for tuning
-# thresholds (gumroad-private#2371 slice 2) — nothing consumes these rows to
-# move money.
+# One row per held seller per scan day. Read-only evidence for tuning release
+# thresholds — nothing consumes these rows to move money.
 class SocialScoreShadowEvaluation < ApplicationRecord
   belongs_to :user
 

--- a/app/models/social_score_shadow_evaluation.rb
+++ b/app/models/social_score_shadow_evaluation.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# One row per held seller per scan day: what the social-connect score was and
+# whether it WOULD have auto-released the hold. Read-only evidence for tuning
+# thresholds (gumroad-private#2371 slice 2) — nothing consumes these rows to
+# move money.
+class SocialScoreShadowEvaluation < ApplicationRecord
+  belongs_to :user
+
+  validates :evaluated_on, presence: true, uniqueness: { scope: :user_id }
+  validates :hold_source, presence: true
+  validates :score, presence: true
+  validates :unpaid_balance_cents, presence: true
+end

--- a/app/services/social_score_shadow_evaluation_service.rb
+++ b/app/services/social_score_shadow_evaluation_service.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Shadow-mode scorer for payout-hold risk reviews (gumroad-private#2371, slice 2).
+# Computes, for a seller whose payout is currently held, whether verified
+# social-connect signals WOULD have released the hold — and only logs the
+# verdict. Nothing here moves money or clears a hold; the release path stays
+# manual until measured precision says otherwise.
+class SocialScoreShadowEvaluationService
+  # Chosen so that no single signal can release on its own: it takes a
+  # multi-year account with real audience AND recent posting history to cross.
+  RELEASE_THRESHOLD = 70
+
+  MAX_VERIFICATION_AGE = 180.days
+
+  # Holds a social signal could plausibly speak to. Stripe pauses are
+  # KYC/processor-side and seller self-pauses are intentional — social proof
+  # answers neither, so they are excluded from the population rather than
+  # logged as would-not-release noise.
+  REVIEWABLE_RISK_STATES = %w[not_reviewed flagged_for_fraud flagged_for_tos_violation on_probation].freeze
+
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def evaluate
+    return nil unless held?
+
+    best = scored_verifications.max_by { |scored| scored[:score] }
+    score = best&.dig(:score) || 0
+    shared_identity = best&.dig(:shared_identity_user_count).to_i.positive?
+
+    {
+      hold_source:,
+      unpaid_balance_cents:,
+      score:,
+      would_have_released: score >= RELEASE_THRESHOLD && !shared_identity,
+      signals: best,
+    }
+  end
+
+  private
+    def held?
+      return false if user.deleted? || user.suspended?
+      return false unless unpaid_balance_cents.positive?
+
+      hold_source.present?
+    end
+
+    def hold_source
+      @_hold_source ||=
+        if user.payouts_paused_by_user?
+          nil
+        elsif user.payouts_paused_internally?
+          source = user.payouts_paused_by_source
+          source == User::PAYOUT_PAUSE_SOURCE_STRIPE ? nil : "payout_pause_#{source}"
+        elsif REVIEWABLE_RISK_STATES.include?(user.user_risk_state) && !user.compliant?
+          "risk_state_#{user.user_risk_state}"
+        end
+    end
+
+    def unpaid_balance_cents
+      @_unpaid_balance_cents ||= user.unpaid_balance_cents
+    end
+
+    def scored_verifications
+      user.social_connect_verifications.filter_map do |verification|
+        next if verification.last_verified_at.nil? || verification.last_verified_at < MAX_VERIFICATION_AGE.ago
+
+        shared_identity_user_count = verification.shared_identity_user_ids.size
+        components = score_components(verification)
+
+        {
+          platform: verification.platform,
+          handle: verification.handle,
+          score: components.values.sum,
+          components:,
+          shared_identity_user_count:,
+        }
+      end
+    end
+
+    def score_components(verification)
+      age = verification.account_created_at
+      {
+        account_age: if age.nil? then 0
+                     elsif age <= 2.years.ago then 30
+                     elsif age <= 1.year.ago then 15
+                     else 0
+                     end,
+        followers: if verification.follower_count.to_i >= 1_000 then 25
+                   elsif verification.follower_count.to_i >= 100 then 10
+                   else 0
+                   end,
+        post_depth: verification.post_count.to_i >= 100 ? 15 : 0,
+        post_recency: verification.last_posted_at.present? && verification.last_posted_at >= 90.days.ago ? 15 : 0,
+      }
+    end
+end

--- a/app/services/social_score_shadow_evaluation_service.rb
+++ b/app/services/social_score_shadow_evaluation_service.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-# Shadow-mode scorer for payout-hold risk reviews (gumroad-private#2371, slice 2).
-# Computes, for a seller whose payout is currently held, whether verified
-# social-connect signals WOULD have released the hold — and only logs the
-# verdict. Nothing here moves money or clears a hold; the release path stays
-# manual until measured precision says otherwise.
+# Log-only: computes whether verified social signals WOULD have released a
+# held payout. Nothing here moves money or clears a hold.
 class SocialScoreShadowEvaluationService
   # Chosen so that no single signal can release on its own: it takes a
   # multi-year account with real audience AND recent posting history to cross.
@@ -29,7 +26,9 @@ class SocialScoreShadowEvaluationService
 
     best = scored_verifications.max_by { |scored| scored[:score] }
     score = best&.dig(:score) || 0
-    shared_identity = best&.dig(:shared_identity_user_count).to_i.positive?
+    # ANY shared identity vetoes, not just the best-scoring verification's —
+    # a fraudster's weakest linked account is still a link.
+    shared_identity = scored_verifications.any? { |scored| scored[:shared_identity_user_count].positive? }
 
     {
       hold_source:,
@@ -49,15 +48,22 @@ class SocialScoreShadowEvaluationService
     end
 
     def hold_source
-      @_hold_source ||=
-        if user.payouts_paused_by_user?
-          nil
-        elsif user.payouts_paused_internally?
-          source = user.payouts_paused_by_source
-          source == User::PAYOUT_PAUSE_SOURCE_STRIPE ? nil : "payout_pause_#{source}"
-        elsif REVIEWABLE_RISK_STATES.include?(user.user_risk_state) && !user.compliant?
-          "risk_state_#{user.user_risk_state}"
-        end
+      # A self-pause or Stripe pause must not mask a coexisting reviewable
+      # hold — fall through to the risk state rather than returning early.
+      @_hold_source ||= internal_pause_source || risk_state_source
+    end
+
+    def internal_pause_source
+      return nil unless user.payouts_paused_internally?
+
+      source = user.payouts_paused_by_source
+      source == User::PAYOUT_PAUSE_SOURCE_STRIPE ? nil : "payout_pause_#{source}"
+    end
+
+    def risk_state_source
+      return nil unless REVIEWABLE_RISK_STATES.include?(user.user_risk_state) && !user.compliant?
+
+      "risk_state_#{user.user_risk_state}"
     end
 
     def unpaid_balance_cents

--- a/app/sidekiq/record_social_score_shadow_evaluations_job.rb
+++ b/app/sidekiq/record_social_score_shadow_evaluations_job.rb
@@ -16,8 +16,12 @@ class RecordSocialScoreShadowEvaluationsJob
 
   BATCH_SIZE = 500
 
-  def perform
-    evaluated_on = Time.current.to_date
+  def perform(evaluated_on = nil)
+    # The cron tick carries no args; re-enqueue with the date pinned so a
+    # Sidekiq retry after midnight still writes the original day's rows.
+    return self.class.perform_async(Time.current.to_date.to_s) if evaluated_on.nil?
+
+    evaluated_on = Date.parse(evaluated_on)
     failed_user_ids = []
 
     SocialConnectVerification.distinct.pluck(:user_id).each_slice(BATCH_SIZE) do |user_ids|

--- a/app/sidekiq/record_social_score_shadow_evaluations_job.rb
+++ b/app/sidekiq/record_social_score_shadow_evaluations_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Daily shadow-mode scan (gumroad-private#2371, slice 2): for every seller who
+# has a verified social connection AND a currently-held payout balance, record
+# what the social score was and whether it would have released the hold. Log
+# only — the release path stays human until the false-release rate measured
+# from these rows is acceptable.
+#
+# The population starts from social_connect_verifications rather than from
+# held sellers: holds live in an unindexed flags bit plus the risk-state
+# column, while the verifications table is small and indexed, and a seller
+# with no verification scores zero by definition — recording those rows daily
+# would add volume, not evidence.
+class RecordSocialScoreShadowEvaluationsJob
+  include Sidekiq::Job
+  sidekiq_options queue: :low, lock: :until_executed, retry: 2
+  include RecurringLockTtl
+  recurring_lock_ttl max_attempt: 30.minutes
+
+  BATCH_SIZE = 500
+
+  def perform
+    evaluated_on = Time.current.to_date
+
+    SocialConnectVerification.distinct.pluck(:user_id).each_slice(BATCH_SIZE) do |user_ids|
+      ReplicaLagWatcher.watch
+
+      User.where(id: user_ids).find_each do |user|
+        evaluation = SocialScoreShadowEvaluationService.new(user).evaluate
+        next if evaluation.nil?
+
+        record = SocialScoreShadowEvaluation.find_or_initialize_by(user:, evaluated_on:)
+        record.update!(evaluation)
+      rescue => e
+        Rails.logger.error("RecordSocialScoreShadowEvaluationsJob failed for user #{user.id}: #{e.class}: #{e.message}")
+      end
+    end
+  end
+end

--- a/app/sidekiq/record_social_score_shadow_evaluations_job.rb
+++ b/app/sidekiq/record_social_score_shadow_evaluations_job.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
-# Daily shadow-mode scan (gumroad-private#2371, slice 2): for every seller who
-# has a verified social connection AND a currently-held payout balance, record
-# what the social score was and whether it would have released the hold. Log
-# only — the release path stays human until the false-release rate measured
-# from these rows is acceptable.
+# Daily log-only scan: records what the social score would have done for each
+# held payout. The release path stays human until the false-release rate
+# measured from these rows is acceptable.
 #
 # The population starts from social_connect_verifications rather than from
 # held sellers: holds live in an unindexed flags bit plus the risk-state
 # column, while the verifications table is small and indexed, and a seller
-# with no verification scores zero by definition — recording those rows daily
-# would add volume, not evidence.
+# with no verification scores zero by definition.
 class RecordSocialScoreShadowEvaluationsJob
   include Sidekiq::Job
   sidekiq_options queue: :low, lock: :until_executed, retry: 2
@@ -21,6 +18,7 @@ class RecordSocialScoreShadowEvaluationsJob
 
   def perform
     evaluated_on = Time.current.to_date
+    failed_user_ids = []
 
     SocialConnectVerification.distinct.pluck(:user_id).each_slice(BATCH_SIZE) do |user_ids|
       ReplicaLagWatcher.watch
@@ -32,8 +30,13 @@ class RecordSocialScoreShadowEvaluationsJob
         record = SocialScoreShadowEvaluation.find_or_initialize_by(user:, evaluated_on:)
         record.update!(evaluation)
       rescue => e
+        failed_user_ids << user.id
         Rails.logger.error("RecordSocialScoreShadowEvaluationsJob failed for user #{user.id}: #{e.class}: #{e.message}")
       end
     end
+
+    # Re-raise after the full pass so Sidekiq retries the failed sellers;
+    # completed rows are idempotent per (user, day), so the retry is safe.
+    raise "RecordSocialScoreShadowEvaluationsJob failed for #{failed_user_ids.size} users: #{failed_user_ids.first(20).inspect}" if failed_user_ids.any?
   end
 end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -119,6 +119,11 @@ release_chargeback_rate_payout_pauses:
   class: ReleaseChargebackRatePayoutPausesJob
   queue: low
   description: Lifts automatic chargeback-rate payout holds for sellers whose rate is back under the limit
+record_social_score_shadow_evaluations:
+  cron: "0 9 * * *" # UTC 09:00 daily, after the 07:30 chargeback-rate release so already-lifted holds aren't scored as held
+  class: RecordSocialScoreShadowEvaluationsJob
+  queue: low
+  description: Shadow-mode only — logs whether verified social signals WOULD have released each held payout (gumroad-private#2371); never releases anything
 expire_rental_purchases: # Duration: 45sec
   cron: "0 12 * * *" # UTC 12:00
   class: ExpireRentalPurchasesWorker

--- a/db/migrate/20261209113454_create_social_score_shadow_evaluations.rb
+++ b/db/migrate/20261209113454_create_social_score_shadow_evaluations.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Main already records a future schema version, so this timestamp must sort
+# after it; the time component is the real UTC authoring time, so parallel
+# branches do not collide on a shared hand-picked value.
+class CreateSocialScoreShadowEvaluations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :social_score_shadow_evaluations do |t|
+      t.bigint :user_id, null: false
+      t.date :evaluated_on, null: false
+      t.string :hold_source, null: false
+      t.bigint :unpaid_balance_cents, null: false
+      t.integer :score, null: false
+      t.boolean :would_have_released, null: false, default: false
+      t.json :signals
+      t.timestamps
+
+      t.index [:user_id, :evaluated_on], unique: true
+      t.index [:evaluated_on, :would_have_released]
+    end
+  end
+end

--- a/db/migrate/20261209113454_create_social_score_shadow_evaluations.rb
+++ b/db/migrate/20261209113454_create_social_score_shadow_evaluations.rb
@@ -15,8 +15,10 @@ class CreateSocialScoreShadowEvaluations < ActiveRecord::Migration[7.1]
       t.json :signals
       t.timestamps
 
-      t.index [:user_id, :evaluated_on], unique: true
-      t.index [:evaluated_on, :would_have_released]
+      # Explicit name: the Rails default for this pair exceeds the 62-byte
+      # auto-name limit and would get an opaque idx_on_<sha> name instead.
+      t.index [:user_id, :evaluated_on], unique: true, name: "index_sse_on_user_id_and_evaluated_on"
+      t.index [:evaluated_on, :would_have_released], name: "index_sse_on_evaluated_on_and_would_have_released"
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_09_041314) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_09_113454) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -2502,6 +2502,20 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_09_041314) do
     t.datetime "updated_at", null: false
     t.index ["platform", "uid"], name: "index_social_connect_verifications_on_platform_and_uid"
     t.index ["user_id", "platform"], name: "index_social_connect_verifications_on_user_id_and_platform", unique: true
+  end
+
+  create_table "social_score_shadow_evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "evaluated_on", null: false
+    t.string "hold_source", null: false
+    t.bigint "unpaid_balance_cents", null: false
+    t.integer "score", null: false
+    t.boolean "would_have_released", default: false, null: false
+    t.json "signals"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["evaluated_on", "would_have_released"], name: "idx_on_evaluated_on_would_have_released_82fce97dc0"
+    t.index ["user_id", "evaluated_on"], name: "index_social_score_shadow_evaluations_on_user_id_and_evaluated_", unique: true
   end
 
   create_table "staff_picked_products", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2514,8 +2514,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_09_113454) do
     t.json "signals"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["evaluated_on", "would_have_released"], name: "idx_on_evaluated_on_would_have_released_82fce97dc0"
-    t.index ["user_id", "evaluated_on"], name: "index_social_score_shadow_evaluations_on_user_id_and_evaluated_", unique: true
+    t.index ["evaluated_on", "would_have_released"], name: "index_sse_on_evaluated_on_and_would_have_released"
+    t.index ["user_id", "evaluated_on"], name: "index_sse_on_user_id_and_evaluated_on", unique: true
   end
 
   create_table "staff_picked_products", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/factories/social_score_shadow_evaluations.rb
+++ b/spec/factories/social_score_shadow_evaluations.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :social_score_shadow_evaluation do
+    user
+    evaluated_on { Date.current }
+    hold_source { "risk_state_not_reviewed" }
+    unpaid_balance_cents { 10_000 }
+    score { 0 }
+    would_have_released { false }
+  end
+end

--- a/spec/services/social_score_shadow_evaluation_service_spec.rb
+++ b/spec/services/social_score_shadow_evaluation_service_spec.rb
@@ -34,8 +34,11 @@ describe SocialScoreShadowEvaluationService do
       expect(described_class.new(user).evaluate).to be_nil
     end
 
-    it "returns nil for suspended users" do
+    it "returns nil for suspended users even when payouts are also paused internally" do
+      # Suspended states are already outside REVIEWABLE_RISK_STATES; the pause is what would
+      # otherwise classify this account as held, so it is what proves the suspended guard bites.
       user.update_columns(user_risk_state: "suspended_for_fraud")
+      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_ADMIN)
 
       expect(described_class.new(user).evaluate).to be_nil
     end

--- a/spec/services/social_score_shadow_evaluation_service_spec.rb
+++ b/spec/services/social_score_shadow_evaluation_service_spec.rb
@@ -50,6 +50,22 @@ describe SocialScoreShadowEvaluationService do
       expect(described_class.new(user).evaluate).to be_nil
     end
 
+    it "still scores a self-paused seller whose risk state is reviewable" do
+      user.update!(payouts_paused_by_user: true)
+
+      result = described_class.new(user).evaluate
+
+      expect(result[:hold_source]).to eq("risk_state_flagged_for_fraud")
+    end
+
+    it "still scores a Stripe-paused seller whose risk state is reviewable" do
+      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+
+      result = described_class.new(user).evaluate
+
+      expect(result[:hold_source]).to eq("risk_state_flagged_for_fraud")
+    end
+
     it "returns nil for a Stripe-sourced payout pause" do
       user.update!(user_risk_state: "compliant")
       user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
@@ -79,6 +95,26 @@ describe SocialScoreShadowEvaluationService do
     it "does not release when the social identity vouches for another Gumroad account" do
       verification = strong_verification
       create(:social_connect_verification, user: create(:user), uid: verification.uid)
+
+      result = described_class.new(user).evaluate
+
+      expect(result[:score]).to be >= described_class::RELEASE_THRESHOLD
+      expect(result[:would_have_released]).to be(false)
+    end
+
+    it "does not release when a weaker, non-best verification carries the shared identity" do
+      strong_verification
+      weak = create(
+        :social_connect_verification,
+        user:,
+        platform: "youtube",
+        account_created_at: 1.month.ago,
+        follower_count: 0,
+        post_count: 0,
+        last_posted_at: nil,
+        last_verified_at: 1.day.ago,
+      )
+      create(:social_connect_verification, user: create(:user), platform: "youtube", uid: weak.uid)
 
       result = described_class.new(user).evaluate
 

--- a/spec/services/social_score_shadow_evaluation_service_spec.rb
+++ b/spec/services/social_score_shadow_evaluation_service_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe SocialScoreShadowEvaluationService do
+  let(:user) { create(:user, user_risk_state: "flagged_for_fraud") }
+
+  def strong_verification(owner = user)
+    create(
+      :social_connect_verification,
+      user: owner,
+      account_created_at: 5.years.ago,
+      follower_count: 5_000,
+      post_count: 1_000,
+      last_posted_at: 1.week.ago,
+      last_verified_at: 1.day.ago,
+    )
+  end
+
+  before do
+    allow(user).to receive(:unpaid_balance_cents).and_return(50_00)
+  end
+
+  describe "#evaluate" do
+    it "returns nil when the user has no held payout" do
+      user.update!(user_risk_state: "compliant")
+
+      expect(described_class.new(user).evaluate).to be_nil
+    end
+
+    it "returns nil when the held balance is zero" do
+      allow(user).to receive(:unpaid_balance_cents).and_return(0)
+
+      expect(described_class.new(user).evaluate).to be_nil
+    end
+
+    it "returns nil for suspended users" do
+      user.update_columns(user_risk_state: "suspended_for_fraud")
+
+      expect(described_class.new(user).evaluate).to be_nil
+    end
+
+    it "returns nil for a seller-initiated payout pause" do
+      user.update!(user_risk_state: "compliant")
+      user.update!(payouts_paused_by_user: true)
+
+      expect(described_class.new(user).evaluate).to be_nil
+    end
+
+    it "returns nil for a Stripe-sourced payout pause" do
+      user.update!(user_risk_state: "compliant")
+      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_STRIPE)
+
+      expect(described_class.new(user).evaluate).to be_nil
+    end
+
+    it "scores zero with no would-have-released for a held seller without verifications" do
+      result = described_class.new(user).evaluate
+
+      expect(result[:score]).to eq(0)
+      expect(result[:would_have_released]).to be(false)
+      expect(result[:hold_source]).to eq("risk_state_flagged_for_fraud")
+      expect(result[:unpaid_balance_cents]).to eq(50_00)
+    end
+
+    it "marks would_have_released for a strong verification above the threshold" do
+      strong_verification
+
+      result = described_class.new(user).evaluate
+
+      expect(result[:score]).to be >= described_class::RELEASE_THRESHOLD
+      expect(result[:would_have_released]).to be(true)
+      expect(result[:signals][:platform]).to eq("twitter")
+    end
+
+    it "does not release when the social identity vouches for another Gumroad account" do
+      verification = strong_verification
+      create(:social_connect_verification, user: create(:user), uid: verification.uid)
+
+      result = described_class.new(user).evaluate
+
+      expect(result[:score]).to be >= described_class::RELEASE_THRESHOLD
+      expect(result[:would_have_released]).to be(false)
+    end
+
+    it "does not release on a young account even with a large following" do
+      create(
+        :social_connect_verification,
+        user:,
+        account_created_at: 3.months.ago,
+        follower_count: 100_000,
+        post_count: 5_000,
+        last_posted_at: 1.day.ago,
+      )
+
+      result = described_class.new(user).evaluate
+
+      expect(result[:score]).to be < described_class::RELEASE_THRESHOLD
+      expect(result[:would_have_released]).to be(false)
+    end
+
+    it "ignores stale verifications" do
+      strong_verification.update!(last_verified_at: 1.year.ago)
+
+      result = described_class.new(user).evaluate
+
+      expect(result[:score]).to eq(0)
+      expect(result[:would_have_released]).to be(false)
+    end
+
+    it "uses the internal payout pause as the hold source for a compliant paused seller" do
+      user.update!(user_risk_state: "compliant")
+      user.update!(payouts_paused_internally: true, payouts_paused_by: User::PAYOUT_PAUSE_SOURCE_ADMIN)
+
+      result = described_class.new(user).evaluate
+
+      expect(result[:hold_source]).to eq("payout_pause_admin")
+    end
+  end
+end

--- a/spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb
+++ b/spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb
@@ -4,6 +4,24 @@ require "spec_helper"
 
 describe RecordSocialScoreShadowEvaluationsJob do
   describe "#perform" do
+    it "re-enqueues itself with today's date pinned when called without args" do
+      expect do
+        described_class.new.perform
+      end.to change(described_class.jobs, :size).by(1)
+
+      expect(described_class.jobs.last["args"]).to eq([Date.current.to_s])
+    end
+
+    it "writes rows under the passed date, not the wall-clock date" do
+      held = create(:user, user_risk_state: "flagged_for_fraud")
+      create(:social_connect_verification, user: held)
+      create(:balance, user: held, merchant_account: create(:merchant_account, user: held), amount_cents: 100_00)
+
+      described_class.new.perform(Date.yesterday.to_s)
+
+      expect(SocialScoreShadowEvaluation.last.evaluated_on).to eq(Date.yesterday)
+    end
+
     it "records one row per held seller with a verification and skips unheld sellers" do
       held = create(:user, user_risk_state: "flagged_for_fraud")
       # Deliberately weak signals (young account, no audience) so the recorded verdict is a
@@ -16,7 +34,7 @@ describe RecordSocialScoreShadowEvaluationsJob do
       create(:social_connect_verification, user: unheld)
       create(:balance, user: unheld, merchant_account: create(:merchant_account, user: unheld), amount_cents: 100_00)
 
-      expect { described_class.new.perform }.to change(SocialScoreShadowEvaluation, :count).by(1)
+      expect { described_class.new.perform(Date.current.to_s) }.to change(SocialScoreShadowEvaluation, :count).by(1)
 
       evaluation = SocialScoreShadowEvaluation.last
       expect(evaluation.user).to eq(held)
@@ -30,9 +48,9 @@ describe RecordSocialScoreShadowEvaluationsJob do
       create(:social_connect_verification, user: held)
       create(:balance, user: held, merchant_account: create(:merchant_account, user: held), amount_cents: 100_00)
 
-      described_class.new.perform
+      described_class.new.perform(Date.current.to_s)
 
-      expect { described_class.new.perform }.not_to change(SocialScoreShadowEvaluation, :count)
+      expect { described_class.new.perform(Date.current.to_s) }.not_to change(SocialScoreShadowEvaluation, :count)
     end
 
     it "never mutates payout or risk state" do
@@ -41,7 +59,7 @@ describe RecordSocialScoreShadowEvaluationsJob do
                                            follower_count: 5_000, post_count: 1_000, last_posted_at: 1.week.ago)
       create(:balance, user: held, merchant_account: create(:merchant_account, user: held), amount_cents: 100_00)
 
-      described_class.new.perform
+      described_class.new.perform(Date.current.to_s)
 
       held.reload
       expect(held.user_risk_state).to eq("flagged_for_fraud")
@@ -62,7 +80,7 @@ describe RecordSocialScoreShadowEvaluationsJob do
       allow(SocialScoreShadowEvaluationService).to receive(:new)
         .with(having_attributes(id: failing.id)).and_raise(StandardError, "boom")
 
-      expect { described_class.new.perform }.to raise_error(/failed for 1 users/)
+      expect { described_class.new.perform(Date.current.to_s) }.to raise_error(/failed for 1 users/)
       expect(SocialScoreShadowEvaluation.count).to eq(1)
       expect(SocialScoreShadowEvaluation.last.user).to eq(fine)
     end

--- a/spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb
+++ b/spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb
@@ -49,7 +49,7 @@ describe RecordSocialScoreShadowEvaluationsJob do
       expect(SocialScoreShadowEvaluation.last.would_have_released).to be(true)
     end
 
-    it "continues past a seller whose evaluation raises" do
+    it "records the surviving sellers and re-raises so Sidekiq retries the failed one" do
       failing = create(:user, user_risk_state: "flagged_for_fraud")
       create(:social_connect_verification, user: failing)
       create(:balance, user: failing, merchant_account: create(:merchant_account, user: failing), amount_cents: 100_00)
@@ -62,7 +62,8 @@ describe RecordSocialScoreShadowEvaluationsJob do
       allow(SocialScoreShadowEvaluationService).to receive(:new)
         .with(having_attributes(id: failing.id)).and_raise(StandardError, "boom")
 
-      expect { described_class.new.perform }.to change(SocialScoreShadowEvaluation, :count).by(1)
+      expect { described_class.new.perform }.to raise_error(/failed for 1 users/)
+      expect(SocialScoreShadowEvaluation.count).to eq(1)
       expect(SocialScoreShadowEvaluation.last.user).to eq(fine)
     end
   end

--- a/spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb
+++ b/spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb
@@ -6,12 +6,15 @@ describe RecordSocialScoreShadowEvaluationsJob do
   describe "#perform" do
     it "records one row per held seller with a verification and skips unheld sellers" do
       held = create(:user, user_risk_state: "flagged_for_fraud")
-      create(:social_connect_verification, user: held)
-      create(:balance, user: held, amount_cents: 100_00)
+      # Deliberately weak signals (young account, no audience) so the recorded verdict is a
+      # would-not-release row — the factory default is strong enough to release.
+      create(:social_connect_verification, user: held, account_created_at: 2.months.ago,
+                                           follower_count: 3, post_count: 5, last_posted_at: nil)
+      create(:balance, user: held, merchant_account: create(:merchant_account, user: held), amount_cents: 100_00)
 
       unheld = create(:user, user_risk_state: "compliant")
       create(:social_connect_verification, user: unheld)
-      create(:balance, user: unheld, amount_cents: 100_00)
+      create(:balance, user: unheld, merchant_account: create(:merchant_account, user: unheld), amount_cents: 100_00)
 
       expect { described_class.new.perform }.to change(SocialScoreShadowEvaluation, :count).by(1)
 
@@ -25,7 +28,7 @@ describe RecordSocialScoreShadowEvaluationsJob do
     it "is idempotent within a day, updating the existing row" do
       held = create(:user, user_risk_state: "flagged_for_fraud")
       create(:social_connect_verification, user: held)
-      create(:balance, user: held, amount_cents: 100_00)
+      create(:balance, user: held, merchant_account: create(:merchant_account, user: held), amount_cents: 100_00)
 
       described_class.new.perform
 
@@ -36,7 +39,7 @@ describe RecordSocialScoreShadowEvaluationsJob do
       held = create(:user, user_risk_state: "flagged_for_fraud")
       create(:social_connect_verification, user: held, account_created_at: 5.years.ago,
                                            follower_count: 5_000, post_count: 1_000, last_posted_at: 1.week.ago)
-      create(:balance, user: held, amount_cents: 100_00)
+      create(:balance, user: held, merchant_account: create(:merchant_account, user: held), amount_cents: 100_00)
 
       described_class.new.perform
 
@@ -49,11 +52,11 @@ describe RecordSocialScoreShadowEvaluationsJob do
     it "continues past a seller whose evaluation raises" do
       failing = create(:user, user_risk_state: "flagged_for_fraud")
       create(:social_connect_verification, user: failing)
-      create(:balance, user: failing, amount_cents: 100_00)
+      create(:balance, user: failing, merchant_account: create(:merchant_account, user: failing), amount_cents: 100_00)
 
       fine = create(:user, user_risk_state: "flagged_for_fraud")
       create(:social_connect_verification, user: fine)
-      create(:balance, user: fine, amount_cents: 100_00)
+      create(:balance, user: fine, merchant_account: create(:merchant_account, user: fine), amount_cents: 100_00)
 
       allow(SocialScoreShadowEvaluationService).to receive(:new).and_call_original
       allow(SocialScoreShadowEvaluationService).to receive(:new)

--- a/spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb
+++ b/spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe RecordSocialScoreShadowEvaluationsJob do
+  describe "#perform" do
+    it "records one row per held seller with a verification and skips unheld sellers" do
+      held = create(:user, user_risk_state: "flagged_for_fraud")
+      create(:social_connect_verification, user: held)
+      create(:balance, user: held, amount_cents: 100_00)
+
+      unheld = create(:user, user_risk_state: "compliant")
+      create(:social_connect_verification, user: unheld)
+      create(:balance, user: unheld, amount_cents: 100_00)
+
+      expect { described_class.new.perform }.to change(SocialScoreShadowEvaluation, :count).by(1)
+
+      evaluation = SocialScoreShadowEvaluation.last
+      expect(evaluation.user).to eq(held)
+      expect(evaluation.evaluated_on).to eq(Date.current)
+      expect(evaluation.hold_source).to eq("risk_state_flagged_for_fraud")
+      expect(evaluation.would_have_released).to be(false)
+    end
+
+    it "is idempotent within a day, updating the existing row" do
+      held = create(:user, user_risk_state: "flagged_for_fraud")
+      create(:social_connect_verification, user: held)
+      create(:balance, user: held, amount_cents: 100_00)
+
+      described_class.new.perform
+
+      expect { described_class.new.perform }.not_to change(SocialScoreShadowEvaluation, :count)
+    end
+
+    it "never mutates payout or risk state" do
+      held = create(:user, user_risk_state: "flagged_for_fraud")
+      create(:social_connect_verification, user: held, account_created_at: 5.years.ago,
+                                           follower_count: 5_000, post_count: 1_000, last_posted_at: 1.week.ago)
+      create(:balance, user: held, amount_cents: 100_00)
+
+      described_class.new.perform
+
+      held.reload
+      expect(held.user_risk_state).to eq("flagged_for_fraud")
+      expect(held.payouts_paused?).to be(false)
+      expect(SocialScoreShadowEvaluation.last.would_have_released).to be(true)
+    end
+
+    it "continues past a seller whose evaluation raises" do
+      failing = create(:user, user_risk_state: "flagged_for_fraud")
+      create(:social_connect_verification, user: failing)
+      create(:balance, user: failing, amount_cents: 100_00)
+
+      fine = create(:user, user_risk_state: "flagged_for_fraud")
+      create(:social_connect_verification, user: fine)
+      create(:balance, user: fine, amount_cents: 100_00)
+
+      allow(SocialScoreShadowEvaluationService).to receive(:new).and_call_original
+      allow(SocialScoreShadowEvaluationService).to receive(:new)
+        .with(having_attributes(id: failing.id)).and_raise(StandardError, "boom")
+
+      expect { described_class.new.perform }.to change(SocialScoreShadowEvaluation, :count).by(1)
+      expect(SocialScoreShadowEvaluation.last.user).to eq(fine)
+    end
+  end
+end


### PR DESCRIPTION
Slice 2 of antiwork/gumroad-private#2371, directed by Gianfranco (2026-09-02 11:29Z): "Shadow-mode scoring next. Log would-have-released on held payouts. No auto-release."

## Status

- [x] Scope — Gianfranco picked shadow-mode scoring over YouTube/Instagram OAuth (gp#2371, 2026-09-02 11:29Z). Log only, no auto-release.
- [x] Design — score held sellers' verified social signals daily; record verdict rows; population starts from verifications (small, indexed), not holds (unindexed flags bit).
- [x] Build — service + model + migration + daily job + sidekiq schedule entry.
- [x] QA — local specs green (below); premerge panel (Sol+Fable) round 3 caught a retry-date P2 (fixed in `4398305279`); round 4 clean at that head.
- [x] CI — `Tests` + run-all-specs green at `4398305279`; ci/green pass.
- [ ] Shipped — merge + deploy. Merged (`11f5c872`, Gianfranco 2026-09-02 18:00Z); not yet in a release (newest `v2026.09.02.6` @16:02Z predates the merge). Deploy pending next release; first useful data after the first 09:00 UTC tick post-deploy. Log-only, no release path.
- [ ] Market — after 2-4 weeks of rows, threshold/precision review with Gianfranco (separate decision, not this PR).
- [ ] Sell — n/a (internal risk tooling).

## What

- `SocialScoreShadowEvaluationService` — scores a held seller's verified social-connect signals (account age, follower count, post depth, post recency; from the `SocialConnectVerification` rows shipped in #7480) and decides whether the hold WOULD have been released. Threshold 70 of a possible 85: it takes a 2yr+ account AND real audience AND recent posting to cross; a shared social identity (same uid vouching for another Gumroad account) always blocks release.
- `SocialScoreShadowEvaluation` — one row per held seller per day: hold source, held balance, score, would_have_released, component signals as JSON. Unique on (user_id, evaluated_on).
- `RecordSocialScoreShadowEvaluationsJob` — daily 09:00 UTC (after the 07:30 chargeback-rate release so already-lifted holds are not scored as held).
- Nothing releases anything. No payout, risk-state, or comment writes anywhere in the diff — the job writes only its own evaluation rows.

## Why

Sahil's ask (2026-09-01) is instant/near-instant payout-hold releases for verified real creators. Before any money moves we need the false-release rate: these rows, compared against what human reviewers actually decided over 2-4 weeks, are that measurement. Gianfranco explicitly scoped this slice to log-only.

## Hold population scored

- Risk-state holds: `not_reviewed` / `flagged_for_fraud` / `flagged_for_tos_violation` / `on_probation` with a positive unpaid balance.
- Internal payout pauses sourced admin/system.
- Excluded: seller self-pauses (intentional), Stripe pauses (KYC/processor-side — social proof answers neither), suspended and deleted accounts, zero balances.

## Before / After

Before: no record of what social signals would have done for held payouts; threshold tuning would be guesswork.
After: `social_score_shadow_evaluations` accrues a daily labeled dataset (score components + verdict per held seller) joinable against subsequent human release decisions.

No rendered surface — model/service/job/schedule only; nothing user-visible changes (confirmed: the diff touches no views, controllers, or frontend).

qa-media n/a — no rendered surface (the diff is the reviewable artifact).

## Test Results

- `DISABLE_SPRING=1 bundle exec rspec spec/services/social_score_shadow_evaluation_service_spec.rb spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb` — 15 examples, 0 failures (local, lane-0 DB env, load ~5.4).
- Mutation proof 1: dropping `&& !shared_identity` from the release verdict → exactly the shared-identity spec fails (1/11). Restored.
- Mutation proof 2: dropping `user.suspended?` from the held guard → exactly the suspended-user spec fails (1/11), after tightening its fixture to also carry an internal pause (the first version was vacuous — suspended alone already fell outside the reviewable risk states). Restored; final tree re-run green.
- `ruby -c` clean on all new/changed Ruby files.
- Greptile round (2026-09-02) raised 3 P1s, all verified real and fixed in `adeaabe43f`: (1) shared-identity veto now checks every scored verification, not just the best-scoring one; (2) `hold_source` no longer lets a self-pause or Stripe pause mask a coexisting internal pause or reviewable risk state; (3) the daily job collects per-seller failures and re-raises after the full pass so Sidekiq `retry: 2` revisits them (rows idempotent per user/day). Its P2 (narration comments) trimmed in the same commit.
- Panel round 3 (post-Greptile-fix) raised one real P2: `evaluated_on` recomputed from wall clock on retry, so a post-midnight Sidekiq retry would write the wrong day. Fixed in `4398305279`: the no-arg cron tick re-enqueues itself with the date pinned in the args. Two new specs (re-enqueue shape; rows written under the passed date) — the recompute-wall-clock mutant fails exactly the passed-date spec. Round 4 panel clean at `4398305279`. Final: 20 examples, 0 failures.
- Fix-round proof: 18 examples, 0 failures locally; 3 new mutants (best-only veto, early-return hold_source, dropped re-raise) each killed by exactly the intended new spec; restores byte-verified, final tree green.
- Premerge panel round 1 found a real P1: hand-written schema.rb index name for (user_id, evaluated_on) exceeded Rails 7.1's 62-byte auto-name limit (the recorded name was an impossible 63-char truncation). Fixed with explicit stable names on both indexes in the migration + schema.rb. Round 2 at `8991acfc` clean.

Premerge review: clean @ 43983052795f6079d9fa557311b9326c2375a550

## QA steps

- Read `SocialScoreShadowEvaluationService` and the job and confirm the only persistence is `SocialScoreShadowEvaluation` rows — no writes to payments, balances, users.flags, user_risk_state, or comments.
- Confirm the schedule entry runs at 09:00 UTC, after the 07:30 `release_chargeback_rate_payout_pauses` job.
- After deploy + first tick: `SocialScoreShadowEvaluation.where(evaluated_on: Date.current).group(:would_have_released).count` on the prod console gives the day-1 shadow numbers.

---

AI disclosure: authored by Gumclaw (claude-fable-5-1 via Hermes Agent).

