### PR TITLE
Buffer installment delivery counts during Resend callback waves

### DIFF
--- a/app/models/email_info.rb
+++ b/app/models/email_info.rb
@@ -46,6 +46,14 @@ class EmailInfo < ApplicationRecord
     self.opened_at = nil
   end
 
+  def already_delivered?
+    delivered? || opened?
+  end
+
+  def already_opened?
+    opened?
+  end
+
   def most_recent_state_at
     if opened_at.present?
       opened_at

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -890,17 +890,36 @@ class Installment < ApplicationRecord
     update_counters installment_id, customer_count: by
   end
 
+  # Drops pending-set membership only while the delta is drained. An eager
+  # SREM would strand an increment that lands mid-flush: the producer's SADD
+  # is a no-op while the id is still in the set.
+  REMOVE_DELIVERED_DELTA_IF_DRAINED = <<~LUA
+    local delta = redis.call('GET', KEYS[1])
+    if delta == false or delta == '0' then
+      redis.call('DEL', KEYS[1])
+      redis.call('SREM', KEYS[2], ARGV[1])
+      return 1
+    end
+    return 0
+  LUA
+
   def self.flush_delivered_deltas!
     ids = $redis.smembers(RedisKey.installment_delivered_delta_ids)
     return if ids.blank?
 
     ids.each do |installment_id|
       key = RedisKey.installment_delivered_delta(installment_id)
-      delta = $redis.getset(key, "0").to_i
-      $redis.srem(RedisKey.installment_delivered_delta_ids, installment_id)
-      next if delta == 0
-
-      update_counters installment_id, customer_count: delta
+      delta = $redis.get(key).to_i
+      if delta != 0
+        # MySQL write before the Redis ack: a failed UPDATE leaves the delta
+        # buffered for the Sidekiq retry. DECRBY (not SET 0) preserves
+        # increments that arrive during the UPDATE.
+        update_counters installment_id, customer_count: delta
+        $redis.decrby(key, delta)
+      end
+      $redis.eval(REMOVE_DELIVERED_DELTA_IF_DRAINED,
+                  keys: [key, RedisKey.installment_delivered_delta_ids],
+                  argv: [installment_id])
     end
   rescue Redis::BaseError, RedisClient::Error
     nil

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -872,7 +872,38 @@ class Installment < ApplicationRecord
   end
 
   def increment_total_delivered(by: 1)
-    self.class.update_counters id, customer_count: by
+    self.class.buffer_delivered_delta(id, by)
+  end
+
+  def self.buffer_delivered_delta(installment_id, by)
+    by = by.to_i
+    return if by == 0
+
+    key = RedisKey.installment_delivered_delta(installment_id)
+    $redis.multi do |redis|
+      redis.incrby(key, by)
+      redis.expire(key, 2.days.to_i)
+      redis.sadd(RedisKey.installment_delivered_delta_ids, installment_id)
+    end
+    FlushInstallmentDeliveredDeltasJob.perform_async
+  rescue Redis::BaseError, RedisClient::Error
+    update_counters installment_id, customer_count: by
+  end
+
+  def self.flush_delivered_deltas!
+    ids = $redis.smembers(RedisKey.installment_delivered_delta_ids)
+    return if ids.blank?
+
+    ids.each do |installment_id|
+      key = RedisKey.installment_delivered_delta(installment_id)
+      delta = $redis.getset(key, "0").to_i
+      $redis.srem(RedisKey.installment_delivered_delta_ids, installment_id)
+      next if delta == 0
+
+      update_counters installment_id, customer_count: delta
+    end
+  rescue Redis::BaseError, RedisClient::Error
+    nil
   end
 
   def eligible_purchase_for_user(user)

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -880,14 +880,22 @@ class Installment < ApplicationRecord
     return if by == 0
 
     key = RedisKey.installment_delivered_delta(installment_id)
-    $redis.multi do |redis|
-      redis.incrby(key, by)
-      redis.expire(key, 2.days.to_i)
-      redis.sadd(RedisKey.installment_delivered_delta_ids, installment_id)
+    begin
+      $redis.multi do |redis|
+        redis.incrby(key, by)
+        redis.expire(key, 2.days.to_i)
+        redis.sadd(RedisKey.installment_delivered_delta_ids, installment_id)
+      end
+    rescue Redis::BaseError, RedisClient::Error
+      update_counters installment_id, customer_count: by
+      return
     end
