### PR TITLE
Make TOTP enrollment confirm single-use under a row lock

### DIFF
--- a/app/controllers/settings/totp_controller.rb
+++ b/app/controllers/settings/totp_controller.rb
@@ -32,17 +32,16 @@ class Settings::TotpController < Settings::BaseController
   def confirm
     credential = @user.totp_credential
 
-    if credential.blank? || credential.confirmed?
+    if credential.blank?
       return render json: { success: false, error_message: "No pending TOTP setup found." }, status: :unprocessable_entity
     end
 
-    if credential.verify_code(params[:code])
-      codes = TotpCredential.transaction do
-        credential.update!(confirmed_at: Time.current)
-        credential.generate_recovery_codes
-      end
+    codes = credential.confirm(params[:code])
 
+    if codes
       render json: { success: true, recovery_codes: format_recovery_codes(codes) }
+    elsif codes.nil?
+      render json: { success: false, error_message: "No pending TOTP setup found." }, status: :unprocessable_entity
     else
       render json: { success: false, error_message: "Invalid code. Please try again." }, status: :unprocessable_entity
     end

--- a/app/models/totp_credential.rb
+++ b/app/models/totp_credential.rb
@@ -24,6 +24,20 @@ class TotpCredential < ApplicationRecord
     authenticate_otp(code, drift: DRIFT).present?
   end
 
+  # Single-use transition from pending to confirmed, protected by a row lock so two
+  # concurrent confirms carrying the same code cannot both complete (gp#2402). Returns
+  # the freshly minted recovery codes on success, nil if the credential is already
+  # confirmed (replayed/redundant), or false if the code is invalid.
+  def confirm(code)
+    with_lock do
+      return nil if confirmed?
+      return false unless verify_code(code)
+
+      update!(confirmed_at: Time.current)
+      generate_recovery_codes
+    end
+  end
+
   def totp_provisioning_uri
     provisioning_uri(user.email, issuer: ISSUER_NAME)
   end

--- a/spec/models/totp_credential_concurrency_spec.rb
+++ b/spec/models/totp_credential_concurrency_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# `use_transactional_tests = false` because a shared connection cannot exhibit the race: each worker
+# needs its own connection, like two web processes.
+describe TotpCredential do
+  self.use_transactional_tests = false
+
+  let(:user) { create(:user) }
+
+  before do
+    @credential = create(:totp_credential, user:)
+    @code = @credential.otp_code
+  end
+
+  after do
+    # No transaction rollback here, so remove what the examples created.
+    TotpCredential.delete_all
+    user.destroy! if user.persisted?
+  end
+
+  it "rejects the second of two concurrent confirms carrying the same code" do
+    # Hold the first confirm open between taking the row lock and minting recovery codes — exactly
+    # the window the race lived in — and only release the second confirm once the lock is held, so
+    # the ordering does not depend on thread scheduling. Each worker acts on its own instance loaded
+    # before the race, like two web processes, so the stale confirmed? read is what the loser would
+    # rely on without the row lock.
+    lock_held = Queue.new
+    allow_any_instance_of(TotpCredential).to receive(:generate_recovery_codes).and_wrap_original do |original, *args|
+      if Thread.current[:hold_open_confirm_window]
+        lock_held << true
+        sleep 1
+      end
+      original.call(*args)
+    end
+
+    first_credential = TotpCredential.find(@credential.id)
+    second_credential = TotpCredential.find(@credential.id)
+    results = Queue.new
+
+    first = Thread.new do
+      Thread.current[:hold_open_confirm_window] = true
+      ActiveRecord::Base.connection_pool.with_connection { results << first_credential.confirm(@code) }
+    end
+
+    if lock_held.pop(timeout: 20).nil?
+      # Surface whatever the first confirm raised instead of blocking on a signal that will never come.
+      first.join(5)
+      raise "the first confirm never reached the write window"
+    end
+
+    second = Thread.new do
+      ActiveRecord::Base.connection_pool.with_connection { results << second_credential.confirm(@code) }
+    end
+
+    [first, second].each { expect(_1.join(20)).to be_present }
+
+    confirmed = Array.new(2) { results.pop }
+    expect(confirmed.count { |r| r.is_a?(Array) }).to eq(1)
+    expect(confirmed.include?(nil)).to be true
+
+    @credential.reload
+    expect(@credential).to be_confirmed
+    expect(@credential.recovery_codes.size).to eq(TotpCredential::RECOVERY_CODE_COUNT)
+  end
+
+  it "rejects a code on a credential that is already confirmed" do
+    @credential.confirm(@code)
+    @credential.reload
+    codes_before = @credential.recovery_codes
+
+    expect(@credential.confirm(@credential.otp_code)).to be nil
+    expect(@credential.reload.recovery_codes).to eq(codes_before)
+  end
+end


