### PR TITLE
Refresh Discover eligibility after bank account deletion

### DIFF
--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -22,6 +22,7 @@ class BankAccount < ApplicationRecord
   after_create_commit :handle_stripe_bank_account
   after_create_commit :handle_compliance_info_request
   after_create :update_user_products_search_index
+  after_update_commit :enqueue_user_products_recommendability_refresh, if: :active_status_changed?
 
   # This state machine can be expanded once we implement a complex verification process.
   state_machine(:state, initial: :unverified) do
@@ -173,5 +174,37 @@ class BankAccount < ApplicationRecord
       user.products.find_each do |product|
         product.enqueue_index_update_for(["is_recommendable"])
       end
+    end
+
+    def active_status_changed?
+      saved_change_to_deleted_at? && saved_change_to_deleted_at.any?(&:nil?)
+    end
+
+    def enqueue_user_products_recommendability_refresh
+      return if user_has_another_payout_method?
+
+      RefreshUserProductsRecommendationEligibilityJob.perform_async(user_id)
+    rescue => enqueue_error
+      report_recommendability_refresh_error(enqueue_error, "enqueue")
+
+      begin
+        RefreshUserProductsRecommendationEligibilityJob.new.perform(user_id)
+      rescue => refresh_error
+        report_recommendability_refresh_error(refresh_error, "run synchronously")
+      end
+    end
+
+    def user_has_another_payout_method?
+      user.payment_address.present? ||
+        user.bank_accounts.alive.where.not(id:).exists? ||
+        user.stripe_connect_account.present? ||
+        user.has_paypal_account_connected?
+    end
+
+    def report_recommendability_refresh_error(error, action)
+      Rails.logger.error("Failed to #{action} product recommendation refresh for bank account #{id}: #{error.class}: #{error.message}")
+      ErrorNotifier.notify(error, bank_account_id: id, user_id:)
+    rescue
+      nil
     end
 end

--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -185,13 +185,10 @@ class BankAccount < ApplicationRecord
 
       RefreshUserProductsRecommendationEligibilityJob.perform_async(user_id)
     rescue => enqueue_error
+      # Do not run the catalog refresh inline: Stripe payout recovery calls
+      # mark_deleted! before reverse_internal_transfer_or_hold_payouts!, and a
+      # large-catalog sync pass would delay money reverse/hold when Redis is down.
       report_recommendability_refresh_error(enqueue_error, "enqueue")
-
-      begin
-        RefreshUserProductsRecommendationEligibilityJob.new.perform(user_id)
-      rescue => refresh_error
-        report_recommendability_refresh_error(refresh_error, "run synchronously")
-      end
     end
 
     def user_has_another_payout_method?

--- a/app/sidekiq/refresh_user_products_recommendation_eligibility_job.rb
+++ b/app/sidekiq/refresh_user_products_recommendation_eligibility_job.rb
@@ -2,14 +2,15 @@
 
 class RefreshUserProductsRecommendationEligibilityJob
   include Sidekiq::Job
-  # lock: :until_executing so a bank-account transition during a scan can
-  # enqueue a follow-up. :until_and_while_executing + client: :log dropped
-  # that follow-up and left mixed is_recommendable values.
+  # Runtime-only lock: until_and_while + client: :log dropped a mid-scan
+  # follow-up; until_executing let an older Elasticsearch write finish after it.
   sidekiq_options retry: 3,
                   queue: :low,
-                  lock: :until_executing,
+                  lock: :while_executing,
+                  lock_timeout: 0,
                   lock_ttl: 6.hours.to_i,
-                  on_conflict: { client: :log }
+                  schedule_in: 1.minute.to_i,
+                  on_conflict: { server: :reschedule }
 
   def perform(user_id)
     user = User.find_by(id: user_id)

--- a/app/sidekiq/refresh_user_products_recommendation_eligibility_job.rb
+++ b/app/sidekiq/refresh_user_products_recommendation_eligibility_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class RefreshUserProductsRecommendationEligibilityJob
+  include Sidekiq::Job
+  # Follow-up scans must remain enqueueable and cannot overtake the scan already running.
+  sidekiq_options retry: 3,
+                  queue: :low,
+                  lock: :until_and_while_executing,
+                  lock_ttl: 6.hours.to_i,
+                  on_conflict: { client: :log, server: :reschedule }
+
+  def perform(user_id)
+    user = User.find_by(id: user_id)
+    return if user.nil?
+
+    user.products.find_each do |product|
+      product.enqueue_index_update_for(%w[is_recommendable])
+    end
+  end
+end

