### PR TITLE
Expose historical social shadow evidence in the admin API

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -137,6 +137,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
 
     render json: internal_admin_user_success_payload(user, {
                                                        social_connections: user.social_connect_verifications.order(:platform).map { serialize_social_connect_verification(_1) },
+                                                       latest_shadow_evaluation: serialize_latest_social_shadow_evaluation(user),
                                                      })
   end
 
@@ -1005,6 +1006,22 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         reason: credit.reason,
         crediting_user_id: credit.crediting_user&.external_id,
         created_at: credit.created_at.iso8601
+      }
+    end
+
+    def serialize_latest_social_shadow_evaluation(user)
+      evaluation = SocialScoreShadowEvaluation.where(user_id: user.id).order(evaluated_on: :desc, id: :desc).first
+      return nil unless evaluation
+
+      {
+        mode: "historical_shadow",
+        notice: "Stored shadow evidence only; not current eligibility or payout authorization.",
+        evaluated_on: evaluation.evaluated_on.iso8601,
+        recorded_at: evaluation.created_at.iso8601,
+        score: evaluation.score,
+        would_have_released: evaluation.would_have_released,
+        hold_source: evaluation.hold_source,
+        signals: evaluation.signals,
       }
     end
 

--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -1019,6 +1019,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         evaluated_on: evaluation.evaluated_on.iso8601,
         recorded_at: evaluation.created_at.iso8601,
         score: evaluation.score,
