### PR TITLE
Stop direct-listed-currency checkouts failing on a stale tax total

### DIFF
--- a/app/services/order/prepare_payment_intent_service.rb
+++ b/app/services/order/prepare_payment_intent_service.rb
@@ -7,6 +7,10 @@ class Order::PreparePaymentIntentService
 
   # The browser's resolved card country is more trustworthy than a client-supplied field.
   CARD_COUNTRY_SOURCE = "stripe"
+  # The direct-listed amount token fields the buyer actually agreed to. Tax and shipping are
+  # recomputed server-side at prepare and are deliberately not compared (see
+  # #direct_listed_allocations_match?).
+  BUYER_AGREED_ALLOCATION_FIELDS = %w[permalink price_cents tip_cents].freeze
   GENERIC_CHARGE_ERROR = "There is a temporary problem, please try again (your card was not charged)."
   # A Klarna amount-window rejection is deterministic — retrying Klarna on the same cart can
   # never succeed — so it must not reuse the retry-oriented generic message above. Tell the
@@ -736,8 +740,11 @@ class Order::PreparePaymentIntentService
       nil
     end
 
-    # Only a signed surcharge snapshot can prove what mounted the Element. The browser cannot
+    # Only a signed surcharge snapshot can prove what the buyer agreed to. The browser cannot
     # alter it to make a changed offer look current, and the snapshot never sets charge amounts.
+    # Only the buyer-agreed listed price and tip are compared: tax and shipping are the server's
+    # numbers, recomputed at prepare from the submitted address/VAT ID, so a delta there means
+    # the snapshot is stale, not that the buyer is paying a price they never saw.
     def method_forced_listed_allocations_match?(charge, currency)
       return true unless purchases_to_charge.all? { _1.link.price_currency_type.to_s.downcase == currency }
 
@@ -768,12 +775,9 @@ class Order::PreparePaymentIntentService
           "permalink" => allocation.purchase.link.unique_permalink,
           "price_cents" => allocation.presentment_price_cents,
           "tip_cents" => allocation.presentment_tip_cents,
-          "tax_cents" => allocation.presentment_seller_tax_cents + allocation.presentment_gumroad_tax_cents,
-          "shipping_cents" => allocation.presentment_shipping_cents,
-          "total_cents" => allocation.presentment_total_cents,
         }
       end
-      reported == expected
+      reported.map { _1.slice(*BUYER_AGREED_ALLOCATION_FIELDS) } == expected
     end
 
     # Legacy fallback for clients that did not report their Element's mount currency. It

--- a/app/services/order/prepare_payment_intent_service.rb
+++ b/app/services/order/prepare_payment_intent_service.rb
@@ -7,10 +7,10 @@ class Order::PreparePaymentIntentService
 
   # The browser's resolved card country is more trustworthy than a client-supplied field.
   CARD_COUNTRY_SOURCE = "stripe"
-  # The direct-listed amount token fields the buyer actually agreed to. Tax and shipping are
-  # recomputed server-side at prepare and are deliberately not compared (see
-  # #direct_listed_allocations_match?).
-  BUYER_AGREED_ALLOCATION_FIELDS = %w[permalink price_cents tip_cents].freeze
+  # The direct-listed amount token fields compared at prepare: what the buyer agreed to (price,
+  # tip) plus the deterministic shipping rate. Tax is deliberately absent; see
+  # #direct_listed_allocations_match?.
+  DIRECT_LISTED_AMOUNT_COMPARED_FIELDS = %w[permalink price_cents tip_cents shipping_cents].freeze
   GENERIC_CHARGE_ERROR = "There is a temporary problem, please try again (your card was not charged)."
   # A Klarna amount-window rejection is deterministic — retrying Klarna on the same cart can
   # never succeed — so it must not reuse the retry-oriented generic message above. Tell the
@@ -742,9 +742,10 @@ class Order::PreparePaymentIntentService
 
     # Only a signed surcharge snapshot can prove what the buyer agreed to. The browser cannot
     # alter it to make a changed offer look current, and the snapshot never sets charge amounts.