+
     FlushInstallmentDeliveredDeltasJob.perform_async
   rescue Redis::BaseError, RedisClient::Error
-    update_counters installment_id, customer_count: by
+    # Buffer already committed; the minute cron will flush. Do not also
+    # write through — that double-counts when the cron runs.
+    nil
   end
 
   # Drops pending-set membership only while the delta is drained. An eager
@@ -909,13 +917,18 @@ class Installment < ApplicationRecord
 
     ids.each do |installment_id|
       key = RedisKey.installment_delivered_delta(installment_id)
-      delta = $redis.get(key).to_i
+      # Claim before MySQL: GETSET 0 so a crash after UPDATE cannot re-apply
+      # the same delta. INCRBY during the UPDATE lands on the zeroed key and
+      # the Lua SREM-if-drained leaves that remainder discoverable.
+      delta = $redis.getset(key, 0).to_i
       if delta != 0
-        # MySQL write before the Redis ack: a failed UPDATE leaves the delta
-        # buffered for the Sidekiq retry. DECRBY (not SET 0) preserves
-        # increments that arrive during the UPDATE.
-        update_counters installment_id, customer_count: delta
-        $redis.decrby(key, delta)
+        begin
+          update_counters installment_id, customer_count: delta
+        rescue StandardError
+          $redis.incrby(key, delta)
+          $redis.expire(key, 2.days.to_i)
+          raise
+        end
       end
       $redis.eval(REMOVE_DELIVERED_DELTA_IF_DRAINED,
                   keys: [key, RedisKey.installment_delivered_delta_ids],

--- a/app/modules/post/caching.rb
+++ b/app/modules/post/caching.rb
@@ -1,12 +1,27 @@
 # frozen_string_literal: true
 
 module Post::Caching
-  # The _ddb suffix is permanent: dropping it would resurface counts cached
-  # before the engagement store moved. dynamodb_reads: false still names the
-  # unsuffixed legacy key so event handlers can purge it per installment
-  # (Memcached cannot bulk-delete).
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    # The _ddb suffix is permanent: dropping it would resurface counts cached
+    # before the engagement store moved. dynamodb_reads: false still names the
+    # unsuffixed legacy key so event handlers can purge it per installment
+    # (Memcached cannot bulk-delete).
+    def cache_key_for(installment_id, key, dynamodb_reads: true)
+      "#{key}_for_installment_#{installment_id}#{dynamodb_reads ? "_ddb" : ""}"
+    end
+
+    def invalidate_engagement_cache(installment_id, key)
+      Rails.cache.delete(cache_key_for(installment_id, key))
+      Rails.cache.delete(cache_key_for(installment_id, key, dynamodb_reads: false))
+    end
+  end
+
   def key_for_cache(key, dynamodb_reads: true)
-    "#{key}_for_installment_#{id}#{dynamodb_reads ? "_ddb" : ""}"
+    self.class.cache_key_for(id, key, dynamodb_reads:)
   end
 
   def invalidate_cache(key)

--- a/app/services/handle_email_event_info/for_abandoned_cart_email.rb
+++ b/app/services/handle_email_event_info/for_abandoned_cart_email.rb
@@ -46,8 +46,7 @@ class HandleEmailEventInfo::ForAbandonedCartEmail
     end
 
     def update_installment_cache(installment, key)
-      installment.invalidate_cache(key)
-      installment.invalidate_legacy_engagement_cache(key)
+      Installment.invalidate_engagement_cache(installment.id, key)
     end
 
     def common_event_attributes(installment)

--- a/app/services/handle_email_event_info/for_installment_email.rb
+++ b/app/services/handle_email_event_info/for_installment_email.rb
@@ -35,14 +35,16 @@ class HandleEmailEventInfo::ForInstallmentEmail
 
     def handle_delivered_event!
       email_info = pull_creator_contacting_customers_email_info(email_event_info)
-      email_info.mark_delivered!(email_event_info.created_at) if email_info.present?
+      return if email_info.blank? || email_info.already_delivered?
+
+      email_info.mark_delivered!(email_event_info.created_at)
     end
 
     def handle_open_event!
       EmailEngagementDynamoStore.record_open(**dynamo_engagement_attributes)
 
       email_info = pull_creator_contacting_customers_email_info(email_event_info)
-      email_info.mark_opened!(email_event_info.created_at) if email_info.present?
+      email_info.mark_opened!(email_event_info.created_at) if email_info.present? && !email_info.already_opened?
 
       update_installment_cache(email_event_info.installment_id, :unique_open_count)
     end
@@ -55,7 +57,7 @@ class HandleEmailEventInfo::ForInstallmentEmail
       update_installment_cache(email_event_info.installment_id, :unique_open_count)
 
       email_info = pull_creator_contacting_customers_email_info(email_event_info)
-      email_info.mark_opened!(email_event_info.created_at) if email_info&.persisted? && !email_info.opened?
+      email_info.mark_opened!(email_event_info.created_at) if email_info&.persisted? && !email_info.already_opened?
     end
 
     def handle_spamreport_event!
@@ -93,11 +95,10 @@ class HandleEmailEventInfo::ForInstallmentEmail
     end
 
     def update_installment_cache(installment_id, key)
-      installment = Installment.find(installment_id)
       # DDB aggregates are live GetItem reads. Clear stale cache entries for
-      # this event, but do not precompute counters from the discarded instance.
-      installment.invalidate_cache(key)
-      installment.invalidate_legacy_engagement_cache(key)
+      # this event, but do not precompute counters from a discarded instance —
+      # and do not SELECT installments just to build a key from the id.
+      Installment.invalidate_engagement_cache(installment_id, key)
     end
 
     def dynamo_engagement_attributes

--- a/app/services/handle_email_event_info/for_receipt_email.rb
+++ b/app/services/handle_email_event_info/for_receipt_email.rb
@@ -18,9 +18,9 @@ class HandleEmailEventInfo::ForReceiptEmail
     when EmailEventInfo::EVENT_BOUNCED
       email_info.mark_bounced!
     when EmailEventInfo::EVENT_DELIVERED
-      email_info.mark_delivered!(email_event_info.created_at)
+      email_info.mark_delivered!(email_event_info.created_at) unless email_info.already_delivered?
     when EmailEventInfo::EVENT_OPENED
-      email_info.mark_opened!(email_event_info.created_at)
+      email_info.mark_opened!(email_event_info.created_at) unless email_info.already_opened?
     when EmailEventInfo::EVENT_COMPLAINED
       unless email_event_info.email_provider == MailerInfo::EMAIL_PROVIDER_RESEND
         Purchase.find_by(id: email_event_info.purchase_id)

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -139,5 +139,9 @@ class RedisKey
     def workflow_immediate_fanout_max_spread_seconds = "workflow_immediate_fanout_max_spread_seconds"
     def seller_large_blast_threshold = "seller_large_blast_threshold"
     def seller_large_blast_quota(seller_id, day) = "seller_large_blast_quota:#{seller_id}:#{day}"
+    # Buffered installment.customer_count increments. Midnight Resend callback
+    # waves (and blast sends) used to UPDATE the same row per event/batch.
+    def installment_delivered_delta(installment_id) = "installment:#{installment_id}:delivered_delta"
+    def installment_delivered_delta_ids = "installment:delivered_delta_ids"
   end
 end

--- a/app/sidekiq/flush_installment_delivered_deltas_job.rb
+++ b/app/sidekiq/flush_installment_delivered_deltas_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FlushInstallmentDeliveredDeltasJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low, lock: :until_executed
+
+  include RecurringLockTtl
+  recurring_lock_ttl max_attempt: 10.minutes
+
+  def perform
+    Installment.flush_delivered_deltas!
+  end
+end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -18,6 +18,10 @@ update_purchase_healthcheck_threshold:
   cron: "* * * * *" # Every minute — the threshold carries a 1h TTL, so the healthcheck fails closed if this stalls
   class: UpdatePurchaseHealthcheckThresholdJob
   description: Recomputes the /healthcheck/purchases threshold from the prior 7 days' purchase rate
+flush_installment_delivered_deltas:
+  cron: "* * * * *" # Every minute
+  class: FlushInstallmentDeliveredDeltasJob
+  description: Flushes Redis-buffered installment customer_count increments from blast sends and email callbacks
 
 # Hourly
 repair_order_charge_outcomes:

--- a/spec/services/handle_email_event_info/for_abandoned_cart_email_spec.rb
+++ b/spec/services/handle_email_event_info/for_abandoned_cart_email_spec.rb
@@ -22,6 +22,7 @@ describe HandleEmailEventInfo::ForAbandonedCartEmail do
       it "tracks a delivered event" do
         expect do
           handler_class_for(email_provider).new.perform(params)
+          Installment.flush_delivered_deltas!
         end.to change { abandoned_cart_workflow_installment1.reload.customer_count }.from(nil).to(1)
           .and change { abandoned_cart_workflow_installment3.reload.customer_count }.from(nil).to(1)
 

--- a/spec/services/handle_email_event_info/for_installment_email_spec.rb
+++ b/spec/services/handle_email_event_info/for_installment_email_spec.rb
@@ -206,6 +206,33 @@ describe HandleEmailEventInfo::ForInstallmentEmail do
             expect(@email_info.reload.delivered_at).to eq(Time.zone.at(params["_json"].first["timestamp"]))
           end
 
+          it "does not rewrite an already-delivered email_info" do
+            @email_info.mark_sent!
+            @email_info.mark_delivered!(2.days.ago)
+            original_delivered_at = @email_info.reload.delivered_at
+
+            params = { "_json" => [{ "event" => "delivered", "type" => "CreatorContactingCustomersMailer.purchase_installment",
+                                     "identifier" => @identifier, "installment_id" => @installment.id, "timestamp" => Time.current.to_i }] }
+            HandleSendgridEventJob.new.perform(params)
+
+            expect(@email_info.reload.state).to eq "delivered"
+            expect(@email_info.delivered_at.to_i).to eq(original_delivered_at.to_i)
+          end
+
+          it "does not downgrade an opened email_info on a late delivered event" do
+            @email_info.mark_sent!
+            @email_info.mark_delivered!
+            @email_info.mark_opened!
+            opened_at = @email_info.reload.opened_at
+
+            params = { "_json" => [{ "event" => "delivered", "type" => "CreatorContactingCustomersMailer.purchase_installment",
+                                     "identifier" => @identifier, "installment_id" => @installment.id, "timestamp" => Time.current.to_i }] }
+            HandleSendgridEventJob.new.perform(params)
+
+            expect(@email_info.reload.state).to eq "opened"
+            expect(@email_info.opened_at.to_i).to eq(opened_at.to_i)
+          end
+
           it "marks it as opened" do
             params = { "_json" => [{ "event" => "open", "type" => "CreatorContactingCustomersMailer.purchase_installment",
                                      "identifier" => @identifier, "installment_id" => @installment.id, "timestamp" => 1.hour.ago.to_i }] }

--- a/spec/services/post_resend_api_spec.rb
+++ b/spec/services/post_resend_api_spec.rb
@@ -389,6 +389,7 @@ describe PostResendApi, :freeze_time do
                   { email: "c1@example.com" },
                   { email: "c2@example.com" }
                 ], blast: blast_1)
