### PR TITLE
Refresh discounts for formerly eligible products

### DIFF
--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -34,6 +34,7 @@ class OfferCode < ApplicationRecord
   MAX_OWNERSHIP_DURATION_TIERS = 10
   # Enough for the seller to recognise the products without an unbounded message.
   NAMED_DEFAULT_DISCOUNT_PRODUCTS = 3
+  PRODUCT_REINDEX_BATCH_SIZE = 1_000
 
   # Regex modified from https://stackoverflow.com/a/26900132
   validates :code, presence: true, format: { with: /\A[A-Za-zÀ-ÖØ-öø-ÿ0-9\-_]*\z/, message: "can only contain numbers, letters, dashes, and underscores." }, unless: -> { is_cancellation_discount? || upsell.present? }
@@ -616,12 +617,27 @@ class OfferCode < ApplicationRecord
       # A universal code's applicable set is every alive product, so running the
       # per-product index updates inline after_commit blows the request timeout
       # for large catalogs. Enqueue them as background jobs after the row commits.
-      product_ids = products_to_reindex.map(&:id)
       AfterCommitEverywhere.after_commit do
-        SendToElasticsearchWorker.perform_bulk(
-          product_ids.map { |product_id| [product_id, "update", ["offer_codes"]] }
-        )
+        enqueue_offer_code_document_updates(products_to_reindex)
       end
+    end
+
+    def enqueue_offer_code_document_updates(products_to_reindex)
+      if products_to_reindex.is_a?(ActiveRecord::Relation)
+        products_to_reindex.in_batches(of: PRODUCT_REINDEX_BATCH_SIZE) do |batch|
+          enqueue_offer_code_document_ids(batch.ids)
+        end
+      else
+        enqueue_offer_code_document_ids(Array(products_to_reindex).map(&:id))
+      end
+    end
+
+    def enqueue_offer_code_document_ids(product_ids)
+      return if product_ids.empty?
+
+      SendToElasticsearchWorker.perform_bulk(
+        product_ids.map { |product_id| [product_id, "update", ["offer_codes"]] }
+      )
     end
 
     def reindex_removed_product(product)

--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -20,7 +20,7 @@ class OfferCode < ApplicationRecord
 
   stripped_fields :code
 
-  has_and_belongs_to_many :products, class_name: "Link", join_table: "offer_codes_products", association_foreign_key: "product_id", after_add: :note_applicability_change, after_remove: [:note_applicability_change, :note_removed_product]
+  has_and_belongs_to_many :products, class_name: "Link", join_table: "offer_codes_products", association_foreign_key: "product_id", after_add: :note_applicability_change, after_remove: [:note_applicability_change, :note_removed_product, :reindex_removed_product]
   has_and_belongs_to_many :ownership_products, class_name: "Link", join_table: "offer_codes_ownership_products", association_foreign_key: "product_id"
   has_and_belongs_to_many :excluded_products, class_name: "Link", join_table: "offer_codes_excluded_products", association_foreign_key: "product_id", after_add: [:invalidate_excluded_product_cache, :note_applicability_change], after_remove: [:invalidate_excluded_product_cache, :note_applicability_change]
   belongs_to :user
@@ -52,6 +52,7 @@ class OfferCode < ApplicationRecord
   after_save :invalidate_product_cache
   after_save :reindex_associated_products
   after_save :note_column_applicability_changes
+  before_update :reindex_previous_universal_products
   after_commit :repair_detached_default_discounts, if: -> { @applicability_changed }
   after_rollback :forget_applicability_changes
   before_destroy :capture_associated_product_ids
@@ -621,6 +622,18 @@ class OfferCode < ApplicationRecord
           product_ids.map { |product_id| [product_id, "update", ["offer_codes"]] }
         )
       end
+    end
+
+    def reindex_removed_product(product)
+      reindex_associated_products(products_to_reindex: [product])
+    end
+
+    def reindex_previous_universal_products
+      return unless universal_in_database && (will_save_change_to_universal? || will_save_change_to_currency_type?)
+
+      products = Link.alive.where(user_id: user_id_in_database)
+      products = products.where(price_currency_type: currency_type_in_database) if currency_type_in_database.present?
+      reindex_associated_products(products_to_reindex: products)
     end
 
     def capture_associated_product_ids

--- a/spec/models/offer_code_spec.rb
+++ b/spec/models/offer_code_spec.rb
@@ -1488,6 +1488,22 @@ describe OfferCode do
         expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
       end
 
