### PR TITLE
Fail fast on a full Puma accept queue, and make that queue deeper

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,7 +17,13 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+# Spelled as `bind` rather than `port` only because the backlog has to ride on the query
+# string -- the `port` DSL builds a bare tcp:// URI, so it always takes Puma's default
+# backlog of 1024. That queue is shared by every worker and drained by workers * threads
+# request slots, so a burst of slow requests fills it in seconds; past that the kernel
+# drops SYNs and nginx reports a connect timeout. 4096 matches the listen backlog nginx
+# uses out front, and somaxconn clamps both to the same ceiling.
+bind "tcp://0.0.0.0:#{ENV.fetch("PORT") { 3000 }}?backlog=4096"
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -94,6 +94,13 @@ server {
         proxy_set_header        Connection "";
 
         keepalive_timeout       75;
+
+        # Upstream is a port on the docker bridge, so a connect either completes in
+        # about a millisecond or Puma's accept queue is full and the kernel is dropping
+        # the SYN. nginx's 60s default then pins a worker slot for a full minute per
+        # doomed request, which is what turns a few seconds of queue overflow into
+        # minutes of 504s. 2s still covers the first SYN retransmit at 1s.
+        proxy_connect_timeout   2;
         proxy_read_timeout      120;
 
         proxy_buffers           16 64k;


### PR DESCRIPTION
## What

Two ceilings on the nginx → Puma handoff, both left at a library default.

- **`proxy_connect_timeout 2`** in `location @app`. It was never set, so nginx's 60s default applied.
- **Puma's listen backlog 1024 → 4096.** Spelled as `bind "tcp://0.0.0.0:#{port}?backlog=4096"` because the backlog can only ride on the query string — the `port` DSL builds a bare `tcp://` URI, so it always takes Puma's default.

Address, port, worker count and thread count are unchanged.

Refs gumroad-private#2431.

## Why

`upstream app` is a port on the docker bridge. A connect there either completes in about a millisecond or Puma's accept queue is full and the kernel is silently dropping the SYN — there is no middle case where waiting a minute helps. With the 60s default, each doomed request pinned an nginx worker connection slot for a full minute, so a queue overflow lasting a few seconds kept generating 504s long after the burst that caused it had passed. Failing at 2s frees the slot roughly thirty times sooner, and still covers the first SYN retransmit at 1s.

That is the amplifier. The queue itself is the second half:

#7527 closed with `backlog` named as "the next ceiling behind `worker_connections`" and raised nginx's own listen socket from 511 to 4096. That is the right ceiling for connections arriving *from* the load balancer, but a proxied request has to cross a second accept queue on the way out — Puma's — and that one was still on the library default of 1024, because `config/puma.rb` never set it. So the fleet had 8192 connection slots per nginx worker and a 4096-deep front door feeding a 1024-deep back door. 4096 makes both queues the same depth, and `somaxconn` on these hosts is 4096, so it is also the most the kernel will honour.

Worth being explicit that this raises a queue rather than adding capacity: the queue only buys time for a transient burst. What sets the drain rate is `workers * threads` request slots per host, and the web tasks set no `RAILS_MAX_THREADS`, so `config/puma.rb` falls back to 2 (Sidekiq sets 10). Raising that is the real capacity lever, but it moves per-worker memory against a cgroup limit, so it belongs in its own change with the headroom test in front of it. This PR is the part that is free.

## Before / After

Not user-visible, and not reproducible in a preview app — it takes a saturated accept queue, which a preview app has no way to produce. Measured directly instead.

**The 60s hold.** A listener with a deliberately tiny backlog that never calls `accept`, its queue held full by a second container, with the shipped `location @app` config in the pinned `nginx:1.23.4` image:

| `proxy_connect_timeout` | client sees | after |
|---|---|---|
| 60s (before, the default) | 504 | **60.1s** |
| 2s (this branch) | 504 | **2.0s** |

Both log the same line, which is the one this incident class produces:

```
upstream timed out (110: Connection timed out) while connecting to upstream
```

Same error, same status — the change is only how long a worker slot is held producing it.

**The backlog.** Loading the real `config/puma.rb` and reading back what the binder would use:

| | bind string | backlog |
|---|---|---|
| `origin/main` | `tcp://0.0.0.0:3000` | 1024 |
| this branch | `tcp://0.0.0.0:3000?backlog=4096` | 4096 |

with `workers => 6` and `threads => 2..2` identical on both sides, confirming nothing but the backlog moved.

## Test Results

```
nginx -t                     # syntax ok, in the pinned nginx:1.23.4 image
connect-timeout harness      # 60.1s -> 2.0s to the same 504 (table above)
Puma::Configuration#load     # backlog 1024 -> 4096; host, port, workers, threads unchanged
Puma::Binder#parse           # accepts the new bind string, returns a listening TCPServer
bundle exec rubocop          # config/puma.rb: no offenses
ruby bin/branch-specs        # ESCALATE (no spec maps to config/puma.rb)
```

`bin/branch-specs` cannot attribute a spec to `config/puma.rb`, so this carries the `run-all-specs` label rather than a computed subset. `config/puma.rb` is on the boot path for every spec that boots the app, which is what that label exercises.

No JS or TS changed, so eslint and typecheck have nothing to say about this diff. `bin/test-confidence` needs `ANTHROPIC_API_KEY`, which is not set in the shell this was prepared in, so it was not run — the `run-all-specs` CI job is the gate here.

---

## AI disclosure

Generated with **Claude Opus 5**.
