### PR TITLE
Refresh Discover eligibility after payout-account changes

### DIFF
--- a/app/models/concerns/json_data.rb
+++ b/app/models/concerns/json_data.rb
@@ -88,13 +88,17 @@ module JsonData
     # until the enclosing save commits; without it the merge is just a narrower version of the
     # same race.
     def merge_json_data_with_current_row
-      base = (json_data_was || {}).deep_stringify_keys
+      # Non-Hash was/current can appear when a row was written corruptly (e.g. a JSON string
+      # scalar). deep_stringify_keys is Hash-only; treat corrupt shapes as {} so an intentional
+      # rewrite (MerchantAccount disconnect clearing meta) is not aborted mid-save.
+      was = json_data_was
+      base = (was.is_a?(Hash) ? was : {}).deep_stringify_keys
       mine = json_data
 
       current = self.class.unscoped.lock.where(id:).pick(:json_data)
       return if current.nil?
 
-      merged = current.deep_stringify_keys
+      merged = (current.is_a?(Hash) ? current : {}).deep_stringify_keys
       (base.keys | mine.keys).each do |key|
         next if base.key?(key) == mine.key?(key) && base[key] == mine[key]
 

--- a/app/models/merchant_account.rb
+++ b/app/models/merchant_account.rb
@@ -185,6 +185,7 @@ class MerchantAccount < ApplicationRecord
   end
 
   def delete_charge_processor_account!
+    clear_non_hash_json_data_for_disconnect!
     mark_deleted!
     self.meta = {} unless is_a_stripe_connect_account?
     self.charge_processor_deleted_at = Time.current
@@ -278,6 +279,16 @@ class MerchantAccount < ApplicationRecord
   end
 
   private
+    # JsonData#json_data raises ArgumentError on non-Hash, which aborts mark_deleted! validations
+    # and meta=. Reset corrupt metadata so disconnect can finish. Discover refresh still sees the
+    # prior value via changes_to_save on the first save.
+    def clear_non_hash_json_data_for_disconnect!
+      data = self[:json_data]
+      return if data.nil? || data.is_a?(Hash)
+
+      self[:json_data] = {}
+    end
+
     def schedule_products_recommendability_refresh
       current_attributes = attributes
       previous_attributes = current_attributes.merge(changes_to_save.transform_values(&:first))

--- a/app/models/merchant_account.rb
+++ b/app/models/merchant_account.rb
@@ -63,6 +63,8 @@ class MerchantAccount < ApplicationRecord
   validates :charge_processor_merchant_id, presence: true, if: -> { user && charge_processor_alive? }
   validates :charge_processor_merchant_id, uniqueness: { case_sensitive: true, message: "This account is already connected with another Gumroad account" }, allow_blank: true, if: proc { |ma| ma.is_a_gumroad_managed_stripe_account? }
 
+  before_save :schedule_products_recommendability_refresh
+
   scope :charge_processor_alive, -> { where.not(charge_processor_alive_at: nil).where(charge_processor_deleted_at: nil) }
   scope :charge_processor_verified, -> { where.not(charge_processor_verified_at: nil) }
   scope :charge_processor_unverified, -> { where(charge_processor_verified_at: nil) }
@@ -276,6 +278,67 @@ class MerchantAccount < ApplicationRecord
   end
 
   private
