### PR TITLE
Fix download-page claim 500 on charge-incomplete purchases

### DIFF
--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -270,8 +270,11 @@ class UrlRedirectsController < ApplicationController
       return redirect_to url_redirect_check_purchaser_path({ id: @url_redirect.token, next: params[:next].presence }.compact)
     end
 
-    purchase.purchaser = logged_in_user
-    purchase.save!
+    # A purchaser-only claim must not re-run charge validation. `financial_transaction_validation`
+    # is registered on the `:successful` state and raises on success rows whose charge fields are
+    # incomplete (older/migrated or imported purchases), which a `save!` here would turn into a 500.
+    # `update_column` writes just `purchaser_id`, skipping that validator so the claim succeeds.
+    purchase.update_column(:purchaser_id, logged_in_user.id)
     redirect_to_next
   end
 

--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -270,10 +270,8 @@ class UrlRedirectsController < ApplicationController
       return redirect_to url_redirect_check_purchaser_path({ id: @url_redirect.token, next: params[:next].presence }.compact)
     end
 
-    # A purchaser-only claim must not re-run charge validation. `financial_transaction_validation`
-    # is registered on the `:successful` state and raises on success rows whose charge fields are
-    # incomplete (older/migrated or imported purchases), which a `save!` here would turn into a 500.
-    # `update_column` writes just `purchaser_id`, skipping that validator so the claim succeeds.
+    # `update_column` skips `financial_transaction_validation`, which raises on successful
+    # legacy/imported purchases with incomplete charge fields and would 500 the claim.
     purchase.update_column(:purchaser_id, logged_in_user.id)
     redirect_to_next
   end

--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -270,9 +270,13 @@ class UrlRedirectsController < ApplicationController
       return redirect_to url_redirect_check_purchaser_path({ id: @url_redirect.token, next: params[:next].presence }.compact)
     end
 
-    # `update_column` skips `financial_transaction_validation`, which raises on successful
-    # legacy/imported purchases with incomplete charge fields and would 500 the claim.
-    purchase.update_column(:purchaser_id, logged_in_user.id)
+    # A purchaser-only claim must not re-run charge validation: `financial_transaction_validation`
+    # is registered on the `:successful` state and would reject a success row whose charge fields
+    # are incomplete (older/migrated or imported purchases), turning the claim into a 500. Save with
+    # `validate: false` so the write still runs the same callbacks and touches `updated_at` as before,
+    # skipping only the validators.
+    purchase.purchaser = logged_in_user
+    purchase.save!(validate: false)
     redirect_to_next
   end
 

--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -270,6 +270,10 @@ class UrlRedirectsController < ApplicationController
       return redirect_to url_redirect_check_purchaser_path({ id: @url_redirect.token, next: params[:next].presence }.compact)
     end
 
+    # A signed-out claim would persist a nil purchaser, silently removing the purchase from its
+    # current owner's library.
+    return redirect_to login_path(next: url_redirect_check_purchaser_path({ id: @url_redirect.token, next: params[:next].presence }.compact)) if logged_in_user.nil?
+
     # A purchaser-only claim must not re-run charge validation: `financial_transaction_validation`
     # is registered on the `:successful` state and would reject a success row whose charge fields
     # are incomplete (older/migrated or imported purchases), turning the claim into a 500. Save with

--- a/app/controllers/url_redirects_controller.rb
+++ b/app/controllers/url_redirects_controller.rb
@@ -271,8 +271,13 @@ class UrlRedirectsController < ApplicationController
     end
 
     # A signed-out claim would persist a nil purchaser, silently removing the purchase from its
-    # current owner's library.
-    return redirect_to login_path(next: url_redirect_check_purchaser_path({ id: @url_redirect.token, next: params[:next].presence }.compact)) if logged_in_user.nil?
+    # current owner's library. Pin login to the app domain: /login is not routed on seller
+    # subdomains or custom domains (same reason library_url uses host: DOMAIN above).
+    return redirect_to login_url(
+      next: url_redirect_check_purchaser_path({ id: @url_redirect.token, next: params[:next].presence }.compact),
+      host: DOMAIN,
+      protocol: PROTOCOL
+    ), allow_other_host: true if logged_in_user.nil?
 
     # A purchaser-only claim must not re-run charge validation: `financial_transaction_validation`
     # is registered on the `:successful` state and would reject a success row whose charge fields

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -198,13 +198,15 @@ class UsersController < ApplicationController
 
       if logged_in_user.present?
         purchase.purchaser = logged_in_user