+      it "enqueues the previous universal catalog in bounded batches" do
+        universal_offer_code = create(:universal_offer_code, user: creator)
+        SendToElasticsearchWorker.clear
+        stub_const("OfferCode::PRODUCT_REINDEX_BATCH_SIZE", 1)
+
+        batch_sizes = []
+        allow(SendToElasticsearchWorker).to receive(:perform_bulk) do |args, **|
+          batch_sizes << args.size
+        end
+
+        universal_offer_code.update!(universal: false, products: [product2])
+
+        expect(batch_sizes.max).to eq(1)
+        expect(batch_sizes.sum).to be >= 2
+      end
+
       it "reindexes products removed from a product-specific offer code" do
         SendToElasticsearchWorker.clear
 

--- a/spec/models/offer_code_spec.rb
+++ b/spec/models/offer_code_spec.rb
@@ -1403,6 +1403,101 @@ describe OfferCode do
     let!(:offer_code) { create(:offer_code, user: creator, code: "BLACKFRIDAY2025", products: [product1, product2]) }
 
     describe "after_save callback" do
+      it "waits for the enclosing transaction before indexing a removed product" do
+        SendToElasticsearchWorker.clear
+
+        OfferCode.transaction(requires_new: true) do
+          OfferCode.transaction(requires_new: true) do
+            offer_code.update!(products: [product2])
+          end
+          expect(SendToElasticsearchWorker.jobs.size).to eq(0)
+        end
+
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+      end
+
+      it "does not index a removal rolled back with its transaction" do
+        SendToElasticsearchWorker.clear
+
+        OfferCode.transaction(requires_new: true) do
+          offer_code.update!(products: [product2])
+          raise ActiveRecord::Rollback
+        end
+
+        expect(SendToElasticsearchWorker.jobs.size).to eq(0)
+        expect(offer_code.reload.products).to contain_exactly(product1, product2)
+      end
+
+      it "does not index a removal rolled back to a savepoint" do
+        SendToElasticsearchWorker.clear
+
+        OfferCode.transaction(requires_new: true) do
+          OfferCode.transaction(requires_new: true) do
+            offer_code.update!(products: [product2])
+            raise ActiveRecord::Rollback
+          end
+        end
+
+        expect(SendToElasticsearchWorker.jobs.size).to eq(0)
+        expect(offer_code.reload.products).to contain_exactly(product1, product2)
+      end
+
+      it "indexes a successful retry after a failed removal update" do
+        SendToElasticsearchWorker.clear
+
+        expect(offer_code.update(products: [product2], amount_cents: -1)).to be(false)
+        expect(SendToElasticsearchWorker.jobs.size).to eq(0)
+        expect(offer_code.reload.products).to contain_exactly(product1, product2)
+
+        offer_code.update!(products: [product2])
+
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+      end
+
+      it "does not index an old universal scope when its change rolls back" do
+        universal_offer_code = create(:universal_offer_code, user: creator)
+        SendToElasticsearchWorker.clear
+
+        OfferCode.transaction(requires_new: true) do
+          universal_offer_code.update!(universal: false, products: [product2])
+          raise ActiveRecord::Rollback
+        end
+
+        expect(SendToElasticsearchWorker.jobs.size).to eq(0)
+        expect(universal_offer_code.reload).to be_universal
+      end
+
+      it "reindexes formerly eligible products when a universal code becomes product-specific" do
+        universal_offer_code = create(:universal_offer_code, user: creator)
+        SendToElasticsearchWorker.clear
+
+        universal_offer_code.update!(universal: false, products: [product2])
+
+        expect(product1.reload.product_and_universal_offer_codes).not_to include(universal_offer_code)
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+      end
+
+      it "reindexes the old currency's products when a universal discount changes currency" do
+        universal_offer_code = create(:universal_offer_code, user: creator, currency_type: "usd")
+        create(:product, user: creator, price_currency_type: "eur")
+        SendToElasticsearchWorker.clear
+
+        universal_offer_code.update!(currency_type: "eur")
+
+        expect(product1.reload.product_and_universal_offer_codes).not_to include(universal_offer_code)
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+      end
+
+      it "reindexes products removed from a product-specific offer code" do
+        SendToElasticsearchWorker.clear
+
+        offer_code.update!(products: [product2])
+
+        expect(product1.reload.product_and_universal_offer_codes).not_to include(offer_code)
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product2.id, "update", ["offer_codes"])
+      end
+
       it "reindexes products when they are excluded from a universal offer code" do
         universal_offer_code = create(:universal_offer_code, user: creator)
 

--- a/spec/modules/product/searchable/offer_codes_spec.rb
+++ b/spec/modules/product/searchable/offer_codes_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 describe "Product::Searchable - Offer codes filtering" do
   describe "filtering by offer_codes", :elasticsearch_wait_for_refresh do
     before do