+    Installment.flush_delivered_deltas!
 
     expect(@post.reload.customer_count).to eq(2)
     expect(blast_1.reload.delivery_count).to eq(2)
@@ -397,6 +398,7 @@ describe PostResendApi, :freeze_time do
     send_emails(recipients: [
                   { email: "c3@example.com" }
                 ], blast: blast_2)
+    Installment.flush_delivered_deltas!
 
     expect(@post.reload.customer_count).to eq(3)
     expect(blast_2.reload.delivery_count).to eq(1)

--- a/spec/services/post_sendgrid_api_spec.rb
+++ b/spec/services/post_sendgrid_api_spec.rb
@@ -366,6 +366,7 @@ describe PostSendgridApi, :freeze_time do
                   { email: "c1@example.com" },
                   { email: "c2@example.com" }
                 ], blast: blast_1)
+    Installment.flush_delivered_deltas!
 
     expect(@post.reload.customer_count).to eq(2)
     expect(blast_1.reload.delivery_count).to eq(2)
@@ -374,6 +375,7 @@ describe PostSendgridApi, :freeze_time do
     send_emails(recipients: [
                   { email: "c3@example.com" }
                 ], blast: blast_2)
+    Installment.flush_delivered_deltas!
 
     expect(@post.reload.customer_count).to eq(3)
     expect(blast_2.reload.delivery_count).to eq(1)

