### PR TITLE
Recheck buyer call reminders before delivery

### DIFF
--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -371,7 +371,10 @@ class CustomerMailer < ApplicationMailer
   end
 
   def upcoming_call_reminder(call_id)
-    @purchase = Call.find(call_id).purchase
+    call = Call.find(call_id)
+    return unless call.eligible_for_reminder?
+
+    @purchase = call.purchase
     @subject = "Your scheduled call with #{@purchase.seller.display_name} is tomorrow!"
     @item_info = ReceiptPresenter::ItemInfo.new(@purchase)
     mail(

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -1347,6 +1347,7 @@ describe CustomerMailer do
     let(:call) { create(:call) }
 
     before do
+      create(:merchant_account, user: nil, charge_processor_merchant_id: "reminder_#{SecureRandom.hex(12)}")
       call.purchase.update!(variant_attributes: [create(:variant, name: "1 hour")])
       call.purchase.seller.update!(name: "Phone Man")
       call.purchase.create_url_redirect!
@@ -1362,6 +1363,48 @@ describe CustomerMailer do
       expect(mail.body.sanitized).to have_text("Call schedule #{call.formatted_time_range} #{call.formatted_date_range}")
       expect(mail.body.sanitized).to have_text("Duration 1 hour")
       expect(mail.body.sanitized).to have_text("Product price $1")
+    end
+
+    it "does not deliver a queued reminder after a full refund" do
+      expect do
+        CustomerMailer.upcoming_call_reminder(call.id).deliver_later
+      end.to have_enqueued_mail(CustomerMailer, :upcoming_call_reminder).with(call.id)
+      call.purchase.update!(stripe_refunded: true)
+      create(:refund, purchase: call.purchase, amount_cents: call.purchase.price_cents)
+
+      expect(call.reload.eligible_for_reminder?).to be(false)
+      expect do
+        perform_enqueued_jobs(only: CustomerMailer.delivery_job)
+      end.not_to change(ActionMailer::Base.deliveries, :count)
+    end
+
+    it "does not deliver a queued reminder after the payment fails" do
+      call.purchase.update!(purchase_state: "in_progress")
+      expect(call.reload.eligible_for_reminder?).to be(true)
+      expect do
+        CustomerMailer.upcoming_call_reminder(call.id).deliver_later
+      end.to have_enqueued_mail(CustomerMailer, :upcoming_call_reminder).with(call.id)
+      call.purchase.update!(purchase_state: "failed")
+
+      expect do
+        perform_enqueued_jobs(only: CustomerMailer.delivery_job)
+      end.not_to change(ActionMailer::Base.deliveries, :count)
+    end
+
+    it "does not send a reminder for a charged-back purchase" do
+      call.purchase.update!(chargeback_date: Time.current)
+
+      expect(CustomerMailer.upcoming_call_reminder(call.id).message).to be_a(ActionMailer::Base::NullMail)
+    end
+
+    it "still sends a reminder after a partial refund" do
+      call.purchase.update!(stripe_partially_refunded: true)
+      create(:refund, purchase: call.purchase, amount_cents: call.purchase.price_cents / 2)
+
+      expect do
+        CustomerMailer.upcoming_call_reminder(call.id).deliver_now
+      end.to change(ActionMailer::Base.deliveries, :count).by(1)
+      expect(ActionMailer::Base.deliveries.last.to).to eq([call.purchase.email])
     end
   end
 


### PR DESCRIPTION
## What

Recheck `Call#eligible_for_reminder?` when a queued buyer reminder renders, matching the seller reminder's existing behavior.

## Why

Call creation schedules reminders in advance. A purchase can be fully refunded, charged back, or fail before delivery, but the buyer mailer previously sent the reminder anyway. Reading the persisted eligibility at delivery fixes that gap while preserving valid purchases, gift recipients, and partial refunds. This does not make delivery atomic with a concurrent reversal.

Canonical base: `8ffccef5b6d96fff1daae272ac7f9d465b5ff6c4`. Searches found no matching active upstream or fork fix.

## Before/After

Before: a queued reminder is delivered after the purchase is fully refunded. After: no reminder is delivered. Eligible calls still receive the existing email template.

[Before/after verification walkthrough](https://raw.githubusercontent.com/adityawrk/gumroad/fix/buyer-reminder-delivery-eligibility/qa-media/pr-42-buyer-reminder-walkthrough.mp4)

The recording shows the actual canonical failure followed by the passing regression selection in a local terminal. This is a backend delivery change with no template or layout changes.

## Test Results

- Full CustomerMailer, ContactingCreatorMailer, and Call suites: 386 examples, zero failures.
- Focused reminder selection: five examples, zero failures.
- Canonical revert proof: full-refund, failed-payment, and chargeback regressions fail without the application change; positive content and partial-refund tests pass.
- Ruby lint: two files, no offenses. `git diff --check` passes.

QA: queue a buyer reminder for an eligible call, fully refund its purchase before executing the mail job, then confirm no email is delivered. Repeat with a failed payment and chargeback. Confirm a partial refund still delivers the reminder. The regression tests execute the real mail job and check actual test deliveries.

Visual evidence: https://github.com/adityawrk/gumroad/pull/42

`qa-media/` binaries were not imported.

Addresses antiwork/gumroad-private#2426.

---

Based on https://github.com/adityawrk/gumroad/pull/42 by @adityawrk.

AI Disclosure: OpenAI GPT-6 (Codex) implemented the fork fix. Grok 4.6 reviewed the original PR and imported the code changes.

Premerge review: clean @ b7c0e7dc850b07ed23a072dfc8d49b8f644b1e50

- [ ] Scope
- [ ] Design
- [ ] Build
- [ ] Ship
- [ ] Market
- [ ] Sell