-    # Only the buyer-agreed listed price and tip are compared: tax and shipping are the server's
-    # numbers, recomputed at prepare from the submitted address/VAT ID, so a delta there means
-    # the snapshot is stale, not that the buyer is paying a price they never saw.
+    # Tax is not compared: it is the server's own number, recomputed at prepare from the submitted
+    # address/VAT ID, and the same inputs can produce a different result seconds apart. Failing
+    # the charge on that delta loops the buyer through "price changed" until they give up, while
+    # the canonical USD lane has always charged the prepare-time tax.
     def method_forced_listed_allocations_match?(charge, currency)
       return true unless purchases_to_charge.all? { _1.link.price_currency_type.to_s.downcase == currency }
 
@@ -775,9 +776,10 @@ class Order::PreparePaymentIntentService
           "permalink" => allocation.purchase.link.unique_permalink,
           "price_cents" => allocation.presentment_price_cents,
           "tip_cents" => allocation.presentment_tip_cents,
+          "shipping_cents" => allocation.presentment_shipping_cents,
         }
       end
-      reported.map { _1.slice(*BUYER_AGREED_ALLOCATION_FIELDS) } == expected
+      reported.map { _1.slice(*DIRECT_LISTED_AMOUNT_COMPARED_FIELDS) } == expected
     end
 
     # Legacy fallback for clients that did not report their Element's mount currency. It

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -1611,6 +1611,33 @@ describe Order::PreparePaymentIntentService, :vcr do
           expect(purchase.purchase_presentment).to be_nil
         end
 
+        it "rejects a shipping snapshot that does not match the purchase" do
+          order, params = build_order
+          purchase = order.purchases.first
+          purchase.update!(displayed_price_cents: 15_00,
+                           displayed_price_currency_type: Currency::EUR,
+                           rate_converted_to_usd: BigDecimal("0.8"))
+          params[:payment_details_source] = PurchasePaymentFlow::PAYMENT_ELEMENT
+          params[:payment_element_mount_currency] = Currency::EUR
+          params[:direct_listed_amount_token] = Checkout::DirectListedAmountToken.issue(
+            allocations: [{
+              permalink: product.unique_permalink,
+              price_cents: 15_00,
+              tip_cents: 0,
+              tax_cents: 0,
+              shipping_cents: 5_00,
+              total_cents: 20_00,
+            }],
+            sellers: [seller],
+            currency: Currency::EUR
+          )
+
+          create_args, responses = perform_with_ideal_preview(order, params, confirmation_token: "ctoken_shipping_mismatch_method_forced")
+
+          expect(create_args).to be_nil
+          expect(responses["unique-id-0"][:error_code]).to eq(PurchaseErrorCode::BUYER_CURRENCY_QUOTE_INVALID)
+        end
+
         it "charges the server's tax on a method-forced allocation minted before the tax changed" do
           order, params = build_order
           purchase = order.purchases.first

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -1611,6 +1611,36 @@ describe Order::PreparePaymentIntentService, :vcr do
           expect(purchase.purchase_presentment).to be_nil
         end
 
+        it "charges the server's tax on a method-forced allocation minted before the tax changed" do
+          order, params = build_order
+          purchase = order.purchases.first
+          purchase.update!(displayed_price_cents: 15_00,
+                           displayed_price_currency_type: Currency::EUR,
+                           rate_converted_to_usd: BigDecimal("0.8"),
+                           gumroad_tax_cents: 1_25,
+                           was_purchase_taxable: true)
+          params[:payment_details_source] = PurchasePaymentFlow::PAYMENT_ELEMENT
+          params[:payment_element_mount_currency] = Currency::EUR
+          params[:direct_listed_amount_token] = Checkout::DirectListedAmountToken.issue(
+            allocations: [{
+              permalink: product.unique_permalink,
+              price_cents: 15_00,
+              tip_cents: 0,
+              tax_cents: 0,
+              shipping_cents: 0,
+              total_cents: 15_00,
+            }],
+            sellers: [seller],
+            currency: Currency::EUR
+          )
+
+          create_args, responses = perform_with_ideal_preview(order, params, confirmation_token: "ctoken_tax_moved_method_forced")
+
+          expect(responses["unique-id-0"][:success]).to eq(true)
+          expect(create_args[:currency]).to eq(Currency::EUR)
+          expect(create_args[:amount_cents]).to eq(16_00)
+        end
+
         it "prepares one forced-currency intent for a multi-item cart uniformly priced in the forced currency" do
           expect(StripeFxQuote).not_to receive(:create)
           other_product = create(:product, user: seller, price_currency_type: Currency::EUR, price_cents: 7_00)
