### PR TITLE
Match Tier category titles case-insensitively in API V2 preload

### DIFF
--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -462,7 +462,8 @@ module Product::Prices
 
       return nil unless association(:variant_categories_alive).loaded?
 
-      tier_categories = variant_categories_alive.select { |category| category.title == "Tier" }
+      # is_tier_category is where(title: "Tier") on utf8mb4_unicode_ci; match that in memory.
+      tier_categories = variant_categories_alive.select { |category| category.title.to_s.casecmp?("Tier") }
       return nil if tier_categories.empty?
       return nil unless tier_categories.all? { |category| category.association(:alive_variants).loaded? }
 


### PR DESCRIPTION
## What
Use a case-insensitive check when finding the membership "Tier" category in the preloaded API V2 path.

## Why
#7506 batch-loads associations for `GET /api/v2/products`, but the in-memory filter still used `title == "Tier"`. MySQL `is_tier_category` uses `utf8mb4_unicode_ci`, so a category titled `tier` matches in SQL and misses in memory. That forces a per-product fallback and undoes the preload.

## Before / After
**Before:** Preloaded membership products with a differently cased Tier title fell back to extra queries.

**After:** The in-memory filter uses `casecmp?("Tier")`, so those products stay on the batched path.

## Test Results
No new automated test. Diff is one predicate on the preloaded association path already covered by the #7506 API V2 products specs. Revert would restore `title == "Tier"` and miss case variants again.

## QA
Not run. Behavior change is case matching on an internal category title; no seller-visible UI.

---
Implemented by Claude Fable 5.1 (Claude Code).
