### PR TITLE
Drive seller reputation aggregate from links to fix product page timeouts

### DIFF
--- a/app/modules/user/reputation_summary.rb
+++ b/app/modules/user/reputation_summary.rb
@@ -72,12 +72,14 @@ module User::ReputationSummary
     # Drive from links.user_id, never FROM product_review_stats:
     # product_review_stats is unique on link_id only, so with the stats table
     # first MySQL scans it and probes links per row (gumroad-private#2388).
+    # FROM order alone does not constrain MySQL's join order — the
+    # STRAIGHT_JOIN hint is what pins links as the driving table.
     def reputation_aggregate
       Rails.cache.fetch(reputation_cache_key, expires_in: CACHE_TTL) do
         products_count, total, weighted = Link.alive.not_draft
           .where(user_id: id)
           .where(Arel.sql("links.flags & #{Link.flag_mapping["flags"][:display_product_reviews]} != 0"))
-          .joins(:product_review_stat)
+          .joins("STRAIGHT_JOIN product_review_stats ON product_review_stats.link_id = links.id")
           .where.not(product_review_stats: { reviews_count: 0 })
           .pick(Arel.sql("COUNT(*), SUM(reviews_count), SUM(ratings_of_five_count * 5 + ratings_of_four_count * 4 + ratings_of_three_count * 3 + ratings_of_two_count * 2 + ratings_of_one_count)"))
         [products_count.to_i, total.to_i, weighted.to_i]

--- a/app/modules/user/reputation_summary.rb
+++ b/app/modules/user/reputation_summary.rb
@@ -69,11 +69,9 @@ module User::ReputationSummary
     # products — bounded regardless of catalogue size (gumroad-private#2384).
     # display_product_reviews is a Link flag bit, not a column, so it is
     # meshed here exactly the way ProfileData already does (links.flags & BIT).
-    # Drive from links.user_id, never FROM product_review_stats: with the
-    # stats table first, MySQL is free to scan it and probe links per row
-    # (product_review_stats is unique on link_id only), which timed out every
-    # product page at 120s and kept the cache permanently unfilled
-    # (gumroad-private#2388).
+    # Drive from links.user_id, never FROM product_review_stats:
+    # product_review_stats is unique on link_id only, so with the stats table
+    # first MySQL scans it and probes links per row (gumroad-private#2388).
     def reputation_aggregate
       Rails.cache.fetch(reputation_cache_key, expires_in: CACHE_TTL) do
         products_count, total, weighted = Link.alive.not_draft

--- a/app/modules/user/reputation_summary.rb
+++ b/app/modules/user/reputation_summary.rb
@@ -69,13 +69,18 @@ module User::ReputationSummary
     # products — bounded regardless of catalogue size (gumroad-private#2384).
     # display_product_reviews is a Link flag bit, not a column, so it is
     # meshed here exactly the way ProfileData already does (links.flags & BIT).
+    # Drive from links.user_id, never FROM product_review_stats: with the
+    # stats table first, MySQL is free to scan it and probe links per row
+    # (product_review_stats is unique on link_id only), which timed out every
+    # product page at 120s and kept the cache permanently unfilled
+    # (gumroad-private#2388).
     def reputation_aggregate
       Rails.cache.fetch(reputation_cache_key, expires_in: CACHE_TTL) do
-        products_count, total, weighted = ProductReviewStat.joins(:link)
-          .merge(Link.alive.not_draft)
-          .where(links: { user_id: id })
-          .where.not("product_review_stats.reviews_count" => 0)
+        products_count, total, weighted = Link.alive.not_draft
+          .where(user_id: id)
           .where(Arel.sql("links.flags & #{Link.flag_mapping["flags"][:display_product_reviews]} != 0"))
+          .joins(:product_review_stat)
+          .where.not(product_review_stats: { reviews_count: 0 })
           .pick(Arel.sql("COUNT(*), SUM(reviews_count), SUM(ratings_of_five_count * 5 + ratings_of_four_count * 4 + ratings_of_three_count * 3 + ratings_of_two_count * 2 + ratings_of_one_count)"))
         [products_count.to_i, total.to_i, weighted.to_i]
       end