-        purchase.save
+        # Same legacy charge-incomplete successful rows as change_purchaser: skip
+        # charge-field validators so a library claim does not silently no-op.
+        purchase.save!(validate: false)
         return render json: { success: true, redirect_location: library_path }
       else
         user = User.alive.find_by(email: purchase.email)
         if user.present? && user.valid_password?(params["user"]["password"])
           purchase.purchaser = user
-          purchase.save
+          purchase.save!(validate: false)
 
           sign_in_or_prepare_for_two_factor_auth(user)
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -3301,11 +3301,10 @@ class Purchase < ApplicationRecord
       subscription.save!
     end
 
-    begin
-      save!
-    rescue ActiveRecord::RecordInvalid => e
-      logger.info("Attaching user to purchase #{id}: Could save purchase after attaching user #{user.id}. Exception: #{e.message}")
-    end
+    # Same legacy charge-incomplete successful rows as change_purchaser: a plain
+    # save! re-runs financial_transaction_validation and the attach no-ops. Skip
+    # validators only; keep callbacks and updated_at.
+    save!(validate: false)
   end
 
   def seller_balance_update_eligible?

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -2451,6 +2451,17 @@ describe UrlRedirectsController, inertia: true do
       expect(response).to redirect_to("/r/#{@token}")
     end
 
+    it "requires sign-in and does not clear the existing purchaser for signed-out claims" do
+      owner = create(:user)
+      @url_redirect.purchase.update!(purchaser: owner)
+
+      expect do
+        post :change_purchaser, params: { id: @token, next: "/r/#{@token}", email: @url_redirect.purchase.email }
+      end.not_to change { @url_redirect.purchase.reload.purchaser }
+
+      expect(response).to redirect_to(login_path(next: url_redirect_check_purchaser_path(id: @token, next: "/r/#{@token}")))
+    end
+
     it "redirects to root path when next param is missing" do
       user = create(:user)
 

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -2430,6 +2430,27 @@ describe UrlRedirectsController, inertia: true do
       expect(response).to redirect_to("/r/#{@token}")
     end
 
+    it "claims a successful purchase with incomplete charge fields without re-running charge validation" do
+      user = create(:user)
+      # Older/migrated or imported purchases can be successful and paid (price_cents > 0) while
+      # missing charge fields, which fails `financial_transaction_validation` on a `save!`. Write
+      # the row directly to bypass that validator exactly like production's legacy rows.
+      @url_redirect.purchase.update_columns(
+        price_cents: 100,
+        stripe_transaction_id: nil,
+        stripe_fingerprint: nil,
+        merchant_account_id: nil,
+        charge_processor_id: nil
+      )
+
+      expect do
+        sign_in user
+        post :change_purchaser, params: { id: @token, next: "/r/#{@token}", email: @url_redirect.purchase.email }
+      end.to change { @url_redirect.purchase.reload.purchaser }.to(user)
+
+      expect(response).to redirect_to("/r/#{@token}")
+    end
+
     it "redirects to root path when next param is missing" do
       user = create(:user)
 

--- a/spec/controllers/url_redirects_controller_spec.rb
+++ b/spec/controllers/url_redirects_controller_spec.rb
@@ -2459,7 +2459,11 @@ describe UrlRedirectsController, inertia: true do
         post :change_purchaser, params: { id: @token, next: "/r/#{@token}", email: @url_redirect.purchase.email }
       end.not_to change { @url_redirect.purchase.reload.purchaser }
 
-      expect(response).to redirect_to(login_path(next: url_redirect_check_purchaser_path(id: @token, next: "/r/#{@token}")))
+      expect(response).to redirect_to(login_url(
+        next: url_redirect_check_purchaser_path(id: @token, next: "/r/#{@token}"),
+        host: DOMAIN,
+        protocol: PROTOCOL
+      ))
     end
 
     it "redirects to root path when next param is missing" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -870,6 +870,24 @@ describe UsersController do
       expect(@purchase.reload.purchaser).to eq @user
     end
 
