### PR TITLE
Return extra-thread Active Record checkouts on web Puma

### DIFF
--- a/app/controllers/api/internal/agent_message_streams_controller.rb
+++ b/app/controllers/api/internal/agent_message_streams_controller.rb
@@ -220,7 +220,7 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
       # markers still reading "in_progress", never a recorded outcome.
       if heartbeat
         stop_heartbeat << true
-        heartbeat.join
+        ActiveSupport::Dependencies.interlock.permit_concurrent_loads { heartbeat.join }
       end
       sse.close
       ActiveRecord::Base.connection_pool.release_connection

--- a/app/controllers/api/internal/agent_message_streams_controller.rb
+++ b/app/controllers/api/internal/agent_message_streams_controller.rb
@@ -94,32 +94,36 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
       # interruptible sleep: it returns nil each interval until the ensure below pushes the stop
       # signal, so shutdown is immediate rather than waiting out a sleep.
       heartbeat = Thread.new do
-        socket_alive = true
-        until stop_heartbeat.pop(timeout: STREAM_HEARTBEAT_INTERVAL.to_f)
-          # The marker refresh must outlive the socket: the request thread keeps generating after
-          # a client disconnect (silent tool iterations write nothing, so nothing raises) and can
-          # legitimately persist the turn minutes later — and a recovering client is told
-          # "in_progress" only while this marker lives. So refresh unconditionally, and only skip
-          # the socket write once the client is known to be gone. A Redis blip must not kill the
-          # heartbeat either — the socket comment below is what keeps the client's stall detector
-          # fed — so refresh failures are logged and retried on the next tick.
-          begin
-            refresh_agent_turn_in_progress!(client_turn_id)
-          rescue => e
-            Rails.logger.error("Store agent heartbeat marker refresh failed: #{e.message}")
-          end
-          next unless socket_alive
+        Rails.application.executor.wrap do
+          socket_alive = true
+          until stop_heartbeat.pop(timeout: STREAM_HEARTBEAT_INTERVAL.to_f)
+            # The marker refresh must outlive the socket: the request thread keeps generating after
+            # a client disconnect (silent tool iterations write nothing, so nothing raises) and can
+            # legitimately persist the turn minutes later — and a recovering client is told
+            # "in_progress" only while this marker lives. So refresh unconditionally, and only skip
+            # the socket write once the client is known to be gone. A Redis blip must not kill the
+            # heartbeat either — the socket comment below is what keeps the client's stall detector
+            # fed — so refresh failures are logged and retried on the next tick.
+            begin
+              refresh_agent_turn_in_progress!(client_turn_id)
+            rescue => e
+              Rails.logger.error("Store agent heartbeat marker refresh failed: #{e.message}")
+            end
+            next unless socket_alive
 
-          begin
-            write_lock.synchronize { response.stream.write(": heartbeat\n\n") }
-          rescue IOError, SystemCallError, ActionController::Live::ClientDisconnected
-            # The client is gone — stop writing to the dead socket, but keep the marker refreshes
-            # going. The request thread's own next write surfaces the disconnect through its
-            # existing handling. SystemCallError is included because a dead socket can surface as
-            # Errno::EPIPE / Errno::ECONNRESET rather than the wrapped ClientDisconnected, and an
-            # uncaught error here would kill the whole heartbeat thread, refreshes included.
-            socket_alive = false
+            begin
+              write_lock.synchronize { response.stream.write(": heartbeat\n\n") }
+            rescue IOError, SystemCallError, ActionController::Live::ClientDisconnected
+              # The client is gone — stop writing to the dead socket, but keep the marker refreshes
+              # going. The request thread's own next write surfaces the disconnect through its
+              # existing handling. SystemCallError is included because a dead socket can surface as
+              # Errno::EPIPE / Errno::ECONNRESET rather than the wrapped ClientDisconnected, and an
+              # uncaught error here would kill the whole heartbeat thread, refreshes included.
+              socket_alive = false
+            end
           end
