### PR TITLE
Fix custom landing buy button ignoring checkout postMessage

### DIFF
--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -702,7 +702,7 @@ module RendersCustomHtmlPages
             var ENDPOINT = #{endpoint_json};
             var GENERIC_ERROR = "Something went wrong. Please try again.";
             window.addEventListener("message", function (e) {
-              if (!frame || e.source !== frame.contentWindow || e.origin !== "null") return;
+              if (!frame || e.source !== frame.contentWindow) return;
               var d = e.data;
               if (!d || typeof d !== "object" || d.type !== "gumroad:follow") return;
               // Echoed back so the child can route each reply to the form that
@@ -744,7 +744,7 @@ module RendersCustomHtmlPages
     # gumroad:products messages from the sandboxed landing iframe and fetches the requested
     # catalogue slice from the profile's landing/products endpoint. The iframe content is
     # seller-authored and untrusted, so this side is the security boundary:
-    # - only messages from the landing frame's opaque origin are accepted;
+    # - only messages from the landing frame (e.source) are accepted;
     # - the endpoint URL is baked from this wrapper's render context — nothing in the message
     #   picks the seller, so the page can never read another seller's catalogue slice;
     # - offset/limit are validated as non-negative integers and limit is clamped to MAX_ITEMS
@@ -764,7 +764,7 @@ module RendersCustomHtmlPages
             var ENDPOINT = #{endpoint_json};
             var MAX_ITEMS = #{Pages::ProfileData::MAX_ITEMS};
             window.addEventListener("message", function (e) {
-              if (!frame || e.source !== frame.contentWindow || e.origin !== "null") return;
+              if (!frame || e.source !== frame.contentWindow) return;
               var d = e.data;
               if (!d || typeof d !== "object" || d.type !== "gumroad:products") return;
               var requestId = typeof d.requestId === "string" ? d.requestId : null;
@@ -862,7 +862,7 @@ module RendersCustomHtmlPages
               frame.contentWindow.postMessage({ type: "gumroad:background:request" }, "*");
             });
             window.addEventListener("message", function (e) {
-              if (!frame || e.source !== frame.contentWindow || e.origin !== "null") return;
+              if (!frame || e.source !== frame.contentWindow) return;
               var d = e.data;
               if (!d || typeof d !== "object" || d.type !== "gumroad:background") return;
               var colorScheme = d.colorScheme == null ? null : d.colorScheme;

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -2175,7 +2175,8 @@ class LinksController < ApplicationController
                 } catch (_e) { return base; }
               }
               window.addEventListener("message", function (e) {
-                if (e.source !== frame.contentWindow || e.origin !== "null") return;
+                // Opaque-origin e.origin isn't a usable check — gate on e.source.
+                if (!frame || e.source !== frame.contentWindow) return;
                 // String form: back-compat for any caller still sending the old signal.
                 if (e.data === "gumroad:checkout") { window.location.href = BASE_CHECKOUT; return; }
                 // Structured form: {type:"gumroad:checkout", params:{variant,quantity,price,recurrence}}.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -373,9 +373,8 @@ class UsersController < ApplicationController
                 var STORE_HOSTNAMES = #{store_hostnames_json};
                 #{custom_html_navigation_allowlist_js.indent(16).strip}
                 window.addEventListener("message", function (e) {
-                  // Only the sandboxed landing iframe (opaque origin, so
-                  // e.origin is the literal string "null") may drive this.
-                  if (e.source !== frame.contentWindow || e.origin !== "null") return;
+                  // Opaque-origin e.origin isn't a usable check — gate on e.source.
+                  if (!frame || e.source !== frame.contentWindow) return;
                   if (!e.data || typeof e.data !== "object" || e.data.type !== "gumroad:navigate") return;
                   var url;
                   try { url = new URL(String(e.data.url), window.location.href); } catch (_err) { return; }

--- a/app/javascript/entrypoints/custom_html_analytics.ts
+++ b/app/javascript/entrypoints/custom_html_analytics.ts
@@ -77,11 +77,10 @@ if (configElement) {
     // a "gumroad:checkout" message to this wrapper (see custom_html_wrapper_document),
     // which then navigates to checkout. That message is the custom page's equivalent
     // of the product page's "I want this" CTA, so mirror its add_to_cart tracking.
-    // We re-check origin/source exactly like the wrapper's navigation handler so a
-    // message from anything but the sandboxed (opaque-origin) iframe is ignored.
+    // Gate on e.source like the wrapper. Opaque-origin e.origin isn't usable.
     const landingFrame = document.querySelector<HTMLIFrameElement>("#gumroad-landing-frame");
     window.addEventListener("message", (event) => {
-      if (event.source !== landingFrame?.contentWindow || event.origin !== "null") return;
+      if (event.source !== landingFrame?.contentWindow) return;
       const data: unknown = event.data;
       const isCheckout =
         data === "gumroad:checkout" || (typia.is<{ type: string }>(data) && data.type === "gumroad:checkout");

--- a/spec/controllers/links_controller_custom_html_spec.rb
+++ b/spec/controllers/links_controller_custom_html_spec.rb
@@ -43,7 +43,9 @@ describe LinksController, :vcr, type: :controller do
       expect(response.body).to include(%(BASE_CHECKOUT = "/l/#{product.unique_permalink}?wanted=true"))
       expect(response.body).to include('e.data === "gumroad:checkout"')
       expect(response.body).to include('e.data.type === "gumroad:checkout"')
-      expect(response.body).to include('e.origin !== "null"')
+      # Opaque-origin e.origin isn't usable (Chrome reports "null", other
+      # engines report the frame URL). Gate on e.source only.
+      expect(response.body).not_to include('e.origin !== "null"')
       # Script carries a nonce — script-src has no 'unsafe-inline', so without
       # it the listener would be CSP-blocked in the browser. It also opts out of
       # Rocket Loader so Cloudflare doesn't rewrite the inline handler and drop

--- a/spec/controllers/users_controller_custom_html_spec.rb
+++ b/spec/controllers/users_controller_custom_html_spec.rb
@@ -40,6 +40,10 @@ describe UsersController, :vcr, type: :controller do
       get :show
       expect(response.body).to include("gumroad:navigate")
       expect(response.body).to include("STORE_HOSTNAMES")
+      # Opaque-origin e.origin isn't usable (Chrome reports "null", other
+      # engines report the frame URL). Gate on e.source only.
+      expect(response.body).not_to include('e.origin !== "null"')
+      expect(response.body).to include("e.source !== frame.contentWindow")
     end
 
     describe "facebook-domain-verification meta tag" do
@@ -83,6 +87,10 @@ describe UsersController, :vcr, type: :controller do
       expect(response.body).to include("data-gumroad-products-wrapper")
       expect(response.body).to include("gumroad:products:result")
       expect(response.body).to include("/landing/products")
+      # Opaque-origin e.origin isn't usable (Chrome reports "null", other
+      # engines report the frame URL). Gate on e.source only.
+      expect(response.body).not_to include('e.origin !== "null"')
+      expect(response.body).to include("e.source !== frame.contentWindow")
     end
 
     it "falls back to the default profile page when custom_html is blank" do

--- a/spec/requests/custom_html_background_wiring_spec.rb
+++ b/spec/requests/custom_html_background_wiring_spec.rb
@@ -14,6 +14,13 @@ describe "Custom HTML background bridge wiring", type: :request do
 
   before { Feature.activate_user(:custom_html_pages, seller) }
 
+  # Product wrappers always load custom_html_analytics via vite_typescript_tag.
+  # Stub the tag so this wiring guard stays about the background bridge, not Vite.
+  before do
+    allow_any_instance_of(ActionView::Base).to receive(:vite_typescript_tag)
+      .with("custom_html_analytics").and_return(%(<script src="/custom_html_analytics.js"></script>).html_safe)
+  end
+
   shared_examples "a surface carrying both halves of the bridge" do
     it "injects the reporter into the sandboxed embed" do
       get "#{host}#{embed_path}"
@@ -45,6 +52,10 @@ describe "Custom HTML background bridge wiring", type: :request do
       # oklch(… / 0). Pinning the shared source on both sides is what makes a
       # re-fork fail here rather than in a browser months later.
       expect(response.body).to include(RendersCustomHtmlPages::CANVAS_OPAQUE_FN.strip)
+      # Opaque-origin e.origin isn't usable (Chrome reports "null", other
+      # engines report the frame URL). Gate on e.source only.
+      expect(response.body).not_to include('e.origin !== "null"')
+      expect(response.body).to include("e.source !== frame.contentWindow")
     end
   end
 

--- a/spec/requests/products/show/custom_html_analytics_spec.rb
+++ b/spec/requests/products/show/custom_html_analytics_spec.rb
@@ -119,4 +119,16 @@ describe "Custom HTML landing page analytics", type: :request do
       expect(props["has_product_third_party_analytics"]).to eq(true)
     end
   end
+
+  # The checkout listener lives in the Vite entrypoint, not the rendered wrapper
+  # HTML, so pin the source the same way the product-wrapper controller spec pins
+  # the inline script: no origin "null" gate, source check stays.
+  it "gates the checkout message on event.source only" do
+    source = File.read(Rails.root.join("app/javascript/entrypoints/custom_html_analytics.ts"))
+
+    # Opaque-origin event.origin isn't usable (Chrome reports "null", other
+    # engines report the frame URL). Gate on event.source only.
+    expect(source).not_to include('event.origin !== "null"')
+    expect(source).to include("event.source !== landingFrame?.contentWindow")
+  end
 end

--- a/spec/requests/profile_custom_html_spec.rb
+++ b/spec/requests/profile_custom_html_spec.rb
@@ -232,6 +232,10 @@ describe "Profile custom HTML rendering", type: :request do
       # signed-in visitor following with their own verified email skip the
       # confirmation-email round trip.
       expect(response.body).to include(%(name="csrf-token"))
+      # Opaque-origin e.origin isn't usable (Chrome reports "null", other
+      # engines report the frame URL). Gate on e.source only.
+      expect(response.body).not_to include('e.origin !== "null"')
+      expect(response.body).to include("e.source !== frame.contentWindow")
     end
 
     # These two examples are about ROUTING: that the follow endpoint is


### PR DESCRIPTION
## What
Custom product landing pages listen for `gumroad:checkout` from the sandboxed embed and navigate to checkout. The production wrapper (and the follow / products / background / analytics / navigate listeners) also required `event.origin === "null"`. The dashboard preview already dropped that check because opaque-origin `event.origin` is not a usable identity signal.

## Why
A buy click posts `{type:"gumroad:checkout", params}` from the embed. Chrome reports origin `"null"` so CI system specs pass. Other engines, and some Chromium history states, report the frame URL origin instead. The source check still proves the message came from our iframe; the origin check silently drops it, so the URL never changes.

Security is unchanged: `event.source === frame.contentWindow` cannot be spoofed. Destination URLs are still built only from `BASE_CHECKOUT` plus the existing checkout-key allowlist.

## Before / After
**Before:** wrapper returns early unless `e.origin === "null"`, even when `e.source` is the landing iframe.
**After:** same source check the preview already uses. Checkout, navigate, follow, products, background, and analytics listeners all match. Specs pin origin-negative + source-positive on all six surfaces (product wrapper plus the other five).

## Test Results
- `DISABLE_SPRING=1 VITE_RUBY_AUTO_BUILD=false bundle exec rspec spec/controllers/links_controller_custom_html_spec.rb spec/controllers/users_controller_custom_html_spec.rb` — 98 examples, 0 failures
- Pin examples for navigate / products / follow / background / analytics — 18 examples, 0 failures
- Controller and request examples now pin each listener does **not** contain `e.origin !== "null"` (analytics: `event.origin !== "null"`) and still gates on source
- Existing system specs (`spec/requests/products/show/custom_html_spec.rb`, `spec/requests/product_custom_html_navigation_spec.rb`) already click the buy control in Chrome; they stay the Chrome-origin-null path. Multi-engine E2E not required for this pin follow-up

## QA (preview @ `3777543ef92b`)
Host: `https://seller.gumclaw-gp2399-custom-html-check.apps.staging.gumroad.org` (`x-revision: 3777543ef92b`).

Seeded the preview seller's `demo` product with Flipper `:custom_html_pages` plus a Page row whose HTML is `<a data-gumroad-action="buy">`.

- `GET /l/demo` 200, emits `gumroad-landing-frame`. Served wrapper contains `if (!frame || e.source !== frame.contentWindow) return;` and the comment `Opaque-origin e.origin isn't a usable check — gate on e.source.` It does **not** contain `e.origin !== "null"`.
- `GET /l/demo/landing/embed` 200, contains `data-gumroad-action="buy"` and the seeded `QA buy` heading.
- No new rendered UI. The wrapper script is the surface.

Implements antiwork/gumroad-private#2399

---
AI disclosure: Implemented by Grok.
