### PR TITLE
Move the Docker images off end-of-life Debian bullseye

### DIFF
--- a/.buildkite/scripts/build_base.sh
+++ b/.buildkite/scripts/build_base.sh
@@ -10,7 +10,7 @@ logger() {
 source .buildkite/scripts/buildkit_cache.sh
 
 WEB_BASE_REPO=${ECR_REGISTRY}/gumroad/web_base
-RUBY_IMAGE=ruby:$(cat .ruby-version)-slim-bullseye
+RUBY_IMAGE=ruby:$(cat .ruby-version)-slim-bookworm
 
 # generate_tag_for_web_base.sh hashes `docker history` of the ruby base image,
 # so it must be present and current locally. The helper always pulls (cheap

--- a/.buildkite/scripts/build_web.sh
+++ b/.buildkite/scripts/build_web.sh
@@ -13,7 +13,7 @@ WEB_REPO=${ECR_REGISTRY}/gumroad/web
 WEB_BASE_REPO=${ECR_REGISTRY}/gumroad/web_base
 AWS_NGINX_REPO=${ECR_REGISTRY}/gumroad/web_nginx
 REVISION=${BUILDKITE_COMMIT}
-RUBY_IMAGE=ruby:$(cat .ruby-version)-slim-bullseye
+RUBY_IMAGE=ruby:$(cat .ruby-version)-slim-bookworm
 
 # The Makefile's generate_tag_for_web_base.sh hashes `docker history` of the
 # ruby base image, so it must be present and current locally. The helper always

--- a/.buildkite/scripts/buildkit_cache.sh
+++ b/.buildkite/scripts/buildkit_cache.sh
@@ -85,7 +85,7 @@ buildkit_fallback_notice() {
 # image, so every agent must converge on the same upstream image or two agents
 # will compute different tags for identical source — and a `build_web` step can
 # then reference a web_base tag nobody pushed (hard build failure). Docker Hub
-# re-tags `*-slim-bullseye` on Debian security rebuilds, so a warm agent's
+# re-tags `*-slim-bookworm` on Debian security rebuilds, so a warm agent's
 # months-old local copy is NOT safe to trust. Always pull; when the local image
 # is already current this is a cheap manifest check, not a re-download. If the
 # pull fails (Hub outage / rate limit) fall back to a present local image

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -225,13 +225,13 @@ jobs:
           logger() {
             echo -e "${GREEN}$(date '+%Y/%m/%d %H:%M:%S') build.sh: $1${NC}"
           }
-          logger "pulling ruby:$(cat .ruby-version)-slim-bullseye"
-          docker pull --quiet ruby:$(cat .ruby-version)-slim-bullseye
-          WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base.sh)
+          logger "pulling ruby:$(cat .ruby-version)-slim-bookworm"
+          docker pull --quiet ruby:$(cat .ruby-version)-slim-bookworm
+          WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bookworm docker/base/generate_tag_for_web_base.sh)
           if ! docker manifest inspect $WEB_BASE_REPO:$WEB_BASE_SHA > /dev/null 2>&1; then
             logger "Building $WEB_BASE_REPO:$WEB_BASE_SHA"
             NEW_BASE_REPO=$WEB_BASE_REPO \
-              WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye \
+              WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bookworm \
               BUNDLE_GEMS__CONTRIBSYS__COM=${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }} \
               make build_base
 
@@ -258,7 +258,7 @@ jobs:
         run: |
           set -e
           # Resolve the base test SHA (used as a hash input).
-          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
+          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bookworm docker/base/generate_tag_for_web_base_test.sh)
           TAG=test-$(BASE_TEST_SHA=$WEB_BASE_TEST_SHA docker/base/generate_tag_for_test_image.sh)
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Computed test image tag: $TAG"
@@ -288,8 +288,8 @@ jobs:
           logger() {
             echo -e "${GREEN}$(date '+%Y/%m/%d %H:%M:%S') build.sh: $1${NC}"
           }
