### PR TITLE
Raise the nginx connection ceiling and stop per-request upstream sockets

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,5 +1,11 @@
 FROM nginx:1.23.4
 
+# worker_connections is main-context only and consul-template renders just
+# conf.d/default.conf, so patch the pinned base conf. The stock 1024 per worker is
+# reachable when a traffic shift grows the load balancer's connection pool; the grep
+# fails the build if nginx restyles the line.
+RUN grep -qE '^[[:space:]]*worker_connections[[:space:]]+1024;' /etc/nginx/nginx.conf \
+  && sed -i -E 's/^([[:space:]]*worker_connections)[[:space:]]+1024;/\1  8192;/' /etc/nginx/nginx.conf
 
 COPY public /public
 COPY docker/nginx/nginx.conf /nginx.conf

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,13 +1,7 @@
 FROM nginx:1.23.4
 
-# worker_connections is main-context only and consul-template renders just
-# conf.d/default.conf, so patch the pinned base conf. The stock 1024 per worker is
-# reachable when a traffic shift grows the load balancer's connection pool; the grep
-# fails the build if nginx restyles the line.
-RUN grep -qE '^[[:space:]]*worker_connections[[:space:]]+1024;' /etc/nginx/nginx.conf \
-  && sed -i -E 's/^([[:space:]]*worker_connections)[[:space:]]+1024;/\1  8192;/' /etc/nginx/nginx.conf
-
 COPY public /public
+COPY docker/nginx/main.conf /etc/nginx/nginx.conf
 COPY docker/nginx/nginx.conf /nginx.conf
 COPY docker/nginx/run_nginx.sh /run_nginx.sh
 