@@ -2457,6 +2487,64 @@ describe Order::PreparePaymentIntentService, :vcr do
         expect(purchase.reload).to be_failed
         expect(order.charges.last.charge_presentment).to be_nil
         expect(purchase.purchase_presentment).to be_nil
+      end
+
+      it "rejects a tampered tip even when the listed price matches" do
+        order, params = build_order
+        purchase = order.purchases.first
+        purchase.update!(displayed_price_cents: 15_00,
+                         displayed_price_currency_type: Currency::CAD,
+                         rate_converted_to_usd: BigDecimal("0.8"))
+        params[:direct_listed_amount_token] = Checkout::DirectListedAmountToken.issue(
+          allocations: [{
+            permalink: product.unique_permalink,
+            price_cents: 15_00,
+            tip_cents: 2_00,
+            tax_cents: 0,
+            shipping_cents: 0,
+            total_cents: 17_00,
+          }],
+          sellers: [seller],
+          currency: Currency::CAD
+        )
+
+        create_args, responses = perform_with_direct_listed_card(order, params)
+
+        expect(create_args).to be_nil
+        expect(responses["unique-id-0"][:error_code]).to eq(PurchaseErrorCode::BUYER_CURRENCY_QUOTE_INVALID)
+        expect(purchase.reload).to be_failed
+      end
+
+      it "charges the server's tax when it differs from the tax the Element loaded with" do
+        order, params = build_order
+        purchase = order.purchases.first
+        # The token was minted when the surcharge request computed no tax; the purchase now
+        # carries Gumroad-collected tax (a different tax location, VAT ID state, or rate).
+        purchase.update!(displayed_price_cents: 15_00,
+                         displayed_price_currency_type: Currency::CAD,
+                         rate_converted_to_usd: BigDecimal("0.8"),
+                         gumroad_tax_cents: 1_25,
+                         was_purchase_taxable: true)
+        params[:direct_listed_amount_token] = Checkout::DirectListedAmountToken.issue(
+          allocations: [{
+            permalink: product.unique_permalink,
+            price_cents: 15_00,
+            tip_cents: 0,
+            tax_cents: 0,
+            shipping_cents: 0,
+            total_cents: 15_00,
+          }],
+          sellers: [seller],
+          currency: Currency::CAD
+        )
+
+        create_args, responses = perform_with_direct_listed_card(order, params)
+
+        expect(responses["unique-id-0"][:success]).to eq(true)
+        expect(create_args[:currency]).to eq(Currency::CAD)
+        expect(create_args[:amount_cents]).to eq(16_00)
+        expect(purchase.reload.purchase_presentment)
+          .to have_attributes(presentment_price_cents: 15_00, presentment_gumroad_tax_cents: 1_00, presentment_total_cents: 16_00)
       end
 
       it "preserves a token-less checkout opened before the snapshot deployed" do


### PR DESCRIPTION
## Finding

Since the direct-listed-currency checkout lane went global on Sep 2, ~20 checkouts a day (105 failed purchases across 39 sellers and 71 products) fail at prepare with `buyer_currency_quote_invalid` and the buyer sees "The local-currency price changed or expired". Every failure involves Gumroad-collected tax, and the same order is retried 3–6 times with only the tax amount changing between attempts (e.g. 0 → 38 → 139 cents on one EUR order) while listed price and tip never change. Roughly half of those buyers never complete the purchase.

## Cause