--- a/app/sidekiq/refresh_user_products_recommendation_eligibility_job.rb
+++ b/app/sidekiq/refresh_user_products_recommendation_eligibility_job.rb
@@ -2,12 +2,14 @@
 
 class RefreshUserProductsRecommendationEligibilityJob
   include Sidekiq::Job
-  # Follow-up scans must remain enqueueable and cannot overtake the scan already running.
+  # lock: :until_executing so a bank-account transition during a scan can
+  # enqueue a follow-up. :until_and_while_executing + client: :log dropped
+  # that follow-up and left mixed is_recommendable values.
   sidekiq_options retry: 3,
                   queue: :low,
-                  lock: :until_and_while_executing,
+                  lock: :until_executing,
                   lock_ttl: 6.hours.to_i,
-                  on_conflict: { client: :log, server: :reschedule }
+                  on_conflict: { client: :log }
 
   def perform(user_id)
     user = User.find_by(id: user_id)

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -28,6 +28,7 @@ describe StripePayoutProcessor do
 
       allow(Stripe::Payout).to receive(:create).and_raise(stripe_error)
       allow(RefreshUserProductsRecommendationEligibilityJob).to receive(:perform_async).and_raise("Redis unavailable")
+      allow(RefreshUserProductsRecommendationEligibilityJob).to receive(:new).and_call_original
       allow(ErrorNotifier).to receive(:notify)
       allow(described_class).to receive(:reverse_internal_transfer_or_hold_payouts!)
 
@@ -38,6 +39,7 @@ describe StripePayoutProcessor do
         Payment::FailureReason::BANK_ACCOUNT_NOT_FOUND_AT_STRIPE,
         reraise: true
       )
+      expect(RefreshUserProductsRecommendationEligibilityJob).not_to have_received(:new)
       expect(payment.reload.failure_reason).to eq(Payment::FailureReason::BANK_ACCOUNT_NOT_FOUND_AT_STRIPE)
       expect(bank_account.reload).to be_deleted
     end

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe StripePayoutProcessor do
+  describe ".perform_payment" do
+    it "continues payout recovery when the recommendation refresh cannot be enqueued" do
+      seller = create(:user, payment_address: nil)
+      create(:product, user: seller)
+      create(:merchant_account, user: seller, charge_processor_merchant_id: "acct_managed")
+      bank_account = create(
+        :canadian_bank_account,
+        user: seller,
+        stripe_connect_account_id: "acct_managed",
+        stripe_external_account_id: "ba_missing"
+      )
+      payment = create(
+        :payment,
+        user: seller,
+        bank_account:,
+        processor: PayoutProcessorType::STRIPE,
+        stripe_connect_account_id: "acct_managed"
+      )
+      stripe_error = Stripe::InvalidRequestError.new(
+        "The bank account ba_missing has been deleted and can no longer be used.",
+        "external_account"
+      )
+
+      allow(Stripe::Payout).to receive(:create).and_raise(stripe_error)
+      allow(RefreshUserProductsRecommendationEligibilityJob).to receive(:perform_async).and_raise("Redis unavailable")
+      allow(ErrorNotifier).to receive(:notify)
+      allow(described_class).to receive(:reverse_internal_transfer_or_hold_payouts!)
+
+      expect { described_class.perform_payment(payment) }.not_to raise_error
+
+      expect(described_class).to have_received(:reverse_internal_transfer_or_hold_payouts!).with(
+        payment,
+        Payment::FailureReason::BANK_ACCOUNT_NOT_FOUND_AT_STRIPE,
+        reraise: true
+      )
+      expect(payment.reload.failure_reason).to eq(Payment::FailureReason::BANK_ACCOUNT_NOT_FOUND_AT_STRIPE)
+      expect(bank_account.reload).to be_deleted
+    end
+  end
+end

--- a/spec/modules/product/searchable/indexing_spec.rb
+++ b/spec/modules/product/searchable/indexing_spec.rb
@@ -291,6 +291,100 @@ describe "Product::Searchable - Indexing scenarios" do
         create(:canadian_bank_account, user: @product.user)
       end
 
