### PR TITLE
Fixed n+1 issues from GET api/v2/sales

### DIFF
--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -17,6 +17,15 @@ class Api::V2::SalesController < Api::V2::BaseController
     :subscription,
     :tip,
     :utm_link,
+    :purchaser,
+    :seller,
+    :variant_attributes,
+    :purchase_custom_fields,
+    :shipment,
+    :product_review,
+    :offer_code,
+    { link: [:user, :variant_categories_alive, :product_review_stat] },
+    { upsell_purchase: [:upsell, :selected_product, { upsell_variant: :selected_variant }] },
     # buyer_presentment fields (v2): presentment row + its charge_presentment (fx_rate)
     # and refunds (in-memory presentment refunded sum) — avoids per-sale queries.
     :refunds,
@@ -65,9 +74,9 @@ class Api::V2::SalesController < Api::V2::BaseController
           has_next_page = paginated_sales.size > RESULTS_PER_PAGE
           paginated_sales = paginated_sales.first(RESULTS_PER_PAGE)
           if has_next_page
-            success_with_object(:sales, paginated_sales.as_json(version: 2, include_buyer_presentment: true), pagination_info(paginated_sales.last))
+            success_with_object(:sales, sales_json(paginated_sales), pagination_info(paginated_sales.last))
           else
-            success_with_object(:sales, paginated_sales.as_json(version: 2, include_buyer_presentment: true))
+            success_with_object(:sales, sales_json(paginated_sales))
           end
         end
       rescue WithMaxExecutionTime::QueryTimeoutError
@@ -103,7 +112,7 @@ class Api::V2::SalesController < Api::V2::BaseController
         has_next_page = paginated_sales.size > RESULTS_PER_PAGE
         paginated_sales = paginated_sales.first(RESULTS_PER_PAGE)
         additional_response = has_next_page ? pagination_info(paginated_sales.last) : {}
-        success_with_object(:sales, paginated_sales.as_json(version: 2, include_buyer_presentment: true), additional_response)
+        success_with_object(:sales, sales_json(paginated_sales), additional_response)
       end
     rescue WithMaxExecutionTime::QueryTimeoutError
       error_400("Query timed out. Try narrowing your date range with 'after'/'before' or filtering by product_id.")
@@ -226,6 +235,24 @@ class Api::V2::SalesController < Api::V2::BaseController
   private
     def success_with_sale(sale = nil)
       success_with_object(:sale, sale)
+    end
+
+    def sales_json(sales)
+      variants = sales.flat_map(&:variant_attributes).grep(Variant)
+      ActiveRecord::Associations::Preloader.new(records: variants, associations: :variant_category).call if variants.any?
+
+      following_emails = Follower.active
+        .where(followed_id: current_resource_owner.id, email: sales.map(&:email))
+        .pluck(:email)
+        .to_set
+
+      sales.map do |sale|
+        sale.as_json(
+          version: 2,
+          include_buyer_presentment: true,
+          is_following: following_emails.include?(sale.email)
+        )
+      end
     end
 
     def sale_purchase_policy(purchase)

--- a/app/controllers/api/v2/sales_controller.rb
+++ b/app/controllers/api/v2/sales_controller.rb
@@ -244,13 +244,13 @@ class Api::V2::SalesController < Api::V2::BaseController
       following_emails = Follower.active
         .where(followed_id: current_resource_owner.id, email: sales.map(&:email))
         .pluck(:email)
-        .to_set
+        .to_set { |email| email.to_s.downcase }
 
       sales.map do |sale|
         sale.as_json(
           version: 2,
           include_buyer_presentment: true,
-          is_following: following_emails.include?(sale.email)
+          is_following: following_emails.include?(sale.email.to_s.downcase)
         )
       end
     end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1052,7 +1052,7 @@ class Purchase < ApplicationRecord
       purchaser_id: purchaser.try(:external_id),
       is_recurring_billing: link.is_recurring_billing,
       can_contact: can_contact?,
-      is_following: is_following?,
+      is_following: options.key?(:is_following) ? options[:is_following] : is_following?,
       disputed: chargedback?,
       dispute_won: chargeback_reversed?,
       is_additional_contribution:,
@@ -2799,7 +2799,12 @@ class Purchase < ApplicationRecord
   end
 
   def variants_and_quantity
-    variants_and_quantity_displayable(variant_attributes.not_is_default_sku, quantity)
+    variants = if variant_attributes.loaded?
+      variant_attributes.reject(&:is_default_sku?)
+    else
+      variant_attributes.not_is_default_sku
+    end
+    variants_and_quantity_displayable(variants, quantity)
   end
 
   def is_recurring_subscription_charge

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -78,6 +78,62 @@ describe Api::V2::SalesController do
         expect(per_row_queries).to be_empty
       end
 