--- a/spec/sidekiq/flush_installment_delivered_deltas_job_spec.rb
+++ b/spec/sidekiq/flush_installment_delivered_deltas_job_spec.rb
@@ -57,6 +57,28 @@ describe FlushInstallmentDeliveredDeltasJob do
     end.to change { installment.reload.customer_count }.from(4).to(7)
   end
 
+  it "does not write through when enqueueing the flush job fails" do
+    allow(FlushInstallmentDeliveredDeltasJob).to receive(:perform_async).and_raise(Redis::BaseError)
+    expect do
+      installment.increment_total_delivered(by: 2)
+    end.not_to change { installment.reload.customer_count }
+
+    allow(FlushInstallmentDeliveredDeltasJob).to receive(:perform_async).and_call_original
+    expect do
+      described_class.new.perform
+    end.to change { installment.reload.customer_count }.from(4).to(6)
+  end
+
+  it "does not re-apply a claimed delta on a second flush" do
+    installment.increment_total_delivered(by: 2)
+    described_class.new.perform
+    expect(installment.reload.customer_count).to eq(6)
+
+    expect do
+      described_class.new.perform
+    end.not_to change { installment.reload.customer_count }
+  end
+
   it "does not SELECT installments to drop engagement cache" do
     allow(Installment).to receive(:find).and_call_original
     Rails.cache.write(installment.key_for_cache(:unique_open_count), 0)

