### PR TITLE
Cap workflow email fanout so Resend callbacks cannot fill shopper Puma

### DIFF
--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -136,6 +136,7 @@ class RedisKey
     def workflow_seller_fanout_retry_seconds = "workflow_seller_fanout_retry_seconds"
     def workflow_immediate_fanout_threshold = "workflow_immediate_fanout_threshold"
     def workflow_immediate_enqueue_per_second = "workflow_immediate_enqueue_per_second"
+    def workflow_immediate_fanout_pacing_cursor = "workflow_immediate_fanout_pacing_cursor"
     def workflow_immediate_fanout_max_spread_seconds = "workflow_immediate_fanout_max_spread_seconds"
     def seller_large_blast_threshold = "seller_large_blast_threshold"
     def seller_large_blast_quota(seller_id, day) = "seller_large_blast_quota:#{seller_id}:#{day}"

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -10,8 +10,7 @@ class SendWorkflowPostEmailsJob
   FOLLOWER_LOOKUP_BATCH_SIZE = 1_000
   AFFILIATE_LOOKUP_BATCH_SIZE = 1_000
   IMMEDIATE_FANOUT_THRESHOLD = 2_000
-  DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND = 80
-  MAX_IMMEDIATE_SPREAD = 15.minutes
+  DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND = 20
 
   def perform(post_id, earliest_valid_time = nil, reschedule_on_stale = false, minimum_rule_version = nil, schedule_intent_token = nil, schedule_intent_fanout_token = nil)
     @schedule_intent_token = schedule_intent_token
@@ -309,7 +308,7 @@ class SendWorkflowPostEmailsJob
       now = @immediate_fanout_started_at || Time.current
       return natural_at if natural_at > now
 
-      offset = @immediate_fanout_index.to_f / effective_immediate_enqueue_per_second
+      offset = @immediate_fanout_index.to_f / immediate_enqueue_per_second
       @immediate_fanout_index += 1
       now + offset
     end
@@ -324,22 +323,11 @@ class SendWorkflowPostEmailsJob
       IMMEDIATE_FANOUT_THRESHOLD
     end
 
-    def effective_immediate_enqueue_per_second
-      [immediate_enqueue_per_second, @immediate_fanout_recipient_count.to_f / max_immediate_spread_seconds].max
-    end
-
     def immediate_enqueue_per_second
       per_second = ($redis.get(RedisKey.workflow_immediate_enqueue_per_second) || DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND).to_f
       per_second.positive? ? per_second : DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND
     rescue Redis::BaseError, RedisClient::Error
       DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND
-    end
-
-    def max_immediate_spread_seconds
-      spread_seconds = ($redis.get(RedisKey.workflow_immediate_fanout_max_spread_seconds) || MAX_IMMEDIATE_SPREAD).to_i
-      spread_seconds.positive? ? spread_seconds : MAX_IMMEDIATE_SPREAD.to_i
-    rescue Redis::BaseError, RedisClient::Error
-      MAX_IMMEDIATE_SPREAD.to_i
     end
 
     def claim_seller_fanout_lock

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -11,6 +11,7 @@ class SendWorkflowPostEmailsJob
   AFFILIATE_LOOKUP_BATCH_SIZE = 1_000
   IMMEDIATE_FANOUT_THRESHOLD = 2_000
   DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND = 20
+  PACING_BACKLOG_WARNING_SECONDS = 15.minutes.to_i
 
   # Reserves the next delivery slot on a cursor shared by ALL fanout jobs, so concurrent
   # sellers collectively respect the cap instead of each getting the full rate.
@@ -329,11 +330,22 @@ class SendWorkflowPostEmailsJob
         argv: [now.to_f, 1.0 / immediate_enqueue_per_second]
       ).to_f
       @immediate_fanout_index += 1
+      warn_on_pacing_backlog(slot - now.to_f)
       slot
     rescue Redis::BaseError, RedisClient::Error
       offset = @immediate_fanout_index.to_f / immediate_enqueue_per_second
       @immediate_fanout_index += 1
       now.to_f + offset