+    def schedule_products_recommendability_refresh
+      current_attributes = attributes
+      previous_attributes = current_attributes.merge(changes_to_save.transform_values(&:first))
+      previous_user_id = recommendation_payout_account_user_id_for(previous_attributes)
+      current_user_id = recommendation_payout_account_user_id_for(current_attributes)
+      return if previous_user_id == current_user_id
+
+      affected_user_ids = [previous_user_id, current_user_id].compact.uniq
+      AfterCommitEverywhere.after_commit { enqueue_products_recommendability_refresh(affected_user_ids) }
+    end
+
+    def recommendation_payout_account_user_id_for(account_attributes)
+      return if account_attributes["user_id"].blank?
+      return if account_attributes["deleted_at"].present?
+      return if account_attributes["charge_processor_alive_at"].blank?
+      return if account_attributes["charge_processor_deleted_at"].present?
+
+      charge_processor_id = account_attributes["charge_processor_id"]
+      connected_account = charge_processor_id == PaypalChargeProcessor.charge_processor_id ||
+                          (charge_processor_id == StripeChargeProcessor.charge_processor_id &&
+                            account_attributes["json_data"].to_h.dig("meta", "stripe_connect") == "true")
+      account_attributes["user_id"] if connected_account
+    end
+
+    def enqueue_products_recommendability_refresh(affected_user_ids)
+      affected_user_ids.each { |affected_user_id| enqueue_products_recommendability_refresh_for(affected_user_id) }
+    end
+
+    def enqueue_products_recommendability_refresh_for(affected_user_id)
+      return if user_has_another_payout_method?(affected_user_id)
+
+      RefreshMerchantAccountProductsRecommendationEligibilityJob.perform_async(affected_user_id)
+    rescue => enqueue_error
+      report_recommendability_refresh_error(enqueue_error, "enqueue", affected_user_id)
+
+      begin
+        RefreshMerchantAccountProductsRecommendationEligibilityJob.new.perform(affected_user_id)
+      rescue => refresh_error
+        report_recommendability_refresh_error(refresh_error, "run synchronously", affected_user_id)
+      end
+    end
+
+    def user_has_another_payout_method?(affected_user_id)
+      affected_user = User.find_by(id: affected_user_id)
+      return false if affected_user.nil?
+      return true if affected_user.payment_address.present? || affected_user.active_bank_account.present?
+
+      affected_user.merchant_accounts
+        .alive
+        .charge_processor_alive
+        .where.not(id:)
+        .any? { |account| account.is_a_paypal_connect_account? || account.is_a_stripe_connect_account? }
+    end
+
+    def report_recommendability_refresh_error(error, action, affected_user_id)
+      Rails.logger.error("Failed to #{action} product recommendation refresh for merchant account #{id}, user #{affected_user_id}: #{error.class}: #{error.message}")
+      ErrorNotifier.notify(error, merchant_account_id: id, user_id: affected_user_id)
+    rescue
+      nil
+    end
+
     # Shared TTL check for both marker formats (per-currency map values and the legacy
     # blanket timestamp).
     def fresh_mismatch_timestamp?(raw)

--- a/app/models/merchant_account.rb
+++ b/app/models/merchant_account.rb
@@ -296,9 +296,15 @@ class MerchantAccount < ApplicationRecord
       return if account_attributes["charge_processor_deleted_at"].present?
 
       charge_processor_id = account_attributes["charge_processor_id"]
+      json_data = account_attributes["json_data"] || {}
+      stripe_connect = if json_data.is_a?(Hash)
+        json_data.dig("meta", "stripe_connect") == "true"
+      else
+        # Non-Hash metadata is the same shape the backfill treats as a connected payout account.
+        true
+      end
       connected_account = charge_processor_id == PaypalChargeProcessor.charge_processor_id ||
-                          (charge_processor_id == StripeChargeProcessor.charge_processor_id &&
-                            account_attributes["json_data"].to_h.dig("meta", "stripe_connect") == "true")
+                          (charge_processor_id == StripeChargeProcessor.charge_processor_id && stripe_connect)
       account_attributes["user_id"] if connected_account
     end
 

--- a/app/models/merchant_account.rb
+++ b/app/models/merchant_account.rb
@@ -318,12 +318,6 @@ class MerchantAccount < ApplicationRecord
       RefreshMerchantAccountProductsRecommendationEligibilityJob.perform_async(affected_user_id)
     rescue => enqueue_error
       report_recommendability_refresh_error(enqueue_error, "enqueue", affected_user_id)
-
-      begin
-        RefreshMerchantAccountProductsRecommendationEligibilityJob.new.perform(affected_user_id)
-      rescue => refresh_error
-        report_recommendability_refresh_error(refresh_error, "run synchronously", affected_user_id)
-      end
     end
 
     def user_has_another_payout_method?(affected_user_id)