-          docker pull --quiet ruby:$(cat .ruby-version)-slim-bullseye
-          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base_test.sh)
+          docker pull --quiet ruby:$(cat .ruby-version)-slim-bookworm
+          WEB_BASE_TEST_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bookworm docker/base/generate_tag_for_web_base_test.sh)
 
           # Check if both images already exist (content-addressed cache hit).
           BASE_TEST_EXISTS=false
@@ -304,7 +304,7 @@ jobs:
             if [ "$BASE_TEST_EXISTS" = "false" ]; then
               logger "building $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA"
               NEW_BASE_REPO=$WEB_BASE_REPO NEW_WEB_BASE_TEST_REPO=$WEB_BASE_TEST_REPO \
-                WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye \
+                WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bookworm \
                 make build_base_test
               logger "pushing $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA"
               for i in {1..3}; do
@@ -320,7 +320,7 @@ jobs:
             # sticky-disk-backed BuildKit builder that persists the layer cache
             # across runs automatically — no explicit --cache-from/--cache-to needed.
             logger "building $WEB_REPO:$TEST_IMAGE_TAG"
-            WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bullseye docker/base/generate_tag_for_web_base.sh)
+            WEB_BASE_SHA=$(WEB_BASE_DOCKERFILE_FROM=ruby:$(cat .ruby-version)-slim-bookworm docker/base/generate_tag_for_web_base.sh)
             # Pull the FROM images that the multi-stage Dockerfile needs.
             docker pull --quiet $WEB_BASE_REPO:$WEB_BASE_SHA &
             docker pull --quiet $WEB_BASE_TEST_REPO:$WEB_BASE_TEST_SHA &

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ WEB_COMMAND ?= "/usr/local/bin/gosu app docker/web/server.sh"
 NEW_WEB_TAG ?= $(shell git rev-parse --short=12 HEAD)
 COMPOSE_PROJECT_NAME ?= web
 RUBY_VERSION := $(shell cat .ruby-version)
-WEB_BASE_DOCKERFILE_FROM ?= ruby:$(RUBY_VERSION)-slim-bullseye
+# Debian 12. An EOL Debian stops having its security metadata re-signed, which
+# breaks `apt-get update` in every image built on it -- bump before June 2028.
+WEB_BASE_DOCKERFILE_FROM ?= ruby:$(RUBY_VERSION)-slim-bookworm
 DOCKER_CMD ?= docker
 # Overridable so CI can swap in `docker buildx build --load` (BuildKit) while
 # local/fallback builds keep the classic builder. --compress lives here because

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -27,7 +27,6 @@ RUN mkdir -p /usr/share/man/man1
 
 # PACKAGES
 RUN cd /tmp \
-  && sed -i "s/bullseye main/bullseye main contrib non-free/" /etc/apt/sources.list \
   && apt-get update -y -qq \
   && apt-get install -yq --no-install-recommends \
   build-essential \
@@ -80,8 +79,12 @@ RUN cd /tmp \
   && chmod +x /usr/local/bin/gosu \
   # s6_overlay
   # TODO: would this have effects on the test container?
+  # The tarball carries a ./bin/ directory entry and Debian merged /usr, so
+  # without --keep-directory-symlink tar replaces the /bin -> usr/bin symlink
+  # with a directory holding only execline: /bin/sh disappears and every
+  # `#!/bin/sh` script, apt's signature check included, stops working.
   && curl -J -L -o /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz \
-  && tar xzf /tmp/s6-overlay-amd64.tar.gz -C / \
+  && tar xzf /tmp/s6-overlay-amd64.tar.gz -C / --keep-directory-symlink \
   # node 22.x
   && mkdir -p /etc/apt/keyrings \
   && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --batch --yes --dearmor -o /etc/apt/keyrings/nodesource.gpg \