The Payment Element mounts on a signed snapshot of each line's listed price, tip, tax, shipping and total, minted by the surcharge endpoint. At prepare, `Order::PreparePaymentIntentService#direct_listed_allocations_match?` rebuilt the allocation from the purchase and required an exact match on **every** field. Tax is not a buyer input: the server recomputes it at prepare from the submitted address / VAT ID / IP, and that computation can differ from the one the surcharge request made moments earlier (taxable-state flips, VAT-ID validation state, rate lookups, minor-unit rounding). Because tax fed `tax_cents` and `total_cents`, a server-vs-server tax delta failed the checkout closed with the "price changed" error. The client already re-mints the token and retries on this error, but re-minting cannot fix a comparison the server disagrees with itself about — hence the retry loops.

## Fix

Compare `permalink`, `price_cents`, `tip_cents` and `shipping_cents` — what the buyer agreed to plus the deterministic shipping rate — and let the server's prepare-time tax flow into the charge amount, which is what the canonical USD lane has always done. A tampered price, tip or shipping snapshot still fails with `buyer_currency_quote_invalid`. The same comparator covers the method-forced (iDEAL/UPI/Pix) lane.

- `app/services/order/prepare_payment_intent_service.rb`: `DIRECT_LISTED_AMOUNT_COMPARED_FIELDS`; comparison narrowed to those fields; tax excluded with the reasoning in a comment.
- `spec/services/order/prepare_payment_intent_service_spec.rb`: tax-moved-after-mint now succeeds on both the direct-listed card lane and the method-forced lane (both RED against the previous code, 2 → 0); tampered tip still rejected; token shipping that disagrees with the purchase still rejected (RED when shipping is dropped from the comparison); existing stale-price rejections unchanged.

No client change: `payment.ts` already invalidates surcharges (and re-mints the token) on every tax-affecting edit, and `Show.tsx` already runs the quote recovery for this error code.

## Test Results

Local, at head:
- `spec/services/order/prepare_payment_intent_service_spec.rb` + `spec/services/checkout/direct_listed_amount_token_spec.rb`: 141 examples, 0 failures (before the shipping pin was added; the direct-listed + method-forced contexts re-run after: 34 examples, 0 failures).
- `spec/controllers/customer_surcharge_controller_spec.rb` + `spec/services/checkout/buyer_currency_eligibility_spec.rb` + `spec/services/charge/direct_listed_presentment_spec.rb`: 165 examples, 0 failures.
- Rubocop clean on both touched files.

## QA steps

Backend-only change on the prepare path; no rendered surface changes. Reviewer click-path on a preview app: EUR-listed product, US buyer with a taxable zip → load checkout, change the zip after the Payment Element mounts, pay with a test card; the purchase should succeed and the charged amount should include the prepare-time tax rather than failing with "price changed or expired". A tampered `direct_listed_amount_token` (e.g. replayed from a different tip) still fails.

## Pre-merge review triage

The earlier clean verdict and tax-P1 dismissal are withdrawn. Stripe accepting a ConfirmationToken with a higher PaymentIntent amount proves technical feasibility, not buyer authorization; parity with the USD lane does not establish that charging above the reviewed total is safe.

At head `6ddb862f434478c317587412092d6dca1755287f`:
- **P1 accepted, blocks merge:** `app/javascript/data/order.ts:402–417` proceeds from the prepare response's client secret directly to `stripe.confirmPayment`, with no updated-total display or buyer approval. The added direct-listed and method-forced specs explicitly allow a signed 15.00 total to produce a 16.00 intent. The existing hosted QA proves a tax delta can be charged, not that the buyer consented to a higher total.
- **Tax-timing P2 accepted:** `Purchase#process!` calculates taxes (`app/models/purchase.rb:4556`) before intent preparation. The new comment incorrectly locates this calculation in prepare and must be shortened/corrected with the design fix.
- **Guard/rollout P2 unresolved:** do not disable enforcement or treat observe-only as a substitute for buyer consent. Reversible rollout and mismatch detection need to be evaluated against the replacement design; this session did not verify the bot's external custom-rule source.

**Decision owner: @gianfrancopiana. Do not merge this head.** Recommended contract: never confirm above the buyer-reviewed total; on an increase, return the authoritative recalculated total, display it, and require a new buyer confirmation rather than silently accepting it or repeating the same stale surcharge quote. This changes the payment authorization contract across server and client, so it needs an explicit design decision before rebuilding this money-path change. No code, production settings, charges, or rollout flags were changed by this triage. A replacement needs fresh regression tests, hosted checkout evidence, and the current-head panel before it can be called ready.

