### PR TITLE
Trim StripePaymentPresenter PWYW comments to the selected-tier traps

### DIFF
--- a/app/presenters/checkout/stripe_payment_presenter.rb
+++ b/app/presenters/checkout/stripe_payment_presenter.rb
@@ -631,28 +631,12 @@ class Checkout::StripePaymentPresenter
       end
     end
 
-    # The saved-cart twin of buyer_can_name_price? below. A cart line records the tier the buyer
-    # picked in `option`, so the same rule applies: what decides whether a price is still unknown
-    # is the SELECTED tier, not whether the membership happens to offer a pay-what-you-want tier
-    # somewhere. `Link#has_customizable_price_option?` answers the latter — it scans every alive
-    # tier — so a cart line on a free non-pay-what-you-want tier of a membership that also sells a
-    # pay-what-you-want tier reported a customizable price, suppressed the "not_charged"
-    # classification, and mounted the Payment Element on a checkout that charges nothing.
-    #
-    # Only a TIERED MEMBERSHIP's option carries the flag. `Variant::Prices#set_customizable_price`
-    # returns early for anything else, so an ordinary product's variants always read false even
-    # when the product itself is pay-what-you-want — reading the option there would wrongly call a
-    # real pay-what-you-want cart free. For a non-membership the product's own
-    # `customizable_price` column is authoritative, which is what has_customizable_price_option?
-    # returns for that case.
-    #
-    # A membership line with NO tier recorded reads false rather than deferring to the product.
-    # Both of the product-level answers available here are wrong for it: the tier scan inside
-    # has_customizable_price_option? is the product-wide question this method exists to stop
-    # asking (one pay-what-you-want tier would speak for a line that selected none), and the
-    # `customizable_price` column is unreliable on memberships — it can be stale-true, which is
-    # why buyer_can_name_price? guards it too. On a membership the buyer names a price only
-    # through a tier, so with no tier there is no pending amount and the price is known.
+    # Saved-cart twin of buyer_can_name_price?: unknown price follows the selected tier
+    # (`option`). Link#has_customizable_price_option? scans every alive tier and would
+    # mount Payment Element on a free non-PWYW tier of a mixed membership.
+    # Only a tiered membership's option carries the flag (Variant::Prices#set_customizable_price
+    # early-returns otherwise — a non-membership variant is always false even on PWYW products).
+    # No recorded tier → false; product-level answers are wrong (see stale-true below).
     def cart_line_buyer_can_name_price?(cart_product)
       product = cart_product.product
       return product.has_customizable_price_option? unless product.is_tiered_membership?
@@ -661,36 +645,18 @@ class Checkout::StripePaymentPresenter
       option.present? && option.customizable_price?
     end
 
-    # Whether the buyer can still name their own price for this line, which fallback_reason_for
-    # must not read as "free" (see the zero-total comment there).
+    # Whether the buyer can still name a price — fallback_reason_for must not treat that as
+    # "free" (see the zero-total comment there). Product-level `pwyw` is not tier-aware.
     #
-    # The product-level `pwyw` field is not enough on its own, because it is not tier-aware. For a
-    # tiered membership the TIER carries the flag, via `Variant::Prices` — so the tier is what has
-    # to be consulted, and the product column must not be trusted. A $0 pay-what-you-want
-    # membership opened through /checkout?product=… fell back to CardElement while the same product
-    # added from a saved cart did not.
+    # On a membership the TIER carries the flag (`Variant::Prices`). The product column can
+    # be stale-true: Product::Prices#write_customizable_price runs via price_range= before
+    # is_tiered_membership is set, so a $0 starting price persists customizable_price=true,
+    # and set_customizable_price after_save early-returns for memberships. The column is
+    # also writable on the web and v2 API. Trusting it would mount Payment Element on a
+    # genuinely free membership tier.
     #
