### PR TITLE
Batch email_infos delivered writes from Resend callbacks

### DIFF
--- a/app/models/email_info.rb
+++ b/app/models/email_info.rb
@@ -54,6 +54,9 @@ class EmailInfo < ApplicationRecord
     local items = redis.call("LRANGE", KEYS[1], 0, tonumber(ARGV[1]) - 1)
     if #items == 0 then return {} end
     redis.call("LTRIM", KEYS[1], #items, -1)
+    for i = 1, #items do
+      redis.call("RPUSH", KEYS[2], items[i])
+    end
     return items
   LUA
   RENEW_FLUSH_LOCK_LUA = <<~LUA
@@ -94,23 +97,21 @@ class EmailInfo < ApplicationRecord
     return unless $redis.set(lock_key, token, nx: true, ex: FLUSH_LOCK_TTL.to_i)
 
     key = RedisKey.email_info_delivered_buffer
+    inflight_key = RedisKey.email_info_delivered_inflight
     chunks = 0
     begin
       loop do
         break if chunks >= MAX_FLUSH_CHUNKS
         renew_flush_lock!(lock_key, token)
 
-        # Claim the prefix atomically so a second flush cannot LTRIM a chunk it
-        # never applied if this run outlives the lock during the UPDATEs.
-        raw = $redis.eval(TAKE_CHUNK_LUA, keys: [key], argv: [DELIVERED_BUFFER_CHUNK])
+        raw = $redis.lrange(inflight_key, 0, -1)
+        if raw.blank?
+          raw = $redis.eval(TAKE_CHUNK_LUA, keys: [key, inflight_key], argv: [DELIVERED_BUFFER_CHUNK])
+        end
         break if raw.blank?
 
-        begin
-          apply_delivered_chunk!(raw.map { JSON.parse(_1) }) { renew_flush_lock!(lock_key, token) }
-        rescue StandardError
-          $redis.lpush(key, *raw.reverse) if raw.present?
-          raise
-        end
+        apply_delivered_chunk!(raw.map { JSON.parse(_1) }) { renew_flush_lock!(lock_key, token) }
+        $redis.del(inflight_key)
         chunks += 1
       end
     ensure

--- a/app/models/email_info.rb
+++ b/app/models/email_info.rb
@@ -65,6 +65,13 @@ class EmailInfo < ApplicationRecord
     end
     return 0
   LUA
+  ACK_INFLIGHT_LUA = <<~LUA
+    if redis.call("GET", KEYS[1]) == ARGV[1] then
+      redis.call("DEL", KEYS[2])
+      return 1
+    end
+    return 0
+  LUA
   RELEASE_FLUSH_LOCK_LUA = <<~LUA
     if redis.call("GET", KEYS[1]) == ARGV[1] then
       return redis.call("DEL", KEYS[1])
@@ -102,7 +109,7 @@ class EmailInfo < ApplicationRecord
     begin
       loop do
         break if chunks >= MAX_FLUSH_CHUNKS
-        renew_flush_lock!(lock_key, token)
+        break unless renew_flush_lock!(lock_key, token)
 
         raw = $redis.lrange(inflight_key, 0, -1)
         if raw.blank?
@@ -110,8 +117,13 @@ class EmailInfo < ApplicationRecord
         end
         break if raw.blank?
 
-        apply_delivered_chunk!(raw.map { JSON.parse(_1) }) { renew_flush_lock!(lock_key, token) }
-        $redis.del(inflight_key)
+        lost_lock = false
+        apply_delivered_chunk!(raw.map { JSON.parse(_1) }) do
+          renew_flush_lock!(lock_key, token).tap { |held| lost_lock = true unless held }
+        end
+        break if lost_lock
+
+        $redis.eval(ACK_INFLIGHT_LUA, keys: [lock_key, inflight_key], argv: [token])
         chunks += 1
       end
     ensure
@@ -120,12 +132,12 @@ class EmailInfo < ApplicationRecord
   end
 
   def self.renew_flush_lock!(lock_key, token)
-    $redis.eval(RENEW_FLUSH_LOCK_LUA, keys: [lock_key], argv: [token, FLUSH_LOCK_TTL.to_i])
+    $redis.eval(RENEW_FLUSH_LOCK_LUA, keys: [lock_key], argv: [token, FLUSH_LOCK_TTL.to_i]).to_i == 1
   end
 
   def self.apply_delivered_chunk!(records)
     records.group_by { _1["i"] }.each do |installment_id, group|
-      yield if block_given?
+      return if block_given? && !yield
 
       delivered_at_by_purchase = group.each_with_object({}) do |record, acc|
         acc[record["p"]] = [acc[record["p"]], record["t"]].compact.min

--- a/app/models/email_info.rb
+++ b/app/models/email_info.rb
@@ -46,6 +46,63 @@ class EmailInfo < ApplicationRecord
     self.opened_at = nil
   end
 
+  DELIVERED_BUFFER_CHUNK = 1000
+
+  # Delivered callbacks arrive in waves of ~1M within minutes; a row-per-event
+  # UPDATE+commit is what shows up as COMMIT/binlog waits. Buffer in Redis and
+  # let FlushDeliveredEmailInfosJob apply one UPDATE per installment.
+  # Returns false when Redis rejects the push so the caller can write through.
+  def self.buffer_delivered(installment_id:, purchase_id:, delivered_at:)
+    payload = { i: installment_id, p: purchase_id, t: delivered_at.to_i }.to_json
+    begin
+      $redis.rpush(RedisKey.email_info_delivered_buffer, payload)
+    rescue Redis::BaseError, RedisClient::Error
+      return false
+    end
+
+    # Buffered already; if the enqueue fails the minute cron picks it up.
+    FlushDeliveredEmailInfosJob.perform_async
+    true
+  rescue Redis::BaseError, RedisClient::Error
+    true
+  end
+
+  def self.flush_delivered_buffer!
+    key = RedisKey.email_info_delivered_buffer
+    loop do
+      raw = $redis.lpop(key, DELIVERED_BUFFER_CHUNK)
+      break if raw.blank?
+
+      begin
+        apply_delivered_chunk!(raw.map { JSON.parse(_1) })
+      rescue StandardError
+        # Re-applying is harmless: the state filter makes the UPDATE idempotent,
+        # so a chunk that half-landed can be replayed by the retry.
+        $redis.rpush(key, raw)
+        raise
+      end
+    end
+  end
+
+  def self.apply_delivered_chunk!(records)
+    records.group_by { _1["i"] }.each do |installment_id, group|
+      delivered_at_by_purchase = group.each_with_object({}) do |record, acc|
+        acc[record["p"]] = [acc[record["p"]], record["t"]].compact.min
+      end
+
+      delivered_at_by_purchase.each_slice(DELIVERED_BUFFER_CHUNK) do |slice|
+        whens = slice.map do |purchase_id, epoch|
+          sanitize_sql_array(["WHEN ? THEN ?", purchase_id, Time.zone.at(epoch)])
+        end
+        # Only created/sent rows move: a late delivered callback must never
+        # downgrade opened, and an existing delivered_at is kept.
+        CreatorContactingCustomersEmailInfo
+          .where(installment_id:, purchase_id: slice.map(&:first), state: %w[created sent])
+          .update_all(Arel.sql("state = 'delivered', delivered_at = CASE purchase_id #{whens.join(' ')} END"))
+      end
+    end
+  end
+
   def most_recent_state_at
     if opened_at.present?
       opened_at

--- a/app/models/email_info.rb
+++ b/app/models/email_info.rb
@@ -70,17 +70,13 @@ class EmailInfo < ApplicationRecord
   def self.flush_delivered_buffer!
     key = RedisKey.email_info_delivered_buffer
     loop do
-      raw = $redis.lpop(key, DELIVERED_BUFFER_CHUNK)
+      # Peek then drop. LPOP-then-restore loses the chunk if both the UPDATE
+      # and the recovery RPUSH fail.
+      raw = $redis.lrange(key, 0, DELIVERED_BUFFER_CHUNK - 1)
       break if raw.blank?
 
-      begin
-        apply_delivered_chunk!(raw.map { JSON.parse(_1) })
-      rescue StandardError
-        # Re-applying is harmless: the state filter makes the UPDATE idempotent,
-        # so a chunk that half-landed can be replayed by the retry.
-        $redis.rpush(key, raw)
-        raise
-      end
+      apply_delivered_chunk!(raw.map { JSON.parse(_1) })
+      $redis.ltrim(key, raw.size, -1)
     end
   end
 

--- a/app/models/email_info.rb
+++ b/app/models/email_info.rb
@@ -48,7 +48,26 @@ class EmailInfo < ApplicationRecord
 
   DELIVERED_BUFFER_CHUNK = 1000
   MAX_FLUSH_CHUNKS = 50
-  FLUSH_LOCK_TTL = 2.minutes
+  FLUSH_LOCK_TTL = 10.minutes
+
+  TAKE_CHUNK_LUA = <<~LUA
+    local items = redis.call("LRANGE", KEYS[1], 0, tonumber(ARGV[1]) - 1)
+    if #items == 0 then return {} end
+    redis.call("LTRIM", KEYS[1], #items, -1)
+    return items
+  LUA
+  RENEW_FLUSH_LOCK_LUA = <<~LUA
+    if redis.call("GET", KEYS[1]) == ARGV[1] then
+      return redis.call("EXPIRE", KEYS[1], ARGV[2])
+    end
+    return 0
+  LUA
+  RELEASE_FLUSH_LOCK_LUA = <<~LUA
+    if redis.call("GET", KEYS[1]) == ARGV[1] then
+      return redis.call("DEL", KEYS[1])
+    end
+    return 0
+  LUA
 
   # Delivered callbacks arrive in waves of ~1M within minutes; a row-per-event
   # UPDATE+commit is what shows up as COMMIT/binlog waits. Buffer in Redis and
@@ -79,23 +98,34 @@ class EmailInfo < ApplicationRecord
     begin
       loop do
         break if chunks >= MAX_FLUSH_CHUNKS
+        renew_flush_lock!(lock_key, token)
 
-        # Peek then drop. Safe only with one consumer (the Redis lock above).
-        raw = $redis.lrange(key, 0, DELIVERED_BUFFER_CHUNK - 1)
+        # Claim the prefix atomically so a second flush cannot LTRIM a chunk it
+        # never applied if this run outlives the lock during the UPDATEs.
+        raw = $redis.eval(TAKE_CHUNK_LUA, keys: [key], argv: [DELIVERED_BUFFER_CHUNK])
         break if raw.blank?
 
-        apply_delivered_chunk!(raw.map { JSON.parse(_1) })
-        $redis.ltrim(key, raw.size, -1)
+        begin
+          apply_delivered_chunk!(raw.map { JSON.parse(_1) }) { renew_flush_lock!(lock_key, token) }
+        rescue StandardError
+          $redis.lpush(key, *raw.reverse) if raw.present?
+          raise
+        end
         chunks += 1
-        $redis.expire(lock_key, FLUSH_LOCK_TTL.to_i)
       end
     ensure
-      $redis.del(lock_key) if $redis.get(lock_key) == token
+      $redis.eval(RELEASE_FLUSH_LOCK_LUA, keys: [lock_key], argv: [token])
     end
+  end
+
+  def self.renew_flush_lock!(lock_key, token)
+    $redis.eval(RENEW_FLUSH_LOCK_LUA, keys: [lock_key], argv: [token, FLUSH_LOCK_TTL.to_i])
   end
 
   def self.apply_delivered_chunk!(records)
     records.group_by { _1["i"] }.each do |installment_id, group|
+      yield if block_given?
+
       delivered_at_by_purchase = group.each_with_object({}) do |record, acc|
         acc[record["p"]] = [acc[record["p"]], record["t"]].compact.min
       end

--- a/app/models/email_info.rb
+++ b/app/models/email_info.rb
@@ -47,6 +47,8 @@ class EmailInfo < ApplicationRecord
   end
 
   DELIVERED_BUFFER_CHUNK = 1000
+  MAX_FLUSH_CHUNKS = 50
+  FLUSH_LOCK_TTL = 2.minutes
 
   # Delivered callbacks arrive in waves of ~1M within minutes; a row-per-event
   # UPDATE+commit is what shows up as COMMIT/binlog waits. Buffer in Redis and
@@ -68,15 +70,27 @@ class EmailInfo < ApplicationRecord
   end
 
   def self.flush_delivered_buffer!
-    key = RedisKey.email_info_delivered_buffer
-    loop do
-      # Peek then drop. LPOP-then-restore loses the chunk if both the UPDATE
-      # and the recovery RPUSH fail.
-      raw = $redis.lrange(key, 0, DELIVERED_BUFFER_CHUNK - 1)
-      break if raw.blank?
+    lock_key = RedisKey.email_info_delivered_flush_lock
+    token = SecureRandom.uuid
+    return unless $redis.set(lock_key, token, nx: true, ex: FLUSH_LOCK_TTL.to_i)
 
-      apply_delivered_chunk!(raw.map { JSON.parse(_1) })
-      $redis.ltrim(key, raw.size, -1)
+    key = RedisKey.email_info_delivered_buffer
+    chunks = 0
+    begin
+      loop do
+        break if chunks >= MAX_FLUSH_CHUNKS
+
+        # Peek then drop. Safe only with one consumer (the Redis lock above).
+        raw = $redis.lrange(key, 0, DELIVERED_BUFFER_CHUNK - 1)
+        break if raw.blank?
+
+        apply_delivered_chunk!(raw.map { JSON.parse(_1) })
+        $redis.ltrim(key, raw.size, -1)
+        chunks += 1
+        $redis.expire(lock_key, FLUSH_LOCK_TTL.to_i)
+      end
+    ensure
+      $redis.del(lock_key) if $redis.get(lock_key) == token
     end
   end
 

--- a/app/services/handle_email_event_info/for_installment_email.rb
+++ b/app/services/handle_email_event_info/for_installment_email.rb
@@ -34,6 +34,14 @@ class HandleEmailEventInfo::ForInstallmentEmail
     end
 
     def handle_delivered_event!
+      ids = creator_contacting_customers_email_info_ids(email_event_info)
+      return if ids.nil?
+
+      # No row is created here for ancient purchases: the batch UPDATE just
+      # affects 0 rows. Bounce/open still go through the loading path.
+      return if EmailInfo.buffer_delivered(installment_id: ids[:installment_id], purchase_id: ids[:purchase_id],
+                                           delivered_at: email_event_info.created_at || Time.current)
+
       email_info = pull_creator_contacting_customers_email_info(email_event_info)
       email_info.mark_delivered!(email_event_info.created_at) if email_info.present?
     end
@@ -71,25 +79,31 @@ class HandleEmailEventInfo::ForInstallmentEmail
     end
 
     def pull_creator_contacting_customers_email_info(email_event_info)
-      purchase_id = email_event_info.purchase_id
-      installment_id = email_event_info.installment_id
-      email_name = nil
-      if email_event_info.mailer_class_and_method.end_with?(EmailEventInfo::PURCHASE_INSTALLMENT_MAILER_METHOD)
-        email_name = EmailEventInfo::PURCHASE_INSTALLMENT_MAILER_METHOD
-        email_info = CreatorContactingCustomersEmailInfo.where(purchase_id:, installment_id:).last
-      elsif email_event_info.mailer_class_and_method.end_with?(EmailEventInfo::SUBSCRIPTION_INSTALLMENT_MAILER_METHOD)
-        email_name = EmailEventInfo::SUBSCRIPTION_INSTALLMENT_MAILER_METHOD
-        purchase_id = Subscription.find(email_event_info.purchase_id).original_purchase.id
-        email_info = CreatorContactingCustomersEmailInfo.where(purchase_id:, installment_id:).last
-      else
-        return nil
-      end
+      ids = creator_contacting_customers_email_info_ids(email_event_info)
+      return nil if ids.nil?
+
+      email_info = CreatorContactingCustomersEmailInfo.where(purchase_id: ids[:purchase_id], installment_id: ids[:installment_id]).last
 
       # We create these records when sending emails so we shouldn't really need to create them again here.
       # However, this code needs to stay so as to support events which are triggered on emails which were sent before
       # the code to create these records was in place. From our investigation, we saw that we still receive events
       # for ancient purchases.
-      email_info || CreatorContactingCustomersEmailInfo.new(purchase_id:, installment_id:, email_name:)
+      email_info || CreatorContactingCustomersEmailInfo.new(**ids)
+    end
+
+    def creator_contacting_customers_email_info_ids(email_event_info)
+      purchase_id = email_event_info.purchase_id
+      installment_id = email_event_info.installment_id
+      if email_event_info.mailer_class_and_method.end_with?(EmailEventInfo::PURCHASE_INSTALLMENT_MAILER_METHOD)
+        email_name = EmailEventInfo::PURCHASE_INSTALLMENT_MAILER_METHOD
+      elsif email_event_info.mailer_class_and_method.end_with?(EmailEventInfo::SUBSCRIPTION_INSTALLMENT_MAILER_METHOD)
+        email_name = EmailEventInfo::SUBSCRIPTION_INSTALLMENT_MAILER_METHOD
+        purchase_id = Subscription.find(email_event_info.purchase_id).original_purchase.id
+      else
+        return nil
+      end
+
+      { purchase_id:, installment_id:, email_name: }
     end
 
     def update_installment_cache(installment_id, key)

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -141,6 +141,7 @@ class RedisKey
     def seller_large_blast_quota(seller_id, day) = "seller_large_blast_quota:#{seller_id}:#{day}"
     # LIST of JSON {i: installment_id, p: purchase_id, t: epoch} pending an email_infos delivered UPDATE.
     def email_info_delivered_buffer = "email_info:delivered_buffer"
+    def email_info_delivered_inflight = "email_info:delivered_inflight"
     def email_info_delivered_flush_lock = "email_info:delivered_flush_lock"
   end
 end

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -141,5 +141,6 @@ class RedisKey
     def seller_large_blast_quota(seller_id, day) = "seller_large_blast_quota:#{seller_id}:#{day}"
     # LIST of JSON {i: installment_id, p: purchase_id, t: epoch} pending an email_infos delivered UPDATE.
     def email_info_delivered_buffer = "email_info:delivered_buffer"
+    def email_info_delivered_flush_lock = "email_info:delivered_flush_lock"
   end
 end

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -139,5 +139,7 @@ class RedisKey
     def workflow_immediate_fanout_max_spread_seconds = "workflow_immediate_fanout_max_spread_seconds"
     def seller_large_blast_threshold = "seller_large_blast_threshold"
     def seller_large_blast_quota(seller_id, day) = "seller_large_blast_quota:#{seller_id}:#{day}"
+    # LIST of JSON {i: installment_id, p: purchase_id, t: epoch} pending an email_infos delivered UPDATE.
+    def email_info_delivered_buffer = "email_info:delivered_buffer"
   end
 end

--- a/app/sidekiq/flush_delivered_email_infos_job.rb
+++ b/app/sidekiq/flush_delivered_email_infos_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FlushDeliveredEmailInfosJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :low, lock: :until_executed
+
+  include RecurringLockTtl
+  recurring_lock_ttl max_attempt: 10.minutes
+
+  def perform
+    EmailInfo.flush_delivered_buffer!
+  end
+end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -18,6 +18,10 @@ update_purchase_healthcheck_threshold:
   cron: "* * * * *" # Every minute — the threshold carries a 1h TTL, so the healthcheck fails closed if this stalls
   class: UpdatePurchaseHealthcheckThresholdJob
   description: Recomputes the /healthcheck/purchases threshold from the prior 7 days' purchase rate
+flush_delivered_email_infos:
+  cron: "* * * * *" # Every minute
+  class: FlushDeliveredEmailInfosJob
+  description: Applies Redis-buffered email_infos delivered marks from Resend/SendGrid callbacks when the fast-path enqueue was lost
 
 # Hourly
 repair_order_charge_outcomes:

--- a/spec/models/email_info_spec.rb
+++ b/spec/models/email_info_spec.rb
@@ -94,6 +94,18 @@ describe EmailInfo do
       expect(email_info.reload.state).to eq("sent")
     end
 
+    it "keeps the chunk even if Redis would reject a recovery write" do
+      email_info = create(:creator_contacting_customers_email_info_sent, installment: installment_a)
+      buffer(email_info)
+      allow(CreatorContactingCustomersEmailInfo).to receive(:where).and_raise(ActiveRecord::StatementInvalid, "boom")
+      allow($redis).to receive(:rpush).and_raise(Redis::CannotConnectError)
+
+      expect { EmailInfo.flush_delivered_buffer! }.to raise_error(ActiveRecord::StatementInvalid)
+
+      expect($redis.llen(buffer_key)).to eq(1)
+      expect(email_info.reload.state).to eq("sent")
+    end
+
     it "is a no-op on an empty buffer" do
       expect { EmailInfo.flush_delivered_buffer! }.not_to raise_error
     end

--- a/spec/models/email_info_spec.rb
+++ b/spec/models/email_info_spec.rb
@@ -83,15 +83,29 @@ describe EmailInfo do
       expect { EmailInfo.flush_delivered_buffer! }.not_to change { CreatorContactingCustomersEmailInfo.count }
     end
 
-    it "keeps the chunk in the buffer and re-raises when the UPDATE fails" do
+    it "keeps the chunk in the inflight list and re-raises when the UPDATE fails" do
       email_info = create(:creator_contacting_customers_email_info_sent, installment: installment_a)
       buffer(email_info)
       allow(CreatorContactingCustomersEmailInfo).to receive(:where).and_raise(ActiveRecord::StatementInvalid, "boom")
 
       expect { EmailInfo.flush_delivered_buffer! }.to raise_error(ActiveRecord::StatementInvalid)
 
-      expect($redis.llen(buffer_key)).to eq(1)
+      expect($redis.llen(buffer_key)).to eq(0)
+      expect($redis.llen(RedisKey.email_info_delivered_inflight)).to eq(1)
       expect(email_info.reload.state).to eq("sent")
+    end
+
+    it "applies a leftover inflight chunk before taking more from the buffer" do
+      leftover = create(:creator_contacting_customers_email_info_sent, installment: installment_a)
+      later = create(:creator_contacting_customers_email_info_sent, installment: installment_a)
+      $redis.rpush(RedisKey.email_info_delivered_inflight, { i: leftover.installment_id, p: leftover.purchase_id, t: delivered_at.to_i }.to_json)
+      buffer(later)
+
+      EmailInfo.flush_delivered_buffer!
+
+      expect(leftover.reload).to have_attributes(state: "delivered", delivered_at:)
+      expect(later.reload.state).to eq("delivered")
+      expect($redis.llen(RedisKey.email_info_delivered_inflight)).to eq(0)
     end
 
     it "is a no-op on an empty buffer" do

--- a/spec/models/email_info_spec.rb
+++ b/spec/models/email_info_spec.rb
@@ -94,18 +94,6 @@ describe EmailInfo do
       expect(email_info.reload.state).to eq("sent")
     end
 
-    it "keeps the chunk even if Redis would reject a recovery write" do
-      email_info = create(:creator_contacting_customers_email_info_sent, installment: installment_a)
-      buffer(email_info)
-      allow(CreatorContactingCustomersEmailInfo).to receive(:where).and_raise(ActiveRecord::StatementInvalid, "boom")
-      allow($redis).to receive(:rpush).and_raise(Redis::CannotConnectError)
-
-      expect { EmailInfo.flush_delivered_buffer! }.to raise_error(ActiveRecord::StatementInvalid)
-
-      expect($redis.llen(buffer_key)).to eq(1)
-      expect(email_info.reload.state).to eq("sent")
-    end
-
     it "is a no-op on an empty buffer" do
       expect { EmailInfo.flush_delivered_buffer! }.not_to raise_error
     end

--- a/spec/models/email_info_spec.rb
+++ b/spec/models/email_info_spec.rb
@@ -109,5 +109,38 @@ describe EmailInfo do
     it "is a no-op on an empty buffer" do
       expect { EmailInfo.flush_delivered_buffer! }.not_to raise_error
     end
+
+    it "leaves the buffer untouched when another flush holds the lock" do
+      email_info = create(:creator_contacting_customers_email_info_sent, installment: installment_a)
+      buffer(email_info)
+      $redis.set(RedisKey.email_info_delivered_flush_lock, "held", nx: true, ex: 60)
+
+      EmailInfo.flush_delivered_buffer!
+
+      expect($redis.llen(buffer_key)).to eq(1)
+      expect(email_info.reload.state).to eq("sent")
+    ensure
+      $redis.del(RedisKey.email_info_delivered_flush_lock)
+    end
+
+    it "stops after MAX_FLUSH_CHUNKS and leaves the rest for the next run" do
+      stub_const("EmailInfo::DELIVERED_BUFFER_CHUNK", 1)
+      stub_const("EmailInfo::MAX_FLUSH_CHUNKS", 1)
+      first = create(:creator_contacting_customers_email_info_sent, installment: installment_a)
+      second = create(:creator_contacting_customers_email_info_sent, installment: installment_a)
+      buffer(first)
+      buffer(second)
+
+      EmailInfo.flush_delivered_buffer!
+
+      expect(first.reload.state).to eq("delivered")
+      expect(second.reload.state).to eq("sent")
+      expect($redis.llen(buffer_key)).to eq(1)
+
+      EmailInfo.flush_delivered_buffer!
+
+      expect(second.reload.state).to eq("delivered")
+      expect($redis.llen(buffer_key)).to eq(0)
+    end
   end
 end

--- a/spec/models/email_info_spec.rb
+++ b/spec/models/email_info_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe EmailInfo do
+  let(:buffer_key) { RedisKey.email_info_delivered_buffer }
+
+  describe ".buffer_delivered" do
+    it "pushes a record and enqueues the flush job without touching MySQL" do
+      email_info = create(:creator_contacting_customers_email_info_sent)
+      delivered_at = 1.hour.ago
+
+      result = EmailInfo.buffer_delivered(installment_id: email_info.installment_id, purchase_id: email_info.purchase_id, delivered_at:)
+
+      expect(result).to eq(true)
+      expect($redis.lrange(buffer_key, 0, -1)).to eq([{ i: email_info.installment_id, p: email_info.purchase_id, t: delivered_at.to_i }.to_json])
+      expect(FlushDeliveredEmailInfosJob).to have_enqueued_sidekiq_job
+      expect(email_info.reload.state).to eq("sent")
+      expect(email_info.delivered_at).to be_nil
+    end
+
+    it "returns false when Redis rejects the push" do
+      allow($redis).to receive(:rpush).and_raise(Redis::CannotConnectError)
+
+      result = EmailInfo.buffer_delivered(installment_id: 1, purchase_id: 2, delivered_at: Time.current)
+
+      expect(result).to eq(false)
+      expect(FlushDeliveredEmailInfosJob).not_to have_enqueued_sidekiq_job
+    end
+  end
+
+  describe ".flush_delivered_buffer!" do
+    let(:installment_a) { create(:installment) }
+    let(:installment_b) { create(:installment) }
+    let(:delivered_at) { 2.hours.ago.change(usec: 0) }
+
+    def buffer(email_info, at = delivered_at)
+      $redis.rpush(buffer_key, { i: email_info.installment_id, p: email_info.purchase_id, t: at.to_i }.to_json)
+    end
+
+    it "marks created and sent rows delivered with the event timestamp, grouped by installment" do
+      a1 = create(:creator_contacting_customers_email_info_sent, installment: installment_a)
+      a2 = create(:creator_contacting_customers_email_info, installment: installment_a)
+      b1 = create(:creator_contacting_customers_email_info_sent, installment: installment_b)
+      untouched = create(:creator_contacting_customers_email_info_sent, installment: installment_a)
+      buffer(a1)
+      buffer(a2, delivered_at + 5.minutes)
+      buffer(b1, delivered_at + 10.minutes)
+
+      expect(CreatorContactingCustomersEmailInfo).to receive(:where).twice.and_call_original
+      EmailInfo.flush_delivered_buffer!
+
+      expect(a1.reload).to have_attributes(state: "delivered", delivered_at:)
+      expect(a2.reload).to have_attributes(state: "delivered", delivered_at: delivered_at + 5.minutes)
+      expect(b1.reload).to have_attributes(state: "delivered", delivered_at: delivered_at + 10.minutes)
+      expect(untouched.reload).to have_attributes(state: "sent", delivered_at: nil)
+      expect($redis.llen(buffer_key)).to eq(0)
+    end
+
+    it "does not downgrade an opened row" do
+      opened = create(:creator_contacting_customers_email_info_opened, installment: installment_a)
+      buffer(opened)
+
+      EmailInfo.flush_delivered_buffer!
+
+      expect(opened.reload.state).to eq("opened")
+      expect(opened.opened_at).to be_present
+    end
+
+    it "keeps the original delivered_at of an already-delivered row" do
+      original = 1.day.ago.change(usec: 0)
+      delivered = create(:creator_contacting_customers_email_info_delivered, installment: installment_a, delivered_at: original)
+      buffer(delivered)
+
+      EmailInfo.flush_delivered_buffer!
+
+      expect(delivered.reload).to have_attributes(state: "delivered", delivered_at: original)
+    end
+
+    it "does not create a row for a purchase with no send record" do
+      $redis.rpush(buffer_key, { i: installment_a.id, p: 123_456_789, t: delivered_at.to_i }.to_json)
+
+      expect { EmailInfo.flush_delivered_buffer! }.not_to change { CreatorContactingCustomersEmailInfo.count }
+    end
+
+    it "keeps the chunk in the buffer and re-raises when the UPDATE fails" do
+      email_info = create(:creator_contacting_customers_email_info_sent, installment: installment_a)
+      buffer(email_info)
+      allow(CreatorContactingCustomersEmailInfo).to receive(:where).and_raise(ActiveRecord::StatementInvalid, "boom")
+
+      expect { EmailInfo.flush_delivered_buffer! }.to raise_error(ActiveRecord::StatementInvalid)
+
+      expect($redis.llen(buffer_key)).to eq(1)
+      expect(email_info.reload.state).to eq("sent")
+    end
+
+    it "is a no-op on an empty buffer" do
+      expect { EmailInfo.flush_delivered_buffer! }.not_to raise_error
+    end
+  end
+end

--- a/spec/models/email_info_spec.rb
+++ b/spec/models/email_info_spec.rb
@@ -112,6 +112,21 @@ describe EmailInfo do
       expect { EmailInfo.flush_delivered_buffer! }.not_to raise_error
     end
 
+    it "does not delete inflight after losing the flush lock" do
+      email_info = create(:creator_contacting_customers_email_info_sent, installment: installment_a)
+      buffer(email_info)
+      allow(EmailInfo).to receive(:apply_delivered_chunk!).and_wrap_original do |original, *args, &blk|
+        $redis.set(RedisKey.email_info_delivered_flush_lock, "stolen", ex: 60)
+        original.call(*args, &blk)
+      end
+
+      EmailInfo.flush_delivered_buffer!
+
+      expect($redis.llen(RedisKey.email_info_delivered_inflight)).to eq(1)
+    ensure
+      $redis.del(RedisKey.email_info_delivered_flush_lock, RedisKey.email_info_delivered_inflight)
+    end
+
     it "leaves the buffer untouched when another flush holds the lock" do
       email_info = create(:creator_contacting_customers_email_info_sent, installment: installment_a)
       buffer(email_info)

--- a/spec/services/handle_email_event_info/for_installment_email_spec.rb
+++ b/spec/services/handle_email_event_info/for_installment_email_spec.rb
@@ -194,14 +194,30 @@ describe HandleEmailEventInfo::ForInstallmentEmail do
             expect(@email_info.reload.state).to eq "bounced"
           end
 
-          it "marks it as delivered" do
+          it "buffers the delivered mark and applies it on flush" do
             params = { "_json" => [{ "event" => "delivered", "type" => "CreatorContactingCustomersMailer.purchase_installment",
                                      "identifier" => @identifier, "installment_id" => @installment.id, "timestamp" => 1.day.ago.to_i }] }
             travel_to(Time.current) do
               HandleSendgridEventJob.new.perform(params)
             end
 
+            expect(@email_info.reload.state).to eq "created"
+            expect(FlushDeliveredEmailInfosJob).to have_enqueued_sidekiq_job
+
+            FlushDeliveredEmailInfosJob.new.perform
+
             expect(CreatorContactingCustomersEmailInfo.count).to eq 1
+            expect(@email_info.reload.state).to eq "delivered"
+            expect(@email_info.reload.delivered_at).to eq(Time.zone.at(params["_json"].first["timestamp"]))
+          end
+
+          it "marks it as delivered synchronously when Redis is unavailable" do
+            allow($redis).to receive(:rpush).and_raise(Redis::CannotConnectError)
+            params = { "_json" => [{ "event" => "delivered", "type" => "CreatorContactingCustomersMailer.purchase_installment",
+                                     "identifier" => @identifier, "installment_id" => @installment.id, "timestamp" => 1.day.ago.to_i }] }
+            HandleSendgridEventJob.new.perform(params)
+
+            expect(FlushDeliveredEmailInfosJob).not_to have_enqueued_sidekiq_job
             expect(@email_info.reload.state).to eq "delivered"
             expect(@email_info.reload.delivered_at).to eq(Time.zone.at(params["_json"].first["timestamp"]))
           end
@@ -269,17 +285,16 @@ describe HandleEmailEventInfo::ForInstallmentEmail do
             expect(CreatorContactingCustomersEmailInfo.last.email_name).to eq "purchase_installment"
           end
 
-          it "creates a new email info and mark it as delivered" do
+          it "does not create a new email info for a delivered event" do
             expect(CreatorContactingCustomersEmailInfo.count).to eq 0
             params = { "_json" => [{ "event" => "delivered", "type" => "CreatorContactingCustomersMailer.purchase_installment",
                                      "identifier" => @identifier, "installment_id" => @installment.id, "timestamp" => 1.day.ago.to_i }] }
             travel_to(Time.current) do
               HandleSendgridEventJob.new.perform(params)
             end
+            FlushDeliveredEmailInfosJob.new.perform
 
-            expect(CreatorContactingCustomersEmailInfo.count).to eq 1
-            expect(CreatorContactingCustomersEmailInfo.last.state).to eq "delivered"
-            expect(CreatorContactingCustomersEmailInfo.last.delivered_at).to eq(Time.zone.at(params["_json"].first["timestamp"]))
+            expect(CreatorContactingCustomersEmailInfo.count).to eq 0
           end
 
           it "creates a new email info and mark it as opened" do
@@ -321,6 +336,16 @@ describe HandleEmailEventInfo::ForInstallmentEmail do
             @email_info = create(:creator_contacting_customers_email_info, installment: @installment, purchase: @purchase)
           end
 
+          it "buffers the delivered mark against the original purchase and applies it on flush" do
+            params = { "_json" => [{ "event" => "delivered", "type" => "CreatorContactingCustomersMailer.subscription_installment",
+                                     "identifier" => "[#{@subscription.id}, #{@installment.id}]", "installment_id" => @installment.id, "timestamp" => 1.day.ago.to_i }] }
+            HandleSendgridEventJob.new.perform(params)
+            FlushDeliveredEmailInfosJob.new.perform
+
+            expect(@email_info.reload.state).to eq "delivered"
+            expect(@email_info.delivered_at).to eq(Time.zone.at(params["_json"].first["timestamp"]))
+          end
+
           it "marks it as opened" do
             params = { "_json" => [{ "event" => "open", "type" => "CreatorContactingCustomersMailer.subscription_installment",
                                      "identifier" => "[#{@subscription.id}, #{@installment.id}]", "installment_id" => @installment.id, "timestamp" => 1.hour.ago.to_i }] }
@@ -348,17 +373,16 @@ describe HandleEmailEventInfo::ForInstallmentEmail do
             expect(CreatorContactingCustomersEmailInfo.last.email_name).to eq "subscription_installment"
           end
 
-          it "creates a new email info and mark it as delivered" do
+          it "does not create a new email info for a delivered event" do
             expect(CreatorContactingCustomersEmailInfo.count).to eq 0
             params = { "_json" => [{ "event" => "delivered", "type" => "CreatorContactingCustomersMailer.subscription_installment",
                                      "identifier" => "[#{@subscription.id}, #{@installment.id}]", "installment_id" => @installment.id, "timestamp" => 1.day.ago.to_i }] }
             travel_to(Time.current) do
               HandleSendgridEventJob.new.perform(params)
             end
+            FlushDeliveredEmailInfosJob.new.perform
 
-            expect(CreatorContactingCustomersEmailInfo.count).to eq 1
-            expect(CreatorContactingCustomersEmailInfo.last.state).to eq "delivered"
-            expect(CreatorContactingCustomersEmailInfo.last.delivered_at).to eq(Time.zone.at(params["_json"].first["timestamp"]))
+            expect(CreatorContactingCustomersEmailInfo.count).to eq 0
           end
         end
       end


### PR DESCRIPTION
- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell


## What

Delivered callbacks for installment emails (`HandleEmailEventInfo::ForInstallmentEmail#handle_delivered_event!`) no longer load and save one `email_infos` row per event. The handler RPUSHes `{installment_id, purchase_id, delivered_at}` onto `email_info:delivered_buffer` and enqueues `FlushDeliveredEmailInfosJob` (`lock: :until_executed`, plus a `* * * * *` cron safety net). The job:

1. Takes a Redis NX lock (token-checked renew/release, 10 min TTL).
2. Drains any leftover `email_info:delivered_inflight` list, then atomically moves up to 1000 buffer entries onto inflight (Lua LRANGE+LTRIM+RPUSH).
3. Groups by installment and applies one `UPDATE ... WHERE installment_id = ? AND purchase_id IN (...) AND state IN ('created','sent') SET state='delivered', delivered_at = CASE purchase_id ... END` per installment (IN list ≤1000).
4. ACKs inflight with Lua only while the lock token still matches. Caps at 50 chunks per run.

If Redis rejects the callback RPUSH, the handler falls back to synchronous `mark_delivered!`. If the UPDATE raises, inflight is left in place for the next job. Re-applying is idempotent via the state filter.

Monotonic by construction: only `created`/`sent` rows move, so a late delivered callback cannot downgrade `opened`, and an already-`delivered` row keeps its original `delivered_at`. Bounce/open/click paths are unchanged.

No rendered surface (Sidekiq/Redis/MySQL only).

## Why

Midnight Resend callback waves (antiwork/gumroad-private#2383: 650,734 `POST /resend-webhook` between 00:00 and 00:12 UTC on 2026-09-03) drive a MySQL commit storm that slows shopper pages — Performance Insights showed COMMIT at 16 AAS, the `email_infos` lookup at 4.1 AAS, and binlog commit sync waits. Each delivered callback was 1 SELECT + 1 single-row UPDATE + 1 commit on `email_infos`.

This is independent of #7489 (`gp2383-batch-resend-writes`), which batches the `installments.customer_count` counter and does not touch `email_infos`.

## Before / After (per 650k delivered callbacks)

| | Before | After |
|---|---|---|
| `email_infos` SELECTs | ~650k (`WHERE purchase_id AND installment_id ... LIMIT 1`) | 0 on the callback path |
| `email_infos` UPDATEs | ~650k single-row | one UPDATE per installment per 1000-record flush chunk |
| MySQL commits | ~650k | one per UPDATE above |
| Redis | — | 1 RPUSH per callback + 1 atomic claim/ack per 1000 |

The `Subscription.find(...).original_purchase` PK read for subscription installments is kept on the callback path (one indexed read; the buffered `purchase_id` is already the original purchase).

## Behavior change

For a delivered event on an email with no `email_infos` row (ancient purchases predating row creation on send), the old code created a new `CreatorContactingCustomersEmailInfo` and marked it delivered. The batch UPDATE simply affects 0 rows, so no row is created any more for **delivered** events. Bounce/open/click keep the `.new(...)` fallback.

## Test Results

- `spec/models/email_info_spec.rb`: 12 examples, 0 failures (local, this head). Covers lock held, inflight leftover, lost-lock ACK, MAX_FLUSH_CHUNKS, UPDATE-fail leaves inflight.
- `spec/services/handle_email_event_info/for_installment_email_spec.rb`: 33 examples, 0 failures (from the first commit; file unchanged this round).
- `spec/models/concerns/recurring_lock_ttl_spec.rb`: 158 examples, 0 failures, 8 pending (from the first commit; file unchanged this round).
- `spec/models/creator_contacting_customers_email_info_spec.rb`: 5 examples, 0 failures (from the first commit; file unchanged this round).

## QA steps

1. On a branch app with Sidekiq running, send an installment to a purchase and confirm the `email_infos` row is `sent`.
2. POST a Resend `email.delivered` webhook for it (or run `HandleEmailEventInfo::ForInstallmentEmail.perform(ResendEventInfo.new(json))` in console). Immediately: `$redis.llen(RedisKey.email_info_delivered_buffer)` is 1 and the row is still `sent`.
3. Within seconds (job) or at most a minute (cron) the row is `delivered` with `delivered_at` equal to the event's `data.created_at` (second precision) and both buffer and inflight lists are empty.
4. Mark a row `opened`, replay its delivered event, flush: row stays `opened`.
5. Stop Redis, replay a delivered event: the row is marked delivered synchronously.

Refs antiwork/gumroad-private#2383

---

AI disclosure: Generated with grok-4.6. The code was reviewed, tested, and I take full responsibility for it.




Premerge review: clean @ 9c54ba8112bb6a4f06e18d18bed6a3221d1c3e8d