--- a/app/sidekiq/backfill_merchant_account_recommendation_eligibility_job.rb
+++ b/app/sidekiq/backfill_merchant_account_recommendation_eligibility_job.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Enqueue once after deployment to repair product documents left by older account disconnects:
+#   BackfillMerchantAccountRecommendationEligibilityJob.perform_async
+class BackfillMerchantAccountRecommendationEligibilityJob
+  include Sidekiq::Job
+  sidekiq_options retry: 3, queue: :low, lock: :until_executed, lock_ttl: 6.hours.to_i
+
+  BATCH_SIZE = 500
+
+  def perform
+    disconnected_accounts.find_in_batches(batch_size: BATCH_SIZE) do |accounts|
+      accounts.filter_map { |account| account.user_id if connected_payout_account?(account) }.uniq.each do |user_id|
+        RefreshMerchantAccountProductsRecommendationEligibilityJob.perform_async(user_id)
+      end
+    end
+  end
+
+  private
+    def disconnected_accounts
+      MerchantAccount
+        .where.not(user_id: nil)
+        .where(charge_processor_id: [PaypalChargeProcessor.charge_processor_id, StripeChargeProcessor.charge_processor_id])
+        .where("deleted_at IS NOT NULL OR charge_processor_deleted_at IS NOT NULL OR charge_processor_alive_at IS NULL")
+    end
+
+    def connected_payout_account?(account)
+      return true if account.paypal_charge_processor?
+      return false unless account.stripe_charge_processor?
+
+      json_data = account[:json_data] || {}
+      return true unless json_data.is_a?(Hash)
+
+      json_data.dig("meta", "stripe_connect") == "true"
+    end
+end

--- a/app/sidekiq/refresh_merchant_account_products_recommendation_eligibility_job.rb
+++ b/app/sidekiq/refresh_merchant_account_products_recommendation_eligibility_job.rb
@@ -2,12 +2,14 @@
 
 class RefreshMerchantAccountProductsRecommendationEligibilityJob
   include Sidekiq::Job
-  # Follow-up scans must remain enqueueable and cannot overtake the scan already running.
+  # lock: :until_executing so a payout-account transition during a scan can
+  # enqueue a follow-up. :until_and_while_executing held the client lock and
+  # client: :log dropped that follow-up, leaving mixed is_recommendable values.
   sidekiq_options retry: 3,
                   queue: :low,
-                  lock: :until_and_while_executing,
+                  lock: :until_executing,
                   lock_ttl: 6.hours.to_i,
-                  on_conflict: { client: :log, server: :reschedule }
+                  on_conflict: { client: :log }
 
   def perform(user_id)
     user = User.find_by(id: user_id)

--- a/app/sidekiq/refresh_merchant_account_products_recommendation_eligibility_job.rb
+++ b/app/sidekiq/refresh_merchant_account_products_recommendation_eligibility_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class RefreshMerchantAccountProductsRecommendationEligibilityJob
+  include Sidekiq::Job
+  # Follow-up scans must remain enqueueable and cannot overtake the scan already running.
+  sidekiq_options retry: 3,
+                  queue: :low,
+                  lock: :until_and_while_executing,
+                  lock_ttl: 6.hours.to_i,
+                  on_conflict: { client: :log, server: :reschedule }
+
+  def perform(user_id)
+    user = User.find_by(id: user_id)
+    return if user.nil?
+
+    user.products.find_each do |product|
+      product.enqueue_index_update_for(%w[is_recommendable])
+    end
+  end
+end

--- a/spec/business/payments/merchant_registration/paypal/paypal_merchant_account_manager_spec.rb
+++ b/spec/business/payments/merchant_registration/paypal/paypal_merchant_account_manager_spec.rb
@@ -351,4 +351,32 @@ describe PaypalMerchantAccountManager, :vcr do
       expect(creator.merchant_account("paypal").charge_processor_merchant_id).to eq(new_paypal_merchant_id)
     end
   end
+
+  describe "#disconnect" do
+    it "removes products from recommendable search results when PayPal was the seller's only payout method", :elasticsearch_wait_for_refresh do
+      seller = create(:compliant_user, name: "PayPal seller", payment_address: nil)
+      product = create(:product, user: seller, taxonomy: create(:taxonomy))
+      create(:merchant_account, user: nil)
+      create(:purchase, link: product, seller:, price_cents: product.price_cents)
+      create(:merchant_account_paypal, user: seller, charge_processor_verified_at: Time.current)
+      index_model_records(Link)
+
+      recommendable_product_ids = -> {
+        Link.search(Link.search_options(ids: [product.id], include_rated_as_adult: true)).records.map(&:id)
+      }
+      expect(product.reload.recommendable?).to eq(true)
+      expect(recommendable_product_ids.call).to eq([product.id])
+
+      RefreshMerchantAccountProductsRecommendationEligibilityJob.jobs.clear
+      expect do
+        described_class.new.disconnect(user: seller)
+      end.to change(RefreshMerchantAccountProductsRecommendationEligibilityJob.jobs, :size).by(1)
+      RefreshMerchantAccountProductsRecommendationEligibilityJob.drain
+      Link.__elasticsearch__.refresh_index!
+
+      expect(product.reload.recommendable?).to eq(false)
+      expect(EsClient.get(index: Link.index_name, id: product.id).dig("_source", "is_recommendable")).to eq(false)
+      expect(recommendable_product_ids.call).to be_empty
+    end
+  end
 end