+    end
+
+    def warn_on_pacing_backlog(lag_seconds)
+      return if @pacing_backlog_notified || lag_seconds <= PACING_BACKLOG_WARNING_SECONDS
+
+      @pacing_backlog_notified = true
+      ErrorNotifier.notify(
+        "SendWorkflowPostEmailsJob: shared pacing cursor is #{lag_seconds.round}s behind aggregate demand",
+        installment_id: @post.id
+      )
     end
 
     def pace_immediate_fanout?

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -12,6 +12,17 @@ class SendWorkflowPostEmailsJob
   IMMEDIATE_FANOUT_THRESHOLD = 2_000
   DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND = 20
 
+  # Reserves the next delivery slot on a cursor shared by ALL fanout jobs, so concurrent
+  # sellers collectively respect the cap instead of each getting the full rate.
+  RESERVE_PACING_SLOT = <<~LUA
+    local now = tonumber(ARGV[1])
+    local step = tonumber(ARGV[2])
+    local base = tonumber(redis.call("GET", KEYS[1]))
+    if not base or base < now then base = now end
+    redis.call("SET", KEYS[1], base + step, "EX", math.ceil(base + step - now) + 60)
+    return tostring(base)
+  LUA
+
   def perform(post_id, earliest_valid_time = nil, reschedule_on_stale = false, minimum_rule_version = nil, schedule_intent_token = nil, schedule_intent_fanout_token = nil)
     @schedule_intent_token = schedule_intent_token
     @schedule_intent_fanout_token = schedule_intent_fanout_token
@@ -308,9 +319,21 @@ class SendWorkflowPostEmailsJob
       now = @immediate_fanout_started_at || Time.current
       return natural_at if natural_at > now
 
+      Time.zone.at(reserve_pacing_slot(now))
+    end
+
+    def reserve_pacing_slot(now)
+      slot = $redis.eval(
+        RESERVE_PACING_SLOT,
+        keys: [RedisKey.workflow_immediate_fanout_pacing_cursor],
+        argv: [now.to_f, 1.0 / immediate_enqueue_per_second]
+      ).to_f
+      @immediate_fanout_index += 1
+      slot
+    rescue Redis::BaseError, RedisClient::Error
       offset = @immediate_fanout_index.to_f / immediate_enqueue_per_second
       @immediate_fanout_index += 1
-      now + offset
+      now.to_f + offset
     end
 
     def pace_immediate_fanout?

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -968,6 +968,7 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       @post_rule.update!(delayed_delivery_time: 0)
       stub_const("#{described_class}::IMMEDIATE_FANOUT_THRESHOLD", 3)
       stub_const("#{described_class}::DEFAULT_IMMEDIATE_ENQUEUE_PER_SECOND", 2)
+      $redis.del(RedisKey.workflow_immediate_fanout_pacing_cursor)
       @paced_purchases = []
       4.times do |i|
         purchase = create(:free_purchase, link: @product, email: "paced-buyer-#{i}@example.com", created_at: 1.hour.ago)
@@ -984,6 +985,28 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       ats = jobs.filter_map { _1["at"] }.sort
       expect(ats.size).to eq(3)
       expect(ats.last - Time.current.to_f).to be_within(0.05).of(1.5)
+    end
+
+    it "shares the pacing cursor across fanouts so concurrent sellers respect the aggregate cap" do
+      other_seller = create(:named_user)
+      other_workflow = create(:audience_workflow, seller: other_seller)
+      other_product = create(:product, user: other_seller, price_cents: 0)
+      other_post = create(:audience_post, :published, workflow: other_workflow, seller: other_seller,
+                                                      installment_type: Installment::PRODUCT_TYPE,
+                                                      link: other_product,
+                                                      bought_products: [other_product.unique_permalink])
+      create(:post_rule, installment: other_post, delayed_delivery_time: 0)
+      4.times do |i|
+        create(:free_purchase, link: other_product, email: "paced-other-#{i}@example.com", created_at: 1.hour.ago)
+          .rebuild_audience_member_details
+      end
+
+      described_class.new.perform(@post.id)
+      described_class.new.perform(other_post.id)
+
+      ats = SendWorkflowInstallmentWorker.jobs.filter_map { _1["at"] }.sort
+      expect(SendWorkflowInstallmentWorker.jobs.size).to eq(8)
+      expect(ats.last - Time.current.to_f).to be_within(0.05).of(3.5)
     end
 
     it "does not raise the paced rate to fit a shorter spread window" do

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -1009,6 +1009,16 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       expect(ats.last - Time.current.to_f).to be_within(0.05).of(3.5)
     end
 