-    # Note the product column can be STALE-true on a membership, which is why this reads
-    # `is_tiered_membership` before trusting `pwyw` at all. During create,
-    # `Product::Prices#write_customizable_price` runs (via `price_range=`) while
-    # `is_tiered_membership` is still false, so any membership created with a $0 starting price
-    # persists `customizable_price = true`; the `set_customizable_price` after_save callback
-    # early-returns for memberships, so nothing ever clears it. `customizable_price` is also a
-    # directly writable param on both the web and v2 API update paths. Trusting it here would mount
-    # the Payment Element on a genuinely free membership tier — the defect this method's
-    # selected-tier check exists to prevent — and would disagree with
-    # cart_line_buyer_can_name_price?, which already guards on the membership flag first.
-    #
-    # The tier-level check has to look at the tier the buyer actually SELECTED, not at every tier
-    # the product offers. `options` lists all of them, so asking "does any option allow naming a
-    # price" says yes for a membership that merely HAS a pay-what-you-want tier somewhere — which
-    # would suppress the "free" classification even when the buyer picked a genuinely free tier
-    # with no amount to charge, and mount the Payment Element on a checkout that charges nothing.
-    # `option_id` is the selected tier (CheckoutPresenter sets it from the accepted upsell, the
-    # cart item, or an upgrading subscription's current tier), so scope the check to that option.
-    # A membership with no option_id has no selected tier, and a membership's price can only be
-    # named through a tier, so there is no pending amount and the price is known — the same answer
-    # cart_line_buyer_can_name_price? gives a cart line with no option.
+    # Check the selected option_id (upsell / cart item / upgrading subscription tier), not
+    # every offered tier. No option_id → price known, same as cart_line with no option.
     def buyer_can_name_price?(checkout_product)
       product = checkout_product[:product]
       return product[:pwyw].present? unless product[:is_tiered_membership]


### PR DESCRIPTION
Premerge review: exempt (comments only, no behaviour change)

## What

Compressed the two overlapping PWYW comment essays on `Checkout::StripePaymentPresenter#cart_line_buyer_can_name_price?` and `#buyer_can_name_price?`.

Comments only, no behaviour change. The diff touches no executable code.

## Why

Keep the selected-tier and stale-true traps, cut the restated bug story and the duplicated scan-every-tier explanation so a maintainer who already knows this file can skim it.

## Before / after line counts

- `app/presenters/checkout/stripe_payment_presenter.rb`: 733 → 699 lines (−34)
- `git diff --numstat`: 16 insertions, 50 deletions

## Kept deliberately

- Unknown price follows the selected tier (`option` / `option_id`), not whether the membership offers a PWYW tier somewhere.
- `Link#has_customizable_price_option?` scans every alive tier and would mount Payment Element on a free non-PWYW tier of a mixed membership.
- Only a tiered membership's option carries the flag (`Variant::Prices#set_customizable_price` early-returns otherwise).
- Stale-true `customizable_price`: `write_customizable_price` runs via `price_range=` before `is_tiered_membership` is set; `set_customizable_price` after_save early-returns for memberships; the column is also writable on the web and v2 API.
- No recorded tier → price known. `fallback_reason_for` must not treat a still-nameable price as "free".

## Rejected as not slop

- `Purchase` IOF / tax-report / state-machine comments: already trimmed in #7475; remaining blocks are domain.
- `Order::PreparePaymentIntentService` IOF / Klarna / Pix comments: already trimmed in #7447 and #7463.
- `payment.ts` checkout invariants: already trimmed in #7373.
- `Checkout::BuyerCurrencyEligibility` settlement comments: already trimmed in #7333 / #7283.
- `Checkout/Show.tsx` Inertia `useForm`, Apple Pay precompute, and offer-invalidation ordering comments: load-bearing traps, left alone.

## Test Results

- `ruby -c app/presenters/checkout/stripe_payment_presenter.rb` — Syntax OK
- `bundle exec rubocop app/presenters/checkout/stripe_payment_presenter.rb` — 1 file inspected, no offenses detected
- Isolated `rspec spec/presenters/checkout/stripe_payment_presenter_spec.rb` — 138 examples, 0 failures
- Branch CI push run 33652989040: green on attempt 3. Attempt 1 Compute relevant specs failed on `git fetch origin main` (exit 128, no credentials); attempt 2 Test Relevant shards timed out at 25 minutes in unrelated request specs. `gh run rerun --failed` twice; no code changed.

---

AI disclosure: Grok 4.6. Prompt: scheduled ai-slop-reducer cron for already-merged antiwork/gumroad code; cut AI slop comments only, no behaviour change.