--- a/spec/models/concerns/json_data_spec.rb
+++ b/spec/models/concerns/json_data_spec.rb
@@ -130,4 +130,18 @@ describe JsonData do
       user.update!(name: "Fresh name")
     end
   end
+
+  describe "corrupt non-Hash json_data" do
+    let!(:user) { create(:user) }
+
+    it "allows a rewrite save when the stored value is a JSON string scalar" do
+      user.update_column(:json_data, '"not a hash"')
+      user.reload
+      user[:json_data] = {}
+      user.payout_threshold_cents = 1234
+
+      expect { user.save! }.not_to raise_error
+      expect(user.reload.payout_threshold_cents).to eq(1234)
+    end
+  end
 end

--- a/spec/models/merchant_account_spec.rb
+++ b/spec/models/merchant_account_spec.rb
@@ -175,10 +175,8 @@ describe MerchantAccount do
       merchant_account.reload
       expect(merchant_account).to be_deleted
       expect(merchant_account).to be_charge_processor_deleted
-      # Revert check: without clear_non_hash_json_data_for_disconnect! (or without
-      # JsonData treating non-Hash was/current as {}), disconnect raises ArgumentError
-      # and never reaches charge_processor_deleted_at / a Hash json_data.
-      expect(merchant_account.json_data).to eq({})
+      # Without the harden, disconnect raises before charge_processor_deleted_at is set.
+      expect(merchant_account.json_data).to eq("meta" => {})
     end
 
     it "does not enqueue when another payout method remains" do

--- a/spec/models/merchant_account_spec.rb
+++ b/spec/models/merchant_account_spec.rb
@@ -165,6 +165,17 @@ describe MerchantAccount do
       merchant_account.delete_charge_processor_account!
     end
 
+    it "does not abort a Stripe disconnect when json_data is not a Hash" do
+      merchant_account = create(:merchant_account, user: seller)
+      merchant_account.update_column(:json_data, '"not a hash"')
+      merchant_account.reload
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).with(seller.id).once
+
+      expect { merchant_account.delete_charge_processor_account! }.not_to raise_error
+      expect(merchant_account.reload).to be_deleted
+      expect(merchant_account).to be_charge_processor_deleted
+    end
+
     it "does not enqueue when another payout method remains" do
       merchant_account = create(:merchant_account_paypal, user: seller)
       seller.update!(payment_address: "seller@example.com")

--- a/spec/models/merchant_account_spec.rb
+++ b/spec/models/merchant_account_spec.rb
@@ -100,6 +100,159 @@ describe MerchantAccount do
     end
   end
 
