### PR TITLE
Reject PayPal OAuth grants issued to other partners

### DIFF
--- a/app/business/payments/merchant_registration/implementations/paypal/paypal_merchant_account_manager.rb
+++ b/app/business/payments/merchant_registration/implementations/paypal/paypal_merchant_account_manager.rb
@@ -112,12 +112,17 @@ class PaypalMerchantAccountManager
         return "There was an error connecting your PayPal account with Gumroad." unless merchant_account.save
       end
 
-      oauth_integration = parsed_response.dig("oauth_integrations", 0)
+      gumroad_oauth_integration = Array.wrap(parsed_response["oauth_integrations"]).find do |oauth_integration|
+        next false unless oauth_integration.is_a?(Hash)
 
-      if oauth_integration && parsed_response["primary_email_confirmed"] && parsed_response["payments_receivable"] &&
-          oauth_integration["integration_type"] == "OAUTH_THIRD_PARTY" &&
-          oauth_integration["integration_method"] == "PAYPAL"
-        oauth_integration["oauth_third_party"][0]["partner_client_id"] == PAYPAL_PARTNER_CLIENT_ID
+        oauth_integration["integration_type"] == "OAUTH_THIRD_PARTY" &&
+          oauth_integration["integration_method"] == "PAYPAL" &&
+          Array.wrap(oauth_integration["oauth_third_party"]).any? do |oauth_grant|
+            oauth_grant.is_a?(Hash) && oauth_grant["partner_client_id"] == PAYPAL_PARTNER_CLIENT_ID
+          end
+      end
+
+      if gumroad_oauth_integration && parsed_response["primary_email_confirmed"] && parsed_response["payments_receivable"]
         merchant_account.charge_processor_alive_at = Time.current
         merchant_account.mark_charge_processor_verified!
         MerchantRegistrationMailer.paypal_account_updated(user.id).deliver_later(queue: "default")

--- a/spec/business/payments/merchant_registration/paypal/paypal_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/paypal/paypal_merchant_account_manager_spec.rb
@@ -254,6 +254,97 @@ describe PaypalMerchantAccountManager, :vcr do
       end
     end
 
+    context "when the PayPal OAuth grant belongs to another partner" do
+      let(:creator) { create(:user) }
+      let(:paypal_merchant_id) { "GSQ5PDPXZCWGW" }
+      let(:oauth_integrations) do
+        [{
+          "integration_type" => "OAUTH_THIRD_PARTY",
+          "integration_method" => "PAYPAL",
+          "oauth_third_party" => [{ "partner_client_id" => "another-partner-client-id" }]
+        }]
+      end
+
+      before do
+        allow_any_instance_of(MerchantAccount).to receive(:paypal_account_details).and_return(
+          "country" => "US",
+          "primary_currency" => "USD",
+          "primary_email_confirmed" => true,
+          "payments_receivable" => true,
+          "primary_email" => "seller@example.com",
+          "oauth_integrations" => oauth_integrations
+        )
+      end
+
+      it "leaves the account incomplete" do
+        result = subject.update_merchant_account(user: creator, paypal_merchant_id:)
+
+        expect(result).to eq("Your PayPal account connect with Gumroad is incomplete because of missing permissions. Please try connecting again and grant the requested permissions.")
+        expect(creator.merchant_accounts.charge_processor_verified.paypal).to be_empty
+        expect(creator.reload.paypal_connect_account).to be_nil
+      end
+
+      it "accepts Gumroad's grant when it follows another partner's grant" do
+        oauth_integrations.first["oauth_third_party"] << { "partner_client_id" => PAYPAL_PARTNER_CLIENT_ID }
+
+        result = subject.update_merchant_account(user: creator, paypal_merchant_id:)
+
+        expect(result).to eq("You have successfully connected your PayPal account with Gumroad.")
+        expect(creator.merchant_accounts.charge_processor_verified.paypal.count).to eq(1)
+      end
+
+      it "accepts Gumroad's grant when it is in a later integration" do
+        oauth_integrations << {
+          "integration_type" => "OAUTH_THIRD_PARTY",
+          "integration_method" => "PAYPAL",
+          "oauth_third_party" => [{ "partner_client_id" => PAYPAL_PARTNER_CLIENT_ID }]
+        }
+
+        result = subject.update_merchant_account(user: creator, paypal_merchant_id:)
+
+        expect(result).to eq("You have successfully connected your PayPal account with Gumroad.")
+        expect(creator.merchant_accounts.charge_processor_verified.paypal.count).to eq(1)
+      end
+
+      it "treats a partial OAuth integration as incomplete" do
+        oauth_integrations.first.delete("oauth_third_party")
+        result = nil
+
+        expect { result = subject.update_merchant_account(user: creator, paypal_merchant_id:) }.not_to raise_error
+        expect(result).to eq("Your PayPal account connect with Gumroad is incomplete because of missing permissions. Please try connecting again and grant the requested permissions.")
+      end
+
+      it "treats malformed integration and grant entries as incomplete" do
+        oauth_integrations.replace([nil, {
+                                     "integration_type" => "OAUTH_THIRD_PARTY",
+                                     "integration_method" => "PAYPAL",
+                                     "oauth_third_party" => [nil]
+                                   }])
+        result = nil
+
+        expect { result = subject.update_merchant_account(user: creator, paypal_merchant_id:) }.not_to raise_error
+        expect(result).to eq("Your PayPal account connect with Gumroad is incomplete because of missing permissions. Please try connecting again and grant the requested permissions.")
+      end
+
+      it "rejects Gumroad's grant under the wrong integration type" do
+        oauth_integrations.first["integration_type"] = "FIRST_PARTY"
+        oauth_integrations.first["oauth_third_party"] = [{ "partner_client_id" => PAYPAL_PARTNER_CLIENT_ID }]
+
+        result = subject.update_merchant_account(user: creator, paypal_merchant_id:)
+
+        expect(result).to eq("Your PayPal account connect with Gumroad is incomplete because of missing permissions. Please try connecting again and grant the requested permissions.")
+      end
+
+      it "rejects Gumroad's grant under the wrong integration method" do
+        oauth_integrations.first["integration_method"] = "BRAINTREE"
+        oauth_integrations.first["oauth_third_party"] = [{ "partner_client_id" => PAYPAL_PARTNER_CLIENT_ID }]
+
+        result = subject.update_merchant_account(user: creator, paypal_merchant_id:)
+
+        expect(result).to eq("Your PayPal account connect with Gumroad is incomplete because of missing permissions. Please try connecting again and grant the requested permissions.")
+      end
+    end
+
     describe "connecting a PayPal account whose email PayPal has permanently refused for payouts" do
       let(:creator) { create(:user) }
       let(:paypal_merchant_id) { "GSQ5PDPXZCWGW" }


