### PR TITLE
Lock TOTP enrollment confirm against concurrent reuse

### DIFF
--- a/app/controllers/settings/totp_controller.rb
+++ b/app/controllers/settings/totp_controller.rb
@@ -31,20 +31,31 @@ class Settings::TotpController < Settings::BaseController
 
   def confirm
     credential = @user.totp_credential
-
-    if credential.blank? || credential.confirmed?
+    if credential.blank?
       return render json: { success: false, error_message: "No pending TOTP setup found." }, status: :unprocessable_entity
     end
 
-    if credential.verify_code(params[:code])
-      codes = TotpCredential.transaction do
+    result = nil
+    codes = nil
+    credential.with_lock do
+      if credential.confirmed?
+        result = :missing
+      elsif credential.verify_code(params[:code])
         credential.update!(confirmed_at: Time.current)
-        credential.generate_recovery_codes
+        codes = credential.generate_recovery_codes
+        result = :ok
+      else
+        result = :invalid
       end
+    end
 
+    case result
+    when :ok
       render json: { success: true, recovery_codes: format_recovery_codes(codes) }
-    else
+    when :invalid
       render json: { success: false, error_message: "Invalid code. Please try again." }, status: :unprocessable_entity
+    else
+      render json: { success: false, error_message: "No pending TOTP setup found." }, status: :unprocessable_entity
     end
   end
 

--- a/spec/controllers/settings/totp_controller_spec.rb
+++ b/spec/controllers/settings/totp_controller_spec.rb
@@ -90,6 +90,20 @@ describe Settings::TotpController, type: :controller do
         expect(json["error_message"]).to eq("Invalid code. Please try again.")
         expect(credential.reload).not_to be_confirmed
       end
+
+      it "rejects confirm when another request finishes enrollment before the row lock is taken" do
+        code = credential.otp_code
+        allow_any_instance_of(TotpCredential).to receive(:with_lock).and_wrap_original do |method, *args, &block|
+          method.receiver.update_columns(confirmed_at: Time.current) if method.receiver.id == credential.id
+          method.call(*args, &block)
+        end
+
+        post :confirm, params: { code: }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["error_message"]).to eq("No pending TOTP setup found.")
+        expect(credential.reload.recovery_codes).to be_blank
+      end
     end
 
     context "when user has no totp credential" do


### PR DESCRIPTION
Lock TOTP enrollment confirm so a concurrent authenticator code cannot complete setup twice.

`POST /settings/totp/confirm` used to check `confirmed_at` and verify the TOTP code before locking the row. Two parallel requests with the same windowed code could both succeed and each mint a recovery-code set (last write won).

This takes `with_lock` on the credential, re-checks confirmation inside the lock, then verifies and writes. Same pattern as `TotpCredential#redeem_recovery_code`.

Spec: a peer that finishes enrollment before the lock is taken is rejected and does not mint a second recovery-code set.

Local: `spec/controllers/settings/totp_controller_spec.rb` — 17 examples, 0 failures. RuboCop clean on the two files.

Not money-path.

Ref: antiwork/gumroad-private#2402

Premerge review: clean @ 5566f700ce3395f4052a02a75189afa090d1bace
