### PR TITLE
Fix editor actions deleting the previously selected file

### DIFF
--- a/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/FileEmbed.tsx
@@ -523,6 +523,7 @@ const FileEmbedNodeView = ({
           ) : null}
           <NodeActionsMenu
             editor={editor}
+            getPos={getPos}
             actions={!isInGroup || fileEmbedGroups.length > 0 || parentNode.childCount > 1 ? [folderAction] : []}
           />
           <RowContent className="content">

--- a/app/javascript/components/ProductEdit/ContentTab/FileEmbedGroup.tsx
+++ b/app/javascript/components/ProductEdit/ContentTab/FileEmbedGroup.tsx
@@ -64,6 +64,7 @@ const FileEmbedGroupNodeView = ({
   config,
   extension,
   selected,
+  getPos,
 }: NodeViewProps & { config: FileGroupConfig }) => {
   const [expanded, setExpanded] = React.useState(false);
   const [downloading, setDownloading] = React.useState(false);
@@ -154,6 +155,7 @@ const FileEmbedGroupNodeView = ({
             {editor.isEditable ? (
               <NodeActionsMenu
                 editor={editor}
+                getPos={getPos}
                 actions={[
                   {
                     item: () => (

--- a/app/javascript/components/TiptapExtensions/FileUpload.tsx
+++ b/app/javascript/components/TiptapExtensions/FileUpload.tsx
@@ -37,7 +37,7 @@ export const FileUpload = TiptapNode.create({
   },
 });
 
-const FileUploadNodeView = ({ editor, node }: NodeViewProps) => {
+const FileUploadNodeView = ({ editor, node, getPos }: NodeViewProps) => {
   if (!editor.isEditable) {
     return (
       <NodeViewWrapper>
@@ -49,7 +49,7 @@ const FileUploadNodeView = ({ editor, node }: NodeViewProps) => {
   return (
     <NodeActionsWrapper asChild>
       <NodeViewWrapper contentEditable={false} data-input-embed>
-        <NodeActionsMenu editor={editor} />
+        <NodeActionsMenu editor={editor} getPos={getPos} />
         <Placeholder>
           <Button color="primary">
             <ArrowUp pack="filled" className="size-5" />

--- a/app/javascript/components/TiptapExtensions/LicenseKey.tsx
+++ b/app/javascript/components/TiptapExtensions/LicenseKey.tsx
@@ -43,7 +43,7 @@ export const LicenseKey = TiptapNode.create({
   },
 });
 
-const LicenseKeyNodeView = ({ editor, selected }: NodeViewProps) => {
+const LicenseKeyNodeView = ({ editor, selected, getPos }: NodeViewProps) => {
   const { licenseKey, isMultiSeatLicense, seats, onIsMultiSeatLicenseChange, productId } = useLicense();
   const uid = React.useId();
 
@@ -51,7 +51,7 @@ const LicenseKeyNodeView = ({ editor, selected }: NodeViewProps) => {
     <NodeViewWrapper>
       <NodeActionsWrapper selected={selected} isEditable={editor.isEditable} asChild>
         <Row className="embed">
-          {editor.isEditable ? <NodeActionsMenu editor={editor} /> : null}
+          {editor.isEditable ? <NodeActionsMenu editor={editor} getPos={getPos} /> : null}
           <RowContent className="content" contentEditable={false}>
             <Key pack="filled" className="type-icon size-5" />
             <div>

--- a/app/javascript/components/TiptapExtensions/MoreLikeThis.tsx
+++ b/app/javascript/components/TiptapExtensions/MoreLikeThis.tsx
@@ -42,7 +42,7 @@ export const MoreLikeThis = TiptapNode.create<{ productId: string }>({
   },
 });
 
-const MoreLikeThisNodeView = ({ editor, node, extension, selected }: NodeViewProps) => {
+const MoreLikeThisNodeView = ({ editor, node, extension, selected, getPos }: NodeViewProps) => {
   const [recommendedProducts, setRecommendedProducts] = React.useState<CardProduct[] | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
   const recommendationType = typia.assert<RecommendationType | undefined>(node.attrs.recommendationType);
@@ -78,6 +78,7 @@ const MoreLikeThisNodeView = ({ editor, node, extension, selected }: NodeViewPro
         {editor.isEditable ? (
           <NodeActionsMenu
             editor={editor}
+            getPos={getPos}
             actions={[
               {
                 item: () => (

--- a/app/javascript/components/TiptapExtensions/NodeActionsMenu.test.tsx
+++ b/app/javascript/components/TiptapExtensions/NodeActionsMenu.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { Editor, Node } from "@tiptap/core";
+import { NodeSelection } from "@tiptap/pm/state";
+import { EditorContent, NodeViewProps, NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import * as React from "react";
+import { afterEach, expect, it } from "vitest";
+
+import { NodeActionsMenu } from "$app/components/TiptapExtensions/NodeActionsMenu";
+
+let editor: Editor;
+afterEach(() => {
+  cleanup();
+  editor.destroy();
+});
+
+const FileView = ({ editor, node, getPos }: NodeViewProps) => (
+  <NodeViewWrapper data-testid={String(node.attrs.id)} contentEditable={false}>
+    <NodeActionsMenu editor={editor} getPos={getPos} />
+    {String(node.attrs.id)}
+  </NodeViewWrapper>
+);
+const File = Node.create({
+  name: "fileEmbed",
+  group: "block",
+  atom: true,
+  draggable: true,
+  addAttributes: () => ({ id: { default: null } }),
+  renderHTML: ({ HTMLAttributes }) => ["file-embed", HTMLAttributes],
+  addNodeView: () => ReactNodeViewRenderer(FileView),
+});
+const Folder = Node.create({
+  name: "fileEmbedGroup",
+  group: "block",
+  content: "fileEmbed+",
+  renderHTML: () => ["file-embed-group", 0],
+});
+
+it("deletes the menu's file after moving another file into a folder, and undo restores it", async () => {
+  editor = new Editor({
+    extensions: [StarterKit, File, Folder],
+    content: {
+      type: "doc",
+      content: [
+        { type: "fileEmbed", attrs: { id: "moved" } },
+        { type: "fileEmbed", attrs: { id: "target" } },
+        { type: "fileEmbedGroup", content: [{ type: "fileEmbed", attrs: { id: "inside" } }] },
+      ],
+    },
+  });
+  const screen = render(<EditorContent editor={editor} />);
+  act(() => {
+    const moved = editor.state.doc.firstChild;
+    if (!moved) throw new Error("missing moved file");
+    const tr = editor.state.tr.deleteRange(0, 1);
+    tr.insert(3, moved).setSelection(NodeSelection.create(tr.doc, 3));
+    editor.view.dispatch(tr);
+  });
+  const target = screen.getByTestId("target");
+  const button = target.querySelector("button");
+  if (!button) throw new Error("missing actions button");
+  await act(async () => {
+    fireEvent.mouseDown(button);
+    fireEvent.mouseUp(button);
+    fireEvent.click(button);
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByText("Delete"));
+  });
+  const ids = () => {
+    const result: unknown[] = [];
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === "fileEmbed") result.push(node.attrs.id);
+    });
+    return result;
+  };
+  expect(ids()).toEqual(["inside", "moved"]);
+  act(() => {
+    editor.commands.undo();
+  });
+  expect(ids()).toEqual(["target", "inside", "moved"]);
+});

--- a/app/javascript/components/TiptapExtensions/NodeActionsMenu.tsx
+++ b/app/javascript/components/TiptapExtensions/NodeActionsMenu.tsx
@@ -47,9 +47,11 @@ export const NodeActionsWrapper = ({
 
 export const NodeActionsMenu = ({
   editor,
+  getPos,
   actions,
 }: {
   editor: Editor;
+  getPos: () => number | undefined;
   actions?: { item: () => React.ReactNode; menu: (close: () => void) => React.ReactNode }[];
 }) => {
   const [open, setOpen] = React.useState(false);
@@ -57,7 +59,18 @@ export const NodeActionsMenu = ({
   const selected = React.useContext(SelectedContext);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(open) => {
+        if (open) {
+          const pos = getPos();
+          if (pos === undefined) return;
+          // Button events in node views do not update ProseMirror's selection.
+          editor.commands.setNodeSelection(pos);
+        }
+        setOpen(open);
+      }}
+    >
       <div
         data-actions-menu
         className={classNames(

--- a/app/javascript/components/TiptapExtensions/Posts.tsx
+++ b/app/javascript/components/TiptapExtensions/Posts.tsx
@@ -45,7 +45,7 @@ export const Posts = TiptapNode.create({
   },
 });
 
-const PostsNodeView = ({ editor, selected }: NodeViewProps) => {
+const PostsNodeView = ({ editor, selected, getPos }: NodeViewProps) => {
   const postsData = usePosts();
   const { productPermalink, isLoading, hasMorePosts, fetchMorePosts, total } = postsData;
   const posts = postsData.posts ?? [];
@@ -62,7 +62,7 @@ const PostsNodeView = ({ editor, selected }: NodeViewProps) => {
     <NodeViewWrapper>
       <NodeActionsWrapper selected={selected} isEditable={editor.isEditable} asChild>
         <Row className="embed">
-          {editor.isEditable ? <NodeActionsMenu editor={editor} /> : null}
+          {editor.isEditable ? <NodeActionsMenu editor={editor} getPos={getPos} /> : null}
           <RowContent className="content cursor-pointer all-unset" asChild>
             <button
               onClick={(e) => {

--- a/app/javascript/components/TiptapExtensions/PublicFileEmbed.tsx
+++ b/app/javascript/components/TiptapExtensions/PublicFileEmbed.tsx
@@ -23,7 +23,7 @@ import { Input } from "$app/components/ui/Input";
 import { Label } from "$app/components/ui/Label";
 import { Row, RowActions, RowContent, RowDetails } from "$app/components/ui/Rows";
 
-const NodeView = ({ editor, node }: NodeViewProps) => {
+const NodeView = ({ editor, node, getPos }: NodeViewProps) => {
   const uid = React.useId();
   const { files, updateFile, cancelUpload } = usePublicFilesSettings();
   const id = String(node.attrs.id);
@@ -43,7 +43,7 @@ const NodeView = ({ editor, node }: NodeViewProps) => {
     <NodeViewWrapper contentEditable={false}>
       <NodeActionsWrapper selected={selected} isEditable={editor.isEditable} asChild>
         <Row className="embed">
-          {editor.isEditable ? <NodeActionsMenu editor={editor} /> : null}
+          {editor.isEditable ? <NodeActionsMenu editor={editor} getPos={getPos} /> : null}
           <RowContent className="content">
             <FileRowContent
               extension={file.extension}

--- a/app/javascript/components/TiptapExtensions/TextInputNodeView.tsx
+++ b/app/javascript/components/TiptapExtensions/TextInputNodeView.tsx
@@ -8,7 +8,7 @@ import { Fieldset } from "$app/components/ui/Fieldset";
 import { Input } from "$app/components/ui/Input";
 import { Textarea } from "$app/components/ui/Textarea";
 
-export const TextInputNodeView = ({ editor, node, updateAttributes }: NodeViewProps) => {
+export const TextInputNodeView = ({ editor, node, updateAttributes, getPos }: NodeViewProps) => {
   const label = typia.assert<string | null>(node.attrs.label);
   const type = typia.assert<"shortAnswer" | "longAnswer">(node.type.name);
   const customFieldId = typia.assert<string | null>(node.attrs.id);
@@ -23,7 +23,7 @@ export const TextInputNodeView = ({ editor, node, updateAttributes }: NodeViewPr
       {editor.isEditable ? (
         <NodeActionsWrapper asChild>
           <Fieldset>
-            <NodeActionsMenu editor={editor} />
+            <NodeActionsMenu editor={editor} getPos={getPos} />
 
             <fieldset className="m-0 min-w-0 flex-1 border-0 p-0">
               <Input

--- a/spec/requests/products/edit/rich_text_editor_spec.rb
+++ b/spec/requests/products/edit/rich_text_editor_spec.rb
@@ -1160,7 +1160,7 @@ describe("Product Edit Rich Text Editor", type: :system, js: true) do
       expect(page).to have_alert(text: 'Moved "First file" to "Folder 1".')
 
       within find_embed(name: "File to delete").hover do
-        find_button("Actions").click(x: 2, y: 2)
+        find_button("Actions").click(x: 4, y: 4, offset: :top_left)
       end
       page.document.click_on "Delete"
       expect(page).to_not have_embed(name: "File to delete")

--- a/spec/requests/products/edit/rich_text_editor_spec.rb
+++ b/spec/requests/products/edit/rich_text_editor_spec.rb
@@ -1144,6 +1144,38 @@ describe("Product Edit Rich Text Editor", type: :system, js: true) do
       end
     end
 
+    it "deletes the requested file after moving another file into a folder" do
+      target_file = create(:product_file, display_name: "File to delete", link: @product)
+      rich_content.update!(description: rich_content.description + [
+        { "type" => "fileEmbed", "attrs" => { "id" => target_file.external_id, "uid" => SecureRandom.uuid } }
+      ])
+      visit edit_link_path(@product) + "/content"
+
+      within find_embed(name: "First file").hover do
+        select_disclosure "Actions" do
+          click_on "Move to folder..."
+          click_on "Folder 1"
+        end
+      end
+      expect(page).to have_alert(text: 'Moved "First file" to "Folder 1".')
+
+      within find_embed(name: "File to delete").hover do
+        find_button("Actions").click(x: 2, y: 2)
+      end
+      page.document.click_on "Delete"
+      expect(page).to_not have_embed(name: "File to delete")
+      toggle_file_group "Folder 1"
+      within_file_group "Folder 1" do
+        expect(page).to have_embed(name: "First file")
+        expect(page).to have_embed(name: "Second file")
+        expect(page).to have_embed(name: "Third file")
+      end
+
+      save_change
+      expect(target_file.reload).to be_deleted
+      expect([file1, file2, file3].map { _1.reload.deleted? }).to eq([false, false, false])
+    end
+
     it "supports moving non-nested file embeds to existing folders" do
       visit edit_link_path(@product) + "/content"
 


### PR DESCRIPTION
## What
Select the owning editor node when its Actions menu opens. Pass its live position from every shared-menu caller.

## Why
Tiptap ignores button mouse events inside node views, leaving a previously moved file selected. Selecting the intended node fixes Delete without adding an unrelated confirmation modal.

## Before / after
Before: move First file into Folder 1, then Delete from File to delete's menu; First file disappears and the intended target remains. After: only the intended target is removed; First, Second and Third file remain. The video is a paced sequence of actual local-browser checkpoints, not continuous screen recording. Recaptured result stills scroll to the end of content so the target is visible before and absent after. Additional mobile frames show First file retained inside the folder.

## Status
- [x] Scope — shared editor actions, including files and folders.
- [x] Design — select the owning node at menu open.
- [x] Build — application fix and strengthened regression pushed.
- [x] QA — scrolled end-of-content stills show target present before and absent after; we-fix confirmed claim in frame; Astra pack skipped (media); full CI + Greptile 5/5 at current head.
- [ ] Shipped — not merged or deployed.
- [x] Market — no announcement for a bug fix.
- [x] Sell — no pricing or checkout changes.

## Test Results
- Mounted React/Tiptap component regression: failed on baseline, passed with the fix; includes Undo.
- Product-editor system regression: committed top-left button-padding click fails on baseline (target remains) and passes fixed (1 example, 0 failures), including persisted deletion checks. The former center-relative click was insufficient and has been corrected.
- Browser capture instrumentation confirmed the mousedown target was BUTTON; before and after capture runs passed their respective assertions.
- Focused Ruby lint passed. Previous pushed head passed all GitHub Actions tests and Buildkite; full CI and Buildkite passed on 347d77b30322c3ead5eb27fa7a37577377e10081. Test-confidence reached its 99% milestone: 10 test-file runs passed; 3 broader local Ruby files were classified pre-existing by its merge-base reruns, not claimed green.

## QA steps
1. In a product's Content editor, create a folder and two separate files.
2. Use the first file's Actions menu to move it into the folder.
3. Click the padding of the other file's Actions button, then Delete.
4. Verify the intended file disappears and the moved file remains inside the folder. Save and reload to verify persistence; Undo before saving should restore the deleted file.

## Local browser evidence
Recaptured on current head; baseline swaps only NodeActionsMenu.tsx to f00813e66ec. Both runs assert BUTTON input and the expected deletion outcome. Bottom frames show the target present before and absent after at the same end-of-content crop (Posts where File to delete was); mobile folder frames show First file retained. Synthetic fixtures only. We-fix: after desktop/mobile light+dark end-of-content assets already show License/Posts in frame with File to delete absent — no new capture required. Astra pack-autoreview skipped (stills/media only; no code change).

![Before desktop light: end of content](https://github.com/user-attachments/assets/b1c68ddd-46ca-4eeb-8958-4578a7217a52)

![Before desktop dark: end of content](https://github.com/user-attachments/assets/6f747363-96d2-4c12-bb83-c9cab6bf1c8b)

![Before mobile light: end of content](https://github.com/user-attachments/assets/51479702-25d9-4310-9063-8b37b4fc963d)

![Before mobile dark: end of content](https://github.com/user-attachments/assets/2d0c9441-b8b7-4887-a234-1f6bdc9e8c99)

![After desktop light: end of content](https://github.com/user-attachments/assets/59d2839d-ad75-4fd1-af26-81f09a6379b0)

![After desktop dark: end of content](https://github.com/user-attachments/assets/a6bfc30f-9375-416c-a176-53a1016b37c3)

![After mobile light: end of content](https://github.com/user-attachments/assets/299958b5-905a-4cc8-8dc7-5b82e2e5557b)

![After mobile dark: end of content](https://github.com/user-attachments/assets/6c24cd2e-af4f-4635-8ab0-d8b365afe7af)

![After mobile light: First file retained](https://github.com/user-attachments/assets/b8069ba3-030d-46f6-a00f-c10205fe6258)

![After mobile dark: First file retained](https://github.com/user-attachments/assets/b291b24e-b04b-4e0f-abc1-1be04e3c811a)

Walkthrough (paced browser checkpoints; earlier framing):
https://github.com/user-attachments/assets/ba0ec214-9161-4597-b798-2f6f17b4df3b


Premerge review: clean @ 347d77b30322c3ead5eb27fa7a37577377e10081

## Review handoff
Deletion targeting changes require human review under risk policy. Ready for Gianfranco to review and merge; no automerge. Please verify the intended file is deleted after moving a different file into a folder. Production deploy remains required before closing the linked report.

---
AI disclosure: GPT-6 Astra. Prompt: fix wrong-file deletion after a move, finish browser evidence and full CI, and hand off according to risk policy.