### PR TITLE
Refuse direct-listed prepare when total rises above Element quote

### DIFF
--- a/app/services/order/prepare_payment_intent_service.rb
+++ b/app/services/order/prepare_payment_intent_service.rb
@@ -7,9 +7,9 @@ class Order::PreparePaymentIntentService
 
   # The browser's resolved card country is more trustworthy than a client-supplied field.
   CARD_COUNTRY_SOURCE = "stripe"
-  # The direct-listed amount token fields compared at prepare: what the buyer agreed to (price,
-  # tip) plus the deterministic shipping rate. Tax is deliberately absent; see
-  # #direct_listed_allocations_match?.
+  # The direct-listed amount token fields compared exactly at prepare: what the buyer agreed to
+  # (price, tip) plus the deterministic shipping rate. Tax is deliberately absent; only the total
+  # it feeds is checked, and only for increases. See #direct_listed_allocations_match?.
   DIRECT_LISTED_AMOUNT_COMPARED_FIELDS = %w[permalink price_cents tip_cents shipping_cents].freeze
   GENERIC_CHARGE_ERROR = "There is a temporary problem, please try again (your card was not charged)."
   # A Klarna amount-window rejection is deterministic — retrying Klarna on the same cart can
@@ -742,10 +742,9 @@ class Order::PreparePaymentIntentService
 
     # Only a signed surcharge snapshot can prove what the buyer agreed to. The browser cannot
     # alter it to make a changed offer look current, and the snapshot never sets charge amounts.
-    # Tax is not compared: it is the server's own number, recomputed at prepare from the submitted
-    # address/VAT ID, and the same inputs can produce a different result seconds apart. Failing
-    # the charge on that delta loops the buyer through "price changed" until they give up, while
-    # the canonical USD lane has always charged the prepare-time tax.
+    # Tax is the server's own number and the same inputs can produce a different result seconds
+    # apart, so it is not compared field-for-field: a lower prepare-time tax flows into the
+    # charge, while a higher one fails closed so the client refreshes the quote and remounts.
     def method_forced_listed_allocations_match?(charge, currency)
       return true unless purchases_to_charge.all? { _1.link.price_currency_type.to_s.downcase == currency }
 
@@ -779,7 +778,16 @@ class Order::PreparePaymentIntentService
           "shipping_cents" => allocation.presentment_shipping_cents,
         }
       end
-      reported.map { _1.slice(*DIRECT_LISTED_AMOUNT_COMPARED_FIELDS) } == expected
+      return false unless reported.map { _1.slice(*DIRECT_LISTED_AMOUNT_COMPARED_FIELDS) } == expected
+
+      # The token total is the amount the Element mounted with, so it is the most the buyer has
+      # reviewed. Never confirm above it; a lower prepare-time total is fine to charge.
+      reviewed_total_cents = reported.sum { _1["total_cents"] }
+      prepare_total_cents = actual_allocations.sum(&:presentment_total_cents)
+      if reviewed_total_cents != prepare_total_cents
+        Rails.logger.info("Direct-listed prepare total for order #{order.id} is #{prepare_total_cents} #{currency} cents against a reviewed #{reviewed_total_cents}")
+      end
+      prepare_total_cents <= reviewed_total_cents
     end
 
     # Legacy fallback for clients that did not report their Element's mount currency. It

--- a/spec/services/order/prepare_payment_intent_service_spec.rb
+++ b/spec/services/order/prepare_payment_intent_service_spec.rb
@@ -1638,7 +1638,7 @@ describe Order::PreparePaymentIntentService, :vcr do
           expect(responses["unique-id-0"][:error_code]).to eq(PurchaseErrorCode::BUYER_CURRENCY_QUOTE_INVALID)
         end
 
-        it "charges the server's tax on a method-forced allocation minted before the tax changed" do
+        it "refuses a method-forced allocation whose tax rose above the total the Element mounted with" do
           order, params = build_order
           purchase = order.purchases.first
           purchase.update!(displayed_price_cents: 15_00,
@@ -1661,11 +1661,42 @@ describe Order::PreparePaymentIntentService, :vcr do
             currency: Currency::EUR
           )
 
-          create_args, responses = perform_with_ideal_preview(order, params, confirmation_token: "ctoken_tax_moved_method_forced")
+          create_args, responses = perform_with_ideal_preview(order, params, confirmation_token: "ctoken_tax_rose_method_forced")
+
+          expect(create_args).to be_nil
+          expect(responses["unique-id-0"][:success]).to eq(false)
+          expect(responses["unique-id-0"][:error_code]).to eq(PurchaseErrorCode::BUYER_CURRENCY_QUOTE_INVALID)
+          expect(purchase.reload).to be_failed
+          expect(order.charges.last.charge_presentment).to be_nil
+        end
+
+        it "charges the lower prepare-time total on a method-forced allocation minted with a higher tax" do
+          order, params = build_order
+          purchase = order.purchases.first
+          purchase.update!(displayed_price_cents: 15_00,
+                           displayed_price_currency_type: Currency::EUR,
+                           rate_converted_to_usd: BigDecimal("0.8"))
+          params[:payment_details_source] = PurchasePaymentFlow::PAYMENT_ELEMENT
+          params[:payment_element_mount_currency] = Currency::EUR
+          params[:direct_listed_amount_token] = Checkout::DirectListedAmountToken.issue(
+            allocations: [{
+              permalink: product.unique_permalink,
+              price_cents: 15_00,
+              tip_cents: 0,
+              tax_cents: 1_00,
+              shipping_cents: 0,
+              total_cents: 16_00,
+            }],
+            sellers: [seller],
+            currency: Currency::EUR
+          )
+
+          create_args, responses = perform_with_ideal_preview(order, params, confirmation_token: "ctoken_tax_fell_method_forced")
 
           expect(responses["unique-id-0"][:success]).to eq(true)
           expect(create_args[:currency]).to eq(Currency::EUR)
