### PR TITLE
Replace clsx + tailwind-merge with cn

### DIFF
--- a/app/javascript/utils/classNames.ts
+++ b/app/javascript/utils/classNames.ts
@@ -1,6 +1,1 @@
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function classNames(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn as classNames } from "cn";

--- a/docs/prompts/tailwindcss.md
+++ b/docs/prompts/tailwindcss.md
@@ -40,8 +40,8 @@ I'm migrating a CSS component to Tailwind CSS. Please help me convert the existi
   import cx from "classnames";
   cx("base-class", condition && "conditional-class");
 
-  import twMerge from "tailwind-merge";
-  twMerge("base-class", condition && "conditional-class");
+  import { classNames } from "$app/utils/classNames";
+  classNames("base-class", condition && "conditional-class");
   ```
 
 #### Avoid `!important`

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "class-variance-authority": "^0.7.1",
         "classnames": "^2.3.2",
         "clipboard": "^2.0.11",
-        "clsx": "^2.1.1",
+        "cn": "^0.2.4",
         "date-fns": "^3.0.0",
         "date-fns-tz": "^3.0.0",
         "dompurify": "^3.4.0",
@@ -57,7 +57,6 @@
         "react-sortablejs": "^6.1.4",
         "recharts": "^2.15.2",
         "sortablejs": "^1.15.0",
-        "tailwind-merge": "^3.3.1",
         "typia": "^12.1.1"
       },
       "devDependencies": {
@@ -6363,6 +6362,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cn": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/cn/-/cn-0.2.4.tgz",
+      "integrity": "sha512-SzQvoh5FwizWtQg9+JueKdjWhlfCZMdu5DqNHm9q1wUlRVmKb9WXlepR9bTTbPwzEOyX1ujJ6lcCppmn3bNUCg==",
+      "license": "MIT",
+      "bin": {
+        "cn": "bin/cn.mjs"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/color-convert": {
@@ -14586,16 +14597,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
-      }
-    },
-    "node_modules/tailwind-merge": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
-      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "class-variance-authority": "^0.7.1",
     "classnames": "^2.3.2",
     "clipboard": "^2.0.11",
-    "clsx": "^2.1.1",
+    "cn": "^0.2.4",
     "date-fns": "^3.0.0",
     "date-fns-tz": "^3.0.0",
     "dompurify": "^3.4.0",
@@ -59,7 +59,6 @@
     "react-sortablejs": "^6.1.4",
     "recharts": "^2.15.2",
     "sortablejs": "^1.15.0",
-    "tailwind-merge": "^3.3.1",
     "typia": "^12.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Applies https://x.com/aidenybai/status/2095180564274065825 — shadcn + aidenybai open-sourced [`cn`](https://github.com/shadcn-ui/cn), a drop-in replacement for `clsx` + `tailwind-merge` with the same output and ~30× faster merging.

**Change**
- `classNames()` now re-exports `cn` from the `cn` package (the util keeps its name so no call sites change).
- `clsx` and `tailwind-merge` removed from `package.json` (`clsx` remains transitively via `class-variance-authority` / `recharts`).
- `docs/prompts/tailwindcss.md` example points at our `classNames` util instead of a bare `tailwind-merge` import.

**Verification**
- `tsc --noEmit`: clean.
- `vitest run`: 143 files, 1549 passed, 0 failed (after `npx patch-package` to refresh a stale local install).
- Differential check: extracted the string literals from every `classNames(...)` call in `app/javascript` (206 cases / 108 files) and ran them through `cn` vs `twMerge(clsx(...))` 3.3.1, plus an object/override variant — 0 mismatches.

**Notes**
- `cn` requires Tailwind v4 (we're on v4) and Node 20+ (we pin 22).
- `experimentalParseClassName` is the only tailwind-merge API not supported; we don't use it.


Premerge review: clean @ 3db6c58c8bda313d1efc82df74fc6045c4fe7600