+  describe "recommendation eligibility refresh" do
+    let(:seller) { create(:user, payment_address: nil) }
+
+    it "enqueues a refresh when an active PayPal account is created" do
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).with(seller.id).once
+
+      create(:merchant_account_paypal, user: seller)
+    end
+
+    it "enqueues one refresh when an active PayPal account is disconnected" do
+      merchant_account = create(:merchant_account_paypal, user: seller)
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).with(seller.id).once
+
+      merchant_account.delete_charge_processor_account!
+    end
+
+    it "enqueues a refresh when a PayPal account becomes active again" do
+      merchant_account = create(
+        :merchant_account_paypal,
+        user: seller,
+        deleted_at: 1.day.ago,
+        charge_processor_alive_at: nil,
+        charge_processor_deleted_at: 1.day.ago
+      )
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).with(seller.id).once
+
+      merchant_account.update!(
+        deleted_at: nil,
+        charge_processor_alive_at: Time.current,
+        charge_processor_deleted_at: nil
+      )
+    end
+
+    it "enqueues a refresh when a connected Stripe account is disconnected" do
+      merchant_account = create(:merchant_account_stripe_connect, user: seller)
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).with(seller.id).once
+
+      merchant_account.delete_charge_processor_account!
+    end
+
+    it "enqueues refreshes for both sellers when an active account changes owners" do
+      new_seller = create(:user, payment_address: nil)
+      merchant_account = create(:merchant_account_paypal, user: seller)
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).with(seller.id).once
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).with(new_seller.id).once
+
+      merchant_account.update!(user: new_seller)
+    end
+
+    it "retains the disconnect refresh across multiple saves in an outer transaction" do
+      merchant_account = create(:merchant_account_paypal, user: seller)
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).with(seller.id).once
+
+      ActiveRecord::Base.transaction do
+        merchant_account.delete_charge_processor_account!
+      end
+    end
+
+    it "ignores Gumroad-managed Stripe account changes" do
+      merchant_account = create(:merchant_account, user: seller)
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).not_to receive(:perform_async)
+
+      merchant_account.delete_charge_processor_account!
+    end
+
+    it "does not enqueue when another payout method remains" do
+      merchant_account = create(:merchant_account_paypal, user: seller)
+      seller.update!(payment_address: "seller@example.com")
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).not_to receive(:perform_async)
+
+      merchant_account.delete_charge_processor_account!
+    end
+
+    it "does not enqueue when an active bank account remains" do
+      merchant_account = create(:merchant_account_paypal, user: seller)
+      create(:canadian_bank_account, user: seller)
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).not_to receive(:perform_async)
+
+      merchant_account.delete_charge_processor_account!
+    end
+
+    it "does not enqueue when another connected account remains" do
+      merchant_account = create(:merchant_account_paypal, user: seller)
+      create(:merchant_account_stripe_connect, user: seller)
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).not_to receive(:perform_async)
+
+      merchant_account.delete_charge_processor_account!
+    end
+
+    it "does not enqueue a rolled-back state change" do
+      merchant_account = create(:merchant_account_paypal, user: seller)
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).not_to receive(:perform_async)
+
+      ActiveRecord::Base.transaction do
+        merchant_account.mark_deleted!
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    it "does not let an enqueue failure interrupt account disconnection" do
+      merchant_account = create(:merchant_account_paypal, user: seller)
+      fallback_job = instance_double(RefreshMerchantAccountProductsRecommendationEligibilityJob, perform: nil)
+      allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).and_raise("Redis unavailable")
+      allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:new).and_return(fallback_job)
+      allow(ErrorNotifier).to receive(:notify)
+
+      expect { merchant_account.delete_charge_processor_account! }.not_to raise_error
+
+      expect(merchant_account.reload).to be_deleted
+      expect(merchant_account).to be_charge_processor_deleted
+      expect(ErrorNotifier).to have_received(:notify).with(
+        instance_of(RuntimeError),
+        merchant_account_id: merchant_account.id,
+        user_id: seller.id
+      )
+      expect(fallback_job).to have_received(:perform).with(seller.id)
+    end
+
+    it "does not let refresh or observability failures escape after disconnection commits" do
+      merchant_account = create(:merchant_account_paypal, user: seller)
+      fallback_job = instance_double(RefreshMerchantAccountProductsRecommendationEligibilityJob)
+      allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).and_raise("Redis unavailable")
+      allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:new).and_return(fallback_job)
+      allow(fallback_job).to receive(:perform).and_raise("Elasticsearch unavailable")
+      allow(ErrorNotifier).to receive(:notify).and_raise("Sentry unavailable")
+
+      expect { merchant_account.delete_charge_processor_account! }.not_to raise_error
+
+      expect(merchant_account.reload).to be_deleted
+      expect(merchant_account).to be_charge_processor_deleted
+    end
+
+    it "reports the affected seller when an owner-transfer refresh fails" do
+      new_seller = create(:user, payment_address: nil)
+      merchant_account = create(:merchant_account_paypal, user: seller)
+      fallback_job = instance_double(RefreshMerchantAccountProductsRecommendationEligibilityJob, perform: nil)
+      allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).with(seller.id).and_raise("Redis unavailable")
+      allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).with(new_seller.id)
+      allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:new).and_return(fallback_job)
+      allow(ErrorNotifier).to receive(:notify)
+
+      merchant_account.update!(user: new_seller)
+
+      expect(ErrorNotifier).to have_received(:notify).with(
+        instance_of(RuntimeError),
+        merchant_account_id: merchant_account.id,
+        user_id: seller.id
+      )
+      expect(fallback_job).to have_received(:perform).with(seller.id)
+      expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).to have_received(:perform_async).with(new_seller.id)
+    end
+  end
+
   describe "#is_a_paypal_connect_account?" do
     it "returns true if charge_processor_id is PayPal otherwise false" do
       merchant_account = create(:merchant_account, charge_processor_id: PaypalChargeProcessor.charge_processor_id)

