### PR TITLE
Paint custom HTML wrappers from the store theme before iframe load

### DIFF
--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -775,12 +775,13 @@ module RendersCustomHtmlPages
     end
 
     # The iframe paints after the wrapper, so this is the first color the visitor
-    # sees. The background-bridge script still overwrites it after load.
+    # sees. Paint html only so the bridge's documentElement inline style can
+    # overwrite it; body/iframe rules would sit above that.
     def custom_html_wrapper_theme_background_css(seller)
       color = seller&.seller_profile&.background_color
       return "" unless HexColorValidator.safe_for_css?(color)
 
-      "html,body,iframe{background:#{color}}"
+      "html{background:#{color}}"
     end
 
     # Resolve the untrusted report in this document before painting the wrapper

--- a/app/controllers/concerns/renders_custom_html_pages.rb
+++ b/app/controllers/concerns/renders_custom_html_pages.rb
@@ -774,6 +774,15 @@ module RendersCustomHtmlPages
       HTML
     end
 
+    # The iframe paints after the wrapper, so this is the first color the visitor
+    # sees. The background-bridge script still overwrites it after load.
+    def custom_html_wrapper_theme_background_css(seller)
+      color = seller&.seller_profile&.background_color
+      return "" unless HexColorValidator.safe_for_css?(color)
+
+      "html,body,iframe{background:#{color}}"
+    end
+
     # Resolve the untrusted report in this document before painting the wrapper
     # and theme-color. A detached probe would accept unresolved var()/keywords;
     # backgroundColor cannot fetch a URL.

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -2136,7 +2136,7 @@ class LinksController < ApplicationController
             #{structured_data_tag}
             <meta name="csrf-token" content="#{ERB::Util.h(form_authenticity_token)}">
             #{custom_html_analytics_head(product)}
-            <style>html,body{margin:0;padding:0;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}.seo-summary{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}</style>
+            <style>html,body{margin:0;padding:0;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}.seo-summary{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}#{custom_html_wrapper_theme_background_css(product.user)}</style>
           </head>
           <body>
             <div class="seo-summary">

--- a/app/controllers/user_pages_controller.rb
+++ b/app/controllers/user_pages_controller.rb
@@ -123,7 +123,7 @@ class UserPagesController < ApplicationController
             <meta name="viewport" content="width=device-width, initial-scale=1">
             #{page_meta_head}
             <meta name="csrf-token" content="#{CsrfTokenInjector::TOKEN_PLACEHOLDER}">
-            <style>html,body{margin:0;padding:0;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}</style>
+            <style>html,body{margin:0;padding:0;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}#{custom_html_wrapper_theme_background_css(@user)}</style>
           </head>
           <body>
             <iframe

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -347,7 +347,7 @@ class UsersController < ApplicationController
             #{fb_verification_tag}
             #{profile_custom_html_analytics_head(user)}
             <meta name="csrf-token" content="#{CsrfTokenInjector::TOKEN_PLACEHOLDER}">
-            <style>html,body{margin:0;padding:0;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}</style>
+            <style>html,body{margin:0;padding:0;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}#{custom_html_wrapper_theme_background_css(user)}</style>
           </head>
           <body>
             <iframe

--- a/spec/controllers/users_controller_custom_html_spec.rb
+++ b/spec/controllers/users_controller_custom_html_spec.rb
@@ -381,6 +381,15 @@ describe UsersController, :vcr, type: :controller do
 
       expect(html).not_to include("<script>alert(1)</script>")
     end
+
+    it "paints the wrapper from the store theme before the iframe loads" do
+      seller.seller_profile.update!(background_color: "#0a0d12")
+      controller.instance_variable_set(:@is_user_custom_domain, true)
+
+      html = controller.send(:profile_custom_html_wrapper_document, seller)
+
+      expect(html).to include("html,body,iframe{background:#0a0d12}")
+    end
   end
 
   describe "when the custom_html_pages feature is disabled" do

--- a/spec/controllers/users_controller_custom_html_spec.rb
+++ b/spec/controllers/users_controller_custom_html_spec.rb
@@ -388,7 +388,7 @@ describe UsersController, :vcr, type: :controller do
 
       html = controller.send(:profile_custom_html_wrapper_document, seller)
 
-      expect(html).to include("html,body,iframe{background:#0a0d12}")
+      expect(html).to include("html{background:#0a0d12}")
     end
   end
 

--- a/spec/requests/custom_html_background_wiring_spec.rb
+++ b/spec/requests/custom_html_background_wiring_spec.rb
@@ -51,7 +51,8 @@ describe "Custom HTML background bridge wiring", type: :request do
     end
 
     it "does not interpolate a non-hex store theme into the wrapper style" do