+        ensure
+          ActiveRecord::Base.connection_pool.release_connection
         end
       end
 
@@ -219,6 +223,7 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
         heartbeat.join
       end
       sse.close
+      ActiveRecord::Base.connection_pool.release_connection
     end
   end
 

--- a/app/controllers/api/mobile/agent_streams_controller.rb
+++ b/app/controllers/api/mobile/agent_streams_controller.rb
@@ -187,7 +187,7 @@ class Api::Mobile::AgentStreamsController < Api::Mobile::BaseController
     ensure
       if heartbeat
         stop_heartbeat << true
-        heartbeat.join
+        ActiveSupport::Dependencies.interlock.permit_concurrent_loads { heartbeat.join }
       end
       sse.close
       ActiveRecord::Base.connection_pool.release_connection

--- a/app/controllers/api/mobile/agent_streams_controller.rb
+++ b/app/controllers/api/mobile/agent_streams_controller.rb
@@ -81,22 +81,26 @@ class Api::Mobile::AgentStreamsController < Api::Mobile::BaseController
       mark_agent_turn_in_progress!(client_turn_id)
 
       heartbeat = Thread.new do
-        socket_alive = true
-        until stop_heartbeat.pop(timeout: STREAM_HEARTBEAT_INTERVAL.to_f)
-          begin
-            refresh_agent_turn_in_progress!(client_turn_id)
-          rescue => e
-            Rails.logger.error("Mobile store agent heartbeat marker refresh failed: #{e.message}")
-          end
-          next unless socket_alive
+        Rails.application.executor.wrap do
+          socket_alive = true
+          until stop_heartbeat.pop(timeout: STREAM_HEARTBEAT_INTERVAL.to_f)
+            begin
+              refresh_agent_turn_in_progress!(client_turn_id)
+            rescue => e
+              Rails.logger.error("Mobile store agent heartbeat marker refresh failed: #{e.message}")
+            end
+            next unless socket_alive
 
-          begin
-            write_lock.synchronize { response.stream.write(": heartbeat\n\n") }
-          rescue IOError, SystemCallError, ActionController::Live::ClientDisconnected
-            # Keep refreshing the recovery marker after the socket dies. The request thread can
-            # still finish the turn and persist it during a silent tool iteration.
-            socket_alive = false
+            begin
+              write_lock.synchronize { response.stream.write(": heartbeat\n\n") }
+            rescue IOError, SystemCallError, ActionController::Live::ClientDisconnected
+              # Keep refreshing the recovery marker after the socket dies. The request thread can
+              # still finish the turn and persist it during a silent tool iteration.
+              socket_alive = false
+            end
           end
+        ensure
+          ActiveRecord::Base.connection_pool.release_connection
         end
       end
 
@@ -186,6 +190,7 @@ class Api::Mobile::AgentStreamsController < Api::Mobile::BaseController
         heartbeat.join
       end
       sse.close
+      ActiveRecord::Base.connection_pool.release_connection
     end
   end
 

--- a/app/controllers/api/v2/gumhead/messages_controller.rb
+++ b/app/controllers/api/v2/gumhead/messages_controller.rb
@@ -763,6 +763,7 @@ class Api::V2::Gumhead::MessagesController < Api::V2::BaseController
           record_usage!(model: @body["model"], usage: synthetic_input_usage.merge("output_tokens" => 0))
         end
         response.stream.close if committed
+        ActiveRecord::Base.connection_pool.release_connection
       end
     rescue HTTP::ConnectTimeoutError => e
       # TCP connect failed; the request never reached Anthropic.

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1901,16 +1901,15 @@ class LinksController < ApplicationController
         generate_product_cover_and_thumbnail_using_ai
         generate_product_content_using_ai
       else