### PR DESCRIPTION
## What

Make TOTP enrollment confirm a single-use state transition. `TotpCredential#confirm(code)` now holds a row lock (`with_lock`) around the `confirmed?` re-check, the code verification, and the `confirmed_at` + recovery-code writes. `Settings::TotpController#confirm` calls it.

The `confirmed?` guard previously ran outside any lock/transaction, and TOTP codes are a time-windowed HMAC that is not consumed — so two concurrent `POST /settings/totp/confirm` requests carrying the same valid code could both pass the guard, both verify, and both mint a recovery-code set (last write wins). A second concurrent request now blocks on the row lock, re-reads a confirmed row under `SELECT ... FOR UPDATE`, and falls into the existing "No pending TOTP setup found" branch.

## Why

Race Condition Allows the Same TOTP Code to Be Reused to Enable 2FA Multiple Times (external researcher). Same class as the password-reset single-use fix (gp#1560). `TotpCredential#redeem_recovery_code` already uses `with_lock`; enrollment confirm did not. Reproduced by code read, seeded Low severity (requires an authenticated session that has started TOTP setup).

## Before / After

- Before: guard `confirmed?` outside the lock → concurrent same-code confirms both complete the pending→confirmed transition and each mint a recovery-code set; last write wins on `recovery_codes`.
- After: row lock + re-check inside the lock → exactly one confirm completes; the second returns "No pending TOTP setup found"; exactly one recovery-code set is persisted.

## Test Results

- `spec/models/totp_credential_concurrency_spec.rb` — 2 examples, 0 failures (new). Includes a true two-connection concurrency test (each worker its own instance/connection, first held open inside the mint window) asserting exactly one of two same-code confirms succeeds and one recovery-code set persists.
- Mutation-proof: removing `with_lock` makes the concurrency example fail (`count == 2`, expected 1) — the guard spec has teeth.
- `spec/models/totp_credential_spec.rb` + `spec/controllers/settings/totp_controller_spec.rb` — 35 examples, 0 failures (existing, sequential behavior unchanged: happy path, invalid code, already-confirmed reject, destroy, regenerate).
- `ruby -c` clean on all three touched files.

## QA steps

Backend-only change with no rendered surface (no screenshot applies). Behavioral QA is the mutation-proven concurrency spec above: with the fix, exactly one of two concurrent same-code confirm calls succeeds; the no-lock control shows both succeeding.

## Scope / Design / Build / Ship / Market / Sell

- [x] Scope — Low-severity hardening; mirrors gp#1560 single-use pattern
- [x] Design — row lock + re-check inside lock, matching `redeem_recovery_code`
- [x] Build — `TotpCredential#confirm` extracted + controller delegates
- [x] QA — 2 new concurrency examples green; mutation (drop lock) goes red; 35 existing specs unchanged
- [ ] Ship — awaiting CI + review
- [ ] Market — n/a (internal hardening)
- [ ] Sell — n/a (internal hardening)

---

AI disclosure: Built/generated by Hermes Agent (claude-fable-5-1 default; specs authored by an autonomous agent). This is a security-hardening fix on a money/2FA-adjacent path — held as a draft for adversarial review before ready.

Related: https://github.com/antiwork/gumroad-private/issues/2402