+      it "sends updated is_recommendable flag when the only active bank account is deleted" do
+        bank_account = create(:canadian_bank_account, user: @product.user)
+        @product.user.update!(payment_address: nil)
+        expect(RefreshUserProductsRecommendationEligibilityJob).to receive(:perform_async).with(@product.user_id)
+
+        bank_account.mark_deleted!
+      end
+
+      it "does not index products when another active bank account remains" do
+        bank_account = create(:canadian_bank_account, user: @product.user)
+        create(:canadian_bank_account, user: @product.user)
+        @product.user.update!(payment_address: nil)
+        expect(RefreshUserProductsRecommendationEligibilityJob).not_to receive(:perform_async)
+
+        bank_account.mark_deleted!
+      end
+
+      it "sends updated is_recommendable flag when the first bank account is restored" do
+        bank_account = create(:canadian_bank_account, deleted_at: 1.day.ago, user: @product.user)
+        @product.user.update!(payment_address: nil)
+        expect(RefreshUserProductsRecommendationEligibilityJob).to receive(:perform_async).with(@product.user_id)
+
+        bank_account.mark_undeleted!
+      end
+
+      it "does not index products when bank account deletion is rolled back" do
+        bank_account = create(:canadian_bank_account, user: @product.user)
+        @product.user.update!(payment_address: nil)
+        expect(RefreshUserProductsRecommendationEligibilityJob).not_to receive(:perform_async)
+
+        ActiveRecord::Base.transaction do
+          bank_account.mark_deleted!
+          raise ActiveRecord::Rollback
+        end
+      end
+
+      it "does not enqueue a refresh when another payout method remains" do
+        bank_account = create(:canadian_bank_account, user: @product.user)
+        @product.user.update!(payment_address: "seller@example.com")
+        expect(RefreshUserProductsRecommendationEligibilityJob).not_to receive(:perform_async)
+
+        bank_account.mark_deleted!
+      end
+
+      it "does not enqueue a refresh when Stripe Connect remains" do
+        bank_account = create(:canadian_bank_account, user: @product.user)
+        create(:merchant_account_stripe_connect, user: @product.user)
+        @product.user.update!(payment_address: nil)
+        expect(RefreshUserProductsRecommendationEligibilityJob).not_to receive(:perform_async)
+
+        bank_account.mark_deleted!
+      end
+
+      it "does not enqueue a refresh when PayPal remains" do
+        bank_account = create(:canadian_bank_account, user: @product.user)
+        create(:merchant_account_paypal, user: @product.user)
+        @product.user.update!(payment_address: nil)
+        expect(RefreshUserProductsRecommendationEligibilityJob).not_to receive(:perform_async)
+
+        bank_account.mark_deleted!
+      end
+
+      it "does not let an enqueue failure interrupt bank account deletion" do
+        bank_account = create(:canadian_bank_account, user: @product.user)
+        @product.user.update!(payment_address: nil)
+        fallback_job = instance_double(RefreshUserProductsRecommendationEligibilityJob, perform: nil)
+        allow(RefreshUserProductsRecommendationEligibilityJob).to receive(:perform_async).and_raise("Redis unavailable")
+        allow(RefreshUserProductsRecommendationEligibilityJob).to receive(:new).and_return(fallback_job)
+        allow(ErrorNotifier).to receive(:notify)
+
+        expect { bank_account.mark_deleted! }.not_to raise_error
+        expect(bank_account.reload).to be_deleted
+        expect(ErrorNotifier).to have_received(:notify).with(
+          instance_of(RuntimeError),
+          bank_account_id: bank_account.id,
+          user_id: @product.user_id
+        )
+        expect(fallback_job).to have_received(:perform).with(@product.user_id)
+      end
+
+      it "does not let refresh or observability failures escape after deletion commits" do
+        bank_account = create(:canadian_bank_account, user: @product.user)
+        @product.user.update!(payment_address: nil)
+        fallback_job = instance_double(RefreshUserProductsRecommendationEligibilityJob)
+        allow(RefreshUserProductsRecommendationEligibilityJob).to receive(:perform_async).and_raise("Redis unavailable")
+        allow(RefreshUserProductsRecommendationEligibilityJob).to receive(:new).and_return(fallback_job)
+        allow(fallback_job).to receive(:perform).and_raise("Elasticsearch unavailable")
+        allow(ErrorNotifier).to receive(:notify).and_raise("Sentry unavailable")
+
+        expect { bank_account.mark_deleted! }.not_to raise_error
+
+        expect(bank_account.reload).to be_deleted
+      end
+
       it "sends updated is_recommendable field when user is marked compliant" do
         expect_product_update %w[is_recommendable]
         @product.user.mark_compliant!(author_id: create(:user).id)

--- a/spec/modules/product/searchable/indexing_spec.rb
+++ b/spec/modules/product/searchable/indexing_spec.rb
@@ -316,6 +316,14 @@ describe "Product::Searchable - Indexing scenarios" do
         bank_account.mark_undeleted!
       end
 