-        # Raw Thread.new leaks AR checkouts until the Puma worker dies (gp#2383).
+        # Raw Thread.new skips the executor complete hook, so any AR checkout the
+        # child takes stays owned by a live thread for the whole join (gp#2383).
+        # Wrap the thread; lease AR only around DB sections inside the generators
+        # so the OpenAI round-trip does not pin a pool slot.
         cover_thread = Thread.new do
-          Rails.application.executor.wrap do
-            ActiveRecord::Base.connection_pool.with_connection { generate_product_cover_and_thumbnail_using_ai }
-          end
+          Rails.application.executor.wrap { generate_product_cover_and_thumbnail_using_ai }
         end
         content_thread = Thread.new do
-          Rails.application.executor.wrap do
-            ActiveRecord::Base.connection_pool.with_connection { generate_product_content_using_ai }
-          end
+          Rails.application.executor.wrap { generate_product_content_using_ai }
         end
 
         # Child threads take the load interlock via executor.wrap; joining without
@@ -1929,28 +1928,30 @@ class LinksController < ApplicationController
         service = Ai::ProductDetailsGeneratorService.new(current_seller:)
         result = service.generate_cover_image(product_name: @product.name)
         image_data = result[:image_data]
-        create_blob = ->(identifier) {
-          ActiveStorage::Blob.create_and_upload!(
-            io: StringIO.new(image_data),
-            filename: "#{@product.external_id}_#{identifier}_#{Time.now.to_i}.jpeg",
-            content_type: "image/jpeg",
-            identify: false
-          )
-        }
+        ActiveRecord::Base.connection_pool.with_connection do
+          create_blob = ->(identifier) {
+            ActiveStorage::Blob.create_and_upload!(
+              io: StringIO.new(image_data),
+              filename: "#{@product.external_id}_#{identifier}_#{Time.now.to_i}.jpeg",
+              content_type: "image/jpeg",
+              identify: false
+            )
+          }
 
-        cover_image_blob = create_blob.call("cover")
-        cover_image_blob.analyze
-        asset_preview = @product.asset_previews.build
-        asset_preview.file.attach(cover_image_blob)
-        asset_preview.analyze_file
-        asset_preview.save!
+          cover_image_blob = create_blob.call("cover")
+          cover_image_blob.analyze
+          asset_preview = @product.asset_previews.build
+          asset_preview.file.attach(cover_image_blob)
+          asset_preview.analyze_file
+          asset_preview.save!
 
-        thumbnail_image_blob = create_blob.call("thumbnail")
-        thumbnail_image_blob.analyze
-        thumbnail = @product.build_thumbnail
-        thumbnail.file.attach(thumbnail_image_blob)
-        thumbnail.file.analyze
-        thumbnail.save!
+          thumbnail_image_blob = create_blob.call("thumbnail")
+          thumbnail_image_blob.analyze
+          thumbnail = @product.build_thumbnail
+          thumbnail.file.attach(thumbnail_image_blob)
+          thumbnail.file.analyze
+          thumbnail.save!
+        end
       rescue => e
         ErrorNotifier.notify(e)
       end
@@ -1961,9 +1962,11 @@ class LinksController < ApplicationController
 
       number_of_content_pages = params[:link][:number_of_content_pages]
       if number_of_content_pages.present? && @product.native_type == Link::NATIVE_TYPE_EBOOK
-        attribute = @product.custom_attributes.find { _1["name"] == "Pages" }
-        attribute["value"] = number_of_content_pages.to_s if attribute.present?
-        @product.save!
+        ActiveRecord::Base.connection_pool.with_connection do
+          attribute = @product.custom_attributes.find { _1["name"] == "Pages" }
+          attribute["value"] = number_of_content_pages.to_s if attribute.present?
+          @product.save!
+        end
       end
 
       begin
@@ -1976,12 +1979,14 @@ class LinksController < ApplicationController
         service = Ai::ProductDetailsGeneratorService.new(current_seller:)
         response = service.generate_rich_content_pages(product_info)
 