-          expect(create_args[:amount_cents]).to eq(16_00)
+          expect(create_args[:amount_cents]).to eq(15_00)
+          expect(order.charges.last.charge_presentment).to have_attributes(presentment_currency: Currency::EUR, presentment_total_cents: 15_00)
         end
 
         it "prepares one forced-currency intent for a multi-item cart uniformly priced in the forced currency" do
@@ -2542,7 +2573,7 @@ describe Order::PreparePaymentIntentService, :vcr do
         expect(purchase.reload).to be_failed
       end
 
-      it "charges the server's tax when it differs from the tax the Element loaded with" do
+      it "refuses to confirm above the Element total when the tax rose after the token was minted" do
         order, params = build_order
         purchase = order.purchases.first
         # The token was minted when the surcharge request computed no tax; the purchase now
@@ -2567,11 +2598,40 @@ describe Order::PreparePaymentIntentService, :vcr do
 
         create_args, responses = perform_with_direct_listed_card(order, params)
 
+        expect(create_args).to be_nil
+        expect(responses["unique-id-0"][:success]).to eq(false)
+        expect(responses["unique-id-0"][:error_code]).to eq(PurchaseErrorCode::BUYER_CURRENCY_QUOTE_INVALID)
+        expect(purchase.reload).to be_failed
+        expect(order.charges.last.charge_presentment).to be_nil
+        expect(purchase.purchase_presentment).to be_nil
+      end
+
+      it "charges the lower prepare-time total when the token was minted with a higher tax" do
+        order, params = build_order
+        purchase = order.purchases.first
+        purchase.update!(displayed_price_cents: 15_00,
+                         displayed_price_currency_type: Currency::CAD,
+                         rate_converted_to_usd: BigDecimal("0.8"))
+        params[:direct_listed_amount_token] = Checkout::DirectListedAmountToken.issue(
+          allocations: [{
+            permalink: product.unique_permalink,
+            price_cents: 15_00,
+            tip_cents: 0,
+            tax_cents: 1_00,
+            shipping_cents: 0,
+            total_cents: 16_00,
+          }],
+          sellers: [seller],
+          currency: Currency::CAD
+        )
+
+        create_args, responses = perform_with_direct_listed_card(order, params)
+
         expect(responses["unique-id-0"][:success]).to eq(true)
         expect(create_args[:currency]).to eq(Currency::CAD)
-        expect(create_args[:amount_cents]).to eq(16_00)
+        expect(create_args[:amount_cents]).to eq(15_00)
         expect(purchase.reload.purchase_presentment)
-          .to have_attributes(presentment_price_cents: 15_00, presentment_gumroad_tax_cents: 1_00, presentment_total_cents: 16_00)
+          .to have_attributes(presentment_price_cents: 15_00, presentment_gumroad_tax_cents: 0, presentment_total_cents: 15_00)
       end
 
       it "preserves a token-less checkout opened before the snapshot deployed" do


### PR DESCRIPTION
## What
A buyer paying in a product's own listed currency can see one total on the Payment Element, then hit prepare after tax moves. Today that path can create a PaymentIntent for a higher total than the Element showed.

This change refuses that higher charge. Prepare still accepts an equal or lower total. Price, tip, and shipping tampers stay blocked.

## Why
#7531 fixed false "price changed" failures by dropping tax from the direct-listed amount compare. That also let prepare confirm above the buyer-reviewed total when tax rose.

The contract is: never confirm a Stripe charge above the total the buyer already reviewed. Join #2446.

## Before / After
**Before:** prepare-time tax could raise the presentment total and still create/confirm the intent at that higher amount.

**After:** if prepare-time presentment total is higher than the signed Element total, prepare fails with `buyer_currency_quote_invalid`. Checkout cancels, refreshes surcharges, and remounts the Element on the new total so the buyer confirms again. Equal or lower totals still charge.

## Test Results
Focused examples in `spec/services/order/prepare_payment_intent_service_spec.rb` (not run in this environment; no local Ruby toolchain):
- tax rose above Element total → no intent; `BUYER_CURRENCY_QUOTE_INVALID` (card + method-forced)
- token minted with higher tax → charges prepare-time lower total (card + method-forced)
- stale price / tampered tip / shipping mismatch still rejected

If the increase guard were reverted, the "tax rose" examples would expect success at the higher amount again.

## QA
Backend-only. No new UI. Recovery reuses the existing quote-invalid cancel + surcharge refresh + Element remount path in checkout.

---
Implemented by Claude Fable 5.1 (Claude Code).