+        unpaid_balance_cents: evaluation.unpaid_balance_cents,
         would_have_released: evaluation.would_have_released,
         hold_source: evaluation.hold_source,
         signals: evaluation.signals,

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -2126,6 +2126,7 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body).to eq({
         success: true,
         user_id: user.external_id,
+        latest_shadow_evaluation: nil,
         social_connections: [
           {
             platform: "twitter",
@@ -2201,13 +2202,53 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body["social_connections"].sole).to include("uid" => "17841400000000000", "currently_linked" => false)
     end
 
+    it "returns only the latest dated shadow evidence without evaluating or changing the seller" do
+      user = create(:user, email: "seller@example.com")
+      verification = create(:social_connect_verification, user:)
+      latest = create(:social_score_shadow_evaluation, user:, evaluated_on: Date.new(2026, 9, 2),
+                                                       created_at: Time.utc(2026, 9, 3, 12), score: 70, would_have_released: true,
+                                                       signals: { "platform" => "twitter", "components" => { "followers" => 25 } })
+      create(:social_score_shadow_evaluation, user:, evaluated_on: Date.new(2026, 9, 1), created_at: latest.created_at)
+      create(:social_score_shadow_evaluation, evaluated_on: Date.new(2026, 9, 4), score: 85)
+      original_attributes = user.attributes
+      original_evaluations = SocialScoreShadowEvaluation.order(:id).map(&:attributes)
+      expect(SocialScoreShadowEvaluationService).not_to receive(:new)
+
+      get :social_connections, params: { email: user.email }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["latest_shadow_evaluation"]).to eq({
+                                                                       "mode" => "historical_shadow",
+                                                                       "notice" => "Stored shadow evidence only; not current eligibility or payout authorization.",
+                                                                       "evaluated_on" => "2026-09-02",
+                                                                       "recorded_at" => "2026-09-03T12:00:00Z",
+                                                                       "score" => 70,
+                                                                       "would_have_released" => true,
+                                                                       "hold_source" => latest.hold_source,
+                                                                       "signals" => latest.signals,
+                                                                     })
+      expect(response.parsed_body["social_connections"].sole["uid"]).to eq(verification.uid)
+      expect(user.reload.attributes).to eq(original_attributes)
+      expect(SocialScoreShadowEvaluation.order(:id).map(&:attributes)).to eq(original_evaluations)
+    end
+
+    it "returns null without creating an evaluation when only another seller has evidence" do
+      user = create(:user, email: "seller@example.com")
+      create(:social_score_shadow_evaluation)
+      expect(SocialScoreShadowEvaluationService).not_to receive(:new)
+
+      expect { get :social_connections, params: { email: user.email } }.not_to change(SocialScoreShadowEvaluation, :count)
+
+      expect(response.parsed_body).to include("latest_shadow_evaluation" => nil, "social_connections" => [])
+    end
+
     it "returns an empty list for a user with no connections" do
       user = create(:user, email: "seller@example.com")
 
       get :social_connections, params: { email: user.email }
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to eq({ success: true, user_id: user.external_id, social_connections: [] }.as_json)
+      expect(response.parsed_body).to eq({ success: true, user_id: user.external_id, social_connections: [], latest_shadow_evaluation: nil }.as_json)
     end
 
     it "returns not found when the user does not exist" do

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -2223,6 +2223,7 @@ describe Api::Internal::Admin::UsersController do
                                                                        "evaluated_on" => "2026-09-02",
                                                                        "recorded_at" => "2026-09-03T12:00:00Z",
                                                                        "score" => 70,
+                                                                       "unpaid_balance_cents" => latest.unpaid_balance_cents,
                                                                        "would_have_released" => true,
                                                                        "hold_source" => latest.hold_source,
                                                                        "signals" => latest.signals,


### PR DESCRIPTION
## What
Add `latest_shadow_evaluation` to the read-only internal admin social-connections endpoint: null without a stored row; otherwise evaluation date, recording timestamp, stored score/outcome, hold source and signals. Explicitly historical SHADOW evidence—not current eligibility or payout authorization.

## Why
Reviewers can read connection evidence but not the stored shadow result. A user-scoped ordered LIMIT 1 read reuses existing data without running scoring or changing holds. Existing connections and authorization remain unchanged. No migration, admin UI, flags, credentials or money movement. CLI consumer: https://github.com/antiwork/gumroad-cli/pull/215.

## Before/After
The attached walkthrough runs the before/after CLI against locally replayed responses captured from real Rails controller requests with synthetic test fixtures. It shows absent/dated snapshots and the observed scoped SQL. Not a production or provider test; no browser surface changed.

https://github.com/user-attachments/assets/9b37f732-ab26-4944-b1bd-e940994206fd

| Probe | Result |
| --- | --- |
| No stored evaluation | `latest_shadow_evaluation: null` |
| Multiple dates, tied recording timestamps, older row with higher ID | Evaluation day `2026-09-02`, not `2026-09-01` |
| Another seller has a newer evaluation | Excluded |
| Existing connection payload | Identical before/after |
| Seller attributes and all evaluation rows | Unchanged after GET |
| Shadow query | One user-scoped SELECT, `ORDER BY evaluated_on DESC, id DESC LIMIT 1` |

Same-seller same-day duplicates are prohibited by the existing unique user/date index. The new read performs no scoring, hold or evaluation writes; pre-existing admin-token last-used bookkeeping is unchanged.

QA: run `bundle exec rspec spec/controllers/api/internal/admin/users_controller_spec.rb -e 'GET social_connections'`; inspect the null and dated snapshots above. Use `gumroad admin users social-connections --email "$TEST_SELLER_EMAIL" --json` only against a configured test environment with synthetic fixtures. The snapshot describes its evaluation date, not current eligibility.

## Test Results
- Focused controller group: 11 examples, 0 failures, including existing authorization and connection cases.
- Mutation proof: removing user scope produces 2 failing assertions; reversing date order produces 1; restoring the committed source returns 11 examples, 0 failures.
- Real endpoint capture: 1 example, 0 failures; one bounded shadow SELECT and unchanged seller/evaluation rows asserted.
- RuboCop: 2 files inspected, no offenses after formatting. Ruby syntax and `git diff --check` pass.
- Local Astra dev review clean; current-head Astra+Fable panel clean. Final code/spec/comment and recorded-evidence audit complete, including visual inspection of the dated SHADOW warning and SQL proof frames.
- `bin/test-confidence --strict`: 99% target reached; all four selected spec files passed (admin users controller, social scoring service, admin base controller and internal admin routing). All GitHub Actions checks pass; Buildkite preview build remains pending. Draft remains actively owned until it settles; human risk-review handoff required, no auto-merge.

Premerge review: clean @ 4207a388a32213be58098226d0d2075a0605fb13

---
AI disclosure: OpenAI GPT-6 Astra (`openai/gpt-6-astra`). Prompt: expose latest stored social shadow evaluation through the existing read-only API and backward-compatible CLI; prove absence, ordering, isolation, preserved connections and no writes. Do not alter scoring, holds, flags, credentials or move money.

### Bounded CI owner

All current-head checks settled green; ready for Gianfranco risk-evidence review. No auto-merge.
