### PR TITLE
Require signed-in purchaser for Discord join/leave

### DIFF
--- a/app/controllers/integrations/discord_controller.rb
+++ b/app/controllers/integrations/discord_controller.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class Integrations::DiscordController < ApplicationController
-  before_action :authenticate_user!, except: [:oauth_redirect, :join_server, :leave_server]
+  # join_server and leave_server gate on the signed-in purchaser: the purchase's
+  # external id is public (it is echoed on product reviews), so an unauthenticated
+  # lookup alone would let anyone add or remove the buyer's Discord membership.
+  before_action :authenticate_user!, except: [:oauth_redirect]
 
   def server_info
     discord_api = DiscordApi.new
@@ -23,7 +26,11 @@ class Integrations::DiscordController < ApplicationController
   end
 
   def join_server
+    # Verify the signed-in purchaser before spending a Discord OAuth exchange on an unowned purchase.
     return render json: { success: false } if params[:code].blank? || params[:purchase_id].blank?
+
+    purchase = Purchase.find_by_external_id(params[:purchase_id])
+    return render json: { success: false } unless purchase&.purchaser == current_user
 
     discord_api = DiscordApi.new
     oauth_response = discord_api.oauth_token(params[:code], oauth_redirect_integrations_discord_index_url(host: DOMAIN, protocol: PROTOCOL))
@@ -36,7 +43,6 @@ class Integrations::DiscordController < ApplicationController
       user_response = discord_api.identify(access_token)
       user = JSON.parse(user_response)
 
-      purchase = Purchase.find_by_external_id(params[:purchase_id])
       integration = purchase.find_enabled_integration(Integration::DISCORD)
       return render json: { success: false } if integration.nil?
 
@@ -58,6 +64,8 @@ class Integrations::DiscordController < ApplicationController
     return render json: { success: false } if params[:purchase_id].blank?
 
     purchase = Purchase.find_by_external_id(params[:purchase_id])
+    return render json: { success: false } unless purchase&.purchaser == current_user
+
     integration = purchase.find_integration_by_name(Integration::DISCORD)
     discord_user_id = DiscordIntegration.discord_user_id_for(purchase)
     return render json: { success: false } if integration.nil? || discord_user_id.blank?

--- a/app/controllers/integrations/discord_controller.rb
+++ b/app/controllers/integrations/discord_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Integrations::DiscordController < ApplicationController
-  # Gate join/leave on the signed-in purchaser or the purchase download token:
-  # the external id alone is public on reviews and must not authorize Discord membership.
+  # Gate join/leave on the signed-in purchaser or the purchase download token;
+  # the external id alone must not authorize Discord membership.
   before_action :authenticate_user!, except: [:oauth_redirect, :join_server, :leave_server]
 
   def server_info
@@ -101,9 +101,20 @@ class Integrations::DiscordController < ApplicationController
   private
     def discord_purchase_authorized?(purchase)
       return false if purchase.nil?
+      return false unless discord_purchase_currently_entitled?(purchase)
       return true if current_user.present? && purchase.purchaser == current_user
 
       token = params[:token]
       token.is_a?(String) && token.present? && UrlRedirect.exists?(token:, purchase_id: purchase.id)
+    end
+
+    # Mirrors the entitlement checks in UrlRedirectsController.
+    def discord_purchase_currently_entitled?(purchase)
+      return false if purchase.stripe_refunded
+      return false if purchase.chargeback_date.present? && !purchase.chargeback_reversed
+      return false if purchase.is_access_revoked
+      return false if purchase.subscription.present? && !purchase.subscription.grant_access_to_product?
+
+      true
     end
 end

--- a/app/controllers/integrations/discord_controller.rb
+++ b/app/controllers/integrations/discord_controller.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 class Integrations::DiscordController < ApplicationController
-  # join_server and leave_server gate on the signed-in purchaser OR possession of
-  # the purchase's download token: the external id alone is public (echoed on product
-  # reviews), so it must not grant Discord membership control. The token is the same
-  # per-purchase secret the download page is gated on, so guest purchasers with an
-  # account-free checkout still work.
+  # Gate join/leave on the signed-in purchaser or the purchase download token:
+  # the external id alone is public on reviews and must not authorize Discord membership.
   before_action :authenticate_user!, except: [:oauth_redirect, :join_server, :leave_server]
 
   def server_info
@@ -102,11 +99,6 @@ class Integrations::DiscordController < ApplicationController
   end
 
   private
-    # The purchase's external id is public (echoed on product reviews), so an id alone
-    # must not grant control of its Discord membership. Accept either the signed-in
-    # purchaser or possession of the purchase's download token — the same per-purchase
-    # secret the download page already gates on, which keeps account-free guest
-    # purchasers working without shipping the id-only bypass.
     def discord_purchase_authorized?(purchase)
       return false if purchase.nil?
       return true if current_user.present? && purchase.purchaser == current_user

--- a/app/controllers/integrations/discord_controller.rb
+++ b/app/controllers/integrations/discord_controller.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class Integrations::DiscordController < ApplicationController
-  # join_server and leave_server gate on the signed-in purchaser: the purchase's
-  # external id is public (it is echoed on product reviews), so an unauthenticated
-  # lookup alone would let anyone add or remove the buyer's Discord membership.
-  before_action :authenticate_user!, except: [:oauth_redirect]
+  # join_server and leave_server gate on the signed-in purchaser OR possession of
+  # the purchase's download token: the external id alone is public (echoed on product
+  # reviews), so it must not grant Discord membership control. The token is the same
+  # per-purchase secret the download page is gated on, so guest purchasers with an
+  # account-free checkout still work.
+  before_action :authenticate_user!, except: [:oauth_redirect, :join_server, :leave_server]
 
   def server_info
     discord_api = DiscordApi.new
@@ -26,11 +28,11 @@ class Integrations::DiscordController < ApplicationController
   end
 
   def join_server
-    # Verify the signed-in purchaser before spending a Discord OAuth exchange on an unowned purchase.
+    # Fail fast on an unowned purchase before spending a Discord OAuth exchange.
     return render json: { success: false } if params[:code].blank? || params[:purchase_id].blank?
 
     purchase = Purchase.find_by_external_id(params[:purchase_id])
-    return render json: { success: false } unless purchase&.purchaser == current_user
+    return render json: { success: false } unless discord_purchase_authorized?(purchase)
 
     discord_api = DiscordApi.new
     oauth_response = discord_api.oauth_token(params[:code], oauth_redirect_integrations_discord_index_url(host: DOMAIN, protocol: PROTOCOL))
@@ -64,7 +66,7 @@ class Integrations::DiscordController < ApplicationController
     return render json: { success: false } if params[:purchase_id].blank?
 
     purchase = Purchase.find_by_external_id(params[:purchase_id])
