### PR TITLE
Refresh Discover eligibility after full refund changes

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -412,6 +412,8 @@ class Purchase < ApplicationRecord
     purchase.stripe_refunded_previously_changed?
   }
 
+  before_save :schedule_product_search_refresh_after_refund
+
   after_commit :enqueue_record_order_charge_outcome, if: -> (purchase) {
     purchase.purchase_state_previously_changed? &&
       ORDER_OUTCOME_STATES.include?(purchase.purchase_state)
@@ -6061,6 +6063,38 @@ class Purchase < ApplicationRecord
       # If we indexed sales_volume synchronously, it's likely to fetch outdated data from the purchases index,
       # thus not reflecting the latest purchase that was just made here.
       SendToElasticsearchWorker.perform_in(5.seconds, link.id, "update", ["sales_volume", "total_fee_cents", "past_year_fee_cents"])
+    end
+
+    def enqueue_product_search_refresh_after_refund
+      SendToElasticsearchWorker.perform_async(link_id, "update", %w[is_recommendable])
+    rescue => enqueue_error
+      report_product_search_refresh_error(enqueue_error, "enqueue")
+
+      begin
+        ProductIndexingService.perform(
+          product: link,
+          action: "update",
+          attributes_to_update: %w[is_recommendable]
+        )
+      rescue => indexing_error
+        report_product_search_refresh_error(indexing_error, "update synchronously")
+      end
+    end
+
+    def report_product_search_refresh_error(error, action)
+      Rails.logger.error("Failed to #{action} product search after refunding purchase #{id}: #{error.class}: #{error.message}")
+      ErrorNotifier.notify(error, purchase_id: id, link_id:)
+    rescue
+      nil
+    end
+
+    def schedule_product_search_refresh_after_refund
+      return unless will_save_change_to_stripe_refunded?
+
+      previous_value, new_value = stripe_refunded_change_to_be_saved
+      return if (previous_value == true) == (new_value == true)
+
+      after_commit { enqueue_product_search_refresh_after_refund }
     end
 
     def send_failure_email

--- a/app/sidekiq/reindex_recommendable_products_worker.rb
+++ b/app/sidekiq/reindex_recommendable_products_worker.rb
@@ -32,10 +32,8 @@ class ReindexRecommendableProductsWorker
         to_set
 
       unless ids.empty?
-        # Every scrolled document gets is_recommendable reconciled: a refund-time
-        # refresh can be lost when both the enqueue and the synchronous fallback
-        # fail, leaving an ineligible product indexed as recommendable until this
-        # runs. Sales-volume fields stay limited to products with recent sales.
+        # Reconcile is_recommendable on every document: a lost refund-time refresh
+        # can leave an ineligible product indexed as recommendable until this runs.
         args = ids.map do |id|
           attributes = ["is_recommendable"]
           attributes = SALES_VOLUME_ATTRIBUTES + attributes if recent_sale_ids.include?(id)

--- a/app/sidekiq/reindex_recommendable_products_worker.rb
+++ b/app/sidekiq/reindex_recommendable_products_worker.rb
@@ -7,6 +7,8 @@ class ReindexRecommendableProductsWorker
   SCROLL_SIZE = 1000
   SCROLL_SORT = ["_doc"]
 
+  SALES_VOLUME_ATTRIBUTES = ["sales_volume", "total_fee_cents", "past_year_fee_cents"].freeze
+
   def perform
     response = EsClient.search(
       index: Link.index_name,
@@ -20,17 +22,24 @@ class ReindexRecommendableProductsWorker
     index = 0
     loop do
       hits = response.dig("hits", "hits")
-      ids = hits.map { |hit| hit["_id"] }
+      ids = hits.map { |hit| hit["_id"].to_i }
 
-      filtered_ids = Purchase.
+      recent_sale_ids = Purchase.
         where(link_id: ids).
         group(:link_id).
         having("max(created_at) >= ?", Product::Searchable::DEFAULT_SALES_VOLUME_RECENTNESS.ago).
-        pluck(:link_id)
+        pluck(:link_id).
+        to_set
 
-      unless filtered_ids.empty?
-        args = filtered_ids.map do |id|
-          [id, "update", ["sales_volume", "total_fee_cents", "past_year_fee_cents"]]
+      unless ids.empty?
+        # Every scrolled document gets is_recommendable reconciled: a refund-time
+        # refresh can be lost when both the enqueue and the synchronous fallback
+        # fail, leaving an ineligible product indexed as recommendable until this
+        # runs. Sales-volume fields stay limited to products with recent sales.
+        args = ids.map do |id|
+          attributes = ["is_recommendable"]
+          attributes = SALES_VOLUME_ATTRIBUTES + attributes if recent_sale_ids.include?(id)
+          [id, "update", attributes]
         end
 
         Sidekiq::Client.push_bulk(

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -7,6 +7,132 @@ describe "PurchaseRefunds", :vcr do
   include ProductsHelper
   include ActiveJob::TestHelper
 
+  it "removes a product from recommendable search results when its last sale is fully refunded", :elasticsearch_wait_for_refresh do
+    seller = create(:compliant_user, name: "Refunded sale seller")
+    product = create(:product, user: seller, taxonomy: create(:taxonomy))
+    create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_refund_search_#{SecureRandom.hex(8)}")
+    purchase = create(:purchase, link: product, seller:)
+    index_model_records(Link)
+
+    recommendable_product_ids = -> {
+      Link.search(Link.search_options(ids: [product.id], include_rated_as_adult: true)).records.map(&:id)
+    }
+    expect(product.reload.recommendable?).to eq(true)
+    expect(recommendable_product_ids.call).to eq([product.id])
+
+    flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, purchase.total_transaction_cents)
+    expect(purchase.refund_purchase!(flow_of_funds, seller.id)).to eq(true)
+    SendToElasticsearchWorker.drain
+    Link.__elasticsearch__.refresh_index!
+
+    expect(product.reload.recommendable?).to eq(false)
+    expect(EsClient.get(index: Link.index_name, id: product.id).dig("_source", "is_recommendable")).to eq(false)
+    expect(recommendable_product_ids.call).to be_empty
+  end
+
+  describe "product recommendation refresh after refund status changes" do
+    before do
+      create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_refund_callback_#{SecureRandom.hex(8)}")
+    end
+
+    let!(:purchase) { create(:purchase) }
+    let(:job_args) { [purchase.link_id, "update", %w[is_recommendable]] }
+
+    it "enqueues after a refund and after a failed-refund reversal" do
+      expect do
+        purchase.update!(stripe_refunded: true)
+      end.to change(SendToElasticsearchWorker.jobs, :size).by(1)
+      expect(SendToElasticsearchWorker.jobs.last.fetch("args")).to eq(job_args)
+
+      SendToElasticsearchWorker.jobs.clear
+
+      expect do
+        purchase.update!(stripe_refunded: false)
+      end.to change(SendToElasticsearchWorker.jobs, :size).by(1)
+      expect(SendToElasticsearchWorker.jobs.last.fetch("args")).to eq(job_args)
+    end
+
+    it "retains the refund refresh across multiple saves in one transaction" do
+      expect do
+        ActiveRecord::Base.transaction do
+          purchase.update!(stripe_refunded: true)
+          purchase.update!(email: "updated@example.com")
+        end
+      end.to change(SendToElasticsearchWorker.jobs, :size).by(1)
+      expect(SendToElasticsearchWorker.jobs.last.fetch("args")).to eq(job_args)
+    end
+
+    it "does not enqueue a rolled-back refund change or leak it into a later save" do
+      expect do
+        ActiveRecord::Base.transaction do
+          purchase.update!(stripe_refunded: true)
+          raise ActiveRecord::Rollback
+        end
+      end.not_to change(SendToElasticsearchWorker.jobs, :size)
+
+      expect do
+        purchase.reload.update!(email: "updated@example.com")
+      end.not_to change(SendToElasticsearchWorker.jobs, :size)
+    end
+
+    it "discards a refresh registered inside a rolled-back savepoint" do
+      expect do
+        ActiveRecord::Base.transaction do
+          ActiveRecord::Base.transaction(requires_new: true) do
+            purchase.update!(stripe_refunded: true)
+            raise ActiveRecord::Rollback
+          end
+          purchase.reload.update!(email: "updated@example.com")
+        end
+      end.not_to change(SendToElasticsearchWorker.jobs, :size)
+    end
+
+    it "does not enqueue when only the partial-refund marker changes" do
+      expect do
+        purchase.update!(stripe_partially_refunded: true)
+      end.not_to change(SendToElasticsearchWorker.jobs, :size)
+    end
+
+    it "does not enqueue when an unset refund flag is persisted as false" do
+      purchase.update_column(:stripe_refunded, nil)
+
+      expect do
+        purchase.update!(stripe_refunded: false)
+      end.not_to change(SendToElasticsearchWorker.jobs, :size)
+    end
+
+    it "does not let an enqueue failure change the committed refund state" do
+      allow(SendToElasticsearchWorker).to receive(:perform_async).and_raise("Redis unavailable")
+      allow(ErrorNotifier).to receive(:notify)
+      allow(ProductIndexingService).to receive(:perform)
+
+      expect { purchase.update!(stripe_refunded: true) }.not_to raise_error
+
+      expect(purchase.reload).to be_stripe_refunded
+      expect(ProductIndexingService).to have_received(:perform).with(
+        product: purchase.link,
+        action: "update",
+        attributes_to_update: %w[is_recommendable]
+      )
+      expect(ErrorNotifier).to have_received(:notify).with(
+        instance_of(RuntimeError),
+        purchase_id: purchase.id,
+        link_id: purchase.link_id
+      )
+    end
+
+
+    it "does not let observability failures escape after the refund commits" do
+      allow(SendToElasticsearchWorker).to receive(:perform_async).and_raise("Redis unavailable")
+      allow(ProductIndexingService).to receive(:perform).and_raise("Elasticsearch unavailable")
+      allow(ErrorNotifier).to receive(:notify).and_raise("Sentry unavailable")
+
+      expect { purchase.update!(stripe_refunded: true) }.not_to raise_error
+
+      expect(purchase.reload).to be_stripe_refunded
+    end
+  end
+
   def verify_balance(user, expected_balance)
     expect(user.unpaid_balance_cents).to eq expected_balance
   end

--- a/spec/services/purchase/handle_failed_refund_service_spec.rb
+++ b/spec/services/purchase/handle_failed_refund_service_spec.rb
@@ -5,11 +5,15 @@ require "spec_helper"
 describe Purchase::HandleFailedRefundService do
   let(:seller) { create(:user) }
   let(:product) { create(:product, user: seller, price_cents: 2000) }
+  let(:merchant_account) do
+    create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_failed_refund_#{SecureRandom.hex(8)}")
+  end
 
   let(:purchase) do
     create(:purchase_with_balance,
            link: product,
            seller:,
+           merchant_account:,
            price_cents: 2000,
            total_transaction_cents: 2000)
   end
@@ -119,6 +123,17 @@ describe Purchase::HandleFailedRefundService do
       expect { described_class.new(refund:).perform }
         .to change { purchase.reload.stripe_refunded? }.from(true).to(false)
       expect(purchase.stripe_partially_refunded?).to eq(false)
+    end
+
+    it "refreshes product recommendation eligibility after restoring the sale" do
+      SendToElasticsearchWorker.jobs.clear
+
+      expect do
+        described_class.new(refund:).perform
+      end.to change(SendToElasticsearchWorker.jobs, :size).by(1)
+      expect(SendToElasticsearchWorker.jobs.last.fetch("args")).to eq(
+        [product.id, "update", %w[is_recommendable]]
+      )
     end
 
     it "credits a live balance when the debited balance was already paid out, leaving the paid balance untouched" do
@@ -372,7 +387,11 @@ describe Purchase::HandleFailedRefundService do
         # Stripe custom account: charged_using_gumroad_merchant_account? is true, but
         # the refund also debited the connected account outside our ledger, so an
         # automatic offset here would claim money the external account no longer has.
-        stripe_held_account = create(:merchant_account, user: seller)
+        stripe_held_account = create(
+          :merchant_account,
+          user: seller,
+          charge_processor_merchant_id: "acct_stripe_held_#{SecureRandom.hex(8)}"
+        )
         expect(stripe_held_account.holder_of_funds).to eq(HolderOfFunds::STRIPE)
         purchase.update!(merchant_account: stripe_held_account)
 
@@ -830,7 +849,19 @@ describe Purchase::HandleFailedRefundService do
     let(:product) { create(:product, price_cents: 10_00) }
     let(:seller) { product.user }
     let(:affiliate) { create(:direct_affiliate, affiliate_user:, seller:, affiliate_basis_points: 1000, products: [product]) }
-    let(:purchase) { create(:purchase_in_progress, link: product, seller:, affiliate:, chargeable: create(:chargeable)) }
+    let(:real_path_merchant_account) do
+      create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_real_refund_#{SecureRandom.hex(8)}")
+    end
+    let(:purchase) do
+      create(
+        :purchase_in_progress,
+        link: product,
+        seller:,
+        affiliate:,
+        chargeable: create(:chargeable),
+        merchant_account: real_path_merchant_account
+      )
+    end
 
     def stub_processor_refund!(purchase, amount_cents: nil)
       refunded_cents = amount_cents || purchase.total_transaction_cents

--- a/spec/sidekiq/reindex_recommendable_products_worker_spec.rb
+++ b/spec/sidekiq/reindex_recommendable_products_worker_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe ReindexRecommendableProductsWorker do
-  it "updates time-dependent fields" do
+  it "updates time-dependent fields and reconciles indexed recommendability" do
     freeze_time
 
     products = create_list(:product, 5)
@@ -36,8 +36,8 @@ describe ReindexRecommendableProductsWorker do
     expect(Sidekiq::Client).to receive(:push_bulk).with(
       "class" => SendToElasticsearchWorker,
       "args" => [
-        [products[0].id, "update", ["sales_volume", "total_fee_cents", "past_year_fee_cents"]],
-        [products[2].id, "update", ["sales_volume", "total_fee_cents", "past_year_fee_cents"]]
+        [products[0].id, "update", ["sales_volume", "total_fee_cents", "past_year_fee_cents", "is_recommendable"]],
+        [products[2].id, "update", ["sales_volume", "total_fee_cents", "past_year_fee_cents", "is_recommendable"]]
       ],
       "queue" => "low",
       "at" => Time.current.to_i
@@ -45,7 +45,8 @@ describe ReindexRecommendableProductsWorker do
     expect(Sidekiq::Client).to receive(:push_bulk).with(
       "class" => SendToElasticsearchWorker,
       "args" => [
-        [products[3].id, "update", ["sales_volume", "total_fee_cents", "past_year_fee_cents"]]
+        [products[3].id, "update", ["sales_volume", "total_fee_cents", "past_year_fee_cents", "is_recommendable"]],
+        [products[4].id, "update", ["is_recommendable"]]
       ],
       "queue" => "low",
       "at" => 1.minute.from_now.to_i


### PR DESCRIPTION
## What

Refresh a product's indexed `is_recommendable` value after a purchase crosses the full-refund boundary in either direction (successful full refund or failed-refund reversal). Partial-refund markers and nil-to-false normalization do not enqueue a refresh.

The weekly `ReindexRecommendableProductsWorker` now also reconciles `is_recommendable` for every document indexed as recommendable, so a refresh lost to a simultaneous enqueue + synchronous-index failure is bounded at one week instead of indefinite (Greptile P1).

Imported from https://github.com/adityawrk/gumroad/pull/41 by @adityawrk. `qa-media/` binaries were not imported; walkthrough and screenshots stay on the fork PR.

## Why

Discover eligibility depends in part on a qualifying sale. Full refunds and failed-refund reversals update the purchase row used by the database predicate, but they did not refresh the product document. Indexing failures cannot unwind the committed refund.

## Before / After

| Committed purchase transition | Before | After |
| --- | --- | --- |
| Last qualifying sale fully refunded | Database ineligible, search can stay recommendable | Product refreshes to current eligibility |
| Failed refund restores the sale | Database eligible, search can stay stale | Product refreshes to current eligibility |
| Partial-refund marker only | No refresh | No refresh |

## Test Results

- `bundle exec rspec spec/sidekiq/reindex_recommendable_products_worker_spec.rb` — 1 example, 0 failures (reconciliation change). Rubocop clean on touched files.
- CI on this branch is the authoritative full-file run. This PR touches `Purchase` and carries `run-all-specs`.

## QA steps

1. Create a compliant seller with one recommendable product and one qualifying purchase.
2. Fully refund the purchase, drain the refresh worker, refresh the index.
3. Confirm the database predicate and indexed value are false.
4. Exercise failed-refund reversal and confirm it schedules the same current-state refresh.

Visual evidence: https://github.com/adityawrk/gumroad/pull/41

## Status

- [x] Scope
- [x] Design
- [x] Build
- [ ] Ship
- [ ] Market
- [ ] Sell

Addresses antiwork/gumroad-private#2406.

AI Disclosure: Grok 4.6 reviewed the fork PR and imported the code-and-spec diff (qa-media excluded).

Premerge review: clean @ 4ace63a53c0bf1621d1ef58b178404f9e667d2c3

Head 141f9e6f is a comment-only delta on the reviewed file (Greptile P2: comment length); no behaviour change.