-        response[:pages].each.with_index do |page_data, index|
-          rich_content = @product.alive_rich_contents.build
-          rich_content.title = page_data["title"]
-          rich_content.description = page_data["content"] || []
-          rich_content.position = index
-          rich_content.save!
+        ActiveRecord::Base.connection_pool.with_connection do
+          response[:pages].each.with_index do |page_data, index|
+            rich_content = @product.alive_rich_contents.build
+            rich_content.title = page_data["title"]
+            rich_content.description = page_data["content"] || []
+            rich_content.position = index
+            rich_content.save!
+          end
         end
       rescue => e
         ErrorNotifier.notify(e)

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1913,8 +1913,12 @@ class LinksController < ApplicationController
           end
         end
 
-        cover_thread.join
-        content_thread.join
+        # Child threads take the load interlock via executor.wrap; joining without
+        # yielding deadlocks a concurrent reload in development (no-op in production).
+        ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+          cover_thread.join
+          content_thread.join
+        end
       end
     end
 

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1901,8 +1901,17 @@ class LinksController < ApplicationController
         generate_product_cover_and_thumbnail_using_ai
         generate_product_content_using_ai
       else
-        cover_thread = Thread.new { generate_product_cover_and_thumbnail_using_ai }
-        content_thread = Thread.new { generate_product_content_using_ai }
+        # Raw Thread.new leaks AR checkouts until the Puma worker dies (gp#2383).
+        cover_thread = Thread.new do
+          Rails.application.executor.wrap do
+            ActiveRecord::Base.connection_pool.with_connection { generate_product_cover_and_thumbnail_using_ai }
+          end
+        end
+        content_thread = Thread.new do
+          Rails.application.executor.wrap do
+            ActiveRecord::Base.connection_pool.with_connection { generate_product_content_using_ai }
+          end
+        end
 
         cover_thread.join
         content_thread.join

--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -407,7 +407,9 @@ class ContentModeration::ModerateRecordService
         Thread.new do
           # Silence Ruby's stderr dump on thread death; Thread#value re-raises for the caller.
           Thread.current.report_on_exception = false
-          strategy.perform
+          Rails.application.executor.wrap do
+            ActiveRecord::Base.connection_pool.with_connection { strategy.perform }
+          end
         end
       end
 

--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -407,9 +407,9 @@ class ContentModeration::ModerateRecordService
         Thread.new do
           # Silence Ruby's stderr dump on thread death; Thread#value re-raises for the caller.
           Thread.current.report_on_exception = false
-          Rails.application.executor.wrap do
-            ActiveRecord::Base.connection_pool.with_connection { strategy.perform }
-          end
+          # Strategies are HTTP/GlobalConfig only; do not pin an AR lease for the
+          # OpenAI round-trip. executor.wrap still clears any lazy checkout.
+          Rails.application.executor.wrap { strategy.perform }
         end
       end
 

--- a/app/services/content_moderation/moderate_record_service.rb
+++ b/app/services/content_moderation/moderate_record_service.rb
@@ -413,7 +413,7 @@ class ContentModeration::ModerateRecordService
         end
       end
 
-      threads.map(&:value)
+      ActiveSupport::Dependencies.interlock.permit_concurrent_loads { threads.map(&:value) }
     end
 
     # The preset is about EMPTY listings that route buyers off-platform, so the emptiness half

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,12 +7,13 @@ development: &development
   port: <%= ENV.fetch("DATABASE_PORT") %>
   # Makara does not work well with Sidekiq's threaded model. We set the pool size to be more than the Sidekiq
   # concurrency so that Sidekiq jobs don't run out of Active Record connections to the database.
-  # As of writing this, only Sidekiq workers set ENV["DB_POOL_SIZE"]. `ENV["RAILS_MAX_THREADS"].presence` is put in the
-  # condition so that migrating to anything that uses the ENV var will require no changes to this file. (also a fallback)
-  # If both the ENV vars are missing the pool size will evaluate to 5 (which is the Rails default in case you're
-  # wondering).
+  # Sidekiq sets ENV["DB_POOL_SIZE"] to its concurrency. Web Puma does not, and
+  # ActionController::Live plus publish-time AI threads checkout extra connections
+  # beyond RAILS_MAX_THREADS (gp#2383), so production/staging fall back to 10
+  # instead of Rails' 5. Tests and development keep 5.
   # See https://github.com/gumroad/infrastructure/issues/479 for more details.