### PR DESCRIPTION
## What

Require PayPal's merchant-status payload to contain a Gumroad-owned OAuth third-party grant before marking the merchant account verified. The check scans every integration and nested grant, and treats missing or malformed entries as incomplete.

Imported from https://github.com/adityawrk/gumroad/pull/39 by @adityawrk. `qa-media/` binaries were not imported; walkthrough and screenshots stay on the fork PR.

## Why

`PaypalMerchantAccountManager` compared the first grant's `partner_client_id` to Gumroad's client ID and discarded the boolean. A seller whose only grant belongs to another PayPal partner could still be marked verified. This is prospective and does not disconnect already-verified accounts.

## Before / After

| PayPal merchant-status payload | Before | After |
| --- | --- | --- |
| Another partner's OAuth grant only | Account marked verified | Account remains incomplete |
| Gumroad grant after another grant | Only the first grant was inspected | Account marked verified |
| Gumroad grant in a later integration | Only the first integration was inspected | Account marked verified |
| Missing or malformed entries | Could raise or rely on the first entry | Account remains incomplete |

## Test Results

- Failing-first (reproduced by gumclaw QA 2026-09-05 at `720b21d7`; `app/...paypal_merchant_account_manager.rb` reverted to origin/main, new examples kept): **7 examples, 2 failures**. Reds: `leaves the account incomplete` — `Expected "You have successfully connected your PayPal account with Gumroad." to eq "Your PayPal account connect with Gumroad is incomplete because of missing permissions. ..."` (spec:282) and `treats a partial OAuth integration as incomplete` — `Expected raised exception #<NoMethodError "undefined method '[]' for nil"> not to match a kind of Exception` (spec:313). The other 5 examples pass on the pre-fix code because the discarded comparison still marked the account verified whenever type/method matched.
- Fix restored, new context: **7 examples, 0 failures**.
- Full spec file (`paypal_merchant_account_manager_spec.rb`) seeds 7 / 999 / 4242: **30 examples, 0 failures** each.
- Extra mutation (drop the `partner_client_id == PAYPAL_PARTNER_CLIENT_ID` comparison, accept any grant hash): **7 examples, 1 failure** — `leaves the account incomplete` (spec:279) reddens, so the partner-id check is load-bearing.
- Payload shape verified against recorded PayPal merchant-status VCR cassettes (`oauth_integrations[] → {integration_type: "OAUTH_THIRD_PARTY", integration_method: "PAYPAL", oauth_third_party: [{partner_client_id, merchant_client_id, scopes}]}`); the recorded Gumroad grant still verifies.
- Already-verified accounts are untouched: the `already_verified` / `charge_processor_verified?` early return precedes this check, so it only applies to new connections (both the settings redirect and the `MERCHANT.ONBOARDING.COMPLETED` webhook path).
- CI at `720b21d7`: `ci/green` + `buildkite/gumroad` SUCCESS, 0 pending, 0 failing (`run-all-specs`).
- Sol+Fable panel at `720b21d7`: 0 findings from both reviewers. Greptile: 5/5, no inline findings.

## QA steps

1. Stub a merchant-status response whose only OAuth grant uses another partner client ID; update the merchant account; confirm the result stays incomplete.
2. Add Gumroad's grant after that unrelated grant; confirm verification succeeds.
3. Repeat with the Gumroad grant in a later integration.
4. Repeat with missing, non-hash, wrong-type, and wrong-method entries and confirm they fail closed.

Visual evidence: https://github.com/adityawrk/gumroad/pull/39

## Status

- [x] Scope
- [x] Design
- [x] Build
- [x] QA (failing-first + CI)
- [ ] Shipped

---

Based on https://github.com/adityawrk/gumroad/pull/39 by @adityawrk.

Addresses antiwork/gumroad-private#2406.

AI Disclosure: Grok 4.6 reviewed the fork PR and imported the code-and-spec diff (qa-media excluded).

Merge authorised by Sahil 2026-09-05: "QA each draft PR and open/merge".

Premerge review: clean @ 720b21d781f602d8d407e98cc3a598a936a0093f

