### PR TITLE
Match YouTube Connect button branding to Connect to X

### DIFF
--- a/app/javascript/components/Button.tsx
+++ b/app/javascript/components/Button.tsx
@@ -17,6 +17,7 @@ export const brandNames = [
   "kindle",
   "zoom",
   "google",
+  "youtube",
 ] as const;
 
 export type BrandName = (typeof brandNames)[number];
@@ -60,6 +61,7 @@ export const buttonVariants = cva(
         kindle: "bg-[#f3a642] text-black border-[#f3a642]",
         zoom: "bg-[#4087fc] text-white border-[#4087fc]",
         google: "bg-[#5383ec] text-white border-[#5383ec]",
+        youtube: "bg-black text-white",
       },
     },
     compoundVariants: [

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -1,4 +1,4 @@
-import { FontFamily, Google, TwitterX } from "@boxicons/react";
+import { FontFamily, TwitterX, Youtube } from "@boxicons/react";
 import { Link, router, usePage } from "@inertiajs/react";
 import { isEqual } from "lodash-es";
 import * as React from "react";
@@ -517,13 +517,13 @@ export default function SettingsPage() {
                     </SocialAuthButton>
                   )}
                   {youtube_connected ? (
-                    <Button type="button" color="google" onClick={handleUnlinkYoutube}>
-                      <Google pack="brands" className="size-5" />
+                    <Button type="button" color="youtube" onClick={handleUnlinkYoutube}>
+                      <Youtube pack="brands" className="size-5" />
                       Disconnect {youtube_handle ? `${youtube_handle} from YouTube` : "YouTube"}
                     </Button>
                   ) : youtube_connect_enabled ? (
-                    <SocialAuthButton provider="google" href={Routes.user_youtube_omniauth_authorize_path()}>
-                      <Google pack="brands" className="size-5" />
+                    <SocialAuthButton provider="youtube" href={Routes.user_youtube_omniauth_authorize_path()}>
+                      <Youtube pack="brands" className="size-5" />
                       Connect to YouTube
                     </SocialAuthButton>
                   ) : null}


### PR DESCRIPTION
## What

Changes the YouTube connect / disconnect buttons in Settings → Profile → Social links to use a flat-black `youtube` brand color and the YouTube mark (boxicon), instead of Google branding (blue fill + Google "G"). Now matches the black "Connect to X" button rendering the same surface.

This is a cosmetic follow-up to the tastelint P2 posted on #7488 after that PR merged.

## Why

The buttons read as a Google sign-in and clash with the flat-black Connect to X button beside them. Gumroad primary actions on this surface are flat black (Sahil design convention).

## Status

- [x] Scope — Settings Profile Social-links button cosmetic fix; no backend/data/flag change.
- [x] Design — reuse the `Youtube` boxicon already shipped on creator profile pages; add a `youtube` brand color to `Button` (flat black, matching `twitter`) rather than overloading `google`.
- [x] Build — `Button.tsx` brand + color variant; `Show.tsx` swap `google`→`youtube`, `<Google>`→`<Youtube>`.
- [x] QA — hosted-preview capture at head confirms both buttons are flat black with the YouTube mark; CI full suite green (run-all-specs).
- [ ] Shipped
- [ ] Market — n/a
- [ ] Sell — n/a

## Test Results

Run on the pushed head (`682147a2`). Full suite (`run-all-specs`) green on CI at this head: Tests workflow (Fast/Slow/minitest shards), Lint JS/TS, Typecheck TS, Lint Ruby, Migration versions all pass; Buildkite preview deploy passed.

- `tsc --noEmit` (CI Typecheck TS) — pass (validates the new `youtube` brand name against `BrandName`).
- Frontend lint (CI Lint JS/TS) — pass.
- Full spec suite (run-all-specs) — green.

No spec change needed: the Settings Profile page has no test asserting the Google brand on the YouTube button (verified by grep), and the `youtube` brand color is covered by CI lint/typecheck.

## QA steps

Rendered evidence from the hosted preview app for this branch at `x-revision 682147a20afa`, logged in as the seeded seller with the `youtube_connect` flag enabled:

![Settings Profile — Social links showing flat-black Connect to YouTube (YouTube mark) beside Connect to X](https://github.com/user-attachments/assets/0a394cb9-b13a-4fdf-9be6-14cbfc2ffc9a)

The Connect to YouTube button resolves to `bg-black text-white` with the YouTube play-button SVG (not Google blue / G). Vision confirmation: both buttons render identically flat-black with their own icons and white text.

Disconnect state uses the same `color="youtube"` brand and mark, so the connected "Disconnect <handle> from YouTube" button carries the same branding fix.

---

Premerge review: clean @ 682147a20afadf0fc2f707f2f6620625038a09c6

AI disclosure: written with DeepSeek V4 Flash (deepseek-v4-flash-0731 via openrouter). Prompt: webhook follow-up to the tastelint P2 on antiwork/gumroad#7488.