--- a/docker/nginx/main.conf
+++ b/docker/nginx/main.conf
@@ -1,0 +1,41 @@
+# Becomes /etc/nginx/nginx.conf, replacing the base image's copy.
+#
+# `worker_connections` is a main-context directive, and run_nginx.sh has consul-template
+# render our app config into conf.d/default.conf, which nginx includes from inside `http`.
+# So there is nowhere else this setting can live.
+#
+# Kept byte-for-byte identical to nginx:1.23.4's default apart from that one value, so a
+# base image bump stays a one-line review:
+#   docker run --rm nginx:<tag> cat /etc/nginx/nginx.conf
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  8192;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,5 +1,11 @@
 upstream app {
     server 172.17.0.1:3000;
+
+    # Without a cache every proxied request opens and closes its own socket, so the
+    # TIME_WAIT count on :3000 tracks the request rate. Expire below Puma's 20s
+    # persistent_timeout so nginx never sends on a socket Puma is already closing.
+    keepalive 32;
+    keepalive_timeout 15s;
 }
 
 server {
@@ -19,7 +25,9 @@ server {
 }
 
 server {
-    listen {{ env "NOMAD_PORT_http" }} default_server;
+    # nginx defaults the backlog to 511. A load balancer's pool to a single host can grow
+    # by orders of magnitude within seconds of a traffic shift, and somaxconn is 4096.
+    listen {{ env "NOMAD_PORT_http" }} default_server backlog=4096;
 
     root /public;
 
@@ -79,10 +87,11 @@ server {
         # framing: a streamed response becomes close-delimited, and any
         # early close then reads as a clean, complete body (Gumhead's SSE
         # truncated silently this way). HTTP/1.1 alone restores chunked
-        # framing; without a keepalive cache in the upstream block, a
-        # Connection override would change nothing but Puma's socket
-        # handling.
+        # framing. The blank Connection header is what lets the upstream
+        # keepalive cache reuse a socket -- without it nginx forwards the
+        # client's Connection and closes after every response.
         proxy_http_version      1.1;
+        proxy_set_header        Connection "";
 
         keepalive_timeout       75;
         proxy_read_timeout      120;


### PR DESCRIPTION
## What

Raises the nginx connection ceiling on the web tier, and stops nginx opening a fresh socket to Puma for every proxied request.

- `worker_connections` 1024 → 8192, set in a new `docker/nginx/main.conf` that is copied over `/etc/nginx/nginx.conf`. It is a main-context directive, and `run_nginx.sh` has consul-template render only `conf.d/default.conf` — which nginx includes from inside `http` — so `events {}` cannot live in our existing config file.
- `keepalive 32` in the `upstream app` block, plus `proxy_set_header Connection ""` in `location @app` so the cache is actually used. The upstream `keepalive_timeout` is set to 15s, below Puma's 20s `persistent_timeout` default, so nginx never writes to a socket Puma has decided to close.
- `backlog=4096` on the listen socket, up from nginx's default of 511.

Refs gumroad-private#2431.

## Why

A traffic shift can grow a load balancer's connection pool to a single host by orders of magnitude within seconds. Each connection holds a worker connection slot for the duration of `keepalive_timeout`, whether or not it is carrying a request. Once a worker hits its limit, nginx logs `1024 worker_connections are not enough while connecting to upstream` and falls through to `error_page 500 502 503 504 /500.html` — so every path on that host fails together, checkout and product pages included, while the app tier behind it is essentially idle.

The slots fill with idle connections rather than work, which is why raising the ceiling is the fix and tuning the app is not. Two supporting details:

- `worker_processes` is `auto` in the base image, so the per-worker limit is multiplied by the core count. The ceiling is per host, not per worker.
- Because `upstream app` had no `keepalive` directive, `proxy_http_version 1.1` alone could not reuse a socket: nginx forwarded the client's `Connection` header and closed after each response. Every request therefore cost a TCP setup and teardown against Puma, and the TIME_WAIT count on `:3000` tracked the request rate.

The existing comment on `proxy_http_version` said a `Connection` override would change nothing without a keepalive cache. That was correct, and this adds the cache, so the comment is updated rather than left to mislead.

`backlog` is the next ceiling behind `worker_connections`: once workers stop accepting, the accept queue fills at nginx's default of 511 and SYNs are dropped. `somaxconn` on these hosts is 4096, so the queue can hold that.

## Why a whole config file for one value

`worker_connections` is main-context, so it can only be set in `/etc/nginx/nginx.conf`. Three ways to reach it, and two do not work:

- `nginx -g 'events { worker_connections 8192; }'` — rejected: `nginx: [emerg] block directives are not supported in -g option in command line`.
- A main-context `include` in the base conf — there isn't one, and adding a second `events` block is a config error.
- Own the file. That is this.

`main.conf` is deliberately a byte-for-byte copy of `nginx:1.23.4`'s default with one value changed, so it stays cheap to audit:

```
$ docker run --rm nginx:1.23.4 cat /etc/nginx/nginx.conf > base.conf
$ diff base.conf <(tail -n +10 docker/nginx/main.conf)
10c10
<     worker_connections  1024;
---
>     worker_connections  8192;
```

Keeping that property is the point — a base image bump is then a one-line re-verification rather than a re-audit of a hand-written config. The header comment says so.

An earlier revision of this branch did it with `sed` in the Dockerfile. That worked and was guarded by a `grep`, but it left the value invisible in the repo and coupled to the base image's whitespace. The second commit replaces it.

## Before / After

Not user-visible, and not reproducible in a preview app — it takes a load balancer connection pool to reach the ceiling. Measured directly instead, in the pinned base image with the shipped config (upstream address changed to loopback, `NOMAD_PORT_http` rendered to 80).

**Socket reuse.** 40 sequential requests through nginx to an upstream that counts accepted TCP connections:

| | upstream TCP connections | requests served |
|---|---|---|
| `origin/main` | 40 | 40 |
| this branch | 14 | 40 |

14 is exactly the nginx worker count in the test container — one socket per worker, reused for every request that lands on it, down from one per request.

**Connection slots.**

```
$ docker run --rm gumroad-nginx grep worker_ /etc/nginx/nginx.conf
worker_processes  auto;
    worker_connections  8192;
```

**Accept queue.** `Send-Q` on a listening socket is the backlog:

```
$ ss -lnt '( sport = :80 )'
State  Recv-Q Send-Q Local Address:Port
LISTEN 0      4096         0.0.0.0:80
```

**Memory.** `worker_connections` is preallocated at startup, so it is paid for up front. At 4 workers:

| worker_connections | workers RSS | master | total |
|---|---|---|---|
| 1024 | 10 MB | 6 MB | 17 MB |
| 8192 | 22 MB | 5 MB | 28 MB |

+12 MB. The matching `resources.memory` bump for the nginx task is antiwork/gumroad-deployment#85, which **must deploy first**, so the larger pool never starts against the old limit.

## Test Results

```
nginx -t                    # syntax ok, in the pinned nginx:1.23.4 image
diff vs base image conf     # exactly one line differs (worker_connections)
socket-reuse harness        # 40 requests -> 14 upstream connections (was 40)
grep /etc/nginx/nginx.conf  # worker_processes auto; worker_connections 8192
ss -lnt                     # backlog 4096 applied to the listen socket
access_log to stdout        # requests still logged to stdout, error_log to stderr
ruby bin/branch-specs       # ESCALATE (no spec mapping for docker/nginx)
```

The stdout check matters because `main.conf` now owns `access_log`/`error_log`; the base image symlinks those paths to `/dev/stdout` and `/dev/stderr`, and keeping the same paths keeps fluentd's view unchanged.

`bin/branch-specs` escalates because nothing under `docker/nginx` maps to a spec, so this carries the `run-all-specs` label rather than a computed subset.

No Ruby, JS or TS changed, so rubocop, eslint and typecheck have nothing to say about this diff.

---

## AI disclosure

Generated with **Claude Opus 5**.