--- a/spec/modules/user/reputation_summary_spec.rb
+++ b/spec/modules/user/reputation_summary_spec.rb
@@ -138,10 +138,8 @@ describe User::ReputationSummary do
         expect(review_stat_queries).to eq(0)
       end
 
-      # Regression for gumroad-private#2388: FROM product_review_stats let
-      # MySQL drive the aggregate from the big stats table (unique on link_id
-      # only), timing out every cold-cache product page at 120s. The aggregate
-      # must start from the seller's indexed links set.
+      # gumroad-private#2388: the aggregate must stay driven by the seller's
+      # indexed links set, not FROM product_review_stats.
       it "drives the aggregate from links, not product_review_stats" do
         create_stat(product_one, five: 8)
         create_stat(product_two, four: 4)

--- a/spec/modules/user/reputation_summary_spec.rb
+++ b/spec/modules/user/reputation_summary_spec.rb
@@ -138,6 +138,27 @@ describe User::ReputationSummary do
         expect(review_stat_queries).to eq(0)
       end
 
+      # Regression for gumroad-private#2388: FROM product_review_stats let
+      # MySQL drive the aggregate from the big stats table (unique on link_id
+      # only), timing out every cold-cache product page at 120s. The aggregate
+      # must start from the seller's indexed links set.
+      it "drives the aggregate from links, not product_review_stats" do
+        create_stat(product_one, five: 8)
+        create_stat(product_two, four: 4)
+        seller.bump_reputation_summary_version
+
+        queries = []
+        callback = ->(_name, _started, _finished, _id, payload) { queries << payload[:sql] }
+        ::ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+          expect(seller.seller_reputation_summary).to eq(average: 4.7, count: 12, products_count: 2)
+        end
+
+        aggregate_sql = queries.find { |sql| sql.include?("product_review_stats") && sql.include?("SUM") }
+        expect(aggregate_sql).to be_present
+        expect(aggregate_sql).to match(/FROM\s+`links`/i)
+        expect(aggregate_sql).not_to match(/FROM\s+`product_review_stats`/i)
+      end
+
       it "returns nil for a large zero-review catalogue" do
         Array.new(230) { create(:product, user: seller) }
         seller.bump_reputation_summary_version

--- a/spec/modules/user/reputation_summary_spec.rb
+++ b/spec/modules/user/reputation_summary_spec.rb
@@ -138,9 +138,10 @@ describe User::ReputationSummary do
         expect(review_stat_queries).to eq(0)
       end
 
-      # gumroad-private#2388: the aggregate must stay driven by the seller's
-      # indexed links set, not FROM product_review_stats.
-      it "drives the aggregate from links, not product_review_stats" do
+      # gumroad-private#2388: FROM order does not constrain the optimizer —
+      # the STRAIGHT_JOIN hint is what pins links as the driving table, so
+      # pin the hint itself.
+      it "pins links as the driving table via STRAIGHT_JOIN" do
         create_stat(product_one, five: 8)
         create_stat(product_two, four: 4)
         seller.bump_reputation_summary_version
@@ -153,8 +154,7 @@ describe User::ReputationSummary do
 
         aggregate_sql = queries.find { |sql| sql.include?("product_review_stats") && sql.include?("SUM") }
         expect(aggregate_sql).to be_present
-        expect(aggregate_sql).to match(/FROM\s+`links`/i)
-        expect(aggregate_sql).not_to match(/FROM\s+`product_review_stats`/i)
+        expect(aggregate_sql).to match(/FROM\s+`links`\s+STRAIGHT_JOIN\s+product_review_stats/i)
       end
 
       it "returns nil for a large zero-review catalogue" do


### PR DESCRIPTION
## What

