### PR TITLE
Match the YouTube connect buttons to the X buttons beside them

### DIFF
--- a/app/javascript/components/Button.test.tsx
+++ b/app/javascript/components/Button.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Button } from "$app/components/Button";
+
+afterEach(cleanup);
+
+describe("Button brand colors", () => {
+  // The YouTube connect and disconnect buttons sit directly beside the X buttons in
+  // Settings > Profile > Social links, so both rows have to read as the same control. Comparing
+  // against the X button, instead of only asserting bg-black, is what catches a switch back to a
+  // provider brand fill such as Google's blue.
+  it("fills the YouTube button like the X button", () => {
+    render(
+      <>
+        <Button color="twitter">Connect to X</Button>
+        <Button color="youtube">Connect to YouTube</Button>
+      </>,
+    );
+
+    const x = screen.getByRole("button", { name: "Connect to X" });
+    const youtube = screen.getByRole("button", { name: "Connect to YouTube" });
+
+    expect(youtube.className).toBe(x.className);
+    expect(youtube.className).toContain("bg-black");
+  });
+});

--- a/app/javascript/components/Button.tsx
+++ b/app/javascript/components/Button.tsx
@@ -17,6 +17,7 @@ export const brandNames = [
   "kindle",
   "zoom",
   "google",
+  "youtube",
 ] as const;
 
 export type BrandName = (typeof brandNames)[number];
@@ -60,6 +61,7 @@ export const buttonVariants = cva(
         kindle: "bg-[#f3a642] text-black border-[#f3a642]",
         zoom: "bg-[#4087fc] text-white border-[#4087fc]",
         google: "bg-[#5383ec] text-white border-[#5383ec]",
+        youtube: "bg-black text-white",
       },
     },
     compoundVariants: [

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -1,4 +1,4 @@
-import { FontFamily, Google, TwitterX } from "@boxicons/react";
+import { FontFamily, TwitterX, Youtube } from "@boxicons/react";
 import { Link, router, usePage } from "@inertiajs/react";
 import { isEqual } from "lodash-es";
 import * as React from "react";
@@ -517,13 +517,13 @@ export default function SettingsPage() {
                     </SocialAuthButton>
                   )}
                   {youtube_connected ? (
-                    <Button type="button" color="google" onClick={handleUnlinkYoutube}>
-                      <Google pack="brands" className="size-5" />
+                    <Button type="button" color="youtube" onClick={handleUnlinkYoutube}>
+                      <Youtube pack="brands" className="size-5" />
                       Disconnect {youtube_handle ? `${youtube_handle} from YouTube` : "YouTube"}
                     </Button>
                   ) : youtube_connect_enabled ? (
-                    <SocialAuthButton provider="google" href={Routes.user_youtube_omniauth_authorize_path()}>
-                      <Google pack="brands" className="size-5" />
+                    <SocialAuthButton provider="youtube" href={Routes.user_youtube_omniauth_authorize_path()}>
+                      <Youtube pack="brands" className="size-5" />
                       Connect to YouTube
                     </SocialAuthButton>
                   ) : null}


### PR DESCRIPTION
Sellers on payout hold confirm their identity in Settings, Profile, Social links. YouTube connect landed there in #7488, directly beside Connect to X. It arrived in Google blue with a Google "G" mark, so the two buttons read as different kinds of control. One is the Gumroad black social button. The other looks like a Google sign-in. A seller who must prove channel ownership sees a Google button and stops to think about it.

## What

Both YouTube states now match the X buttons next to them.

- Connect to YouTube and Disconnect from YouTube use black fill with white text, the same fill as the X buttons.
- Both states show the YouTube mark instead of the Google "G".
- `Button` gets a `youtube` brand color (`bg-black text-white`), the same value the existing `twitter` and `apple` brands already use.

Labels, click behavior, the OAuth route, and the flag-off case do not change. The diff touches the icon and the color only.

## Why

The Google branding came from the OAuth strategy, not from a choice about this surface. YouTube connect runs through a named Google OmniAuth strategy, so the button inherited `color="google"` and the Google mark with it. Sellers do not care which provider is behind the button. They care that they link a YouTube channel next to their X account, so the row must read as one set of social connections.

The YouTube mark keeps the row consistent. The X buttons carry the X mark, so dropping the icon from the YouTube row only would create a second mismatch. `Youtube` from `@boxicons/react` is already used for this brand in `Profile/Layout.tsx`.

Black also removes a contrast failure. White text on Google blue `#5383ec` is 3.60:1, below the WCAG AA minimum of 4.5:1 for 16px text. White on black is 21:1.

## Before / After

What changes on screen, in words:

| | Before | After |
| --- | --- | --- |
| Connect fill | `#5383ec`, Google blue | Black, same as Connect to X |
| Disconnect fill | `#5383ec`, Google blue | Black, same as Disconnect from X |
| Mark | Google "G" | YouTube mark |
| Text contrast | 3.60:1, fails AA | 21:1 |

## Test Results

- `npx vitest run app/javascript/components/Button.test.tsx`: 1 passed. The test asserts that the YouTube button resolves to the same class string as the X button, and that the result includes `bg-black`.
- Reverted check: with `youtube` set back to the Google blue fill, the new test fails. The test therefore guards the fix.
- `npx tsc --noEmit`: clean.
- `DISABLE_TYPE_CHECKED=1 npx eslint --max-warnings 0` on `Button.tsx`, `Button.test.tsx`, and `Show.tsx`: clean.
- Not run: `spec/requests/user/settings_spec.rb`, which needs the full app stack. It asserts on the button labels, and every label is unchanged.

## QA

Real Settings → Profile (`/profile`) Social links captures from the isolated local Gumroad app. `youtube_connect` was on only for the seeded seller (`seller@gumroad.com`). Both frames are cropped to the Social links fieldset. No browser or OS chrome.

**Connect (disconnected YouTube)**

Connect to YouTube sits next to Connect to X. Both buttons are black with white marks and text.

![Connect to YouTube next to Connect to X](https://github.com/user-attachments/assets/613f4898-d9d4-47bb-9958-1e0875982c15)

**Disconnect (connected YouTube)**

Disconnect seller from YouTube sits next to Connect to X after a local YouTube identity (`handle=seller`) was added for that same seller. No OAuth.

![Disconnect seller from YouTube next to Connect to X](https://github.com/user-attachments/assets/bf2b0cd2-9480-4027-a95f-d37a9450692d)

## Flag state

The `youtube_connect` Flipper flag keeps its default of off, so the connect button stays hidden until the flag is switched on for a user. The disconnect state is reachable only for sellers who already linked a channel. The flag-off branch of the component is untouched.

---

Written by Claude Fable 5.1 (Claude Code).
