### PR TITLE
Batch-load associations used to serialize GET /api/v2/products

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -8,7 +8,15 @@ class Api::V2::LinksController < Api::V2::BaseController
   ].freeze
 
   INDEX_PRODUCT_ASSOCIATIONS = (BASE_PRODUCT_ASSOCIATIONS + [
-    { variant_categories_alive: [:alive_variants] },
+    :alive_prices,
+    :global_checkout_custom_fields,
+    :product_checkout_custom_fields,
+    :ordered_alive_product_files,
+    :skus_alive,
+    { thumbnail: [:file_attachment, :file_blob] },
+    { tiers: [:alive_prices] },
+    { default_tier: [:alive_prices] },
+    { variant_categories_alive: [{ alive_variants: [:alive_prices] }] },
   ]).freeze
 
   RESULTS_PER_PAGE = 10

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -130,6 +130,7 @@ class Link < ApplicationRecord
   has_one :tier_category, -> { alive.is_tier_category }, class_name: "VariantCategory"
   has_one :default_tier, through: :tier_category
   has_many :skus
+  has_many :skus_alive, -> { alive }, class_name: "Sku"
   has_many :skus_alive_not_default, -> { alive.not_is_default_sku }, class_name: "Sku"
   has_many :installments
   has_many :subscriptions
@@ -174,6 +175,9 @@ class Link < ApplicationRecord
       .or(where(universal: true))
   }, through: :user, source: :available_cross_sells
   has_and_belongs_to_many :custom_fields, join_table: "custom_fields_products", foreign_key: "product_id"
+  has_many :global_checkout_custom_fields, -> { global.not_is_post_purchase }, through: :user, source: :custom_fields
+  has_and_belongs_to_many :product_checkout_custom_fields, -> { not_is_post_purchase },
+                          class_name: "CustomField", join_table: "custom_fields_products", foreign_key: "product_id"
   has_one :product_refund_policy, foreign_key: "product_id"
   has_one :staff_picked_product, foreign_key: "product_id"
   has_one :custom_domain, -> { alive }, foreign_key: "product_id"
@@ -1261,7 +1265,7 @@ class Link < ApplicationRecord
   end
 
   def checkout_custom_fields
-    user.custom_fields.not_is_post_purchase.global.to_a.concat(custom_fields.not_is_post_purchase)
+    global_checkout_custom_fields.to_a.concat(product_checkout_custom_fields.to_a)
   end
 
   def custom_field_descriptors

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -456,11 +456,17 @@ module Product::Prices
       # CollabProductsPagePresenter#display_price_cents,
       # Product::StructuredData#minimum_offer_price_cents) don't pay a
       # per-category N+1.
-      if association(:variant_categories_alive).loaded? &&
-         variant_categories_alive.all? { |c| c.association(:alive_variants).loaded? } &&
-         association(:skus).loaded?
-        candidates = skus.select(&:alive?) +
-                     variant_categories_alive.flat_map(&:alive_variants)
+      preloaded_skus =
+        if association(:skus_alive).loaded?
+          skus_alive.to_a
+        elsif association(:skus).loaded?
+          skus.select(&:alive?)
+        end
+
+      if preloaded_skus &&
+         association(:variant_categories_alive).loaded? &&
+         variant_categories_alive.all? { |c| c.association(:alive_variants).loaded? }
+        candidates = preloaded_skus + variant_categories_alive.flat_map(&:alive_variants)
         candidates.map(&:price_difference_cents).compact.min
       else
         current_base_variants.minimum(:price_difference_cents)

--- a/app/modules/with_product_files.rb
+++ b/app/modules/with_product_files.rb
@@ -23,7 +23,9 @@ module WithProductFiles
   # Call this method only if you're sure that you're not changing the files within the same action.
   def alive_product_files
     cached_alive_product_files || self.cached_alive_product_files =
-      if association(:product_files).loaded?
+      if association(:ordered_alive_product_files).loaded?
+        ordered_alive_product_files.to_a
+      elsif association(:product_files).loaded?
         # Match MySQL's `ORDER BY position ASC` (used by the `in_order`
         # scope on the cold-cache branch): NULLs sort FIRST in MySQL's
         # default NULL-handling. Ruby's `sort_by` puts unknowns where you

--- a/spec/controllers/api/v2/links_controller_spec.rb
+++ b/spec/controllers/api/v2/links_controller_spec.rb
@@ -194,6 +194,47 @@ describe Api::V2::LinksController do
         expect(cover_blob_queries.count).to eq(1)
         expect(cover_blob_queries.first).to include("IN (")
       end