+      it "serializes a full page without per-sale association lookups" do
+        purchases_with_upsells = (Api::V2::SalesController::RESULTS_PER_PAGE - 2).times.map do |index|
+          product = create(:physical_product, user: @seller, name: "Product #{index}")
+          variant_category = create(:variant_category, link: product, title: "Format")
+          variant = create(:variant, variant_category:, name: "Premium #{index}")
+          purchase = create(:physical_purchase, purchaser: create(:user), link: product, variant_attributes: [variant])
+          create(:purchase_custom_field, purchase:, name: "Company", value: "Buyer #{index}")
+          create(:shipment, purchase:)
+          create(:product_review, purchase:, rating: 5, message: "Review #{index}")
+          upsell = create(:upsell, seller: @seller, product:, name: "Upsell #{index}")
+          upsell_variant = create(:upsell_variant, upsell:, selected_variant: variant, offered_variant: variant)
+          create(:upsell_purchase, purchase:, upsell:, selected_product: product, upsell_variant:)
+          purchase
+        end
+
+        query_counts = Hash.new(0)
+        callback = lambda do |_name, _start, _finish, _id, payload|
+          table = payload[:sql].to_s[/FROM [`](users|links|base_variants|variant_categories|purchase_custom_fields|followers|upsells|upsell_purchases|upsell_variants|shipments|product_review_stats|product_reviews)[`]/, 1]
+          query_counts[table] += 1 if table
+        end
+
+        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+          get :index, params: @params
+        end
+
+        expect(response).to be_successful
+        sales = response.parsed_body["sales"]
+        expect(sales.size).to eq(Api::V2::SalesController::RESULTS_PER_PAGE)
+        purchases_with_upsells.each_with_index do |purchase, index|
+          expect(sales.find { _1["id"] == purchase.external_id }).to include(
+            "product_name" => "Product #{index}",
+            "variants" => { "Format" => "Premium #{index}" },
+            "upsell" => {
+              "name" => "Upsell #{index}",
+              "discount" => nil,
+              "selected_product" => "Product #{index}",
+              "selected_version" => "Premium #{index}",
+            },
+          )
+        end
+        expect(query_counts).to include(
+          "followers" => 1,
+          "purchase_custom_fields" => 1,
+          "shipments" => 1,
+          "product_reviews" => 2,
+          "upsells" => 1,
+          "upsell_purchases" => 1,
+          "upsell_variants" => 1,
+        )
+        expect(query_counts.fetch("users", 0)).to be <= 9
+        expect(query_counts.fetch("links", 0)).to be <= 3
+        expect(query_counts.fetch("base_variants", 0)).to be <= 2
+        expect(query_counts.fetch("variant_categories", 0)).to be <= 2
+        expect(query_counts.fetch("product_review_stats", 0)).to be <= 1
+      end
+
       it "includes web CSV parity fields in the response" do
         add_web_csv_api_fields(@purchase)
 

--- a/spec/controllers/api/v2/sales_controller_spec.rb
+++ b/spec/controllers/api/v2/sales_controller_spec.rb
@@ -78,6 +78,31 @@ describe Api::V2::SalesController do
         expect(per_row_queries).to be_empty
       end
 
+      it "reports is_following when the stored follower email uses different casing" do
+        mixed = "Buyer.Case@Example.COM"
+        purchase = create(:purchase, purchaser: create(:user), link: @product, email: mixed)
+        create(:active_follower, user: @seller, email: mixed)
+
+        expect(purchase.reload.email).to eq(mixed.downcase)
+        expect(Follower.find_by(followed_id: @seller.id, email: mixed).email).to eq(mixed)
+
+        get :index, params: @params
+
+        sale = response.parsed_body["sales"].find { _1["id"] == purchase.external_id }
+        expect(sale["is_following"]).to eq(true)
+      end
+
+      it "reports is_following when the stored purchase email uses different casing" do
+        purchase = create(:purchase, purchaser: create(:user), link: @product, email: "lookup.case@example.com")
+        purchase.update_columns(email: "Lookup.Case@Example.COM")
+        create(:active_follower, user: @seller, email: "lookup.case@example.com")
+
+        get :index, params: @params
+
+        sale = response.parsed_body["sales"].find { _1["id"] == purchase.external_id }
+        expect(sale["is_following"]).to eq(true)
+      end
+
       it "serializes a full page without per-sale association lookups" do
         purchases_with_upsells = (Api::V2::SalesController::RESULTS_PER_PAGE - 2).times.map do |index|
           product = create(:physical_product, user: @seller, name: "Product #{index}")


