### PR TITLE
Fix Instagram OAuth callback URL

### DIFF
--- a/lib/omni_auth/strategies/instagram.rb
+++ b/lib/omni_auth/strategies/instagram.rb
@@ -26,6 +26,10 @@ module OmniAuth
       info { {} }
       extra { { "raw_info" => access_token.params } }
 
+      def callback_url
+        full_host + callback_path
+      end
+
       def request_phase
         return redirect(flag_off_redirect) unless instagram_connect_enabled?
 

--- a/spec/lib/omni_auth/strategies/instagram_spec.rb
+++ b/spec/lib/omni_auth/strategies/instagram_spec.rb
@@ -57,6 +57,30 @@ describe OmniAuth::Strategies::Instagram do
     end
   end
 
+  describe "#build_access_token" do
+    it "uses the authorization redirect URI without callback query parameters" do
+      allow(strategy).to receive(:full_host).and_return("https://example.com")
+      allow(strategy).to receive(:instagram_connect_enabled?).and_return(true)
+      strategy.options.callback_path = "/users/auth/instagram/callback"
+      strategy.instance_variable_set(:@env, Rack::MockRequest.env_for("https://example.com/users/auth/instagram").merge("rack.session" => {}))
+
+      _, headers, = strategy.request_phase
+      redirect_uri = Rack::Utils.parse_query(URI(headers["Location"]).query).fetch("redirect_uri")
+      expect(redirect_uri).to eq("https://example.com/users/auth/instagram/callback")
+
+      callback_request = Rack::Request.new(Rack::MockRequest.env_for("#{redirect_uri}?code=authorization-code&state=oauth-state"))
+      allow(strategy).to receive(:request).and_return(callback_request)
+      token_request = stub_request(:post, "https://api.instagram.com/oauth/access_token")
+        .to_return(
+          headers: { "Content-Type" => "application/json" },
+          body: { access_token: "instagram-token", user_id: "123" }.to_json,
+        )
+
+      expect(strategy.send(:build_access_token).token).to eq("instagram-token")
+      expect(token_request.with(body: hash_including("code" => "authorization-code", "redirect_uri" => redirect_uri))).to have_been_requested.once
+    end
+  end
+
   it "uses the current Instagram Login parameters" do
     expect(strategy.options.authorize_params.to_h).to include(
       "enable_fb_login" => "false",

--- a/spec/lib/omni_auth/strategies/instagram_spec.rb
+++ b/spec/lib/omni_auth/strategies/instagram_spec.rb
@@ -57,27 +57,57 @@ describe OmniAuth::Strategies::Instagram do
     end
   end
 
-  describe "#build_access_token" do
-    it "uses the authorization redirect URI without callback query parameters" do
-      allow(strategy).to receive(:full_host).and_return("https://example.com")
-      allow(strategy).to receive(:instagram_connect_enabled?).and_return(true)
-      strategy.options.callback_path = "/users/auth/instagram/callback"
-      strategy.instance_variable_set(:@env, Rack::MockRequest.env_for("https://example.com/users/auth/instagram").merge("rack.session" => {}))
-
-      _, headers, = strategy.request_phase
-      redirect_uri = Rack::Utils.parse_query(URI(headers["Location"]).query).fetch("redirect_uri")
-      expect(redirect_uri).to eq("https://example.com/users/auth/instagram/callback")
-
-      callback_request = Rack::Request.new(Rack::MockRequest.env_for("#{redirect_uri}?code=authorization-code&state=oauth-state"))
-      allow(strategy).to receive(:request).and_return(callback_request)
-      token_request = stub_request(:post, "https://api.instagram.com/oauth/access_token")
+  describe "#callback_phase" do
+    let(:session) { {} }
+    let(:callback_strategy) { described_class.new(app, "app-id", "app-secret") }
+    let(:redirect_uri) { "https://example.com/users/auth/instagram/callback" }
+    let(:token_request) do
+      stub_request(:post, "https://api.instagram.com/oauth/access_token")
         .to_return(
           headers: { "Content-Type" => "application/json" },
           body: { access_token: "instagram-token", user_id: "123" }.to_json,
         )
+    end
 
-      expect(strategy.send(:build_access_token).token).to eq("instagram-token")
+    before do
+      [strategy, callback_strategy].each do |instance|
+        allow(instance).to receive(:full_host).and_return("https://example.com")
+        allow(instance).to receive(:instagram_connect_enabled?).and_return(true)
+        instance.options.callback_path = "/users/auth/instagram/callback"
+      end
+      strategy.instance_variable_set(:@env, Rack::MockRequest.env_for("https://example.com/users/auth/instagram").merge("rack.session" => session))
+      token_request
+    end
+
+    it "validates state and uses the authorization redirect URI without callback query parameters" do
+      _, headers, = strategy.request_phase
+      authorize_params = Rack::Utils.parse_query(URI(headers["Location"]).query)
+      expect(authorize_params.fetch("redirect_uri")).to eq(redirect_uri)
+      state = authorize_params.fetch("state")
+      expect(state).to be_present
+      expect(session["omniauth.state"]).to eq(state)
+
+      callback_env = Rack::MockRequest.env_for("#{redirect_uri}?#{Rack::Utils.build_query(code: "authorization-code", state:)}").merge("rack.session" => session)
+      callback_strategy.instance_variable_set(:@env, callback_env)
+
+      expect(callback_strategy.callback_phase.first).to eq(200)
+      expect(callback_env["omniauth.auth"].uid).to eq("123")
+      expect(session).not_to have_key("omniauth.state")
       expect(token_request.with(body: hash_including("code" => "authorization-code", "redirect_uri" => redirect_uri))).to have_been_requested.once
+    end
+
+    [nil, "mismatched-state"].each do |state|
+      it "rejects #{state.nil? ? 'missing' : 'mismatched'} state before token exchange" do
+        strategy.request_phase
+        callback_env = Rack::MockRequest.env_for("#{redirect_uri}?#{Rack::Utils.build_query(code: "authorization-code", state:)}").merge("rack.session" => session)
+        callback_strategy.instance_variable_set(:@env, callback_env)
+        allow(OmniAuth.config).to receive(:on_failure).and_return(->(_env) { [401, {}, []] })
+
+        expect(callback_strategy.callback_phase.first).to eq(401)
+        expect(callback_env["omniauth.error.type"]).to eq(:csrf_detected)
+        expect(callback_env).not_to have_key("omniauth.auth")
+        expect(token_request).not_to have_been_requested
+      end
     end
   end
 


### PR DESCRIPTION
Ref antiwork/gumroad-private#2420

## What

Keep the Instagram redirect URL identical during authorization and token exchange. This fixes the connection failure after a seller approves Instagram access.

## Why

OmniAuth appends the callback query parameters to `redirect_uri` during token exchange. Meta rejects that URL because authorization used the callback URL without those parameters. The Instagram strategy now omits the query string while preserving OAuth state validation.

The regression test checks the token request against the authorization redirect URL. It fails on the original code and passes with the fix. The callback tests also verify that matching state succeeds and missing or mismatched state blocks token exchange. All ten strategy examples, RuboCop, and typecheck pass. Autoreview reports no actionable findings.

After merging current main, `bin/test-confidence` reached 99% with 33 passing test files. It reproduced five existing failures on the merge base, covering payment, presenter, and editor tests. Main also supplies the Docker image update that fixes the expired Debian metadata failure in Buildkite.

Live Instagram verification remains pending deployment. Retry Connect to Instagram from Profile settings with an accepted tester account and confirm the connected handle appears.

---

This PR was implemented with AI assistance using GPT-6.
