### PR TITLE
Offer optional social connections during seller setup

### DIFF
--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -69,6 +69,7 @@ export type DashboardPageProps = {
     used_cli?: boolean;
   };
   getting_started_dismissed: boolean;
+  social_connections?: { name: string; connected: boolean }[];
   sales: ProductRow[];
   balances: {
     balance: string;
@@ -319,6 +320,7 @@ const GETTING_STARTED_MINIMIZED_KEY = "dashboardGettingStartedMinimized";
 export const DashboardPage = ({
   getting_started_stats,
   getting_started_dismissed,
+  social_connections,
   sales,
   activity_items,
   balances,
@@ -576,6 +578,29 @@ export const DashboardPage = ({
                   />
                 ))}
               </div>
+              {social_connections?.length ? (
+                <Card>
+                  <CardContent className="grid gap-3">
+                    <h3>Connect a social account (optional)</h3>
+                    <p>
+                      Your verified social history can provide context during account review. Connecting is optional and
+                      does not replace identity verification or guarantee approval or a payout date.
+                    </p>
+                    <ul className="flex flex-wrap gap-x-6 gap-y-2">
+                      {social_connections.map(({ name, connected }) => (
+                        <li key={name}>
+                          {name}: {connected ? "Connected" : "Available to connect"}
+                        </li>
+                      ))}
+                    </ul>
+                    <div>
+                      <NavigationButton href={Routes.settings_profile_path()}>
+                        Manage social connections
+                      </NavigationButton>
+                    </div>
+                  </CardContent>
+                </Card>
+              ) : null}
               <Modal
                 open={showDismissConfirmation}
                 onClose={() => setShowDismissConfirmation(false)}

--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -578,7 +578,7 @@ export const DashboardPage = ({
                   />
                 ))}
               </div>
-              {social_connections?.length ? (
+              {!gettingStartedMinimized && social_connections?.length ? (
                 <Card>
                   <CardContent className="grid gap-3">
                     <h3>Connect a social account (optional)</h3>

--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -583,8 +583,8 @@ export const DashboardPage = ({
                   <CardContent className="grid gap-3">
                     <h3>Connect a social account (optional)</h3>
                     <p>
-                      Your verified social history can provide context during account review. Connecting does not replace
-                      identity verification or guarantee approval or a payout date.
+                      Your verified social history can provide context during account review. Connecting does not
+                      replace identity verification or guarantee approval or a payout date.
                     </p>
                     <ul className="flex flex-wrap gap-x-6 gap-y-2">
                       {social_connections.map(({ name, connected }) => (
@@ -594,9 +594,7 @@ export const DashboardPage = ({
                       ))}
                     </ul>
                     <div>
-                      <NavigationButton href={Routes.profile_path()}>
-                        Manage social connections
-                      </NavigationButton>
+                      <NavigationButton href={Routes.profile_path()}>Manage social connections</NavigationButton>
                     </div>
                   </CardContent>
                 </Card>

--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -583,8 +583,8 @@ export const DashboardPage = ({
                   <CardContent className="grid gap-3">
                     <h3>Connect a social account (optional)</h3>
                     <p>
-                      Your verified social history can provide context during account review. Connecting is optional and
-                      does not replace identity verification or guarantee approval or a payout date.
+                      Your verified social history can provide context during account review. Connecting does not replace
+                      identity verification or guarantee approval or a payout date.
                     </p>
                     <ul className="flex flex-wrap gap-x-6 gap-y-2">
                       {social_connections.map(({ name, connected }) => (
@@ -594,7 +594,7 @@ export const DashboardPage = ({
                       ))}
                     </ul>
                     <div>
-                      <NavigationButton href={Routes.settings_profile_path()}>
+                      <NavigationButton href={Routes.profile_path()}>
                         Manage social connections
                       </NavigationButton>
                     </div>

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -73,6 +73,7 @@ type ProfilePageProps = {
   editable_profile: ProfileEditorProps;
   profile_version: string;
   custom_html_pages_enabled: boolean;
+  twitter_connected: boolean;
   youtube_connect_enabled: boolean;
   youtube_connected: boolean;
   youtube_handle: string | null;
@@ -92,6 +93,7 @@ export default function SettingsPage() {
     editable_profile,
     profile_version,
     custom_html_pages_enabled,
+    twitter_connected,
     youtube_connect_enabled,
     youtube_connected,
     youtube_handle,
@@ -520,10 +522,10 @@ export default function SettingsPage() {
               {loggedInUser?.policies.settings_profile.manage_social_connections ? (
                 <Fieldset>
                   <FieldsetTitle>Social links</FieldsetTitle>
-                  {creatorProfile.twitter_handle ? (
+                  {twitter_connected ? (
                     <Button type="button" color="twitter" onClick={handleUnlinkTwitter}>
                       <TwitterX pack="brands" className="size-5" />
-                      Disconnect {creatorProfile.twitter_handle} from X
+                      Disconnect {creatorProfile.twitter_handle ? `${creatorProfile.twitter_handle} from X` : "X"}
                     </Button>
                   ) : (
                     <SocialAuthButton

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -528,16 +528,24 @@ export default function SettingsPage() {
                       Disconnect {creatorProfile.twitter_handle ? `${creatorProfile.twitter_handle} from X` : "X"}
                     </Button>
                   ) : (
-                    <SocialAuthButton
-                      provider="twitter"
-                      href={Routes.user_twitter_omniauth_authorize_path({
-                        state: "link_twitter_account",
-                        x_auth_access_type: "read",
-                      })}
-                    >
-                      <TwitterX pack="brands" className="size-5" />
-                      Connect to X
-                    </SocialAuthButton>
+                    <>
+                      {creatorProfile.twitter_handle ? (
+                        <Button type="button" color="twitter" onClick={handleUnlinkTwitter}>
+                          <TwitterX pack="brands" className="size-5" />
+                          Disconnect {creatorProfile.twitter_handle} from X
+                        </Button>
+                      ) : null}
+                      <SocialAuthButton
+                        provider="twitter"
+                        href={Routes.user_twitter_omniauth_authorize_path({
+                          state: "link_twitter_account",
+                          x_auth_access_type: "read",
+                        })}
+                      >
+                        <TwitterX pack="brands" className="size-5" />
+                        Connect to X
+                      </SocialAuthButton>
+                    </>
                   )}
                   {youtube_connected ? (
                     <Button type="button" color="youtube" onClick={handleUnlinkYoutube}>

--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -122,10 +122,25 @@ class CreatorHomePresenter
       show_1099_download_notice:,
       tax_center_enabled:,
       **gumhead_props,
+      **social_connection_props,
     }
   end
 
   private
+    def social_connection_props
+      return {} if seller.has_dismissed_getting_started_checklist?
+      return {} unless Pundit.policy!(pundit_user, [:settings, :profile]).manage_social_connections?
+
+      connections = [{ name: "X", connected: seller.twitter_user_id.present? }]
+      if seller.youtube_identity.present? || Feature.active?(:youtube_connect, seller)
+        connections << { name: "YouTube", connected: seller.youtube_identity.present? }
+      end
+      if seller.instagram_identity.present? || Feature.active?(:instagram_connect, seller)
+        connections << { name: "Instagram", connected: seller.instagram_identity.present? }
+      end
+      { social_connections: connections }
+    end
+
     def gumhead_props
       return {} unless Feature.active?(GUMHEAD_FEATURE, seller)
       return {} if seller.has_dismissed_gumhead_promo?

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -81,6 +81,7 @@ class ProfilePresenter
         # username feeds the agent prompt. The HTML itself is never sent here - the form never edits
         # it, it only sends "" to reset, so has_custom_landing_page is all the UI needs.
         custom_html_pages_enabled: Feature.active?(:custom_html_pages, seller),
+        twitter_connected: seller.twitter_user_id.present?,
         youtube_connect_enabled: Feature.active?(:youtube_connect, seller),
         youtube_connected: seller.youtube_identity.present?,
         youtube_handle: seller.youtube_identity&.handle,

--- a/spec/controllers/connections_controller_spec.rb
+++ b/spec/controllers/connections_controller_spec.rb
@@ -52,6 +52,22 @@ describe ConnectionsController do
 
       expect(response.body).to eq({ success: false, error_message: "Failed to unlink Twitter" }.to_json)
     end
+
+    context "with handle only (no twitter_user_id)" do
+      before do
+        seller.update!(twitter_user_id: nil)
+      end
+
+      it "clears the stale handle" do
+        expect(seller.twitter_handle).to eq("gumroad")
+
+        post :unlink_twitter
+
+        seller.reload
+        expect(seller.twitter_handle).to be_nil
+        expect(response.body).to eq({ success: true }.to_json)
+      end
+    end
   end
 
   describe "POST unlink_youtube" do

--- a/spec/presenters/creator_home_presenter_spec.rb
+++ b/spec/presenters/creator_home_presenter_spec.rb
@@ -21,6 +21,67 @@ describe CreatorHomePresenter do
   end
 
   describe "#creator_home_props" do
+    describe "optional social connections" do
+      let(:pundit_user) { SellerContext.new(user: seller, seller:) }
+
+      before do
+        Feature.deactivate(:youtube_connect)
+        Feature.deactivate(:instagram_connect)
+      end
+
+      it "offers X without offering gated providers" do
+        expect(presenter.creator_home_props[:social_connections]).to eq([{ name: "X", connected: false }])
+      end
+
+      it "uses the current X link, not a handle or retained verification" do
+        seller.update!(twitter_handle: "example_creator")
+        seller.social_connect_verifications.create!(platform: "twitter", uid: "example-social-id", last_verified_at: Time.current)
+        expect(presenter.creator_home_props[:social_connections]).to eq([{ name: "X", connected: false }])
+
+        seller.update!(twitter_user_id: "example-social-id")
+        expect(presenter.creator_home_props[:social_connections]).to eq([{ name: "X", connected: true }])
+
+        seller.update!(twitter_user_id: nil)
+        expect(presenter.creator_home_props[:social_connections]).to eq([{ name: "X", connected: false }])
+      end
+
+      it "offers providers enabled for this seller, not another seller" do
+        Feature.activate_user(:youtube_connect, admin_for_seller)
+        expect(presenter.creator_home_props[:social_connections]).to eq([{ name: "X", connected: false }])
+
+        Feature.activate_user(:youtube_connect, seller)
+        Feature.activate_user(:instagram_connect, seller)
+        expect(presenter.creator_home_props[:social_connections]).to eq([
+                                                                          { name: "X", connected: false }, { name: "YouTube", connected: false }, { name: "Instagram", connected: false }
+                                                                        ])
+      end
+
+      it "shows current identities even when new connections are gated and removes disconnected ones" do
+        seller.create_youtube_identity!(channel_id: "example-channel")
+        seller.create_instagram_identity!(instagram_user_id: "example-instagram")
+        expect(presenter.creator_home_props[:social_connections]).to eq([
+                                                                          { name: "X", connected: false }, { name: "YouTube", connected: true }, { name: "Instagram", connected: true }
+                                                                        ])
+
+        seller.youtube_identity.destroy!
+        seller.instagram_identity.destroy!
+        seller.reload
+        expect(presenter.creator_home_props[:social_connections]).to eq([{ name: "X", connected: false }])
+      end
+
+      it "omits the prompt after checklist dismissal" do
+        seller.update!(has_dismissed_getting_started_checklist: true)
+        expect(presenter.creator_home_props).not_to have_key(:social_connections)
+      end
+
+      it "omits the prompt for team members, including admins who can see the checklist" do
+        [admin_for_seller, marketing_for_seller, support_for_seller].each do |member|
+          props = described_class.new(SellerContext.new(user: member, seller:)).creator_home_props
+          expect(props).not_to have_key(:social_connections)
+        end
+      end
+    end
+
     it "deduces creator name from payout info" do
       expect(presenter.creator_home_props[:name]).to match("")
 

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -62,6 +62,14 @@ describe ProfilePresenter do
       expect(described_class.new(pundit_user:, seller:).profile_settings_props(request:)[:youtube_connected]).to eq(true)
     end
 
+    it "reports X connected from the current link rather than a manually entered handle" do
+      seller.update!(twitter_handle: "example_creator")
+      expect(described_class.new(pundit_user:, seller:).profile_settings_props(request:)[:twitter_connected]).to eq(false)
+
+      seller.update!(twitter_user_id: "example-social-id")
+      expect(described_class.new(pundit_user:, seller:).profile_settings_props(request:)[:twitter_connected]).to eq(true)
+    end
+
     it "reports Instagram connected from the live identity, not a dormant verification row" do
       create(:social_connect_verification, user: seller, platform: "instagram", uid: "17841400000000000", handle: "oldhandle")
       seller.reload

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -330,6 +330,7 @@ describe ProfilePresenter do
           seller_fonts_css_source: SellerProfile.seller_fonts_css_source,
           email_confirmation: nil,
           custom_html_pages_enabled: false,
+          twitter_connected: false,
           youtube_connect_enabled: false,
           youtube_connected: false,
           youtube_handle: nil,

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -84,7 +84,12 @@ describe "Dashboard", js: true, type: :system do
       expect(page).to have_current_path(profile_path)
       expect(page).to have_text("Social links")
       expect(page).to have_button("Connect to X")
+      expect(page).to have_button("Disconnect example_creator from X")
+
+      click_on "Disconnect example_creator from X"
       expect(page).not_to have_button("Disconnect example_creator from X")
+      expect(page).to have_button("Connect to X")
+      expect(seller.reload.twitter_handle).to be_nil
     end
 
     it "shows a connected account without making social connections required for checklist completion" do

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -91,11 +91,17 @@ describe "Dashboard", js: true, type: :system do
       seller.update!(twitter_user_id: "example-social-id")
       visit dashboard_path
       expect(page).to have_text("X: Connected")
+      click_on "Manage social connections"
+      click_on "Disconnect X"
+      expect(page).to have_button("Connect to X")
+      expect(seller.reload.twitter_user_id).to be_nil
+      visit dashboard_path
+      expect(page).to have_text("X: Available to connect")
       expect(page).to have_link("Manage social connections")
       click_on "Minimize getting started"
       expect(page).not_to have_text("Connect a social account (optional)")
       click_on "Expand getting started"
-      expect(page).to have_text("X: Connected")
+      expect(page).to have_text("X: Available to connect")
 
       click_on "Dismiss getting started"
       click_on "Yes, hide it"

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -70,6 +70,34 @@ describe "Dashboard", js: true, type: :system do
   end
 
   describe "Getting started" do
+    it "offers optional social connections and opens the existing settings controls" do
+      Feature.deactivate(:youtube_connect)
+      Feature.deactivate(:instagram_connect)
+      visit dashboard_path
+
+      expect(page).to have_text("Connect a social account (optional)")
+      expect(page).to have_text("X: Available to connect")
+      expect(page).not_to have_text("YouTube: Available to connect")
+      expect(page).not_to have_text("Instagram: Available to connect")
+      click_on "Manage social connections"
+      expect(page).to have_current_path(settings_profile_path)
+      expect(page).to have_text("Social links")
+      expect(page).to have_button("Connect to X")
+    end
+
+    it "shows a connected account without making social connections required for checklist completion" do
+      seller.update!(twitter_user_id: "example-social-id")
+      visit dashboard_path
+      expect(page).to have_text("X: Connected")
+      expect(page).to have_link("Manage social connections")
+
+      click_on "Dismiss getting started"
+      click_on "Yes, hide it"
+      expect(page).not_to have_text("Connect a social account (optional)")
+      visit dashboard_path
+      expect(page).not_to have_text("Connect a social account (optional)")
+    end
+
     context "with switching account to user as admin for seller" do
       include_context "with switching account to user as admin for seller"
 
@@ -77,6 +105,7 @@ describe "Dashboard", js: true, type: :system do
         visit dashboard_path
 
         expect(page).to have_text("Getting started")
+        expect(page).not_to have_text("Connect a social account (optional)")
       end
     end
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -81,7 +81,7 @@ describe "Dashboard", js: true, type: :system do
       expect(page).not_to have_text("YouTube: Available to connect")
       expect(page).not_to have_text("Instagram: Available to connect")
       click_on "Manage social connections"
-      expect(page).to have_current_path(settings_profile_path)
+      expect(page).to have_current_path(profile_path)
       expect(page).to have_text("Social links")
       expect(page).to have_button("Connect to X")
       expect(page).not_to have_button("Disconnect example_creator from X")

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -73,6 +73,7 @@ describe "Dashboard", js: true, type: :system do
     it "offers optional social connections and opens the existing settings controls" do
       Feature.deactivate(:youtube_connect)
       Feature.deactivate(:instagram_connect)
+      seller.update!(twitter_handle: "example_creator")
       visit dashboard_path
 
       expect(page).to have_text("Connect a social account (optional)")
@@ -83,6 +84,7 @@ describe "Dashboard", js: true, type: :system do
       expect(page).to have_current_path(settings_profile_path)
       expect(page).to have_text("Social links")
       expect(page).to have_button("Connect to X")
+      expect(page).not_to have_button("Disconnect example_creator from X")
     end
 
     it "shows a connected account without making social connections required for checklist completion" do
@@ -90,6 +92,10 @@ describe "Dashboard", js: true, type: :system do
       visit dashboard_path
       expect(page).to have_text("X: Connected")
       expect(page).to have_link("Manage social connections")
+      click_on "Minimize getting started"
+      expect(page).not_to have_text("Connect a social account (optional)")
+      click_on "Expand getting started"
+      expect(page).to have_text("X: Connected")
 
       click_on "Dismiss getting started"
       click_on "Yes, hide it"


### PR DESCRIPTION
## What

Add an optional social-connection prompt to Dashboard → Getting started, linking to the existing Profile social controls. Show current connection state, gate YouTube/Instagram by the seller's existing availability, and keep existing connections visible. The prompt is owner-only and follows checklist minimization/dismissal without becoming a completion requirement.

## Why

Getting started did not expose social connections. Reuse the existing owner policy and current identities rather than retained verification history. Profile's X control now uses the same current-link predicate, including a handle-free Disconnect X label.

No OAuth scopes/callbacks, scoring, holds, payouts, schema, or production flags change. Hold-specific prompts, consent return routing, provider rollout, and reviewer consumption remain outside this PR.

## Before-After

After: https://feat-optional-social-onboarding.apps.staging.gumroad.org/dashboard — served `b6ccf5d40779`, matching the current head.

Before: https://feat-stored-social-shadow-readou.apps.staging.gumroad.org/dashboard — actual hosted baseline `4207a388a322`. Its Dashboard/Profile components and presenters are byte-identical to this PR's merge base `f00813e66ec6`. Both previews have matching getting-started state. No response rewriting, injected UI, or local substitute was used.

| View | Before | After | Profile destination |
|---|---|---|---|
| Desktop, light | ![Before desktop light](https://github.com/user-attachments/assets/1066bdd3-a979-4373-a2b9-b978ce6a24fb) | ![After desktop light](https://github.com/user-attachments/assets/164b1354-5d3d-49f0-9fe9-4e81f0b45ecf) | ![Profile desktop light](https://github.com/user-attachments/assets/9fa46f91-bb75-4a0f-8d72-caf52012aabe) |
| Desktop, dark | ![Before desktop dark](https://github.com/user-attachments/assets/f3de84d9-162b-49ee-b7c1-91ae6aceb431) | ![After desktop dark](https://github.com/user-attachments/assets/beff0a2e-1ab5-42e0-b8da-2f77505a89c0) | ![Profile desktop dark](https://github.com/user-attachments/assets/9d6d4052-36e2-4161-9884-0cd7dfd546fa) |
| Mobile, light | ![Before mobile light](https://github.com/user-attachments/assets/70c39be5-9f11-492c-8c16-15c39eee7acf) | ![After mobile light](https://github.com/user-attachments/assets/2154766f-7719-4807-9ac0-34534d1f9d2b) | ![Profile mobile light](https://github.com/user-attachments/assets/263f2822-8fd3-4295-a7d0-6464c5a63096) |
| Mobile, dark | ![Before mobile dark](https://github.com/user-attachments/assets/7a5b2296-30c7-4525-8a3f-9289b426ccfb) | ![After mobile dark](https://github.com/user-attachments/assets/1768de33-05a6-4bad-b9c8-e4f01c984b45) | ![Profile mobile dark](https://github.com/user-attachments/assets/dd535b88-b089-40fb-9bb3-130fde271c33) |

Desktop: 1440×1080; mobile: 390×844. Computed backgrounds verified light `rgb(244, 244, 240)` / dark `rgb(36, 36, 35)`. Screenshots inspected visually/OCR; the complete prompt, disclaimer, state, and destination control are readable.

Walkthrough: actual hosted before/after, then a seeded test X identity → Disconnect X → Connect to X → available dashboard state → minimize/expand → persistent dismissal. The seeded identity is not an OAuth authorization; external provider sign-in is outside this change. Preview fixture restored after verification.

https://github.com/user-attachments/assets/2f4a3fa0-4be0-4733-b082-1d8143b75524

## Test Results

- [x] `bin/test-confidence --strict`: 99% milestone, all 7 selected test files passed in 132s; no skipped failure. Includes both full presenters, profile settings props, dashboard browser file, profile custom page browser file, Profile controller, and Dashboard controller. This is the selected plan, not the entire repository suite. Lane acquired normally and released; no shared DB reset.
- [x] Both new browser flows pass. The earlier shared Elasticsearch failure is superseded by the clean full dashboard-file run above.
- [x] Guard mutation proof: baseline/restored 6 examples, 0 failures; retained-history mutant 1 failure, owner-policy mutant 1, provider-gate mutant 4, all at intended assertions; restoration clean.
- [x] Ruby syntax, focused RuboCop/ESLint/Prettier, and TypeScript checks pass.
- [x] Current-head CI complete: all four Test Relevant and both Minitest shards, lint/typecheck, build and migration checks pass. Buildkite 22604 passed. Test Relevant is not a full-suite claim.
- [x] Astra+Fable panel clean at current head; no accepted/actionable findings.
- [x] Separate final code/spec/comment/evidence audit clean. All 12 screenshots and the walkthrough downloaded from GitHub bodyHTML URLs and hash-matched to inspected originals; video renders as a video element.

Premerge review: clean @ b6ccf5d40779a61cb3bd83106d2d72a058de5edd

### Hosted QA

1. Sign into the preview with its documented seeded seller account and test two-factor code. Getting started is expanded and unfinished.
2. Read the optional prompt: X is available; gated YouTube/Instagram are absent. Manage social connections reaches canonical `/profile`, with Social links → Connect to X.
3. The recorded seeded connected case verifies Disconnect X, refreshed Connect to X, and dashboard agreement. No external OAuth was performed.
4. Show less hides the prompt; Show more restores it. Dismiss → Yes, hide it removes it across reload. Dismissal is persistent; the recorded test fixture was reset afterward so reviewers can repeat the initial path.

Risk assessment: no money-processing code changes, but the message concerns account review/payout expectations and the Profile control changes which X connection action is offered. Ready for Gianfranco’s final review of the account-review wording and X connection-control consistency; no auto-merge. Broad tracker ownership remains unchanged.

---
AI disclosure: GPT-6 Astra via OpenRouter; adversarial Astra+Fable panel. Instructions: implement the smallest optional onboarding prompt using existing policy/provider gates, then complete real hosted baseline/after QA, strict tests and final readiness gates without changing production flags, OAuth scopes or credentials. No source changes during the final QA pass.