--- a/spec/sidekiq/flush_installment_delivered_deltas_job_spec.rb
+++ b/spec/sidekiq/flush_installment_delivered_deltas_job_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe FlushInstallmentDeliveredDeltasJob do
+  let(:installment) { create(:installment, customer_count: 4) }
+
+  it "folds buffered increments into one customer_count update" do
+    expect do
+      installment.increment_total_delivered(by: 2)
+      installment.increment_total_delivered(by: 3)
+    end.not_to change { installment.reload.customer_count }
+
+    expect do
+      described_class.new.perform
+    end.to change { installment.reload.customer_count }.from(4).to(9)
+  end
+
+  it "writes through immediately when Redis is down" do
+    allow($redis).to receive(:multi).and_raise(Redis::BaseError)
+    expect do
+      installment.increment_total_delivered(by: 2)
+    end.to change { installment.reload.customer_count }.from(4).to(6)
+  end
+
+  it "does not SELECT installments to drop engagement cache" do
+    allow(Installment).to receive(:find).and_call_original
+    Rails.cache.write(installment.key_for_cache(:unique_open_count), 0)
+    Rails.cache.write(installment.key_for_cache(:unique_open_count, dynamodb_reads: false), 0)
+
+    Installment.invalidate_engagement_cache(installment.id, :unique_open_count)
+
+    expect(Installment).not_to have_received(:find)
+    expect(Rails.cache.read(installment.key_for_cache(:unique_open_count))).to be_nil
+    expect(Rails.cache.read(installment.key_for_cache(:unique_open_count, dynamodb_reads: false))).to be_nil
+  end
+end

--- a/spec/sidekiq/flush_installment_delivered_deltas_job_spec.rb
+++ b/spec/sidekiq/flush_installment_delivered_deltas_job_spec.rb
@@ -21,6 +21,42 @@ describe FlushInstallmentDeliveredDeltasJob do
     end.to change { installment.reload.customer_count }.from(4).to(6)
   end
 
+  it "keeps an increment that lands mid-flush discoverable by the next flush" do
+    installment.increment_total_delivered(by: 2)
+
+    allow(Installment).to receive(:update_counters).and_wrap_original do |m, *args, **kwargs|
+      installment.increment_total_delivered(by: 5)
+      m.call(*args, **kwargs)
+    end
+
+    expect do
+      described_class.new.perform
+    end.to change { installment.reload.customer_count }.from(4).to(6)
+
+    expect($redis.sismember(RedisKey.installment_delivered_delta_ids, installment.id)).to be(true)
+
+    allow(Installment).to receive(:update_counters).and_call_original
+    expect do
+      described_class.new.perform
+    end.to change { installment.reload.customer_count }.from(6).to(11)
+    expect($redis.sismember(RedisKey.installment_delivered_delta_ids, installment.id)).to be(false)
+  end
+
+  it "retains the buffered delta when the customer_count update fails" do
+    installment.increment_total_delivered(by: 3)
+
+    allow(Installment).to receive(:update_counters).and_raise(ActiveRecord::StatementInvalid)
+    expect do
+      described_class.new.perform
+    end.to raise_error(ActiveRecord::StatementInvalid)
+    expect(installment.reload.customer_count).to eq(4)
+
+    allow(Installment).to receive(:update_counters).and_call_original
+    expect do
+      described_class.new.perform
+    end.to change { installment.reload.customer_count }.from(4).to(7)
+  end
+
   it "does not SELECT installments to drop engagement cache" do
     allow(Installment).to receive(:find).and_call_original
     Rails.cache.write(installment.key_for_cache(:unique_open_count), 0)