-      seller.seller_profile.update_columns(background_color: "#000000; } body { display: none } /*")
+      profile = seller.seller_profile.tap(&:save!)
+      profile.update_columns(background_color: "#000000; } body { display: none } /*")
 
       get "#{host}#{wrapper_path}"
 

--- a/spec/requests/custom_html_background_wiring_spec.rb
+++ b/spec/requests/custom_html_background_wiring_spec.rb
@@ -47,7 +47,7 @@ describe "Custom HTML background bridge wiring", type: :request do
       get "#{host}#{wrapper_path}"
 
       expect(response).to be_successful
-      expect(response.body).to include("html,body,iframe{background:#000000}")
+      expect(response.body).to include("html{background:#000000}")
     end
 
     it "does not interpolate a non-hex store theme into the wrapper style" do
@@ -58,7 +58,7 @@ describe "Custom HTML background bridge wiring", type: :request do
 
       expect(response).to be_successful
       expect(response.body).not_to include("display: none")
-      expect(response.body).not_to include("html,body,iframe{background:")
+      expect(response.body).not_to include("html{background:")
     end
 
     it "injects the listener into the trusted wrapper" do

--- a/spec/requests/custom_html_background_wiring_spec.rb
+++ b/spec/requests/custom_html_background_wiring_spec.rb
@@ -41,6 +41,25 @@ describe "Custom HTML background bridge wiring", type: :request do
       expect(response.body).to include("visibilitychange")
     end
 
+    it "paints the wrapper from the store theme before the iframe loads" do
+      seller.seller_profile.update!(background_color: "#000000")
+
+      get "#{host}#{wrapper_path}"
+
+      expect(response).to be_successful
+      expect(response.body).to include("html,body,iframe{background:#000000}")
+    end
+
+    it "does not interpolate a non-hex store theme into the wrapper style" do
+      seller.seller_profile.update_columns(background_color: "#000000; } body { display: none } /*")
+
+      get "#{host}#{wrapper_path}"
+
+      expect(response).to be_successful
+      expect(response.body).not_to include("display: none")
+      expect(response.body).not_to include("html,body,iframe{background:")
+    end
+
     it "injects the listener into the trusted wrapper" do
       get "#{host}#{wrapper_path}"
 

--- a/spec/requests/user/profile_custom_html_background_spec.rb
+++ b/spec/requests/user/profile_custom_html_background_spec.rb
@@ -244,6 +244,10 @@ describe "Profile custom HTML page background bridge", type: :system, js: true d
       canvas = wrapper_canvas_for("dark")
       expect_wrapper_background(canvas)
       expect(theme_color).to eq(canvas)
+      # Body/iframe stylesheet backgrounds would cover the bridge's html inline
+      # color. Pin that they stay unpainted so the backplate is what visitors see.
+      expect(page.evaluate_script("getComputedStyle(document.body).backgroundColor")).to eq("rgba(0, 0, 0, 0)")
+      expect(page.evaluate_script("getComputedStyle(document.getElementById('gumroad-landing-frame')).backgroundColor")).to eq("rgba(0, 0, 0, 0)")
     end
   end
 


### PR DESCRIPTION
# Paint custom HTML wrappers from the store theme before the iframe loads

Premerge review: blocked @ 01a036965af2aa9adc16b6f3f249c20e3bd8d466 (current-head visual QA missing)

The controller assertion is fixed at `01a036965af2aa9adc16b6f3f249c20e3bd8d466`, preserving Gianfranco's html-only background change. The current-head Astra + Fable panel exited 1: Astra reported no findings; Fable reported one P1 process blocker for missing current-head browser/visual evidence, not a code defect. No clean gate is recorded.

## Current gate and ownership

