### PR TITLE
Force index_links_on_user_id on the seller reputation aggregate

### DIFF
--- a/app/modules/user/reputation_summary.rb
+++ b/app/modules/user/reputation_summary.rb
@@ -74,11 +74,8 @@ module User::ReputationSummary
     # first MySQL scans it and probes links per row (gumroad-private#2388).
     # FROM order alone does not constrain MySQL's join order — the
     # STRAIGHT_JOIN hint is what pins links as the driving table.
-    # FORCE INDEX pins the access path on that table: on the production
-    # primary the optimizer chose a full scan of links (~9M rows, type ALL)
-    # for an 11k-product seller even with STRAIGHT_JOIN in place, so the
-    # page still hit the 120s timeout. Same query on the replica used
-    # index_links_on_user_id and returned in 72ms.
+    # FORCE INDEX pins the links access path: the production primary chose a
+    # full-table scan even with STRAIGHT_JOIN, timing out large catalogues.
     def reputation_aggregate
       Rails.cache.fetch(reputation_cache_key, expires_in: CACHE_TTL) do
         products_count, total, weighted = Link.alive.not_draft

--- a/app/modules/user/reputation_summary.rb
+++ b/app/modules/user/reputation_summary.rb
@@ -74,9 +74,15 @@ module User::ReputationSummary
     # first MySQL scans it and probes links per row (gumroad-private#2388).
     # FROM order alone does not constrain MySQL's join order — the
     # STRAIGHT_JOIN hint is what pins links as the driving table.
+    # FORCE INDEX pins the access path on that table: on the production
+    # primary the optimizer chose a full scan of links (~9M rows, type ALL)
+    # for an 11k-product seller even with STRAIGHT_JOIN in place, so the
+    # page still hit the 120s timeout. Same query on the replica used
+    # index_links_on_user_id and returned in 72ms.
     def reputation_aggregate
       Rails.cache.fetch(reputation_cache_key, expires_in: CACHE_TTL) do
         products_count, total, weighted = Link.alive.not_draft
+          .from("`links` FORCE INDEX (index_links_on_user_id)")
           .where(user_id: id)
           .where(Arel.sql("links.flags & #{Link.flag_mapping["flags"][:display_product_reviews]} != 0"))
           .joins("STRAIGHT_JOIN product_review_stats ON product_review_stats.link_id = links.id")

--- a/spec/modules/user/reputation_summary_spec.rb
+++ b/spec/modules/user/reputation_summary_spec.rb
@@ -141,7 +141,7 @@ describe User::ReputationSummary do
       # gumroad-private#2388: FROM order does not constrain the optimizer —
       # the STRAIGHT_JOIN hint is what pins links as the driving table, so
       # pin the hint itself.
-      it "pins links as the driving table via STRAIGHT_JOIN" do
+      it "pins links as the driving table via STRAIGHT_JOIN and its access path via FORCE INDEX" do
         create_stat(product_one, five: 8)
         create_stat(product_two, four: 4)
         seller.bump_reputation_summary_version
@@ -154,7 +154,7 @@ describe User::ReputationSummary do
 
         aggregate_sql = queries.find { |sql| sql.include?("product_review_stats") && sql.include?("SUM") }
         expect(aggregate_sql).to be_present
-        expect(aggregate_sql).to match(/FROM\s+`links`\s+STRAIGHT_JOIN\s+product_review_stats/i)
+        expect(aggregate_sql).to match(/FROM\s+`links`\s+FORCE INDEX \(index_links_on_user_id\)\s+STRAIGHT_JOIN\s+product_review_stats/i)
       end
 
       it "returns nil for a large zero-review catalogue" do


### PR DESCRIPTION
## What

Adds `FORCE INDEX (index_links_on_user_id)` to the seller reputation aggregate in `User::ReputationSummary#reputation_aggregate`, on top of the `STRAIGHT_JOIN` from #7496.

## Why

#7496 deployed at 13:49 UTC today and the Flipper flag was re-enabled. GUMROAD-1GG resumed within minutes (47 events between 14:01 and 14:12, all `LinksController#show`, 120s timeouts on the same aggregate). Flag is off again (audited write, 14:11 UTC) so product pages render.

Diagnosis on the production primary, for the seller from the latest Sentry event (~11.6k products, ~11.2k alive and reviewable; identifiers in antiwork/gumroad-private#2388):

| host | plan for `links` | time |
|---|---|---|
| worker replica | `ref` on `index_links_on_user_id_and_updated_at`, 20,444 rows | 72 ms |
| primary | **`ALL`, 8,953,053 rows** (no key chosen) | >25 s, statement timeout |
| primary, `FORCE INDEX (index_links_on_user_id)` | `ref`, const | 105 ms |

`STRAIGHT_JOIN` pins the join order but not the access path. Web pods run against the primary only (`USE_DB_WORKER_REPLICAS` is set on Sidekiq, not on `web_server_*`), so the replica timings that made #7496 look fixed did not describe what puma sees. Index stats on the primary were last updated 2026-09-02 00:10 UTC; cardinality for `user_id` is 4.4M, so this is not a stale-stats miss the optimizer will grow out of. Pinning the index is the durable fix.

Independent re-check on the worker replica for the seller in the *latest* 1GG event (`user_id` 14424305, 16,391 products, 3,577 alive+non-draft; audited reads `20260903T143446Z-ea5ba4c5`, `20260903T143610Z-df9d6c97`):

| shape | plan for `links` | time |
|---|---|---|
| current (`STRAIGHT_JOIN`, `LIMIT 1`) | **`ALL`, 13,013,097 rows** | >40 s, statement timeout |
| current without `LIMIT 1` | `index_merge` intersect(`user_id`,`banned_at`), 16,248 rows | 3,217 ms |
| `FORCE INDEX (index_links_on_user_id)` | `ref`, 32,498 rows → `eq_ref` on `product_review_stats` | 49–81 ms, `[34, 37, 76]` |

So the residual slowness is an optimizer access-path miss, not join order or catalogue size: with the `LIMIT 1` that `pick` appends, MySQL 8.0.42 abandons `index_links_on_user_id` for a full scan of `links` (~13M rows) on both primary and replica. `FORCE INDEX` is the one hint that fixes the observed plan.

## Test Results

- `spec/modules/user/reputation_summary_spec.rb`: 19 examples, 0 failures at head.
- The existing join-order spec now asserts the full `FROM links FORCE INDEX (index_links_on_user_id) STRAIGHT_JOIN product_review_stats` shape. Revert proof: with the model change stashed, that example fails on exactly the hint match.
- rubocop clean on both files.

## QA steps

Backend-only. After deploy: re-enable `:seller_reputation_summary`, watch GUMROAD-1GG for 30 minutes, load a product page of the large-catalogue seller from the latest 1GG event (identifiers in the private issue). Ramp-down rule applies: any new 1GG event with the flag on, flag goes off.

## Status

- [x] Scope: access-path miss on the production primary that #7496's join-order hint did not cover
- [x] Build: `FORCE INDEX` + spec pinning the hint
- [x] QA: 19/19 local, revert proof red
- [x] Premerge panel (Sol + Fable, 0 findings)
- [ ] Shipped: merge, deploy, re-enable flag, 30-minute watch on GUMROAD-1GG

Ref antiwork/gumroad-private#2388

---

AI disclosure: built by Hermes Agent (claude-fable-5-1).

Premerge review: clean @ 28fd0453a6986112587630ac884a05ee73f58059