-    return render json: { success: false } unless purchase&.purchaser == current_user
+    return render json: { success: false } unless discord_purchase_authorized?(purchase)
 
     integration = purchase.find_integration_by_name(Integration::DISCORD)
     discord_user_id = DiscordIntegration.discord_user_id_for(purchase)
@@ -98,4 +100,18 @@ class Integrations::DiscordController < ApplicationController
 
     render inline: "", layout: "application", status: params.key?(:code) ? :ok : :bad_request
   end
+
+  private
+    # The purchase's external id is public (echoed on product reviews), so an id alone
+    # must not grant control of its Discord membership. Accept either the signed-in
+    # purchaser or possession of the purchase's download token — the same per-purchase
+    # secret the download page already gates on, which keeps account-free guest
+    # purchasers working without shipping the id-only bypass.
+    def discord_purchase_authorized?(purchase)
+      return false if purchase.nil?
+      return true if current_user.present? && purchase.purchaser == current_user
+
+      token = params[:token]
+      token.present? && UrlRedirect.exists?(token:, purchase_id: purchase.id)
+    end
 end

--- a/app/controllers/integrations/discord_controller.rb
+++ b/app/controllers/integrations/discord_controller.rb
@@ -112,6 +112,6 @@ class Integrations::DiscordController < ApplicationController
       return true if current_user.present? && purchase.purchaser == current_user
 
       token = params[:token]
-      token.present? && UrlRedirect.exists?(token:, purchase_id: purchase.id)
+      token.is_a?(String) && token.present? && UrlRedirect.exists?(token:, purchase_id: purchase.id)
     end
 end

--- a/app/controllers/product_reviews_controller.rb
+++ b/app/controllers/product_reviews_controller.rb
@@ -25,10 +25,10 @@ class ProductReviewsController < ApplicationController
 
     render json: {
       pagination: PagyPresenter.new(pagination).props,
-      reviews: reviews.map { |review|
+      reviews: reviews.map do |review|
         presenter = ProductReviewPresenter.new(review)
         presenter.product_review_props(include_purchase_id: presenter.viewer_may_see_purchase_id?(viewer: logged_in_user, seller: current_seller))
-      }
+      end
     }
   end
 

--- a/app/controllers/product_reviews_controller.rb
+++ b/app/controllers/product_reviews_controller.rb
@@ -16,7 +16,7 @@ class ProductReviewsController < ApplicationController
       product.product_reviews
         .alive
         .visible_on_product_page
-        .includes(:response, approved_video: :video_file, purchase: :purchaser)
+        .includes(:response, approved_video: :video_file, purchase: :purchaser, link: :user)
         .order(rating: :desc, created_at: :desc, id: :desc),
       page: [permitted_params[:page].to_i, 1].max,
       limit: PER_PAGE,
@@ -25,7 +25,10 @@ class ProductReviewsController < ApplicationController
 
     render json: {
       pagination: PagyPresenter.new(pagination).props,
-      reviews: reviews.map { ProductReviewPresenter.new(_1).product_review_props(include_purchase_id: current_seller == product.user) }
+      reviews: reviews.map { |review|
+        presenter = ProductReviewPresenter.new(review)
+        presenter.product_review_props(include_purchase_id: presenter.viewer_may_see_purchase_id?(viewer: logged_in_user, seller: current_seller))
+      }
     }
   end
 
@@ -36,8 +39,9 @@ class ProductReviewsController < ApplicationController
       .includes(:response, purchase: :purchaser, link: :user)
       .find_by_external_id!(permitted_params[:id])
 
+    presenter = ProductReviewPresenter.new(review)
     render json: {
-      review: ProductReviewPresenter.new(review).product_review_props(include_purchase_id: current_seller == review.link.user)
+      review: presenter.product_review_props(include_purchase_id: presenter.viewer_may_see_purchase_id?(viewer: logged_in_user, seller: current_seller))
     }
   end
 

--- a/app/controllers/product_reviews_controller.rb
+++ b/app/controllers/product_reviews_controller.rb
@@ -25,7 +25,7 @@ class ProductReviewsController < ApplicationController
 
     render json: {
       pagination: PagyPresenter.new(pagination).props,
-      reviews: reviews.map { ProductReviewPresenter.new(_1).product_review_props }
+      reviews: reviews.map { ProductReviewPresenter.new(_1).product_review_props(include_purchase_id: current_seller == product.user) }
     }
   end
 
@@ -37,7 +37,7 @@ class ProductReviewsController < ApplicationController
       .find_by_external_id!(permitted_params[:id])
 
     render json: {
-      review: ProductReviewPresenter.new(review).product_review_props
+      review: ProductReviewPresenter.new(review).product_review_props(include_purchase_id: current_seller == review.link.user)
     }
   end
 