--- a/docker/base/Dockerfile.test
+++ b/docker/base/Dockerfile.test
@@ -11,8 +11,7 @@ FROM ${WEB_BASE_DOCKERFILE_FROM}
 RUN mkdir -p /usr/share/man/man1
 
 # chrome
-RUN sed -i "s/bullseye main/bullseye main contrib non-free/" /etc/apt/sources.list \
-  && apt-get update -y -qq \
+RUN apt-get update -y -qq \
   && apt-get install -yq --no-install-recommends \
     ca-certificates \
     curl \
@@ -31,7 +30,7 @@ RUN sed -i "s/bullseye main/bullseye main contrib non-free/" /etc/apt/sources.li
     libvips-dev \
     libxrender1 \
     locales \
-    netcat \
+    netcat-openbsd \
     pdftk \
     qpdf \
     screen \

--- a/docker/base/generate_tag_for_web_base.sh
+++ b/docker/base/generate_tag_for_web_base.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-WEB_BASE_DOCKERFILE_FROM=${WEB_BASE_DOCKERFILE_FROM:-"ruby:$(cat .ruby-version)-slim-bullseye"}
+WEB_BASE_DOCKERFILE_FROM=${WEB_BASE_DOCKERFILE_FROM:-"ruby:$(cat .ruby-version)-slim-bookworm"}
 DOCKER_CMD=${DOCKER_CMD:-docker}
 
 dockerfile_from_shas=$($DOCKER_CMD history -q $WEB_BASE_DOCKERFILE_FROM \

--- a/docker/base/generate_tag_for_web_base_test.sh
+++ b/docker/base/generate_tag_for_web_base_test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-WEB_BASE_DOCKERFILE_FROM=${WEB_BASE_DOCKERFILE_FROM:-"ruby:$(cat .ruby-version)-slim-bullseye"}
+WEB_BASE_DOCKERFILE_FROM=${WEB_BASE_DOCKERFILE_FROM:-"ruby:$(cat .ruby-version)-slim-bookworm"}
 DOCKER_CMD=${DOCKER_CMD:-docker}
 
 dockerfile_from_shas=$($DOCKER_CMD history -q $WEB_BASE_DOCKERFILE_FROM \

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,27 +1,25 @@
-FROM nginx:1.23.4
+# consul-template is one static binary, so fetch it in a throwaway stage rather
+# than installing curl in the runtime image. Debian stops re-signing a release's
+# security metadata at EOL and `apt-get update` on a pinned image then fails
+# outright, which is what bullseye did on 2026-09-07: it blocked every build.
+FROM nginx:1.30.4-trixie AS consul-template
 
+ARG CONSUL_TEMPLATE_VERSION=0.19.4
+
+RUN curl -fsSL https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.tgz \
+  | tar -xz -C /usr/bin consul-template
+
+FROM nginx:1.30.4-trixie
+
+COPY --from=consul-template /usr/bin/consul-template /usr/bin/consul-template
 COPY public /public
 COPY docker/nginx/main.conf /etc/nginx/nginx.conf
 COPY docker/nginx/nginx.conf /nginx.conf
 COPY docker/nginx/run_nginx.sh /run_nginx.sh
 
-ENV CONSUL_TEMPLATE_VERSION=0.19.4
-
-RUN apt-get update -y -qq \
-  && apt-get install -yq --no-install-recommends \
-    curl \
-    ca-certificates \
-  && curl -L https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.tgz \
-    | tar -xz \
-    && mv /consul-template /usr/bin \
-  && apt-get remove -y \
-    curl \
-    ca-certificates \
-  && apt-get clean autoclean \
-  && apt-get autoremove -y \
-  && rm -rf \
-    /var/lib/apt/lists/ \
-    /tmp/* \
-    /var/tmp/*
+# The base image ships curl and nothing here needs one. Keeping a downloader out
+# of an internet-facing container is also what the old build ended up doing.
+RUN apt-get remove -y --purge curl \
+  && apt-get autoremove -y
 
 CMD ["/run_nginx.sh"]

--- a/docker/nginx/main.conf
+++ b/docker/nginx/main.conf
@@ -4,15 +4,15 @@
 # render our app config into conf.d/default.conf, which nginx includes from inside `http`.
 # So there is nowhere else this setting can live.
 #
-# Kept byte-for-byte identical to nginx:1.23.4's default apart from that one value, so a
-# base image bump stays a one-line review:
+# Kept byte-for-byte identical to nginx:1.30.4-trixie's default apart from that one value,
+# so a base image bump stays a one-line review:
 #   docker run --rm nginx:<tag> cat /etc/nginx/nginx.conf
 
 user  nginx;
 worker_processes  auto;
 
 error_log  /var/log/nginx/error.log notice;
-pid        /var/run/nginx.pid;
+pid        /run/nginx.pid;
 
 
 events {

--- a/spec/services/app_store_walks_jws_verifier_spec.rb
+++ b/spec/services/app_store_walks_jws_verifier_spec.rb
@@ -93,7 +93,7 @@ describe AppStoreWalksJwsVerifier do
         cert.serial = 1
         cert.subject = OpenSSL::X509::Name.parse("/CN=test")
         cert.issuer = cert.subject
-        cert.public_key = OpenSSL::PKey::EC.new(key).tap { |k| k.private_key = nil }
+        cert.public_key = OpenSSL::PKey::EC.new(key.public_to_der)
         cert.not_before = Time.now - 60
         cert.not_after = Time.now + 3600
         cert.sign(key, OpenSSL::Digest.new("SHA256"))
@@ -116,7 +116,7 @@ describe AppStoreWalksJwsVerifier do
           c.serial = 1
           c.subject = OpenSSL::X509::Name.parse("/CN=test-leaf")
           c.issuer = c.subject
-          c.public_key = OpenSSL::PKey::EC.new(key).tap { |k| k.private_key = nil }
+          c.public_key = OpenSSL::PKey::EC.new(key.public_to_der)
           c.not_before = Time.now - 60
           c.not_after = Time.now + 3600
           c.sign(key, OpenSSL::Digest.new("SHA256"))


### PR DESCRIPTION
## What

Debian 11 (bullseye) reached end of life on 2026-08-31, and its `bullseye-security`
`Release` file expired at 2026-09-07 21:13 UTC. `apt-get update` inside any
bullseye-based image now exits 100:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 3h 35min 3s). Updates for this repository will not be applied.
```

Two images are built on bullseye, so both are affected:

- **`docker/nginx`** (`nginx:1.23.4`) — broke immediately. It is rebuilt on every
  `Build Web Image` step, and its `apt-get` layer is only skipped while the
  registry cache is warm, so the first branch to touch `public/` or `docker/nginx`
  takes the whole step down. That is what killed Buildkite #22593 and blocked the
  preview app on #7526.
- **`docker/base`** (`ruby:3.4.3-slim-bullseye`) — same failure, currently masked by
  a warm layer cache. The `COPY Gemfile* .ruby-version` sits *above* the package
  layer, so the next dependency bump invalidates it and the image every deploy and
  every CI test run is built from stops building.

This PR moves both onto supported Debian releases and takes the nginx image off
`apt` altogether.

**nginx image**

- Base image `nginx:1.23.4` → `nginx:1.30.4-trixie` (nginx stable branch, Debian 13,
  supported to 2030). There is no bookworm variant of a current nginx release.
- `consul-template` now comes out of a throwaway build stage instead of an
  `apt-get install curl && curl && apt-get remove curl` round trip, so the runtime
  image runs no package-manager network work at all and cannot be broken by a future
  Debian EOL. Same pinned `0.19.4` binary from the same URL, now fetched with
  `curl -f` so an HTTP error fails the build instead of unpacking garbage.
- `main.conf` refreshed against the new image's default `nginx.conf` (`pid` moved to
  `/run/nginx.pid`), keeping its documented "byte-for-byte identical apart from
  `worker_connections`" property.
- The base image ships `curl` and it is purged, which is where the old build also
  ended up. `apt-get remove` needs no package lists, so that step stays offline.

**app base image**

- `ruby:3.4.3-slim-bullseye` → `ruby:3.4.3-slim-bookworm` (Debian 12, security
  support to June 2028). Ruby 3.4.3 has no trixie variant, and bumping Ruby is a
  separate change. The pin is in six places (Makefile, both tag generators, two
  Buildkite scripts, the GitHub Actions workflow); all move together or the
  content-addressed `web_base` tag stops matching what was pushed.
- `netcat` → `netcat-openbsd` in `Dockerfile.test`. In bookworm `netcat` is a bare
  virtual name with two providers, so `apt-get install netcat` refuses; openbsd is
  the implementation bullseye's transitional package pulled in, and it is the one
  with the `nc -z` that `docker/ci/wait_on_connection.sh` uses.
- s6-overlay is now extracted with `tar --keep-directory-symlink`. bookworm has a
  merged `/usr`, the tarball carries a `./bin/` directory entry, and plain
  extraction replaces the `/bin -> usr/bin` symlink with a directory holding only
  execline — `/bin/sh` disappears and every `#!/bin/sh` script breaks. The first
  casualty is apt's own signature check: `Couldn't execute /usr/bin/apt-key to
  check .../bookworm/InRelease`, for every repository at once.
- Dropped the `s/bullseye main/bullseye main contrib non-free/` sources.list edit.
  Every package in both lists is in `main` (checked against the bullseye and
  bookworm `Packages` indexes), and bookworm's images have no `/etc/apt/sources.list`
  to edit — deb822 `debian.sources` — so the `sed` would have failed the build.

## Why

The build is broken now and stays broken: bullseye's security metadata will never be
re-signed again. Pinning `Acquire::Check-Valid-Until "false"` would paper over it
while leaving us on a distro that receives no further security updates, so the fix is
to move up. The nginx image goes one further and stops depending on Debian's package
metadata at all, because a single static binary does not justify an `apt` round trip
that expires.

`Makefile` now records when the bookworm pin has to move, so the next occurrence is a
calendar item rather than an outage.

## Before / After

Before — `make build_nginx`, unchanged tree, today:

```
 => ERROR [5/5] RUN apt-get update -y -qq   && apt-get install -yq ...
1.722 E: Release file for .../bullseye-security/InRelease is expired (invalid since 3h 35min 3s).
ERROR: failed to solve: ... exit code: 100
make: *** [Makefile:77: build_nginx] Error 1
```

After — same target, this branch, `linux/amd64`:

```
$ make build_nginx NGINX_REPO=local/web_nginx NGINX_TAG=make \
    DOCKER_BUILD="docker build --compress --platform linux/amd64"
 => naming to docker.io/local/web_nginx:make done

$ docker run -d -e NOMAD_PORT_http=8080 -p 18080:8080 local/web_nginx:make
nginx/1.30.4 ... start worker processes

$ curl /healthcheck.txt            -> 200 "ok"
$ curl -H 'Host: www.gumroad.com'  -> 301 https://gumroad.com/discover
$ curl /500.html                   -> 200   (static, from /public)
$ curl /some/app/path              -> 502   (no Puma upstream; matches documented behaviour)
$ consul-template -version         -> consul-template v0.19.4 (68b1da2)
$ nginx -t                         -> syntax is ok / test is successful
$ dpkg-query -W curl               -> no packages found matching curl
```

`consul-template` renders `/etc/nginx/conf.d/default.conf` from the Nomad port
variable exactly as before (`listen 8080`).

## Test Results

Local, `linux/amd64` (the architecture CI builds), since neither image can be built
on this branch without the fixes:

**nginx image**

- `make build_nginx` succeeds; the container run above exercises the whole path —
  consul-template rendering `default.conf` from `NOMAD_PORT_http`, nginx serving
  static files out of `/public`, the www redirect, and the `@app` fallback 502.
- `main.conf` diffed against `docker run --rm nginx:1.30.4-trixie cat /etc/nginx/nginx.conf`:
  identical except `worker_connections 8192`.
- Parity with `nginx:1.23.4`: `nginx` is still uid/gid 101, and
  `/var/log/nginx/{access,error}.log` are still symlinks to `/dev/stdout` and
  `/dev/stderr`, so the fluentd log capture the Nomad task configures is unchanged.

**base image** — probe builds of the package list and every binary the Dockerfiles
download, on `ruby:3.4.3-slim-bookworm`. This is where the two bookworm-specific
failures above were found:

```
PROBE OK   wkhtmltopdf: wkhtmltopdf 0.12.4 (with patched qt)
PROBE OK   dumb-init: dumb-init v1.2.0
PROBE OK   gosu: uid=65534(nobody) gid=65534(nogroup)
PROBE OK   s6-svscan: s6-svscan: usage: s6-svscan [ -S | -s ] ...
PROBE OK   node: v22.23.2          PROBE OK   npm: 10.9.8
PROBE OK   git: git version 2.39.5  PROBE OK   jq: jq-1.6
PROBE OK   pdftk: pdftk port to java 3.3.2
PROBE OK   qpdf: qpdf version 11.3.0
PROBE OK   ffmpeg: ffmpeg version 5.1.9-0+deb12u1
PROBE OK   imagemagick: Version: ImageMagick 6.9.11-60 Q16
PROBE OK   percona: pt-online-schema-change 3.2.1
PROBE OK   chrome: Google Chrome 125.0.6422.76
PROBE OK   chromedriver: ChromeDriver 125.0.6422.76
PROBE OK   jemalloc: /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
PROBE OK   im-policy: /etc/ImageMagick-6/policy.xml
PROBE OK   bin-sh: /bin/sh -> dash
PROBE FAILURES: 0
```

- `libvips.so.42` present for ruby-vips; `ruby -ropenssl` reports Ruby 3.4.3 on
  OpenSSL 3.0.20.
- `Dockerfile.test`'s list installs with main-only sources, and `netcat-openbsd`
  gives `nc -z` the semantics `docker/ci/wait_on_connection.sh` needs (0 against a
  listener, non-zero against a closed port). `locale-gen C.UTF-8` still works.
- `bundle install` on bookworm is **not** verified locally — that needs the
  sidekiq-pro credential, which this machine doesn't have. CI on this PR rebuilds
  `web_base` and `web_base_test` from scratch (the `FROM` change moves the
  content-addressed tag), so the gem build and the full suite run there.
- `bin/branch-specs` escalates on `.github/workflows/tests.yml`, so this needs the
  **run-all-specs** label.

## QA notes for the preview app

nginx moves 7 minor releases. The config is plain HTTP — no TLS, no HTTP/2, no
third-party modules — so nothing in it is deprecated in 1.30, and `nginx -t` plus the
live request path above cover it. The app image picks up runtime library bumps worth
exercising in preview: ffmpeg 4.3 → 5.1 (video duration/bitrate via streamio-ffmpeg,
and video poster generation), libvips 8.10 → 8.14, ImageMagick 6 (policy path
unchanged), OpenSSL 1.1.1 → 3.0, and mysql2 against MariaDB 10.11 client libraries.

`gumroad-deployment`'s nginx readiness comment cites "nginx 1.23.4"; the behaviour it
describes is unchanged (TCP up while `/healthcheck` 502s with no upstream, reproduced
above), but the version reference goes stale.

---

🤖 Written with [Claude Code](https://claude.com/claude-code) — Claude Opus 5.