### PR DESCRIPTION
- [x] Scope
- [x] Design
- [x] Build
- [x] QA — Sol+Fable panel clean at de620b1e472ff810a6e247aaff7267b943e34170; Fast/Slow CI green (pending=0, fail=0); no rendered surface (Sales API JSON)
- [ ] Shipped
- [ ] Market
- [ ] Sell

## What
This PR removes N+1 queries from GET /api/v2/sales.
 It:
- Preloads the buyer, seller, product, variants, custom fields, shipment, review, offer code, and nested upsell associations used by the sale serializer.
- Loads variant categories in one batch.
- Replaces one follower lookup per sale with a single query for the page.
- Uses preloaded variants when generating variants_and_quantity instead of creating a new relation.
- Applies the optimized serialization path to both page-key and deprecated page-number pagination.
- Adds regression coverage using distinct products, variants, reviews, shipments, custom fields, and populated upsells across a full page

## Why
By profiling the endpoint, I found that serializing ten sales executed repeated lookups for buyers, products, variants, custom fields, followers, upsells, shipments, and reviews. Although the controller already preloaded some associations, `Purchase#as_json` traversed several associations outside that preload set. It also called is_following? once per sale and rebuilt a scoped variant relation even when variants had already been loaded.
The new serialization path batches this work for the entire page while preserving the fallback behavior of `Purchase#as_json` for callers outside the Sales API.

## Performance
I did a benchmark with 5 requests per revision after 3 full warmups with ten fully populated sales
### Comparison (mean / median)
| Metric | Before mean | After mean | Mean change | Before median | After median |
|---|---:|---:|---:|---:|---:|
| Request duration (ms) | 284.66 | 139.70 | -50.9% | 272.39 | 134.76 |
| SQL duration (ms) | 76.31 | 13.21 | -82.7% | 72.04 | 13.19 |
| Allocated objects | 82385 | 56504 | -31.4% | 82383 | 56497 |
| SQL events | 155 | 40 | -74.2% | 155 | 40 |
| Duplicate fingerprints | 133 | 16 | -88.0% | 133 | 16 |
| Association point lookups | 135 | 8 | -94.1% | 135 | 8 |

## QA steps
 1. Create a seller with at least ten successful sales across different products.
 2. Include sales with variants, custom fields, followers, shipments, reviews, and upsells
 3. Request `GET /api/v2/sales` using an OAuth token with the `view_sales` scope
 4. Confirm the response still includes the expected product, variant, custom-field, follower, shipment, review, and upsell data
 5. Repeat using both `page_key` and the deprecated `page` parameter
 6. Inspect SQL instrumentation and confirm association queries are batched rather than repeated for each sale

## Self-review
- Both index pagination paths use the optimized serializer.
- `Purchase#as_json` retains its existing follower lookup when no precomputed value is supplied, avoiding behavior changes for other callers.
- The regression spec uses distinct products so per-product queries cannot be hidden by Active Record's association cache
- Nested upsell serialization is populated and asserted, including selected products and variants
- No API fields are intentionally added or removed
- Page-level follower matching downcases both plucked follower emails and the purchase email, matching the previous case-insensitive SQL lookup.

## Test results

-  End-to-end performance profile — passed response validation across five measured runs.
- `rspec ./spec/controllers/api/v2/sales_controller_spec.rb` — 102 examples, 0 failures (verified on import).
- `rspec ./spec/controllers/api/v2/sales_controller_spec.rb -e "reports is_following when the stored"` — 2 examples, 0 failures at 4ddab93a41.
- Mutation: dropping follower-email downcase fails only the mixed-case follower spec; dropping purchase-email downcase fails only the mixed-case purchase spec.
- Fast/Slow CI green at de620b1e472ff810a6e247aaff7267b943e34170 (pending=0, fail=0), including `run-all-specs`.

## Ownership
Low-risk automerge path: read-only GET /api/v2/sales serializer N+1 (no charges, payouts, balances, pricing, fees, or refunds). Assignee stays gumclaw. `working` removed after Sol+Fable panel clean + CI green at this head.

---

Based on https://github.com/haseebeqx/gumroad/pull/2 by @haseebeqx.

AI Disclosure: deepseek-v4-flash-0731 was used to review the original PR and import the changes.

Premerge review: clean @ de620b1e472ff810a6e247aaff7267b943e34170