--- a/spec/models/merchant_account_spec.rb
+++ b/spec/models/merchant_account_spec.rb
@@ -172,8 +172,13 @@ describe MerchantAccount do
       expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).with(seller.id).once
 
       expect { merchant_account.delete_charge_processor_account! }.not_to raise_error
-      expect(merchant_account.reload).to be_deleted
+      merchant_account.reload
+      expect(merchant_account).to be_deleted
       expect(merchant_account).to be_charge_processor_deleted
+      # Revert check: without clear_non_hash_json_data_for_disconnect! (or without
+      # JsonData treating non-Hash was/current as {}), disconnect raises ArgumentError
+      # and never reaches charge_processor_deleted_at / a Hash json_data.
+      expect(merchant_account.json_data).to eq({})
     end
 
     it "does not enqueue when another payout method remains" do

--- a/spec/models/merchant_account_spec.rb
+++ b/spec/models/merchant_account_spec.rb
@@ -212,9 +212,7 @@ describe MerchantAccount do
 
     it "does not let an enqueue failure interrupt account disconnection" do
       merchant_account = create(:merchant_account_paypal, user: seller)
-      fallback_job = instance_double(RefreshMerchantAccountProductsRecommendationEligibilityJob, perform: nil)
       allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).and_raise("Redis unavailable")
-      allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:new).and_return(fallback_job)
       allow(ErrorNotifier).to receive(:notify)
 
       expect { merchant_account.delete_charge_processor_account! }.not_to raise_error
@@ -226,15 +224,11 @@ describe MerchantAccount do
         merchant_account_id: merchant_account.id,
         user_id: seller.id
       )
-      expect(fallback_job).to have_received(:perform).with(seller.id)
     end
 
-    it "does not let refresh or observability failures escape after disconnection commits" do
+    it "does not let observability failures escape after disconnection commits" do
       merchant_account = create(:merchant_account_paypal, user: seller)
-      fallback_job = instance_double(RefreshMerchantAccountProductsRecommendationEligibilityJob)
       allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).and_raise("Redis unavailable")
-      allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:new).and_return(fallback_job)
-      allow(fallback_job).to receive(:perform).and_raise("Elasticsearch unavailable")
       allow(ErrorNotifier).to receive(:notify).and_raise("Sentry unavailable")
 
       expect { merchant_account.delete_charge_processor_account! }.not_to raise_error
@@ -246,10 +240,8 @@ describe MerchantAccount do
     it "reports the affected seller when an owner-transfer refresh fails" do
       new_seller = create(:user, payment_address: nil)
       merchant_account = create(:merchant_account_paypal, user: seller)
-      fallback_job = instance_double(RefreshMerchantAccountProductsRecommendationEligibilityJob, perform: nil)
       allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).with(seller.id).and_raise("Redis unavailable")
       allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:perform_async).with(new_seller.id)
-      allow(RefreshMerchantAccountProductsRecommendationEligibilityJob).to receive(:new).and_return(fallback_job)
       allow(ErrorNotifier).to receive(:notify)
 
       merchant_account.update!(user: new_seller)
@@ -259,7 +251,6 @@ describe MerchantAccount do
         merchant_account_id: merchant_account.id,
         user_id: seller.id
       )
-      expect(fallback_job).to have_received(:perform).with(seller.id)
       expect(RefreshMerchantAccountProductsRecommendationEligibilityJob).to have_received(:perform_async).with(new_seller.id)
     end
   end