+    it "notifies when the shared cursor is far behind aggregate demand" do
+      $redis.set(RedisKey.workflow_immediate_fanout_pacing_cursor, 16.minutes.from_now.to_f)
+      expect(ErrorNotifier).to receive(:notify).once.with(/pacing cursor/, installment_id: @post.id)
+
+      described_class.new.perform(@post.id)
+
+      ats = SendWorkflowInstallmentWorker.jobs.filter_map { _1["at"] }.sort
+      expect(ats.first - Time.current.to_f).to be_within(1).of(16.minutes.to_f)
+    end
+
     it "does not raise the paced rate to fit a shorter spread window" do
       $redis.set(RedisKey.workflow_immediate_fanout_max_spread_seconds, 1)
 

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -986,7 +986,7 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       expect(ats.last - Time.current.to_f).to be_within(0.05).of(1.5)
     end
 
-    it "keeps oversized due-now fanouts inside the window without a terminal burst" do
+    it "does not raise the paced rate to fit a shorter spread window" do
       $redis.set(RedisKey.workflow_immediate_fanout_max_spread_seconds, 1)
 
       described_class.new.perform(@post.id)
@@ -995,13 +995,12 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       expect(jobs.size).to eq(4)
       ats = jobs.filter_map { _1["at"] }.sort
       expect(ats.size).to eq(3)
-      expect(ats.last - Time.current.to_f).to be_between(0.6, 1.0)
-      expect(ats.last - ats[-2]).to be > 0.1
+      expect(ats.last - Time.current.to_f).to be_within(0.05).of(1.5)
     ensure
       $redis.del(RedisKey.workflow_immediate_fanout_max_spread_seconds)
     end
 
-    it "sizes the pacing rate from due-now recipients, not future recipients" do
+    it "paces due-now recipients at the configured rate rather than compressing them" do
       $redis.set(RedisKey.workflow_immediate_fanout_max_spread_seconds, 1)
       @paced_purchases.last.update!(created_at: 1.day.from_now)
       @paced_purchases.last.rebuild_audience_member_details
@@ -1011,7 +1010,7 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       ats = SendWorkflowInstallmentWorker.jobs.filter_map { _1["at"] }.sort
       due_now_ats = ats.select { _1 < 1.hour.from_now.to_f }
       expect(due_now_ats.size).to eq(2)
-      expect(due_now_ats.last - Time.current.to_f).to be_between(0.6, 0.8)
+      expect(due_now_ats.last - Time.current.to_f).to be_within(0.05).of(1.0)
       expect(ats.last).to be_within(1).of(1.day.from_now.to_f)
     ensure
       $redis.del(RedisKey.workflow_immediate_fanout_max_spread_seconds)


### PR DESCRIPTION
Cap workflow email fanout so Resend callbacks cannot fill shopper Puma

> Draft, parked on a design decision (Ershad): strict global cap vs per-seller latency bound — see "Open decision" below. Code, specs, and CI green at `3f4113ffa2`; panel raised the latency tradeoff twice.

## What

Hard-cap immediate workflow fanout at the configured recipients/second (default 20), enforced in AGGREGATE across concurrent fanout jobs via a shared Redis pacing cursor. Large due-now audiences take longer instead of speeding up to finish inside a 15-minute window.

Addresses antiwork/gumroad-private#2431.

## Why