- Accepted P1: screenshots and preview evidence are for `0c3a8acb97`, not this head. A fresh HTTP check still returned `x-revision: 0c3a8acb97b3`.
- `ci/green` passed at this head, but [Buildkite 22592](https://buildkite.com/gumroad-inc/gumroad/builds/22592) failed. The green GitHub preview workflow did not deploy: its log explicitly says Buildkite configuration is missing and the trigger was skipped.
- The earlier local browser run failed with Vite `ERR_MODULE_NOT_FOUND`; this wake did not re-run browser specs or claim current-head screenshots.
- Parked as draft, with `working` removed and ownership returned to @gianfrancopiana under `awaiting-human`, matching the existing final-UI-review owner. Remaining gate: obtain a preview at this SHA, verify first paint and bridge override on the three wrappers, and attach current-head visual evidence. This is a blocked handoff, not a ready-for-final-review request. No automerge and no merge.
- Panel models actually used: `gpt-6-astra` and `claude-fable-5-1`. TruffleHog passed; the detached review worktree remained clean.

## Review fix verification

- Reproduced the obsolete selector assertion: 1 example, 1 failure.
- `bundle exec rspec spec/controllers/users_controller_custom_html_spec.rb:359 spec/requests/custom_html_background_wiring_spec.rb`: 19 examples, 0 failures after the fix.
- Focused RuboCop: no offenses. Local Astra review: clean.
- `bin/test-confidence` exited 1: the broader browser run failed in `spec/requests/user/profile_custom_html_page_spec.rb:67` with Vite `ERR_MODULE_NOT_FOUND`; the background browser spec also lacked a verified baseline. This does not invalidate the focused passing run, but full browser verification is still open.

## What

Custom HTML wrappers (profile, slugged page, product landing) now set `html` background from the seller's store theme (`SellerProfile#background_color`) on first paint. The existing `gumroad:background` bridge still overwrites that after the iframe reports its own color.

## Why

The trusted host document had no background, so dark-theme stores flashed white until the sandboxed iframe loaded and the postMessage round-trip finished.

Addresses antiwork/gumroad-private#2440.

## Before / after

- Before: wrapper CSS was a reset only, so the host painted white.
- After: the same style also includes `html{background:#rrggbb}` when the saved theme is a CSS-safe hex. Non-hex values (raw-column poison) are omitted.

## Checklist

- [x] Scope — first paint on the three custom-HTML wrappers. No new setting. Bridge behavior unchanged.
- [x] Design — honor the store theme; skip a per-page wrapper-color setting.
- [x] Build — `gp2440-wrapper-theme-bg` @ 01a036965a
- [ ] Current-head QA — earlier hosted preview `x-revision` 0c3a8acb97b3; all three wrappers emit `html,body,iframe{background:#000000}`; computed `rgb(0, 0, 0)` with iframe hidden
- [ ] Shipped
- [x] Market — n/a, bugfix
- [x] Sell — n/a

## Earlier test results at 0c3a8acb97

At 0c3a8acb97:

```text
bundle exec rspec spec/requests/custom_html_background_wiring_spec.rb spec/controllers/users_controller_custom_html_spec.rb
54 examples, 3 failures at f86e5e6a8e (poison-hex used update_columns on an unsaved has_one)
bundle exec rspec spec/requests/custom_html_background_wiring_spec.rb -e "does not interpolate a non-hex"
3 examples, 0 failures at 0c3a8acb97
```

The other 51 examples in that pair passed on the first run.

## Earlier QA at 0c3a8acb97 (not current-head evidence)

Hosted preview https://gp2440-wrapper-theme-bg.apps.staging.gumroad.org (`x-revision` 0c3a8acb97b3). Seeded the preview seller's custom HTML + store theme `#000000`.

| Surface | URL | wrapper CSS | computed (iframe hidden) |
|---|---|---|---|
| profile | https://seller.gp2440-wrapper-theme-bg.apps.staging.gumroad.org/ | `html,body,iframe{background:#000000}` | `rgb(0, 0, 0)` |
| slugged page | https://seller.gp2440-wrapper-theme-bg.apps.staging.gumroad.org/free-magic | same | `rgb(0, 0, 0)` |
| product | https://seller.gp2440-wrapper-theme-bg.apps.staging.gumroad.org/l/demo | same | `rgb(0, 0, 0)` |

Stills (iframe `visibility:hidden`, not removed):

![Profile wrapper canvas #000000 with iframe hidden](https://github.com/user-attachments/assets/a7d53daf-e3c7-4583-929d-d2315e22cdfd)

![Slugged /free-magic wrapper canvas #000000 with iframe hidden](https://github.com/user-attachments/assets/aced15aa-f8bc-4fb6-ab02-e6a2b4d641ec)

![Product /l/demo wrapper canvas #000000 with iframe hidden](https://github.com/user-attachments/assets/39772b89-763b-4292-84ed-501057c52187)

---

## AI disclosure

🤖 Generated with **Grok 4.6** (xAI), running as gumclaw.
Review correction: GPT-6 Astra (OpenAI), addressing Greptile review 5135647234.
Prompts/instructions given: GitHub webhook on antiwork/gumroad-private#2440; initialize the custom-HTML wrapper from the store theme before the iframe loads.