--- a/spec/sidekiq/backfill_merchant_account_recommendation_eligibility_job_spec.rb
+++ b/spec/sidekiq/backfill_merchant_account_recommendation_eligibility_job_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe BackfillMerchantAccountRecommendationEligibilityJob do
+  it "uses a finite uniqueness lock for the manually started scan" do
+    expect(described_class.sidekiq_options).to include(
+      "lock" => :until_executed,
+      "lock_ttl" => 6.hours.to_i
+    )
+  end
+
+  it "refreshes each seller with a historically disconnected PayPal or Stripe Connect account" do
+    paypal_seller = create(:user)
+    stripe_seller = create(:user)
+    inactive_paypal_seller = create(:user)
+    malformed_stripe_seller = create(:user)
+    managed_stripe_seller = create(:user)
+    nil_json_stripe_seller = create(:user)
+    create(
+      :merchant_account_paypal,
+      user: paypal_seller,
+      deleted_at: 1.day.ago,
+      charge_processor_deleted_at: 1.day.ago,
+      charge_processor_alive_at: nil
+    )
+    create(
+      :merchant_account_stripe_connect,
+      user: stripe_seller,
+      deleted_at: 1.day.ago,
+      charge_processor_deleted_at: 1.day.ago,
+      charge_processor_alive_at: nil
+    )
+    create(
+      :merchant_account_paypal,
+      user: paypal_seller,
+      deleted_at: 2.days.ago,
+      charge_processor_deleted_at: 2.days.ago,
+      charge_processor_alive_at: nil
+    )
+    create(
+      :merchant_account_paypal,
+      user: inactive_paypal_seller,
+      deleted_at: nil,
+      charge_processor_deleted_at: nil,
+      charge_processor_alive_at: nil
+    )
+    create(:merchant_account, user: managed_stripe_seller, deleted_at: 1.day.ago, charge_processor_deleted_at: 1.day.ago)
+    create(
+      :merchant_account,
+      user: nil_json_stripe_seller,
+      json_data: nil,
+      deleted_at: 1.day.ago,
+      charge_processor_deleted_at: 1.day.ago
+    )
+    malformed_stripe = create(
+      :merchant_account,
+      user: malformed_stripe_seller,
+      deleted_at: 1.day.ago,
+      charge_processor_deleted_at: 1.day.ago
+    )
+    malformed_stripe.update_column(:json_data, '"not a hash"')
+    create(:merchant_account_paypal, user: create(:user))
+    RefreshMerchantAccountProductsRecommendationEligibilityJob.jobs.clear
+
+    described_class.new.perform
+
+    queued_args = RefreshMerchantAccountProductsRecommendationEligibilityJob.jobs.map { |job| job.fetch("args") }
+    expect(queued_args).to include(
+      [paypal_seller.id],
+      [stripe_seller.id],
+      [inactive_paypal_seller.id],
+      [malformed_stripe_seller.id]
+    )
+    expect(queued_args.count([paypal_seller.id])).to eq(1)
+    expect(queued_args).not_to include([managed_stripe_seller.id])
+    expect(queued_args).not_to include([nil_json_stripe_seller.id])
+  end
+
+  it "processes every batch within one locked run" do
+    accounts = Array.new(3) do
+      create(
+        :merchant_account_paypal,
+        user: create(:user),
+        deleted_at: 1.day.ago,
+        charge_processor_deleted_at: 1.day.ago,
+        charge_processor_alive_at: nil
+      )
+    end
+    stub_const("#{described_class}::BATCH_SIZE", 2)
+    job = described_class.new
+    allow(job).to receive(:disconnected_accounts).and_return(MerchantAccount.where(id: accounts.map(&:id)))
+    RefreshMerchantAccountProductsRecommendationEligibilityJob.jobs.clear
+
+    job.perform
+
+    expect(RefreshMerchantAccountProductsRecommendationEligibilityJob.jobs.map { |queued_job| queued_job.fetch("args") }).to match_array(
+      accounts.map { |account| [account.user_id] }
+    )
+  end
+end

--- a/spec/sidekiq/refresh_merchant_account_products_recommendation_eligibility_job_spec.rb
+++ b/spec/sidekiq/refresh_merchant_account_products_recommendation_eligibility_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe RefreshMerchantAccountProductsRecommendationEligibilityJob do
+  it "serializes scans while allowing a transition during a scan to schedule a follow-up" do
+    expect(described_class.sidekiq_options).to include(
+      "lock" => :until_and_while_executing,
+      "lock_ttl" => 6.hours.to_i,
+      "on_conflict" => { "client" => :log, "server" => :reschedule }
+    )
+  end
+
+  it "updates recommendation eligibility for every seller product" do
+    seller = create(:user)
+    products = create_list(:product, 2, user: seller)
+    updated_product_ids = []
+    expect(ProductIndexingService).to receive(:perform).twice do |product:, action:, attributes_to_update:, on_failure:|
+      updated_product_ids << product.id
+      expect(action).to eq("update")
+      expect(attributes_to_update).to eq(%w[is_recommendable])
+      expect(on_failure).to eq(:async)
+    end
+
+    described_class.new.perform(seller.id)
+
+    expect(updated_product_ids).to match_array(products.map(&:id))
+  end
+
+  it "does nothing when the seller no longer exists" do
+    expect { described_class.new.perform(0) }.not_to raise_error
+  end
+end