The 00:08 UTC 2026-09-07 wave sent ~29k workflow emails at 80/s. That still fit the old 15-minute window, so pacing never slowed. `/resend-webhook` then occupied shopper Puma and checkout returned errors.

## Before / after

- Before: `effective_rate = max(configured, due_now / 15 minutes)`, per job. A 29k send stayed at 80/s, and N concurrent sellers each got the full rate.
- After: delivery slots are reserved from one Redis cursor (`workflow_immediate_fanout_pacing_cursor`) shared by all fanout jobs, so concurrent sellers collectively respect the cap (default 20/s). Redis `workflow_immediate_enqueue_per_second` still overrides without a deploy. If Redis is unavailable the job falls back to per-job pacing rather than failing the fanout. A Sentry alert fires when the cursor runs >15 min behind aggregate demand.

## Open decision (Ershad)

The Sol+Fable panel accepts the aggregate cap fixes the Greptile P1 but flags the cost, twice: the shared FIFO cursor has no latency bound, so one 1M-recipient fanout pushes the cursor ~14 h ahead and every later above-threshold seller's "immediate" send waits behind it (head-of-line blocking; previously each job finished within 15 min). Also, sub-threshold (<2k) fanouts bypass the cursor entirely, so the 20/s cap only binds large sends.

Options:
1. Ship as-is: strict global cap, unbounded latency, Sentry alert as the operator lever (raise the rate via Redis at incident time). Protects checkout unconditionally; large-seller UX degrades under contention.
2. Per-seller cursor + keep 20/s per seller: no cross-seller starvation, but concurrent sellers can again exceed the aggregate callback-safe rate (the original P1).
3. Global cap + latency clamp (slot ≤ now + N minutes): bounded latency, but the clamp is exactly the mechanism that let the 29k send run at 80/s — reintroduces overload during the clamped burst.

This is capacity/infra judgment (what rate `/resend-webhook` actually sustains, whether a dedicated webhook fleet lands first), so per standing rule deploy-pipeline/infra judgment routes to Ershad, not Sahil. Non-critical; weekend — no page.

## Review findings addressed

- Greptile P1 (per-job cap): fixed in `dd13f04a3b` — shared Redis cursor makes the cap aggregate.
- Panel rounds 1–2 (Fable P1, unbounded cursor backlog): `3f4113ffa2` adds the Sentry backlog alert; the bound-vs-cap tradeoff itself is the open decision above.

Mutations:
- Restoring `max(configured, due_now / 1s)` reddened `does not raise the paced rate to fit a shorter spread window` (`expected 0.75 to be within 0.05 of 1.5`).
- Reverting the shared cursor to per-job offsets reddened `shares the pacing cursor across fanouts so concurrent sellers respect the aggregate cap` (1 example, 1 failure).

## Checklist

- [x] Scope — app-side send-rate cap only. Not a new webhook ASG/target group.
- [x] Design — aggregate pacing via shared Redis cursor; latency-bound question parked with Ershad
- [x] Build — `3f4113ffa2` on `gp2431-workflow-callback-bound`
- [x] QA — focused specs 6 examples 0 failures; rubocop clean; mutation-verified
- [ ] Shipped — blocked on the open decision
- [x] Market — n/a, backend pacing
- [x] Sell — n/a

## Tests

```text
bundle exec rspec spec/sidekiq/send_workflow_post_emails_job_spec.rb -e "immediate fanout pacing"
6 examples, 0 failures
```

## QA

Not preview-exercisable. Watch the next large workflow send: shopper 5xx and `/resend-webhook` share should stay near baseline; new Sentry signal `shared pacing cursor is Ns behind aggregate demand` indicates the cap needs raising.

---

## AI disclosure

Generated with **grok-4.6** (xAI), running as Gumclaw on antiwork/gumroad-private#2431; review-fix rounds with **claude-fable-5** (Anthropic) via GitHub issue_comment webhook.
Prompts/instructions: GitHub issues.opened webhook; bound workflow immediate-send rate so Resend callbacks cannot consume shopper capacity.
