### PR TITLE
Make the origin/main refresh in Compute relevant specs best-effort

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -965,7 +965,10 @@ jobs:
       - name: Compute relevant specs
         id: specs
         run: |
-          git fetch --no-tags --quiet origin main
+          # Best-effort: checkout (fetch-depth 0) already has origin/main, and this
+          # anonymous fetch (persist-credentials off) intermittently gets a
+          # credential prompt from GitHub, which would fail the job for nothing.
+          git fetch --no-tags --quiet origin main || echo "origin/main refresh failed; using the ref from checkout"
           set +e
           SPECS=$(ruby bin/branch-specs)
           STATUS=$?


### PR DESCRIPTION
## What

The `Compute relevant specs` job refreshes `origin/main` with an anonymous `git fetch` right after a `fetch-depth: 0` checkout that already has it. That fetch intermittently fails with `fatal: could not read Username for 'https://github.com'` and kills the job for a diff that has nothing to do with it. This makes the refresh best-effort: on failure it logs and continues with the ref from checkout.

## Why

Four occurrences in the last 12 hours, every one green on rerun, none related to the diff:

- cn-migrate #7490: [run 33706509944](https://github.com/antiwork/gumroad/actions/runs/33706509944) — failed twice (initial + rerun)
- gp2383-batch-resend-writes: [job 100480210835](https://github.com/antiwork/gumroad/actions/runs/33701018317/job/100480210835)
- gumroad/gp2371-youtube-connect: [run 33688628725](https://github.com/antiwork/gumroad/actions/runs/33688628725)

The job runs with `persist-credentials: false` on purpose (fork-controlled `bin/branch-specs` must never see a token), so the answer is not to authenticate the fetch; it is to not depend on it. `bin/branch-specs` only needs `origin/main` to resolve, which the checkout guarantees.

## Test Results

Workflow-only change; no app code. Validated the YAML parses and the step still fails hard on `bin/branch-specs` exit codes (those paths are untouched).

## QA steps

Reviewer: read the one-line diff in `.github/workflows/tests.yml`.

- [x] Scope
- [x] Build
- [ ] QA — CI on this PR
- [ ] Shipped


Premerge review: clean @ 2bc40bd27ddcf8f4fb8ac0ddca78110c4387f734