## Deliberately not in this PR

- Bucket B, "client-confirm quote expired/mismatch" on the FX-quote lane (21 failures, USD/PHP listed): a different comparator (`Checkout::BuyerCurrencyQuote.verify!`).
- Bucket C, server-confirm quote errors (58): not on the client-confirm path this PR touches.
- Why the tax computation is non-deterministic between two requests seconds apart is worth its own investigation; this PR stops it from failing the purchase.
- No production rollout or marketing is authorized by this PR; remaining residual-error buckets are separate.

Tracker: antiwork/gumroad-private#2446

Premerge review: blocked @ 6ddb862f434478c317587412092d6dca1755287f — buyer-approved total is not enforced

---
AI disclosure: written by Gumclaw (Hermes Agent on claude-fable-5-1). Prompt: fix the `buyer_currency_quote_invalid` failures in the direct-listed-currency checkout lane where the client-submitted listed total disagrees with the server-recomputed tax; TDD, panel review, hand to human review.


## Completion checklist

- [x] Scope — prepare-time tax mismatch only.
- [ ] Design — resolve buyer-approved-total enforcement; current tax bypass is blocked.
- [x] Build — current head `6ddb862f434478c317587412092d6dca1755287f`.
- [ ] Ship — blocked by buyer-approved-total P1; not merged.
- [x] Market — tracked separately in the private tracker; no campaign sent.
- [x] Sell — not applicable to this bug fix.

## Hosted behavioral QA — current head

Preview https://fix-direct-listed-amount-mismatc.apps.staging.gumroad.org served `x-revision: 6ddb862f4344` (deployment 6314935839). These are synthetic staging purchases and real Stripe **test-mode** requests, not production charges.

1. Real browser checkout selected Netherlands on a EUR 15 product, calculating EUR 3.15 VAT. The request carried a valid signed snapshot with zero tax and a EUR 15 total; only the signed allocation token was replaced. The actual client-confirm flow completed with a successful EUR 18.15 PaymentIntent (`livemode=false`), independently reconciled to the purchase and presentment rows. No response or Stripe SDK mock was used.
2. A signed EUR 5 shipping amount against actual zero shipping was rejected through the browser with `buyer_currency_quote_invalid`; no charge was created.
3. A signed EUR 2 tip against actual zero tip was rejected by replay to the hosted prepare endpoint. This was **API replay**, not a completed separate tip UI checkout.

The card inherited the method-forced EUR Payment Element. This does not claim an independently isolated local-card currency branch, wallet QA, or completed mobile payment. Mobile captures show the existing light checkout under a requested dark browser preference, not a dark-theme implementation. No before-deploy tax video was captured; earlier local mutation tests remain the before/after regression evidence. Fixture product/prices, seller preferences and flags were restored and read back; synthetic test purchases were retained.

### Recorded evidence

Tax-drift checkout, real hosted preview:

https://github.com/user-attachments/assets/fc3e05bd-1118-41c3-af4f-e7cdd2f9432a

Shipping-mismatch rejection, real hosted preview:

https://github.com/user-attachments/assets/733a03fb-91c4-4a4c-abb2-0b1909101e17

![Tax-drift checkout completed; numeric amount independently verified in Stripe and database](https://github.com/user-attachments/assets/9c9c93bf-3ff5-4384-9af2-f27c9146ceb7)

![Shipping mismatch is rejected](https://github.com/user-attachments/assets/704fc981-52a5-4e06-b133-0cf06a2e1265)

## CI recovery

All four trimmed Relevant shards exceeded their 25-minute timeout. Added `run-all-specs` and reran the workflow at the same head; full Fast/Slow suite, `ci/green`, and Buildkite passed. No application change or empty commit was made for this recovery.

Hosted QA/compliance by OpenAI GPT-6 Astra: verify actual preview behavior, distinguish test-mode charges from production, retain explicit coverage limits, and do not merge.