--- a/app/javascript/components/Checkout/Receipt.tsx
+++ b/app/javascript/components/Checkout/Receipt.tsx
@@ -93,7 +93,7 @@ const SuccessfulLineItemResultEntry = ({ name, result }: { name: string; result:
                 card
               />
             </CardContent>
-            {result.enabled_integrations.discord ? (
+            {result.enabled_integrations.discord && result.redirect_token ? (
               <CardContent>
                 <DiscordButton
                   purchaseId={result.id}

--- a/app/javascript/components/Checkout/Receipt.tsx
+++ b/app/javascript/components/Checkout/Receipt.tsx
@@ -97,6 +97,7 @@ const SuccessfulLineItemResultEntry = ({ name, result }: { name: string; result:
               <CardContent>
                 <DiscordButton
                   purchaseId={result.id}
+                  token={result.redirect_token}
                   connected={false}
                   redirectSettings={{ host: result.domain, protocol: result.protocol }}
                   customState={JSON.stringify({

--- a/app/javascript/components/DiscordButton.tsx
+++ b/app/javascript/components/DiscordButton.tsx
@@ -11,11 +11,13 @@ import { showAlert } from "$app/components/server-components/Alert";
 
 export const DiscordButton = ({
   purchaseId,
+  token,
   connected,
   redirectSettings,
   customState,
 }: {
   purchaseId: string;
+  token?: string | null;
   connected: boolean;
   redirectSettings?: { host: string; protocol: string };
   customState?: string;
@@ -39,7 +41,7 @@ export const DiscordButton = ({
     startOauthRedirectChecker({
       oauthPopup,
       onSuccess: async (code) => {
-        const response = await joinServer(code, purchaseId);
+        const response = await joinServer(code, purchaseId, token);
         if (response.ok) {
           showAlert(`You've been added to the Discord server #${response.serverName}!`, "success");
           setDiscordConnected(true);
@@ -60,7 +62,7 @@ export const DiscordButton = ({
     if (!discordConnected) return;
     setLoading(true);
 
-    const response = await leaveServer(purchaseId);
+    const response = await leaveServer(purchaseId, token);
     if (response.ok) {
       showAlert(`You've left the Discord server #${response.serverName}.`, "success");
       setDiscordConnected(false);

--- a/app/javascript/components/DownloadPage/WithContent.tsx
+++ b/app/javascript/components/DownloadPage/WithContent.tsx
@@ -249,7 +249,7 @@ export const WithContent = ({
       headerActions={
         <>
           {props.purchase && content.discord ? (
-            <DiscordButton purchaseId={props.purchase.id} connected={content.discord.connected} />
+            <DiscordButton purchaseId={props.purchase.id} token={props.token} connected={content.discord.connected} />
           ) : null}
           {content.community_chat_url ? (
             <Button asChild color="accent">

--- a/app/javascript/components/Review.tsx
+++ b/app/javascript/components/Review.tsx
@@ -80,7 +80,7 @@ export const Review = ({
           </section>
         </section>
       ) : null}
-      {canRespond && !hideResponse ? (
+      {canRespond && !hideResponse && review.purchase_id != null ? (
         <section className="ml-4">
           <ReviewResponseForm
             message={review.response?.message}

--- a/app/javascript/data/discord_integration.ts
+++ b/app/javascript/data/discord_integration.ts
@@ -33,7 +33,12 @@ export const joinServer = async (
 ): Promise<{ ok: true; serverName: string } | { ok: false }> => {
   const response = await request({
     method: "GET",
-    url: Routes.join_server_integrations_discord_index_path({ format: "json", code, purchase_id: purchaseId, token: token ?? undefined }),
+    url: Routes.join_server_integrations_discord_index_path({
+      format: "json",
+      code,
+      purchase_id: purchaseId,
+      token: token ?? undefined,
+    }),
     accept: "json",
   });
   if (response.ok) {
@@ -54,7 +59,11 @@ export const leaveServer = async (
 ): Promise<{ ok: true; serverName: string } | { ok: false }> => {
   const response = await request({
     method: "GET",
-    url: Routes.leave_server_integrations_discord_index_path({ format: "json", purchase_id: purchaseId, token: token ?? undefined }),
+    url: Routes.leave_server_integrations_discord_index_path({
+      format: "json",
+      purchase_id: purchaseId,
+      token: token ?? undefined,
+    }),
     accept: "json",
   });
   if (response.ok) {

--- a/app/javascript/data/discord_integration.ts
+++ b/app/javascript/data/discord_integration.ts
@@ -29,10 +29,11 @@ export const fetchServerInfo = async (code: string): Promise<ServerInfo> => {
 export const joinServer = async (
   code: string,
   purchaseId: string,
+  token?: string | null,
 ): Promise<{ ok: true; serverName: string } | { ok: false }> => {
   const response = await request({
     method: "GET",
-    url: Routes.join_server_integrations_discord_index_path({ format: "json", code, purchase_id: purchaseId }),
+    url: Routes.join_server_integrations_discord_index_path({ format: "json", code, purchase_id: purchaseId, token: token ?? undefined }),
     accept: "json",
   });
   if (response.ok) {
@@ -47,10 +48,13 @@ export const joinServer = async (
   return { ok: false };
 };
 
-export const leaveServer = async (purchaseId: string): Promise<{ ok: true; serverName: string } | { ok: false }> => {
+export const leaveServer = async (
+  purchaseId: string,
+  token?: string | null,
+): Promise<{ ok: true; serverName: string } | { ok: false }> => {
   const response = await request({
     method: "GET",
-    url: Routes.leave_server_integrations_discord_index_path({ format: "json", purchase_id: purchaseId }),
+    url: Routes.leave_server_integrations_discord_index_path({ format: "json", purchase_id: purchaseId, token: token ?? undefined }),
     accept: "json",
   });
   if (response.ok) {

--- a/app/javascript/data/product_reviews.ts
+++ b/app/javascript/data/product_reviews.ts
@@ -57,7 +57,7 @@ export type Review = {
   rating: number;
   message: string | null;
   rater: { name: string; avatar_url: string };
-  // Present only when the viewer is the product's seller; it authorizes review responses.
+  // Present only when the viewer is the product's seller or the review's buyer.
   purchase_id: string | null;
   created_at: string;
   is_new: boolean;

--- a/app/javascript/data/product_reviews.ts
+++ b/app/javascript/data/product_reviews.ts
@@ -57,7 +57,8 @@ export type Review = {
   rating: number;
   message: string | null;
   rater: { name: string; avatar_url: string };
-  purchase_id: string;
+  // Present only when the viewer is the product's seller; it authorizes review responses.
+  purchase_id: string | null;
   created_at: string;
   is_new: boolean;
   response: {

--- a/app/presenters/comment_presenter.rb
+++ b/app/presenters/comment_presenter.rb
@@ -20,7 +20,8 @@ class CommentPresenter
       author_id: author&.external_id,
       author_name: author&.display_name || comment.author_name.presence,
       author_avatar_url: author&.avatar_url || ActionController::Base.helpers.image_url("gumroad-default-avatar-5.png"),
-      purchase_id: comment.purchase&.external_id,
+      # Never serialize comment.purchase — public post payloads must not leak purchase external ids.
+      purchase_id: nil,
       content: {
         original: comment.content,
         formatted: Rinku.auto_link(CGI.escapeHTML(comment.content), :all, %(target="_blank" rel="noopener noreferrer nofollow")),

--- a/app/presenters/comment_presenter.rb
+++ b/app/presenters/comment_presenter.rb
@@ -20,7 +20,6 @@ class CommentPresenter
       author_id: author&.external_id,
       author_name: author&.display_name || comment.author_name.presence,
       author_avatar_url: author&.avatar_url || ActionController::Base.helpers.image_url("gumroad-default-avatar-5.png"),
-      # Never serialize comment.purchase — public post payloads must not leak purchase external ids.
       purchase_id: nil,
       content: {
         original: comment.content,

--- a/app/presenters/product_review_presenter.rb
+++ b/app/presenters/product_review_presenter.rb
@@ -9,7 +9,10 @@ class ProductReviewPresenter
     @product_review = product_review
   end
 
-  def product_review_props
+  # `purchase_id` (the purchase's external id) unlocks seller-only actions elsewhere
+  # (review responses) and doubles as a possession token in older flows, so it is only
+  # included for the product's own seller — never in the public product-page payload.
+  def product_review_props(include_purchase_id: false)
     purchase = product_review.purchase
     purchaser = purchase.purchaser
     {
@@ -20,7 +23,7 @@ class ProductReviewPresenter
         avatar_url: purchase.rater_uses_account_identity? ? purchaser.avatar_url : ActionController::Base.helpers.image_url("gumroad-default-avatar-5.png"),
         name: purchase.rater_name,
       },
-      purchase_id: purchase.external_id,
+      purchase_id: include_purchase_id ? purchase.external_id : nil,
       # `is_new` only says whether the review is recent. The timestamp itself is what a creator
       # building their own product page needs to sort reviews or print "reviewed on ...", so it is
       # returned alongside it rather than being derived away.

--- a/app/presenters/product_review_presenter.rb
+++ b/app/presenters/product_review_presenter.rb
@@ -9,8 +9,6 @@ class ProductReviewPresenter
     @product_review = product_review
   end
 
-  # purchase_id authorizes review responses for the creator and is the buyer's own
-  # possession token; never expose it on anonymous/public payloads.
   def viewer_may_see_purchase_id?(viewer:, seller:)
     seller == product_review.link.user ||
       (viewer.present? && product_review.purchase.purchaser == viewer)

--- a/app/presenters/product_review_presenter.rb
+++ b/app/presenters/product_review_presenter.rb
@@ -9,9 +9,13 @@ class ProductReviewPresenter
     @product_review = product_review
   end
 
-  # `purchase_id` (the purchase's external id) unlocks seller-only actions elsewhere
-  # (review responses) and doubles as a possession token in older flows, so it is only
-  # included for the product's own seller — never in the public product-page payload.
+  # purchase_id authorizes review responses for the creator and is the buyer's own
+  # possession token; never expose it on anonymous/public payloads.
+  def viewer_may_see_purchase_id?(viewer:, seller:)
+    seller == product_review.link.user ||
+      (viewer.present? && product_review.purchase.purchaser == viewer)
+  end
+
   def product_review_props(include_purchase_id: false)
     purchase = product_review.purchase
     purchaser = purchase.purchaser

--- a/spec/controllers/integrations/discord_controller_spec.rb
+++ b/spec/controllers/integrations/discord_controller_spec.rb
@@ -189,14 +189,14 @@ describe Integrations::DiscordController do
       expect(purchase_discord_integration.discord_user_id).to eq(user_id)
     end
 
-    it "rejects a signed-out user" do
+    it "rejects a signed-out user without a download token" do
       sign_out buyer
 
       expect do
         get :join_server, format: :json, params: { code: "test_code", purchase_id: purchase.external_id }
       end.not_to change { PurchaseIntegration.count }
 
-      expect(response.status).not_to eq(200)
+      expect(response.parsed_body).to eq({ "success" => false })
     end
 
     it "rejects a signed-in user joining a purchase they do not own" do
@@ -204,6 +204,44 @@ describe Integrations::DiscordController do
 
       expect do
         get :join_server, format: :json, params: { code: "test_code", purchase_id: other_purchase.external_id }
+      end.not_to change { PurchaseIntegration.count }
+
+      expect(response.parsed_body).to eq({ "success" => false })
+    end
+
+    it "lets a signed-out purchaser holding the download token join" do
+      redirect = create(:url_redirect, purchase:)
+      sign_out buyer
+
+      WebMock.stub_request(:post, DISCORD_OAUTH_TOKEN_URL).
+        with(body: oauth_request_body, headers: oauth_request_header).
+        to_return(status: 200,
+                  body: { access_token: "test_access_token" }.to_json,
+                  headers: { content_type: "application/json" })
+
+      WebMock.stub_request(:get, "#{Discordrb::API.api_base}/users/@me").
+        with(headers: { "Authorization" => "Bearer test_access_token" }).
+        to_return(status: 200,
+                  body: { username: "gumbot", id: user_id }.to_json,
+                  headers: { content_type: "application/json" })
+
+      WebMock.stub_request(:put, "#{Discordrb::API.api_base}/guilds/0/members/#{user_id}").to_return(status: 201)
+
+      expect do
+        get :join_server, format: :json, params: { code: "test_code", purchase_id: purchase.external_id, token: redirect.token }
+      end.to change { PurchaseIntegration.count }.by(1)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq({ "success" => true, "server_name" => "Gaming" })
+    end
+
+    it "rejects a signed-out user with a token for a different purchase" do
+      other_purchase = create(:free_purchase, link: product, purchaser: create(:user))
+      redirect = create(:url_redirect, purchase: other_purchase)
+      sign_out buyer
+
+      expect do
+        get :join_server, format: :json, params: { code: "test_code", purchase_id: purchase.external_id, token: redirect.token }
       end.not_to change { PurchaseIntegration.count }
 
       expect(response.parsed_body).to eq({ "success" => false })
@@ -428,7 +466,7 @@ describe Integrations::DiscordController do
       expect(response.parsed_body).to eq({ "success" => true, "server_name" => "Gaming" })
     end
 
-    it "rejects a signed-out user" do
+    it "rejects a signed-out user without a download token" do
       create(:purchase_integration, integration:, purchase:, discord_user_id: user_id)
       sign_out buyer
 
@@ -436,7 +474,22 @@ describe Integrations::DiscordController do
         get :leave_server, format: :json, params: { purchase_id: purchase.external_id }
       end.to change { purchase.live_purchase_integrations.reload.count }.by(0)
 
-      expect(response.status).not_to eq(200)
+      expect(response.parsed_body).to eq({ "success" => false })
+    end
+
+    it "lets a signed-out purchaser holding the download token leave" do
+      create(:purchase_integration, integration:, purchase:, discord_user_id: user_id)
+      redirect = create(:url_redirect, purchase:)
+      sign_out buyer
+
+      WebMock.stub_request(:delete, "#{Discordrb::API.api_base}/guilds/0/members/#{user_id}").to_return(status: 204)
+
+      expect do
+        get :leave_server, format: :json, params: { purchase_id: purchase.external_id, token: redirect.token }
+      end.to change { purchase.live_purchase_integrations.reload.count }.by(-1)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq({ "success" => true, "server_name" => "Gaming" })
     end
 
     it "rejects a signed-in user leaving a purchase they do not own" do

--- a/spec/controllers/integrations/discord_controller_spec.rb
+++ b/spec/controllers/integrations/discord_controller_spec.rb
@@ -432,6 +432,63 @@ describe Integrations::DiscordController do
       expect(response.parsed_body).to eq({ "success" => false })
     end
 
+    context "when purchase entitlement is lost" do
+      it "rejects a signed-in purchaser with a refunded purchase" do
+        purchase.update!(stripe_refunded: true)
+
+        expect do
+          get :join_server, format: :json, params: { code: "test_code", purchase_id: purchase.external_id }
+        end.not_to change { PurchaseIntegration.count }
+
+        expect(response.parsed_body).to eq({ "success" => false })
+      end
+
+      it "rejects a download-token holder with a refunded purchase" do
+        purchase.update!(stripe_refunded: true)
+        redirect = create(:url_redirect, purchase:)
+        sign_out buyer
+
+        expect do
+          get :join_server, format: :json, params: { code: "test_code", purchase_id: purchase.external_id, token: redirect.token }
+        end.not_to change { PurchaseIntegration.count }
+
+        expect(response.parsed_body).to eq({ "success" => false })
+      end
+
+      it "rejects a signed-in purchaser with a chargebacked purchase" do
+        purchase.update!(chargeback_date: 1.day.ago)
+
+        expect do
+          get :join_server, format: :json, params: { code: "test_code", purchase_id: purchase.external_id }
+        end.not_to change { PurchaseIntegration.count }
+
+        expect(response.parsed_body).to eq({ "success" => false })
+      end
+
+      it "rejects a signed-in purchaser with access revoked" do
+        purchase.update!(is_access_revoked: true)
+
+        expect do
+          get :join_server, format: :json, params: { code: "test_code", purchase_id: purchase.external_id }
+        end.not_to change { PurchaseIntegration.count }
+
+        expect(response.parsed_body).to eq({ "success" => false })
+      end
+
+      it "rejects a signed-in purchaser with an inactive subscription" do
+        subscription = create(:subscription, link: product, user: buyer)
+        subscription.update!(cancelled_at: 1.day.ago)
+        product.update!(is_tiered_membership: true, block_access_after_membership_cancellation: true)
+        purchase.update!(subscription:)
+
+        expect do
+          get :join_server, format: :json, params: { code: "test_code", purchase_id: purchase.external_id }
+        end.not_to change { PurchaseIntegration.count }
+
+        expect(response.parsed_body).to eq({ "success" => false })
+      end
+    end
+
     it "fails if purchase_integration record creation fails" do
       WebMock.stub_request(:post, DISCORD_OAUTH_TOKEN_URL).
         with(body: oauth_request_body, headers: oauth_request_header).
@@ -550,6 +607,57 @@ describe Integrations::DiscordController do
 
       expect(response.status).to eq(200)
       expect(response.parsed_body).to eq({ "success" => true, "server_name" => "Gaming" })
+    end
+
+    context "when purchase entitlement is lost" do
+      it "rejects a signed-in purchaser with a refunded purchase" do
+        create(:purchase_integration, integration:, purchase:, discord_user_id: user_id)
+        purchase.update!(stripe_refunded: true)
+
+        expect do
+          get :leave_server, format: :json, params: { purchase_id: purchase.external_id }
+        end.not_to change { purchase.live_purchase_integrations.reload.count }
+
+        expect(response.parsed_body).to eq({ "success" => false })
+      end
+
+      it "rejects a download-token holder with a refunded purchase" do
+        create(:purchase_integration, integration:, purchase:, discord_user_id: user_id)
+        purchase.update!(stripe_refunded: true)
+        redirect = create(:url_redirect, purchase:)
+        sign_out buyer
+
+        expect do
+          get :leave_server, format: :json, params: { purchase_id: purchase.external_id, token: redirect.token }
+        end.not_to change { purchase.live_purchase_integrations.reload.count }
+
+        expect(response.parsed_body).to eq({ "success" => false })
+      end
+
+      it "rejects a signed-in purchaser with access revoked" do
+        create(:purchase_integration, integration:, purchase:, discord_user_id: user_id)
+        purchase.update!(is_access_revoked: true)
+
+        expect do
+          get :leave_server, format: :json, params: { purchase_id: purchase.external_id }
+        end.not_to change { purchase.live_purchase_integrations.reload.count }
+
+        expect(response.parsed_body).to eq({ "success" => false })
+      end
+
+      it "rejects a signed-in purchaser with an inactive subscription" do
+        create(:purchase_integration, integration:, purchase:, discord_user_id: user_id)
+        subscription = create(:subscription, link: product, user: buyer)
+        subscription.update!(cancelled_at: 1.day.ago)
+        product.update!(is_tiered_membership: true, block_access_after_membership_cancellation: true)
+        purchase.update!(subscription:)
+
+        expect do
+          get :leave_server, format: :json, params: { purchase_id: purchase.external_id }
+        end.not_to change { purchase.live_purchase_integrations.reload.count }
+
+        expect(response.parsed_body).to eq({ "success" => false })
+      end
     end
 
     it "fails if purchase_id is not passed" do

--- a/spec/controllers/integrations/discord_controller_spec.rb
+++ b/spec/controllers/integrations/discord_controller_spec.rb
@@ -247,6 +247,17 @@ describe Integrations::DiscordController do
       expect(response.parsed_body).to eq({ "success" => false })
     end
 
+    it "rejects a nested-hash token without raising" do
+      sign_out buyer
+
+      expect do
+        get :join_server, format: :json, params: { code: "test_code", purchase_id: purchase.external_id, token: { x: "y" } }
+      end.not_to change { PurchaseIntegration.count }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq({ "success" => false })
+    end
+
     it "adds member to server for a variant purchase with an enabled integration and a valid code" do
       variant_category = create(:variant_category, link: product)
       variant = create(:variant, variant_category:, active_integrations: [integration])
@@ -490,6 +501,31 @@ describe Integrations::DiscordController do
 
       expect(response.status).to eq(200)
       expect(response.parsed_body).to eq({ "success" => true, "server_name" => "Gaming" })
+    end
+
+    it "rejects a signed-out user with a token for a different purchase" do
+      create(:purchase_integration, integration:, purchase:, discord_user_id: user_id)
+      other_purchase = create(:free_purchase, link: product, purchaser: create(:user))
+      redirect = create(:url_redirect, purchase: other_purchase)
+      sign_out buyer
+
+      expect do
+        get :leave_server, format: :json, params: { purchase_id: purchase.external_id, token: redirect.token }
+      end.not_to change { purchase.live_purchase_integrations.reload.count }
+
+      expect(response.parsed_body).to eq({ "success" => false })
+    end
+
+    it "rejects a nested-hash token without raising" do
+      create(:purchase_integration, integration:, purchase:, discord_user_id: user_id)
+      sign_out buyer
+
+      expect do
+        get :leave_server, format: :json, params: { purchase_id: purchase.external_id, token: { x: "y" } }
+      end.not_to change { purchase.live_purchase_integrations.reload.count }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq({ "success" => false })
     end
 
     it "rejects a signed-in user leaving a purchase they do not own" do

--- a/spec/controllers/integrations/discord_controller_spec.rb
+++ b/spec/controllers/integrations/discord_controller_spec.rb
@@ -476,9 +476,8 @@ describe Integrations::DiscordController do
       end
 
       it "rejects a signed-in purchaser with an inactive subscription" do
-        subscription = create(:subscription, link: product, user: buyer)
-        subscription.update!(cancelled_at: 1.day.ago)
-        product.update!(is_tiered_membership: true, block_access_after_membership_cancellation: true)
+        subscription = create(:subscription, link: product, user: buyer, failed_at: Time.current)
+        product.update_attribute(:block_access_after_membership_cancellation, true)
         purchase.update!(subscription:)
 
         expect do
@@ -647,9 +646,8 @@ describe Integrations::DiscordController do
 
       it "rejects a signed-in purchaser with an inactive subscription" do
         create(:purchase_integration, integration:, purchase:, discord_user_id: user_id)
-        subscription = create(:subscription, link: product, user: buyer)
-        subscription.update!(cancelled_at: 1.day.ago)
-        product.update!(is_tiered_membership: true, block_access_after_membership_cancellation: true)
+        subscription = create(:subscription, link: product, user: buyer, failed_at: Time.current)
+        product.update_attribute(:block_access_after_membership_cancellation, true)
         purchase.update!(subscription:)
 
         expect do

--- a/spec/controllers/integrations/discord_controller_spec.rb
+++ b/spec/controllers/integrations/discord_controller_spec.rb
@@ -4,9 +4,10 @@ require "spec_helper"
 
 describe Integrations::DiscordController do
   before do
-    sign_in create(:user)
+    sign_in buyer
   end
 
+  let(:buyer) { create(:user) }
   let(:oauth_request_body) do
     {
       grant_type: "authorization_code",
@@ -159,7 +160,7 @@ describe Integrations::DiscordController do
     let(:user_id) { "user-0" }
     let(:integration) { create(:discord_integration) }
     let(:product) { create(:product, active_integrations: [integration]) }
-    let(:purchase) { create(:purchase, link: product) }
+    let(:purchase) { create(:free_purchase, link: product, purchaser: buyer) }
 
     it "adds member to server for a purchase with an enabled integration and a valid code" do
       WebMock.stub_request(:post, DISCORD_OAUTH_TOKEN_URL).
@@ -188,10 +189,30 @@ describe Integrations::DiscordController do
       expect(purchase_discord_integration.discord_user_id).to eq(user_id)
     end
 
+    it "rejects a signed-out user" do
+      sign_out buyer
+
+      expect do
+        get :join_server, format: :json, params: { code: "test_code", purchase_id: purchase.external_id }
+      end.not_to change { PurchaseIntegration.count }
+
+      expect(response.status).not_to eq(200)
+    end
+
+    it "rejects a signed-in user joining a purchase they do not own" do
+      other_purchase = create(:free_purchase, link: product, purchaser: create(:user))
+
+      expect do
+        get :join_server, format: :json, params: { code: "test_code", purchase_id: other_purchase.external_id }
+      end.not_to change { PurchaseIntegration.count }
+
+      expect(response.parsed_body).to eq({ "success" => false })
+    end
+
     it "adds member to server for a variant purchase with an enabled integration and a valid code" do
       variant_category = create(:variant_category, link: product)
       variant = create(:variant, variant_category:, active_integrations: [integration])
-      purchase = create(:purchase, link: product, variant_attributes: [variant])
+      purchase = create(:free_purchase, link: product, variant_attributes: [variant], purchaser: buyer)
 
       WebMock.stub_request(:post, DISCORD_OAUTH_TOKEN_URL).
         with(body: oauth_request_body, headers: oauth_request_header).
@@ -306,7 +327,7 @@ describe Integrations::DiscordController do
     end
 
     it "fails if purchased product does not have an integration" do
-      purchase = create(:purchase)
+      purchase = create(:free_purchase, purchaser: buyer)
 
       WebMock.stub_request(:post, DISCORD_OAUTH_TOKEN_URL).
         with(body: oauth_request_body, headers: oauth_request_header).
@@ -392,7 +413,7 @@ describe Integrations::DiscordController do
     let(:user_id) { "user-0" }
     let(:integration) { create(:discord_integration) }
     let(:product) { create(:product, active_integrations: [integration]) }
-    let(:purchase) { create(:purchase, link: product) }
+    let(:purchase) { create(:free_purchase, link: product, purchaser: buyer) }
 
     it "removes member from server if integration is active" do
       create(:purchase_integration, integration:, purchase:, discord_user_id: user_id)
@@ -405,6 +426,28 @@ describe Integrations::DiscordController do
 
       expect(response.status).to eq(200)
       expect(response.parsed_body).to eq({ "success" => true, "server_name" => "Gaming" })
+    end
+
+    it "rejects a signed-out user" do
+      create(:purchase_integration, integration:, purchase:, discord_user_id: user_id)
+      sign_out buyer
+
+      expect do
+        get :leave_server, format: :json, params: { purchase_id: purchase.external_id }
+      end.to change { purchase.live_purchase_integrations.reload.count }.by(0)
+
+      expect(response.status).not_to eq(200)
+    end
+
+    it "rejects a signed-in user leaving a purchase they do not own" do
+      other_purchase = create(:free_purchase, link: product, purchaser: create(:user))
+      create(:purchase_integration, integration:, purchase: other_purchase, discord_user_id: user_id)
+
+      expect do
+        get :leave_server, format: :json, params: { purchase_id: other_purchase.external_id }
+      end.not_to change { other_purchase.live_purchase_integrations.reload.count }
+
+      expect(response.parsed_body).to eq({ "success" => false })
     end
 
     it "marks the purchase integration as deleted if the Discord server is deleted" do
@@ -430,7 +473,7 @@ describe Integrations::DiscordController do
     end
 
     it "fails if purchased product does not have an integration" do
-      purchase = create(:purchase)
+      purchase = create(:free_purchase, purchaser: buyer)
 
       expect do
         get :leave_server, format: :json, params: { purchase_id: purchase.external_id }

--- a/spec/controllers/product_reviews_controller_spec.rb
+++ b/spec/controllers/product_reviews_controller_spec.rb
@@ -280,6 +280,20 @@ describe ProductReviewsController do
       expect(response.parsed_body["reviews"]).to eq([])
       expect(response.parsed_body["pagination"]).to include("pages" => 2, "page" => 99)
     end
+
+    it "omits purchase external ids from the public payload" do
+      get :index, params: { product_id: product.external_id }
+
+      expect(response.parsed_body["reviews"].map { _1["purchase_id"] }).to all(be_nil)
+    end
+
+    it "includes purchase external ids for the product's seller" do
+      sign_in product.user
+      get :index, params: { product_id: product.external_id }
+
+      expect(response.parsed_body["reviews"].map { _1["purchase_id"] })
+        .to eq(reviews.reverse.first(2).map { _1.purchase.external_id })
+    end
   end
 
   describe "#show" do

--- a/spec/controllers/product_reviews_controller_spec.rb
+++ b/spec/controllers/product_reviews_controller_spec.rb
@@ -294,6 +294,32 @@ describe ProductReviewsController do
       expect(response.parsed_body["reviews"].map { _1["purchase_id"] })
         .to eq(reviews.reverse.first(2).map { _1.purchase.external_id })
     end
+
+    it "includes purchase external id only for the buyer's own review" do
+      buyer = create(:user)
+      # rating-desc page 1 is the two highest ratings; reviews.last (rating 3) is on it
+      own = reviews.last
+      own.purchase.update!(purchaser: buyer)
+      sign_in buyer
+      get :index, params: { product_id: product.external_id }
+
+      returned = response.parsed_body["reviews"]
+      own_review = returned.find { _1["id"] == own.external_id }
+      other_reviews = returned.reject { _1["id"] == own.external_id }
+
+      expect(own_review["purchase_id"]).to eq(own.purchase.external_id)
+      expect(other_reviews.map { _1["purchase_id"] }).to all(be_nil)
+    end
+
+    it "does not expose purchase external id for another buyer" do
+      buyer = create(:user)
+      other_buyer = create(:user)
+      reviews.last.purchase.update!(purchaser: buyer)
+      sign_in other_buyer
+      get :index, params: { product_id: product.external_id }
+
+      expect(response.parsed_body["reviews"].map { _1["purchase_id"] }).to all(be_nil)
+    end
   end
 
   describe "#show" do
@@ -366,9 +392,31 @@ describe ProductReviewsController do
       get :show, params: { id: review.external_id }
 
       expect(response).to be_successful
-      expect(response.parsed_body["review"].deep_symbolize_keys).to eq(
-        ProductReviewPresenter.new(review).product_review_props
-      )
+      expect(response.parsed_body["review"]["purchase_id"]).to be_nil
+    end
+
+    it "includes purchase external id for the product's seller" do
+      sign_in product.user
+      get :show, params: { id: review.external_id }
+
+      expect(response.parsed_body["review"]["purchase_id"]).to eq(review.purchase.external_id)
+    end
+
+    it "includes purchase external id for the review's buyer" do
+      buyer = create(:user)
+      review.purchase.update!(purchaser: buyer)
+      sign_in buyer
+      get :show, params: { id: review.external_id }
+
+      expect(response.parsed_body["review"]["purchase_id"]).to eq(review.purchase.external_id)
+    end
+
+    it "does not expose purchase external id for another buyer" do
+      other_buyer = create(:user)
+      sign_in other_buyer
+      get :show, params: { id: review.external_id }
+
+      expect(response.parsed_body["review"]["purchase_id"]).to be_nil
     end
   end
 end

--- a/spec/presenters/comment_presenter_spec.rb
+++ b/spec/presenters/comment_presenter_spec.rb
@@ -124,6 +124,16 @@ describe CommentPresenter do
       end
     end
 
+    context "when comment is associated with a purchase" do
+      let(:purchase) { create(:purchase, link: product) }
+      let(:comment) { create(:comment, commentable: product_post, author: commenter, purchase:) }
+      let(:pundit_user) { SellerContext.new(user: commenter, seller: commenter) }
+
+      it "does not expose the purchase external id" do
+        expect(presenter.comment_component_props[:purchase_id]).to be_nil
+      end
+    end
+
     context "when comment author has an avatar picture" do
       let(:commenter) { create(:user, :with_avatar) }
       let(:pundit_user) { SellerContext.new(user: commenter, seller: commenter) }

--- a/spec/presenters/product_review_presenter_spec.rb
+++ b/spec/presenters/product_review_presenter_spec.rb
@@ -25,12 +25,46 @@ describe ProductReviewPresenter do
       )
     end
 
-    it "only discloses the purchase external id when explicitly requested for the seller" do
+    it "omits the purchase external id by default" do
       expect(described_class.new(product_review).product_review_props[:purchase_id]).to be_nil
+    end
+
+    it "includes the purchase external id when explicitly requested" do
       expect(described_class.new(product_review).product_review_props(include_purchase_id: true)[:purchase_id])
         .to eq(product_review.purchase.external_id)
     end
+  end
 
+  describe "#viewer_may_see_purchase_id?" do
+    let(:seller) { product_review.link.user }
+    let(:buyer) { create(:user) }
+    let(:other_user) { create(:user) }
+
+    before { product_review.purchase.update!(purchaser: buyer) }
+
+    it "returns true for the product seller" do
+      expect(described_class.new(product_review).viewer_may_see_purchase_id?(viewer: nil, seller: seller)).to be true
+    end
+
+    it "returns true for the review's buyer" do
+      expect(described_class.new(product_review).viewer_may_see_purchase_id?(viewer: buyer, seller: nil)).to be true
+    end
+
+    it "returns false for a different logged-in user" do
+      expect(described_class.new(product_review).viewer_may_see_purchase_id?(viewer: other_user, seller: nil)).to be false
+    end
+
+    it "returns false when no viewer and no matching seller" do
+      expect(described_class.new(product_review).viewer_may_see_purchase_id?(viewer: nil, seller: nil)).to be false
+    end
+
+    it "returns false for a guest purchase with no purchaser" do
+      product_review.purchase.update!(purchaser: nil)
+      expect(described_class.new(product_review).viewer_may_see_purchase_id?(viewer: other_user, seller: nil)).to be false
+    end
+  end
+
+  describe "#product_review_props" do
     context "product review is more than a month old" do
       before { product_review.update!(created_at: 2.months.ago) }
 

--- a/spec/presenters/product_review_presenter_spec.rb
+++ b/spec/presenters/product_review_presenter_spec.rb
@@ -16,13 +16,19 @@ describe ProductReviewPresenter do
             name: "Anonymous"
           },
           rating: product_review.rating,
-          purchase_id: product_review.purchase.external_id,
+          purchase_id: nil,
           created_at: product_review.created_at.iso8601,
           is_new: true,
           response: nil,
           video: nil
         }
       )
+    end
+
+    it "only discloses the purchase external id when explicitly requested for the seller" do
+      expect(described_class.new(product_review).product_review_props[:purchase_id]).to be_nil
+      expect(described_class.new(product_review).product_review_props(include_purchase_id: true)[:purchase_id])
+        .to eq(product_review.purchase.external_id)
     end
 
     context "product review is more than a month old" do


### PR DESCRIPTION
# Require signed-in purchaser or download-token for Discord join/leave; stop publishing purchase ids on reviews

> Draft status: blocked on the verified purchase-entitlement gap, current-head CI and panel review, and the positive Discord integration walkthrough. The earlier clean review and hosted evidence apply only to d66097f6ff, not the current head 9cb0218364.

Previous panel result: clean at d66097f6ff2c955d57e0da4a69d77e7cd1d40adf; invalidated by the subsequent push. No current-head clean verdict.

## Current review blockers at 9cb0218364f475ab66a027618a4ba23cbc4d8e0c

- Greptile's entitlement finding is valid: `discord_purchase_authorized?` accepts the purchaser session or a matching persisted redirect without checking current access. `Purchase#find_enabled_integration` only selects the product/variant integration, so it does not close the gap. `PurchasesController#revoke_access` only sets `is_access_revoked`; the redirect remains usable here, whereas `UrlRedirectsController#check_permissions` rejects revoked access. The signed-in purchaser early return has the same omission; a token-only fix would leave that path open.
- The two repeated five-line authorization comments also remain at this head and should be consolidated.
- These findings are unresolved, not covered by the earlier clean verdict. CI is still running; hosted captures below remain historical evidence. Do not ready or merge.

Gianfranco currently owns this security-sensitive PR and has pushed the latest hardening commit. This event records the verified review blockers without taking over the human-owned, `awaiting-human` branch; the existing Discord sandbox/access prerequisites remain unchanged.

## What

Two related closures of the same exposure:

1. **Discord controller** — `join_server` and `leave_server` on `Integrations::DiscordController` looked up the purchase **only** by `params[:purchase_id]` (the purchase's `external_id`). An unauthenticated caller with any purchase id could add their own Discord account to the seller's paid server (join) or remove the buyer's membership and mark the `PurchaseIntegration` deleted (leave). Fix: authorize both actions on the **signed-in purchaser OR possession of the purchase's download token** (`url_redirect.token`) — the same per-purchase secret the download page already gates content on.
2. **Public review payload** (Sahil, this thread) — `ProductReviewPresenter#product_review_props` published `purchase.external_id` on every public product-page review, which is how an attacker harvests purchase ids in the first place. Fix: `purchase_id` is now `nil` in the public payload and populated only when the viewer is the product's own seller (`current_seller == product.user`), who needs it for review responses. The seller-facing `ReviewResponseForm` renders only when it is present; `review_response` mailer renders no purchase id.

## Why

Refs antiwork/gumroad-private#2448 (external security report). Preserves guest (account-free) purchasers, who legitimately reach the Discord button on the receipt and download page while signed out — they hold the download secret, so they keep working.

## Before / after

- Before: `GET /integrations/discord/join_server?purchase_id=<any public external id>&code=<code>` adds the caller's Discord account; `leave_server` removes the buyer and deletes the integration — no identity check. Public reviews JSON disclosed every reviewer's `purchase.external_id`.
- After: the Discord request must be the signed-in purchaser, or carry the purchase's download token (threaded from the receipt `redirect_token` and the download page `token`). Everyone else gets `{ success: false }` and no state change. Public reviews JSON carries `purchase_id: null`; only the product's seller receives the real id.

## Checklist

- [ ] Scope — both Discord member actions; `server_info`/`oauth_redirect` untouched. Review payload: `purchase_id` seller-only (supersedes the earlier "treat as public" stance per Sahil's direction in this thread).
- [ ] Design — Discord: purchaser identity or token-possession check (signed-in purchaser OR per-purchase download token); `join_server` fails fast before the Discord OAuth exchange. Reviews: presenter takes `include_purchase_id:`, controllers pass `current_seller == product.user`.
- [ ] Build — commits `74e44c7a94`, `0c2fb919bd` (Discord auth), `d66097f6ff` (review payload) on `fix/discord-join-leave-auth-2448` (plus format/CI-trigger `e6d562829c`, `f4698f6335`).
- [ ] QA — `discord_controller_spec.rb`: 37 examples, 0 failures. `product_review_presenter_spec.rb` + `product_reviews_controller_spec.rb`: 48 examples, 0 failures (new: public payload omits ids; seller still receives them). Rubocop + Prettier + tsc clean. run-all-specs full suite green at `d66097f6ff`.
- [ ] Shipped — not merged; human merge authorization remains required.
- [ ] Market — n/a (internal security fix).
- [ ] Sell — n/a.

## Test Results

```text
DISABLE_SPRING=1 bundle exec rspec spec/controllers/integrations/discord_controller_spec.rb
37 examples, 0 failures
DISABLE_SPRING=1 bundle exec rspec spec/presenters/product_review_presenter_spec.rb spec/controllers/product_reviews_controller_spec.rb
48 examples, 0 failures
bundle exec rubocop app/... spec/...  # no offenses
npx tsc -p tsconfig.json --noEmit    # clean
```

## QA

Backend + button-surface change. Controllers exercised via specs (success + every rejection path; public-vs-seller review payloads). The receipt (`redirect_token`) and download page (`token`) already expose the per-purchase download token, so the JS change is a type-safe prop thread. Seller review-response form gated on `purchase_id` presence — sellers keep responding; the public payload no longer carries the id. Hosted-preview QA applies to the guest buttons and public/seller review surfaces; see the measured evidence and remaining gate below.

## Hosted-preview QA at d66097f6ff2c955d57e0da4a69d77e7cd1d40adf

Preview: https://fix-discord-join-leave-auth-2448.apps.staging.gumroad.org

Deployment 6314774475 succeeded for this exact head; the hosted app serves `x-revision: d66097f6ff2c`. Captures use synthetic preview data, not customer records.

Measured through Playwright against the hosted app:
- Guest checkout completed and its download page remained accessible without a signed-in account. A five-star text review was posted through the real form and verified after reload.
- Public review index and individual-review JSON each returned the review with `purchase_id: null`. The signed-in seller's index returned the correct purchase identifier. The seller's Add response action opened the response form; no response email was sent.
- Both Discord actions rejected the real synthetic purchase's id alone and an invalid token: HTTP 200, `success: false` for all four requests.

### Evidence

Public desktop: the review remains readable while its JSON no longer exposes the purchase identifier.

![Public review desktop](https://github.com/user-attachments/assets/441cabb9-900c-46a2-abb5-b32253630bca)

Public mobile, same review and anonymous context.

![Public review mobile](https://github.com/user-attachments/assets/c5a1652e-f6bf-47c8-98a4-5641423c7e03)

Seller-only response form, reached by clicking Add response.

![Seller response form](https://github.com/user-attachments/assets/7b1f6987-8eb5-496f-8115-13a86aebc187)

Seller response walkthrough (hosted preview, no mocked page).

https://github.com/user-attachments/assets/ebada639-da88-4f93-812c-aaca26dd1408

### Remaining QA gate

Successful guest join/leave and receipt/download-button token transmission have not been exercised end to end against a connected Discord integration. An explicitly authorized Discord sandbox and verified preview-console access are required; strict verification of the internal SSH host key still fails. Controller specs and negative HTTP probes do not replace these positive controls, so this PR must remain draft.

The final bounded retry confirmed the rejection paths and public-versus-seller review visibility at the unchanged head. No further retry is scheduled; the attached review/checkout captures are partial evidence, not proof of the Discord walkthrough.

Blocked on @gianfrancopiana to authorize a connected Discord test integration and coordinate verified preview-console access. This is a QA prerequisite handoff, not final code-review readiness. Resume the positive walkthrough only after those prerequisites are supplied; no ready or merge is authorized.


---

AI disclosure: DeepSeek V4 Flash, Claude Fable 5, and OpenAI GPT-6 Astra. Instructions: fix the reported authorization and review-data exposure; verify hosted QA and ownership without merging.

Refs antiwork/gumroad-private#2448