+    it "claims a successful purchase with incomplete charge fields without re-running charge validation" do
+      # Older/migrated or imported purchases can be successful and paid while missing
+      # charge fields, which fails financial_transaction_validation on a plain save.
+      @purchase.update_columns(
+        price_cents: 100,
+        stripe_transaction_id: nil,
+        stripe_fingerprint: nil,
+        merchant_account_id: nil,
+        charge_processor_id: nil
+      )
+
+      sign_in(@user)
+      post :add_purchase_to_library, params: @params
+
+      expect(@purchase.reload.purchaser).to eq @user
+      expect(response.parsed_body["success"]).to eq true
+    end
+
     it "associates the purchase to the user if the password is correct" do
       post :add_purchase_to_library, params: @params
       expect(@purchase.reload.purchaser).to eq @user

--- a/spec/models/purchase/attach_to_user_and_card_spec.rb
+++ b/spec/models/purchase/attach_to_user_and_card_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Purchase, "#attach_to_user_and_card" do
+  let(:user) { create(:user) }
+  let(:purchase) { create(:purchase) }
+
+  it "attaches the purchaser" do
+    purchase.attach_to_user_and_card(user, nil, nil)
+
+    expect(purchase.reload.purchaser).to eq(user)
+  end
+
+  it "attaches a successful purchase with incomplete charge fields without re-running charge validation" do
+    # Older/migrated or imported purchases can be successful and paid while missing
+    # charge fields, which fails financial_transaction_validation on a plain save!.
+    purchase.update_columns(
+      price_cents: 100,
+      stripe_transaction_id: nil,
+      stripe_fingerprint: nil,
+      merchant_account_id: nil,
+      charge_processor_id: nil
+    )
+
+    purchase.attach_to_user_and_card(user, nil, nil)
+
+    expect(purchase.reload.purchaser).to eq(user)
+  end
+
+  it "does not attach a reassignment-locked purchase" do
+    purchase.update!(is_reassignment_locked: true)
+
+    expect(purchase.attach_to_user_and_card(user, nil, nil)).to eq(false)
+    expect(purchase.reload.purchaser).to be_nil
+  end
+end


### PR DESCRIPTION
## What

Buyers can claim older successful purchases that are missing charge fields into their library without a 500 or a silent no-op.

- Download-page claim (`UrlRedirectsController#change_purchaser`) persists the purchaser with `save!(validate: false)` and requires sign-in. Signed-out claims redirect to login on the app domain (`login_url` with `host: DOMAIN`), so seller subdomains and custom domains do not 404 on `/login`.
- Library claim (`UsersController#add_purchase_to_library`) and OAuth/signup attach (`Purchase#attach_to_user_and_card`) use the same purchaser write pattern.
- Charge validation on real charges is unchanged.

## Why

`financial_transaction_validation` runs on every save of a `:successful` purchase. Legacy or imported paid rows can be successful while missing `stripe_transaction_id` / `stripe_fingerprint` / `merchant_account` / `charge_processor_id`. A plain `save!` then raises `RecordInvalid` (download-page 500). A plain `save` or a rescued `save!` leaves the purchaser unchanged while the client may still see success. Sentry GUMROAD-1J7 (3 events / 2 users, all `change_purchaser`). Refs gumroad-private#2405 / gp#2405.

## Before / After

- Before: charge-incomplete successful purchase → download-page claim 500s; library claim and attach silently leave `purchaser_id` unset; signed-out claim can clear the owner; signed-out claim on a custom domain can 404 at `/login`.
- After: signed-in claim/attach updates `purchaser_id` and continues; signed-out claim redirects to app-domain login with `next` back to the claim page; charge validators still run on real charge flows.

## Test Results

```text
DISABLE_SPRING=1 bundle exec rspec spec/controllers/url_redirects_controller_spec.rb -e "change_purchaser"
6 examples, 0 failures

DISABLE_SPRING=1 bundle exec rspec spec/controllers/users_controller_spec.rb -e "add_purchase_to_library"
9 examples, 0 failures

DISABLE_SPRING=1 bundle exec rspec spec/models/purchase/attach_to_user_and_card_spec.rb
3 examples, 0 failures

# revert-proof: incomplete-charge examples with validate:false / equivalent removed
2 examples, 2 failures
# library: purchaser stays nil (plain save no-ops)
# attach: purchaser stays nil (rescued RecordInvalid)
```

## QA

Backend-only claim/attach writes. Proof is the regression specs (green at head; incomplete-charge examples red when the bypass is removed). No rendered surface; no `qa-media/`.

---

Implemented by Claude Fable 5.1 (Claude Code) and Grok.