--- a/spec/sidekiq/refresh_merchant_account_products_recommendation_eligibility_job_spec.rb
+++ b/spec/sidekiq/refresh_merchant_account_products_recommendation_eligibility_job_spec.rb
@@ -5,9 +5,9 @@ require "spec_helper"
 describe RefreshMerchantAccountProductsRecommendationEligibilityJob do
   it "serializes scans while allowing a transition during a scan to schedule a follow-up" do
     expect(described_class.sidekiq_options).to include(
-      "lock" => :until_and_while_executing,
+      "lock" => :until_executing,
       "lock_ttl" => 6.hours.to_i,
-      "on_conflict" => { "client" => :log, "server" => :reschedule }
+      "on_conflict" => { "client" => :log }
     )
   end
 


### PR DESCRIPTION
## What

Refresh every seller product's indexed `is_recommendable` value when a connected PayPal or Stripe Connect merchant account is created, disconnected, restored, or transferred. Includes a one-time backfill job that is **not** enqueued on deploy:

`BackfillMerchantAccountRecommendationEligibilityJob.perform_async`

Disconnect still finishes when `json_data` holds a non-Hash value (for example a JSON string scalar). Corrupt metadata is cleared on disconnect, and the `JsonData` save merge treats a non-Hash prior or row value as an empty hash so the write is not aborted.

Imported from https://github.com/adityawrk/gumroad/pull/40 by @adityawrk. `qa-media/` binaries were not imported; walkthrough and screenshots stay on the fork PR.

## Why

Merchant-account connection state updated the database but did not refresh product documents. A seller could remain in Discover after losing the last PayPal or Stripe Connect account, or remain absent after connecting one.

A corrupt non-Hash `json_data` value also aborted Stripe disconnect through `JsonData` readers and the merge hook. Sellers could not finish disconnecting those accounts.

## Before / After

| Committed merchant-account transition | Before | After |
| --- | --- | --- |
| Last PayPal or Stripe Connect account disconnected | Search can stay recommendable | Products refresh to current eligibility |
| First connected payout account created or restored | Search can stay stale | Products refresh to current eligibility |
| Connected account transferred between sellers | Either seller can be stale | Both sellers refresh independently |
| Historical disconnected accounts | Stale documents remain | Optional bounded backfill (manual enqueue) |
| Disconnect with non-Hash `json_data` | Raises and stops mid-disconnect | Disconnect finishes; corrupt metadata cleared |

## Test Results

- `spec/models/merchant_account_spec.rb` example "does not abort a Stripe disconnect when json_data is not a Hash" — expects disconnect to finish with `charge_processor_deleted_at` set and `json_data` equal to `{"meta"=>{}}` for a Gumroad-managed Stripe account. Without the disconnect clear or the `JsonData` merge harden, it raises and never sets `charge_processor_deleted_at`.
- `spec/models/concerns/json_data_spec.rb` example "allows a rewrite save when the stored value is a JSON string scalar" — fails on revert of the merge harden (`NoMethodError` on `deep_stringify_keys`).
- CI on this branch is the authoritative full-file run.

## QA

1. Create a compliant seller with one recommendable product and a connected PayPal account as the only payout method.
2. Disconnect inside a committed transaction, drain the refresh job, refresh the index.
3. Confirm the database predicate and indexed value are false.
4. Restore and confirm both become true after the job runs.
5. Do not run the backfill against production from this PR.

Visual evidence: https://github.com/adityawrk/gumroad/pull/40

Based on https://github.com/adityawrk/gumroad/pull/40 by @adityawrk.

Addresses antiwork/gumroad-private#2406.

---

Implemented by Grok 4.6.

Premerge review: clean @ 0208cd8c18405680600cec2dabe79e1c81044f1c