+      it "does not enqueue a refresh when a restored bank account is not the only payout method" do
+        bank_account = create(:canadian_bank_account, deleted_at: 1.day.ago, user: @product.user)
+        @product.user.update!(payment_address: "seller@example.com")
+        expect(RefreshUserProductsRecommendationEligibilityJob).not_to receive(:perform_async)
+
+        bank_account.mark_undeleted!
+      end
+
       it "does not index products when bank account deletion is rolled back" do
         bank_account = create(:canadian_bank_account, user: @product.user)
         @product.user.update!(payment_address: nil)
@@ -356,9 +364,8 @@ describe "Product::Searchable - Indexing scenarios" do
       it "does not let an enqueue failure interrupt bank account deletion" do
         bank_account = create(:canadian_bank_account, user: @product.user)
         @product.user.update!(payment_address: nil)
-        fallback_job = instance_double(RefreshUserProductsRecommendationEligibilityJob, perform: nil)
         allow(RefreshUserProductsRecommendationEligibilityJob).to receive(:perform_async).and_raise("Redis unavailable")
-        allow(RefreshUserProductsRecommendationEligibilityJob).to receive(:new).and_return(fallback_job)
+        allow(RefreshUserProductsRecommendationEligibilityJob).to receive(:new).and_call_original
         allow(ErrorNotifier).to receive(:notify)
 
         expect { bank_account.mark_deleted! }.not_to raise_error
@@ -368,16 +375,13 @@ describe "Product::Searchable - Indexing scenarios" do
           bank_account_id: bank_account.id,
           user_id: @product.user_id
         )
-        expect(fallback_job).to have_received(:perform).with(@product.user_id)
+        expect(RefreshUserProductsRecommendationEligibilityJob).not_to have_received(:new)
       end
 
-      it "does not let refresh or observability failures escape after deletion commits" do
+      it "does not let observability failures escape after deletion commits" do
         bank_account = create(:canadian_bank_account, user: @product.user)
         @product.user.update!(payment_address: nil)
-        fallback_job = instance_double(RefreshUserProductsRecommendationEligibilityJob)
         allow(RefreshUserProductsRecommendationEligibilityJob).to receive(:perform_async).and_raise("Redis unavailable")
-        allow(RefreshUserProductsRecommendationEligibilityJob).to receive(:new).and_return(fallback_job)
-        allow(fallback_job).to receive(:perform).and_raise("Elasticsearch unavailable")
         allow(ErrorNotifier).to receive(:notify).and_raise("Sentry unavailable")
 
         expect { bank_account.mark_deleted! }.not_to raise_error

--- a/spec/services/update_user_country_spec.rb
+++ b/spec/services/update_user_country_spec.rb
@@ -82,6 +82,31 @@ describe UpdateUserCountry do
       expect(old_bank_account.reload.deleted?).to eq(true)
     end
 
+    it "removes products from recommendable search results after deleting the seller's only payout method", :elasticsearch_wait_for_refresh do
+      seller = create(:compliant_user, name: "Country change seller")
+      product = create(:product, user: seller, taxonomy: create(:taxonomy))
+      create(:merchant_account, user: nil)
+      create(:purchase, link: product, seller: seller, price_cents: product.price_cents)
+      create(:user_compliance_info, user: seller)
+      create(:canadian_bank_account, user: seller)
+      seller.update!(payment_address: nil)
+      index_model_records(Link)
+
+      recommendable_product_ids = -> {
+        Link.search(Link.search_options(ids: [product.id], include_rated_as_adult: true)).records.map(&:id)
+      }
+      expect(product.reload.recommendable?).to eq(true)
+      expect(recommendable_product_ids.call).to eq([product.id])
+
+      UpdateUserCountry.new(new_country_code: "GB", user: seller).process
+      RefreshUserProductsRecommendationEligibilityJob.drain
+      Link.__elasticsearch__.refresh_index!
+
+      expect(product.reload.recommendable?).to eq(false)
+      expect(EsClient.get(index: Link.index_name, id: product.id).dig("_source", "is_recommendable")).to eq(false)
+      expect(recommendable_product_ids.call).to be_empty
+    end
+
     it "adds country changed comment" do
       UpdateUserCountry.new(new_country_code: "GB", user: @user).process
 

--- a/spec/sidekiq/refresh_user_products_recommendation_eligibility_job_spec.rb
+++ b/spec/sidekiq/refresh_user_products_recommendation_eligibility_job_spec.rb
@@ -3,11 +3,11 @@
 require "spec_helper"
 
 describe RefreshUserProductsRecommendationEligibilityJob do