### PR DESCRIPTION
## What

Reduce MySQL write load from midnight Resend callback waves.

- Buffer `Installment#increment_total_delivered` in Redis and flush to one `UPDATE` per installment (`FlushInstallmentDeliveredDeltasJob`, every minute + on increment).
- Skip `email_info` delivered/opened writes when the row is already in that state (or already opened, so a late `email.delivered` cannot downgrade it).
- Invalidate engagement cache from the installment id without `Installment.find`.

Fixes antiwork/gumroad-private#2383.

## Why

2026-09-03 00:00–00:12 UTC: 650k `POST /resend-webhook` completions. Shopper pages took seconds (blue target RT 4.16s) with zero ALB 5xx. PI showed `COMMIT`, `UPDATE installments SET customer_count`, and `email_infos` lookups as the load. Queue isolation was closed in #7462 (Ershad: keep autoscaling). Remaining work is fewer per-event MySQL writes.

## Before / After

| | Before | After |
|---|---|---|
| Blast / abandoned-cart `customer_count` | One `UPDATE` per batch/callback on the same row | Redis `INCRBY`, one `UPDATE` on flush |
| Delivered callback on already-delivered/opened row | `mark_delivered!` saves (`any => :delivered`, can downgrade opened) | No write |
| Open/click cache drop | `Installment.find` then delete keys | Delete keys from id |

No user-facing UI. Open/click still go to Dynamo.

## Test Results

Local at `80e6d831f3a0b7c84967e44d5e7fffd443626116`:

- `spec/sidekiq/flush_installment_delivered_deltas_job_spec.rb` — **7 examples, 0 failures** in 4.87s (buffer then one UPDATE; Redis-down write-through; mid-flush increment; failed UPDATE restores the claim; enqueue failure does not write through; second flush is a no-op; cache invalidation without `find`)
- Earlier focused set still covers installment/abandoned-cart event handlers (already-delivered not rewritten; opened not downgraded; abandoned-cart still increments after flush)

Flush protocol at this head (premerge round 1, Sol+Fable P1s):

- Buffer `MULTI` has its own rescue (write-through). `perform_async` failure does **not** write through — the minute cron flushes the committed delta. Writing through after a committed buffer double-counts.
- Flush **GETSET**s the delta to 0 **before** `update_counters`, restores with `INCRBY` if the UPDATE fails, and `SREM`s only via the drained-check Lua. A crash after UPDATE cannot re-apply the same delta (the previous MySQL-then-`DECRBY` protocol could).

## Premerge

Sol+Fable panel at `168b049be3`: 3 P1s (enqueue write-through double-count ×2 reviewers; MySQL-then-DECRBY crash double-count). Fixed in `80e6d831f3`.

Sol+Fable panel at `80e6d831f3`: Claude 0 findings; Codex 2 P1s declined — both are the Redis/MySQL dual-write leftover (GETSET-then-kill undercounts; a lost `EXEC` reply plus write-through overcounts). Closing either reopens the other without a MySQL-side ack. Chosen tradeoff: undercount on a killed worker, never double a blast-sized delta. No rendered surface.

## QA steps

No rendered surface. Reviewers:

1. Read `Installment.buffer_delivered_delta` / `flush_delivered_deltas!` and the skip in `HandleEmailEventInfo::ForInstallmentEmail#handle_delivered_event!`.
2. Run `spec/sidekiq/flush_installment_delivered_deltas_job_spec.rb`.

- [x] Scope — batch callback/send MySQL writes, not queue isolation
- [x] Design — Redis buffer + no-op email_info + cache-without-find
- [x] Build
- [ ] QA — CI on `80e6d831f3` (panel done)
- [ ] Shipped

---

AI disclosure: Generated with grok-4.6. The code was reviewed, tested, and I take full responsibility for it.

Premerge review: clean @ 80e6d831f3a0b7c84967e44d5e7fffd443626116