+
+      it "batch loads associations used to serialize products" do
+        global_custom_field = create(:custom_field, seller: @user, global: true)
+        product_custom_fields = [@product1, @product2].index_with do |product|
+          create(:custom_field, seller: @user, name: "Field for #{product.name}").tap { product.custom_fields << _1 }
+        end
+        [@product1, @product2].each do |product|
+          create(:product_file, link: product)
+          category = create(:variant_category, link: product)
+          create(:variant, variant_category: category, price_difference_cents: 100)
+        end
+        create(:thumbnail, product: @product1)
+        create(:thumbnail, product: @product2)
+
+        queries = []
+        counter = lambda do |*, payload|
+          queries << payload[:sql] unless payload[:name] == "SCHEMA"
+        end
+
+        ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+          get @action, params: @params
+        end
+
+        expect(response).to be_successful
+        products_by_id = response.parsed_body["products"].index_by { _1["id"] }
+        [@product1, @product2].each do |product|
+          custom_field_ids = products_by_id.fetch(product.external_id).fetch("custom_fields").pluck("id")
+          expect(custom_field_ids).to contain_exactly(global_custom_field.external_id, product_custom_fields.fetch(product).external_id)
+        end
+
+        expect(queries.grep(/FROM `prices`/).count).to eq(2)
+        expect(queries.grep(/FROM `thumbnails`/).count).to eq(1)
+        expect(queries.grep(/FROM `product_files`/).count).to eq(1)
+        expect(queries.grep(/FROM `custom_fields`/).count).to eq(1)
+        expect(queries.grep(/MIN\(`base_variants`\.`price_difference_cents`\)/)).to be_empty
+
+        thumbnail_attachment_queries = queries.grep(/FROM `active_storage_attachments`.*record_type.*Thumbnail/)
+        thumbnail_blob_queries = queries.grep(/FROM `active_storage_blobs`/)
+        expect(thumbnail_attachment_queries.one? { _1.include?("IN (") }).to be true
+        expect(thumbnail_blob_queries.one? { _1.include?("IN (") }).to be true
+      end
     end
   end
 

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -378,6 +378,26 @@ describe Product::Prices do
           expect(per_row_alive_variants).to be_empty,
                                             "Expected no per-row alive_variants queries when associations are not preloaded, got:\n#{per_row_alive_variants.join("\n")}"
         end
+
+        it "uses the scoped SKU preload without querying variants again" do
+          create(:sku, link: product, price_difference_cents: 99)
+          create(:sku, link: product, price_difference_cents: 50, deleted_at: 1.hour.ago)
+          fresh_product = Link.includes(:alive_prices, :skus_alive, variant_categories_alive: :alive_variants).find(product.id)
+
+          expect(fresh_product.association(:skus_alive)).to be_loaded
+          expect(fresh_product.skus_alive.map(&:price_difference_cents)).to contain_exactly(99)
+
+          queries = []
+          counter = lambda do |*, payload|
+            queries << payload[:sql] if payload[:name] != "SCHEMA" && !payload[:cached]
+          end
+
+          ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+            expect(fresh_product.display_price_cents).to eq 5_99
+          end
+
+          expect(queries.grep(/FROM `base_variants`/)).to be_empty
+        end
       end
     end
 


### PR DESCRIPTION
## What

Fixes N+1 queries in the `GET /api/v2/products` API. When serializing a batched product page, the code was issuing per-product queries for prices, thumbnails, files, checkout custom fields, and SKUs even though the page was already batched. This PR batch-loads those associations.

Specifically:
- Batch-load product, variant, and tier prices
- Thumbnails and their Active Storage records (`file_attachment`, `file_blob`)
- Product files (ordered)
- Global and product-specific checkout custom fields
- Alive SKUs and alive variants with their prices

Update the corresponding model methods (`checkout_custom_fields`, `alive_product_files`, `lowest_variant_price_difference_cents`) and the controller's `INDEX_PRODUCT_ASSOCIATIONS` to consume the preloaded associations in batches rather than querying during serialization.

### Why

A 10-product response executed ~103 SQL statements with repeated per-product queries. After this change, ~23 SQL statements, with all per-product association queries eliminated (-92.3% target-association queries).

### Benchmark (10 populated products, OAuth `GET /api/v2/products`, 5 requests after 3 warmups)

| Metric | Before | After | Change |
|---|---|---|---|
| Request duration (ms) | 162.36 | 96.70 | -40.4% |
| SQL duration (ms) | 29.30 | 8.98 | -69.4% |
| SQL events | 103 | 23 | -77.7% |
| Target association queries | 91 | 7 | -92.3% |
| Per-product target queries | 70 | 0 | -100% |

### QA steps

1. Seller with multiple products containing prices, variants, files, uploaded thumbnails, and checkout custom fields.
2. Create an OAuth token with `view_public` scope.
3. `GET /api/v2/products` with that token.
4. Confirm the response still includes the same prices, files, thumbnails, variants, and global/product-specific custom fields.
5. Inspect SQL instrumentation: associations loaded in batches, not once per product.

### Tests

- `rspec spec/controllers/api/v2/links_controller_spec.rb -e "batch loads associations used to serialize products"`
- `rspec spec/modules/product/prices_spec.rb -e "uses the scoped SKU preload"`

Verified locally by Gumclaw: both specs pass (79/79 in prices_spec).

---

Based on https://github.com/haseebeqx/gumroad/pull/3 by @haseebeqx.

AI Disclosure: Deepseek was used to review the original PR and import the changes.