-  it "serializes scans while allowing a transition during a scan to schedule a follow-up" do
+  it "dedupes queued scans while allowing a transition during a scan to enqueue a follow-up" do
     expect(described_class.sidekiq_options).to include(
-      "lock" => :until_and_while_executing,
+      "lock" => :until_executing,
       "lock_ttl" => 6.hours.to_i,
-      "on_conflict" => { "client" => :log, "server" => :reschedule }
+      "on_conflict" => { "client" => :log }
     )
   end
 

--- a/spec/sidekiq/refresh_user_products_recommendation_eligibility_job_spec.rb
+++ b/spec/sidekiq/refresh_user_products_recommendation_eligibility_job_spec.rb
@@ -3,11 +3,13 @@
 require "spec_helper"
 
 describe RefreshUserProductsRecommendationEligibilityJob do
-  it "dedupes queued scans while allowing a transition during a scan to enqueue a follow-up" do
+  it "serializes scans while allowing a transition during a scan to enqueue a follow-up" do
     expect(described_class.sidekiq_options).to include(
-      "lock" => :until_executing,
+      "lock" => :while_executing,
+      "lock_timeout" => 0,
       "lock_ttl" => 6.hours.to_i,
-      "on_conflict" => { "client" => :log }
+      "schedule_in" => 1.minute.to_i,
+      "on_conflict" => { "server" => :reschedule }
     )
   end
 

--- a/spec/sidekiq/refresh_user_products_recommendation_eligibility_job_spec.rb
+++ b/spec/sidekiq/refresh_user_products_recommendation_eligibility_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe RefreshUserProductsRecommendationEligibilityJob do
+  it "serializes scans while allowing a transition during a scan to schedule a follow-up" do
+    expect(described_class.sidekiq_options).to include(
+      "lock" => :until_and_while_executing,
+      "lock_ttl" => 6.hours.to_i,
+      "on_conflict" => { "client" => :log, "server" => :reschedule }
+    )
+  end
+
+  it "updates recommendation eligibility for every seller product" do
+    seller = create(:user)
+    products = create_list(:product, 2, user: seller)
+    updated_product_ids = []
+    expect(ProductIndexingService).to receive(:perform).twice do |product:, action:, attributes_to_update:, on_failure:|
+      updated_product_ids << product.id
+      expect(action).to eq("update")
+      expect(attributes_to_update).to eq(%w[is_recommendable])
+      expect(on_failure).to eq(:async)
+    end
+
+    described_class.new.perform(seller.id)
+
+    expect(updated_product_ids).to match_array(products.map(&:id))
+  end
+
+  it "does nothing when the seller no longer exists" do
+    expect { described_class.new.perform(0) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
## What

Refresh every seller product's indexed `is_recommendable` value after the seller's bank account changes between active and deleted. The callback runs after commit, skips when another payout rail remains, and uses a low-priority job that stays enqueueable during a scan and serializes execution so an older Elasticsearch write cannot overwrite current eligibility.

Imported from https://github.com/adityawrk/gumroad/pull/38 by @adityawrk. `qa-media/` binaries were not imported; walkthrough and screenshots stay on the fork PR.

## Why

Product recommendation eligibility depends on a usable payout method. Bank-account creation already refreshed the search index; deletion and restoration did not. Country changes and Stripe missing-bank payout recovery can delete the last payout method while Elasticsearch still has `is_recommendable: true`.

## Before / After

| Committed bank-account state change | Before | After |
| --- | --- | --- |
| Last payout bank deleted | Database ineligible, search stays recommendable | Products refresh to current eligibility |
| Deleted bank restored | Search can stay stale | Products refresh to current eligibility |
| Another bank, payment address, Stripe Connect, or PayPal remains | No refresh | No refresh |
| Redis unavailable during payout recovery | Inline catalog scan delayed reverse/hold | Enqueue failure reported; payout reverse/hold continues |

## Test Results

- Panel clean at current head; CI green on this branch.
- CI on this branch is the authoritative full-file run.

## QA

1. Create a compliant seller with one recommendable product and a bank account as the only payout method.
2. Delete the bank (country-change flow), drain the refresh job, refresh the index.
3. Confirm the database predicate and indexed `is_recommendable` are false.
4. Repeat with another payout rail present and confirm no refresh is enqueued.

Visual evidence: https://github.com/adityawrk/gumroad/pull/38

Based on https://github.com/adityawrk/gumroad/pull/38 by @adityawrk.

Addresses antiwork/gumroad-private#2406.

---

Implemented by Grok 4.6.


Premerge review: clean @ eb63036b8e015a2e7a7c74f11aa017775cb52ba9