-  pool: <%= ENV["DB_POOL_SIZE"].presence || ENV["RAILS_MAX_THREADS"].presence || 5 %>
+  <% web_pool_fallback = %w[production staging].include?(ENV.fetch("RAILS_ENV", "development")) ? 10 : 5 %>
+  pool: <%= ENV["DB_POOL_SIZE"].presence || ENV["RAILS_MAX_THREADS"].presence || web_pool_fallback %>
   <%= "reconnect: true" unless ENV["SKIP_NATIVE_MYSQL_RECONNECT"] == "true" %>
   socket: <%= [
   '/var/run/mysqld/mysqld.sock',

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,11 +9,13 @@ development: &development
   # concurrency so that Sidekiq jobs don't run out of Active Record connections to the database.
   # Sidekiq sets ENV["DB_POOL_SIZE"] to its concurrency. Web Puma does not, and
   # ActionController::Live plus publish-time AI threads checkout extra connections
-  # beyond RAILS_MAX_THREADS (gp#2383), so production/staging fall back to 10
-  # instead of Rails' 5. Tests and development keep 5.
+  # beyond RAILS_MAX_THREADS (gp#2383). Production/staging never drop below 10,
+  # even when RAILS_MAX_THREADS is set to Puma's thread count. Tests and
+  # development keep the requested size, or 5.
   # See https://github.com/gumroad/infrastructure/issues/479 for more details.
-  <% web_pool_fallback = %w[production staging].include?(ENV.fetch("RAILS_ENV", "development")) ? 10 : 5 %>
-  pool: <%= ENV["DB_POOL_SIZE"].presence || ENV["RAILS_MAX_THREADS"].presence || web_pool_fallback %>
+  <% requested_pool = (ENV["DB_POOL_SIZE"].presence || ENV["RAILS_MAX_THREADS"].presence)&.to_i %>
+  <% web_pool_floor = %w[production staging].include?(ENV.fetch("RAILS_ENV", "development")) ? 10 : nil %>
+  pool: <%= web_pool_floor ? [requested_pool, web_pool_floor].compact.max : (requested_pool || 5) %>
   <%= "reconnect: true" unless ENV["SKIP_NATIVE_MYSQL_RECONNECT"] == "true" %>
   socket: <%= [
   '/var/run/mysqld/mysqld.sock',

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -40,6 +40,22 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       expect(result.reasons).to eq([])
     end
 
+    it "returns Active Record connections checked out by strategy threads" do
+      checkout = lambda do
+        User.first
+        strategy_result.new(status: "compliant", reasoning: [])
+      end
+      %w[BlocklistStrategy ClassifierStrategy PromptStrategy].each do |name|
+        klass = ContentModeration::Strategies.const_get(name)
+        allow(klass).to receive(:new).and_return(instance_double(klass, perform: nil).tap { |d| allow(d).to receive(:perform, &checkout) })
+      end
+
+      described_class.check(product, :product)
+
+      leaked = ActiveRecord::Base.connection_pool.connections.count { |c| c.in_use? && c.owner && !c.owner.alive? }
+      expect(leaked).to eq(0)
+    end
+
     it "skips moderation for verified sellers" do
       seller.update!(verified: true)
       expect(ContentModeration::ContentExtractor).not_to receive(:new)

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -46,6 +46,11 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
         wraps += 1
         method.call(*args, &block)
       end
+      permits = 0
+      allow(ActiveSupport::Dependencies.interlock).to receive(:permit_concurrent_loads).and_wrap_original do |method, *args, &block|
+        permits += 1
+        method.call(*args, &block)
+      end
       checkout = lambda do
         User.first
         strategy_result.new(status: "compliant", reasoning: [])
@@ -58,6 +63,7 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       described_class.check(product, :product)
 
       expect(wraps).to eq(2)
+      expect(permits).to eq(1)
     end
 
     it "skips moderation for verified sellers" do

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       expect(result.reasons).to eq([])
     end
 
-    it "runs AI strategy threads inside the Rails executor" do
+    it "runs AI strategy threads inside the Rails executor without pinning AR" do
       wraps = 0
       allow(Rails.application.executor).to receive(:wrap).and_wrap_original do |method, *args, &block|
         wraps += 1
@@ -48,25 +48,29 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       end
       permits = 0
       allow(ActiveSupport::Dependencies.interlock).to receive(:permit_concurrent_loads).and_wrap_original do |method, *args, &block|
-        # AR checkout also yields the interlock; count only this service's join wrapper.
+        # Count only this service's join wrapper (other code may also yield the interlock).
         if block&.source_location&.first&.end_with?("moderate_record_service.rb")
           permits += 1
         end
         method.call(*args, &block)
       end
-      checkout = lambda do
-        User.first
-        strategy_result.new(status: "compliant", reasoning: [])
+      checkouts = 0
+      allow(ActiveRecord::Base.connection_pool).to receive(:with_connection).and_wrap_original do |method, *args, &block|
+        checkouts += 1
+        method.call(*args, &block)
       end
       %w[ClassifierStrategy PromptStrategy].each do |name|
         klass = ContentModeration::Strategies.const_get(name)
-        allow(klass).to receive(:new).and_return(instance_double(klass, perform: nil).tap { |d| allow(d).to receive(:perform, &checkout) })
+        allow(klass).to receive(:new).and_return(
+          instance_double(klass, perform: strategy_result.new(status: "compliant", reasoning: []))
+        )
       end
 
       described_class.check(product, :product)
 
       expect(wraps).to eq(2)
       expect(permits).to eq(1)
+      expect(checkouts).to eq(0)
     end
 
     it "skips moderation for verified sellers" do

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -48,7 +48,10 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       end
       permits = 0
       allow(ActiveSupport::Dependencies.interlock).to receive(:permit_concurrent_loads).and_wrap_original do |method, *args, &block|
-        permits += 1
+        # AR checkout also yields the interlock; count only this service's join wrapper.
+        if block&.source_location&.first&.end_with?("moderate_record_service.rb")
+          permits += 1
+        end
         method.call(*args, &block)
       end
       checkout = lambda do

--- a/spec/services/content_moderation/moderate_record_service_spec.rb
+++ b/spec/services/content_moderation/moderate_record_service_spec.rb
@@ -40,20 +40,24 @@ RSpec.describe ContentModeration::ModerateRecordService, :vcr do
       expect(result.reasons).to eq([])
     end
 
-    it "returns Active Record connections checked out by strategy threads" do
+    it "runs AI strategy threads inside the Rails executor" do
+      wraps = 0
+      allow(Rails.application.executor).to receive(:wrap).and_wrap_original do |method, *args, &block|
+        wraps += 1
+        method.call(*args, &block)
+      end
       checkout = lambda do
         User.first
         strategy_result.new(status: "compliant", reasoning: [])
       end
-      %w[BlocklistStrategy ClassifierStrategy PromptStrategy].each do |name|
+      %w[ClassifierStrategy PromptStrategy].each do |name|
         klass = ContentModeration::Strategies.const_get(name)
         allow(klass).to receive(:new).and_return(instance_double(klass, perform: nil).tap { |d| allow(d).to receive(:perform, &checkout) })
       end
 
       described_class.check(product, :product)
 
-      leaked = ActiveRecord::Base.connection_pool.connections.count { |c| c.in_use? && c.owner && !c.owner.alive? }
-      expect(leaked).to eq(0)
+      expect(wraps).to eq(2)
     end
 
     it "skips moderation for verified sellers" do


### PR DESCRIPTION
## What

Stops web Puma workers from exhausting their Active Record pool with extra threads that hold connections too long.

- Production/staging pool fallback is 10 when `DB_POOL_SIZE` and `RAILS_MAX_THREADS` are unset (web Nomad sets neither; Sidekiq still sets `DB_POOL_SIZE`).
- Content-moderation strategy threads keep `Rails.application.executor.wrap` but no longer take `with_connection` — those strategies are HTTP/GlobalConfig only, so they must not pin a pool slot for the OpenAI round-trip.
- Publish-time AI threads keep the executor wrap; `with_connection` wraps only the ActiveStorage/save sections after generation (and the short ebook page-count save before it).
- Agent SSE heartbeats run inside the executor and `release_connection` when they stop; Live actions release on ensure.
- Joins of those executor-wrapped threads go through `permit_concurrent_loads` so a concurrent reload in development cannot deadlock the load interlock (no-op in production).

## Why

[gp#2383](https://github.com/antiwork/gumroad-private/issues/2383): after the Resend write batching shipped, the next midnight wave still 500'd shoppers with `ActiveRecord::ConnectionTimeoutError`. Live Puma env on a current green host: `RAILS_MAX_THREADS` and `DB_POOL_SIZE` unset, `PUMA_WORKER_PROCESSES=6` → 2 threads / pool 5 per worker.

The 23:15 onset was not webhook volume. Completed shopper requests on the hottest host were fast; the first timeout was `CustomDomain.find_by_host` in routing — that worker's pool was already full. Lograge only logs on complete, so hung Live children do not show as in-flight. Host recycle at 00:47–00:53 cleared the 500s; zero `ConnectionTimeoutError` after 01:00.

Completed Live volume is too low to be the concurrent holder (19 mobile agent streams / 15 web / 4 gumhead creates on the hot hosts before onset). Publish is not: 521 `LinksController#publish` on those three hosts 17:45–23:15, each spawning two AR threads without a clear return path, and an eager `with_connection` around the whole OpenAI call would keep pinning slots for generation.

## Before / After

No rendered surface. Pool-floor ERB (`config/database.yml`):

| env | `DB_POOL_SIZE` | `RAILS_MAX_THREADS` | pool |
|---|---|---|---|
| production/staging | unset | unset | 10 |
| production/staging | unset | 2 | 10 (floor) |
| production/staging (Sidekiq) | 30 | any | 30 |
| development/test | unset | unset | 5 |

Moderation strategy threads: executor wrap only (no AR lease for OpenAI). Publish AI: lease only around blob/save work.

## Test Results

- `spec/services/content_moderation/moderate_record_service_spec.rb` pins executor wrap on strategy threads, counts this service's `permit_concurrent_loads` join wrapper, and asserts strategy threads take zero `with_connection` checkouts.
- Prior green Buildkite at `7295f3ec25f1d8f5b2989e5d476a1a67dba8de95` (Fast 18/18, Slow 50/50, Minitest, lint, typecheck); this follow-up is the lease-scope fix on that base.

## QA steps

No preview/screenshot gate (backend pool + thread checkout). Production verification remains post-deploy:

1. Confirm a production/staging web process boots with pool 10 (`ActiveRecord::Base.connection_pool.size`) while Sidekiq stays on its existing `DB_POOL_SIZE`.
2. Publish a product that runs AI cover+content generation; worker should not hold AR checkouts for the OpenAI round-trip.
3. After deploy, a midnight Resend wave should produce no shopper `ConnectionTimeoutError`.

Closes nothing until the next midnight wave is clean.

## Ownership

HIGH RISK (shared web AR pool can 500 shopper/checkout requests). Not auto-merging. Assignee `gianfrancopiana` — review the executor/`with_connection`/`permit_concurrent_loads` checkout before merge.

---
Implemented by Grok 4.6 (xAI).