+      create(:merchant_account, user: nil, charge_processor_merchant_id: "offer_search_#{SecureRandom.hex(12)}")
       Link.__elasticsearch__.create_index!(force: true)
 
       Feature.activate(:offer_codes_search)
@@ -44,6 +45,18 @@ describe "Product::Searchable - Offer codes filtering" do
       expect(records).to include(@product_with_offer)
       expect(records).to include(@product_without_offer)
       expect(records).to include(@product_with_other_offer)
+    end
+
+    it "stops matching a product removed from the discount" do
+      args = Link.search_options(offer_code: @offer_code.code)
+      expect(Link.__elasticsearch__.search(args).records.to_a).to include(@product_with_offer)
+      SendToElasticsearchWorker.clear
+
+      @offer_code.reload.update!(products: [])
+      SendToElasticsearchWorker.drain
+
+      expect(@product_with_offer.reload.product_and_universal_offer_codes).not_to include(@offer_code)
+      expect(Link.__elasticsearch__.search(args).records.to_a).not_to include(@product_with_offer)
     end
 
     it "returns no products when searching with __no_match__ code" do


### PR DESCRIPTION
## What

Refresh indexed discount codes for products removed from a discount and for the old eligible product set when a universal discount becomes product-specific or changes currency.

## Why

The existing save callback only indexed the new applicable product set. Products that had just lost eligibility were omitted, so discount-filtered search could continue returning them after the database association changed. Association removal now captures the removed product, and a narrowly gated pre-update callback captures the previous universal scope using persisted seller and currency values. Both use the existing helper to enqueue after commit. Relation scopes are plucked in batches of 1,000 after commit so a large catalog is not instantiated into one enqueue payload.

Canonical base: `8ffccef5b6d96fff1daae272ac7f9d465b5ff6c4`. Searches found no matching active upstream or fork fix. The prior asynchronous universal-reindex fix addressed request duration, not missing formerly eligible products.

## Before/After

Before: removing a product from a discount leaves it in that discount's search results. After: queued indexing removes the stale match. Universal scope and currency changes refresh both old and new eligible sets. Rolled-back edits enqueue no work.

[Before/after verification walkthrough](https://raw.githubusercontent.com/adityawrk/gumroad/fix/offer-removal-search-refresh/qa-media/pr-43-discount-search-walkthrough.mp4)

The recording shows the actual missing-refresh failure on canonical code followed by passing transaction and Elasticsearch regressions. This is a backend indexing change with no layout changes.

## Checklist

- [x] Scope — search-index refresh for products that lose offer-code eligibility; no pricing or purchase-amount changes; no historical backfill
- [x] Design — capture removed products and previous universal scope, enqueue after commit; relations batched at 1,000 IDs
- [x] Build — `b51d2774c2` on `import/adityawrk-offer-removal-search-refresh`
- [x] QA — local `reindexing products` 15 examples, 0 failures; batching revert reddens the new spec (`Expected 2 to eq 1`)
- [ ] Shipped — draft; waiting on CI and premerge
- [ ] Market — n/a, backend search-index correctness
- [ ] Sell — n/a

## Test Results

- Full OfferCode, product offer-code search, Checkout::DiscountsController, and API v2 offer-code controller suites: 286 examples, zero failures.
- Reindexing describe at `b51d2774c2`: 15 examples, 0 failures. Dropping `in_batches` on the relation path fails the new batch-size example.
- Tests cover enclosing commit, outer and savepoint rollback, validation failure followed by retry, explicit product removal, universal-to-specific changes, currency changes, and bounded previous-scope enqueue.
- Ruby lint: two files, no offenses. `git diff --check` passes.

QA: index a product with a discount and verify it matches a discount-code search. Remove it through a discount update, drain the index worker, and verify that both the database and search exclude the discount. Repeat with a universal discount changed to selected products and with a universal currency change. Confirm rollback preserves the association and schedules no refresh.

Jobs recompute current product state and run after commit. This does not backfill historical stale documents or solve the shared index worker's pre-existing concurrent read/write ordering limitation. No pricing or persisted purchase amounts change.

Visual evidence: https://github.com/adityawrk/gumroad/pull/43

`qa-media/` binaries were not imported.

Addresses antiwork/gumroad-private#2426.

---

Based on https://github.com/adityawrk/gumroad/pull/43 by @adityawrk.

AI Disclosure: OpenAI GPT-6 (Codex) implemented the fork fix. Grok 4.6 reviewed the original PR, imported the code changes, and batched previous-universal reindex enqueue after Greptile P2.

Premerge review: clean @ dc65b6995838c0306dc78f366b3cc8e43ae75137
