### PR TITLE
Trim ProfilePresenter comments to the visitor-shape and analytics traps

### DIFF
--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -33,14 +33,9 @@ class ProfilePresenter
   end
 
   def profile_props(seller_custom_domain_url:, request:)
-    # editing: false keeps the public profile on the visitor section shape - the inline editor moved
-    # to /profile, so the public component no longer renders the owner/editing shape. The real viewer
-    # is still passed through, so "you own this", "already following this wishlist", and currency
-    # reflect them (including the seller viewing their own page).
-    # include_default_products_section only applies to the public page: creators with products
-    # but no saved sections get a virtual products section instead of a bare email signup box.
-    # The profile editor (profile_settings_props below) never asks for it, so the editing
-    # experience is unchanged.
+    # Public page uses the visitor section shape (inline editor lives at /profile).
+    # include_default_products_section synthesizes a products section when the creator
+    # has products but no saved sections; the editor never requests it.
     shared_profile_props(seller_custom_domain_url:, request:, editing: false, include_default_products_section: true).merge(creator_profile:, seller_analytics:)
   end
 
@@ -128,18 +123,10 @@ class ProfilePresenter
       ProfileSectionsPresenter.new(seller:, query: seller.seller_profile_sections.on_profile)
     end
 
-    # Seller GA/pixels never fired on the profile: startTrackingForSeller is only
-    # called from product/checkout surfaces (#5676). These props let Users/Show
-    # boot the account-scoped tracking. The GA/FB/TikTok pixels stay gated on the
-    # gr:*:enabled meta tags the frontend already checks via shouldTrack(), so
-    # this only supplies the ids for them. The universal raw-snippet iframe has
-    # NO shouldTrack() guard (addProfileThirdPartyAnalytics appends it directly),
-    # so its enablement must be honored server-side here — mirroring the custom
-    # HTML path's analytics_enabled?(seller:) gate (production/staging only, plus
-    # the seller's disable_third_party_analytics opt-out). Universal snippets are
-    # limited to location "all": "product"/"receipt" scope a snippet to the
-    # purchase flow, which a profile is not. The snippet iframe URL is
-    # username-based, so it's only offered when a username exists.
+    # Profile tracking props for Users/Show. Pixel ids only — shouldTrack() still gates
+    # GA/FB/TikTok. Universal snippet iframe has no shouldTrack() guard, so enablement
+    # is server-side here (third_party_analytics_enabled?). Location "all" only;
+    # snippet URL is username-based.
     def seller_analytics
       {
         seller_id: seller.external_id,


### PR DESCRIPTION
Premerge review: exempt (comments only, no behaviour change)

## What

Compressed two overlapping comment essays on `ProfilePresenter#profile_props` and `#seller_analytics`.

Comments only, no behaviour change. The diff touches no executable code.

## Why

Keep the visitor-shape / virtual-products-section and universal-snippet tracking traps, cut the restated kwargs and the duplicated `shouldTrack()` / bug-history narration so a maintainer who already knows this file can skim it.

## Before / after line counts

- `app/presenters/profile_presenter.rb`: 170 → 157 lines (−13)
- `git diff --numstat`: 7 insertions, 20 deletions

## Kept deliberately

- Public page uses the visitor section shape because the inline editor lives at `/profile`.
- `include_default_products_section` synthesizes a products section when the creator has products but no saved sections; the editor never requests it.
- Profile tracking props for Users/Show supply pixel ids only — `shouldTrack()` still gates GA/FB/TikTok.
- Universal snippet iframe has no `shouldTrack()` guard, so enablement is server-side (`third_party_analytics_enabled?`).
- Universal snippets are location `"all"` only; snippet URL is username-based.

## Rejected as not slop

- `GdprDataErasureService` KYC / guardian / Stripe Person lock comments: domain + race invariants, left alone.
- `Installment` reply-to / `PURCHASE_LOOKUP_BATCH_SIZE` MySQL range-optimizer comments: already trimmed in #7434; remaining is load-bearing.
- `Checkout::StripePaymentPresenter` PWYW selected-tier comments: already trimmed in #7487.
- `User#custom_html_store_hostnames` / `#paypal_payout_email_for_failure_lookup`: sandbox-host and invalidation-lookup traps, left alone.
- `config/initializers/devise.rb`: Devise generator docs, not AI slop.

## Test Results

- `ruby -c app/presenters/profile_presenter.rb` — Syntax OK
- `bundle exec rubocop app/presenters/profile_presenter.rb` — 1 file inspected, no offenses detected
- Isolated `rspec spec/presenters/profile_presenter_spec.rb` — 31 examples, 0 failures
- Branch CI push run 33777053485 (Tests): success, 0 pending, 0 failures

---

AI disclosure: Grok 4.6. Prompt: scheduled ai-slop-reducer cron for already-merged antiwork/gumroad code; cut AI slop comments only, no behaviour change.