Fixes the production timeout behind [gumroad-private#2388](https://github.com/antiwork/gumroad-private/issues/2388) / Sentry GUMROAD-1GG: `User::ReputationSummary#reputation_aggregate` now drives its one-row SQL aggregate from the seller's indexed `links.user_id` set, pinned with a `STRAIGHT_JOIN` hint so MySQL cannot reorder the join back onto the stats table.

## Why

#7493 (the gumroad-private#2384 fix) replaced the per-row catalogue scan with one SQL aggregate, but wrote it as `ProductReviewStat.joins(:link).where(links: { user_id: ? })`. MySQL drove the join from `product_review_stats` (unique on `link_id` only — no cheap path from that side to one seller's rows), so every cold-cache product page ran an unbounded join and died at the 120s request timeout. Because the timeout precedes the `Rails.cache.fetch` write, the 10-minute cache never fills — the failure is permanent per seller, not slow-once. 580 events / 146 users in ~6h, 571/580 on `LinksController#show`.

Panel finding applied (both reviewers, round 1): rewriting the relation so `links` appears first in FROM does NOT constrain MySQL's inner-join order — the optimizer may still drive from the stats table. The fix therefore uses an explicit `STRAIGHT_JOIN` hint, which forces `links` (filtered by the indexed `user_id`) as the driving table; the 1:1 stat row then joins via `index_product_review_stats_on_link_id`. Same predicates, same SELECT list, same values — only the execution plan is constrained.

## Before / After

Before (shipped in #7493, 500ing production until the flag was pulled):

```sql
SELECT COUNT(*), SUM(...) FROM product_review_stats INNER JOIN links ON links.id = product_review_stats.link_id WHERE links.user_id = ? AND ...
```

After (this PR):

```sql
SELECT COUNT(*), SUM(...) FROM links STRAIGHT_JOIN product_review_stats ON product_review_stats.link_id = links.id WHERE links.user_id = ? AND ...
```

Production mitigation already applied: Flipper `:seller_reputation_summary` was deactivated (audited write, 2026-09-03 ~12:15Z, verified `state=off`) — `seller_reputation_summary` returns nil with the flag off, so product pages render. Re-ramp after this deploys.

## Test Results

- `bundle exec rspec spec/modules/user/reputation_summary_spec.rb` — 19 examples, 0 failures at the current head (15.3s local run after the STRAIGHT_JOIN fix round; also green on the pre-panel round).
- Mutation/revert proof (fix round): swapping `STRAIGHT_JOIN ... ON ...` back to a plain `joins(:product_review_stat)` makes the regression spec fail; restoring turns it green. The other 18 examples pass on both shapes (values are identical) — the defect is the query plan, not the numbers.
- `ruby -c` clean on both changed files.

## QA steps

No rendered surface changes — badge output is value-identical. Executed QA: ran the full `reputation_summary_spec.rb` file (19 green) and captured the generated SQL via `sql.active_record` notifications, confirming `FROM `links` STRAIGHT_JOIN product_review_stats`. The regression spec pins the hint itself (the plan-enforcing token), per the round-1 panel finding that a FROM-order assertion alone is a property of ActiveRecord string generation, not the plan. Post-deploy verification (re-ramp the flag, watch GUMROAD-1GG) is tracked on gumroad-private#2388.

Premerge review: clean @ 3bec315023940a0a6b6114551c5a6fb64a657a0f

## Status

- [x] Scope — join-order inversion in `reputation_aggregate` (gumroad-private#2388)
- [x] Design — STRAIGHT_JOIN pins `links` as the driving table (panel round-1 P1: FROM order alone does not constrain the optimizer)
- [x] Build — hint applied; regression spec pins the hint; Flipper `:seller_reputation_summary` off in production as mitigation (audited)
- [x] QA — spec file green locally (19/19) at head; revert proof red; panel round 2 clean
- [ ] Shipped — merge + deploy, then re-ramp the flag and watch GUMROAD-1GG
- [ ] Market — n/a (internal fix)
- [ ] Sell — n/a

---

AI disclosure: built by Gumclaw running claude-fable-5-1.

