### PR TITLE
Offer optional social connections during account review

### DIFF
--- a/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.test.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import AccountStatusSection, { AccountStatus } from "$app/components/Settings/PaymentsPage/AccountStatusSection";
+
+vi.mock("@inertiajs/react", () => ({ usePage: () => ({ props: { authenticity_token: "test-csrf" } }) }));
+
+const status: AccountStatus = {
+  show_section: true,
+  is_suspended: false,
+  suspension_reason: null,
+  compliance_actions: [{ message: "Complete verification", href: "/settings/payments/remediation" }],
+  needs_id_upload: false,
+  gumroad_status: "Your account is under review and payouts are on hold until it's resolved.",
+  social_connections_for_review: [{ provider: "twitter", connected: false }],
+  stripe_rejected: false,
+  stripe_rejected_balance_status: null,
+  stripe_rejected_formatted_balance: null,
+  stripe_rejected_payout_date: null,
+};
+
+beforeEach(() => {
+  Object.assign(globalThis, {
+    Routes: {
+      help_center_root_path: () => "/help",
+      user_twitter_omniauth_authorize_path: (params: Record<string, string>) =>
+        `/users/auth/twitter?${new URLSearchParams(params).toString()}`,
+      user_youtube_omniauth_authorize_path: () => "/users/auth/youtube",
+      user_instagram_omniauth_authorize_path: () => "/users/auth/instagram",
+    },
+  });
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("optional review connections", () => {
+  it("keeps the ordinary review and verification paths without requiring a connection", () => {
+    render(<AccountStatusSection accountStatus={status} payoutsPausedBy={null} />);
+    expect(screen.getByText("Add social connections (optional)")).toBeTruthy();
+    expect(screen.getByText(/Your review can continue without connecting/u)).toBeTruthy();
+    expect(
+      screen.getByText(/does not replace identity verification or guarantee approval or a payout date/u),
+    ).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Complete verification" }).getAttribute("href")).toBe(
+      "/settings/payments/remediation",
+    );
+    expect(screen.getByRole("link", { name: "contact support" }).getAttribute("href")).toBe("/help");
+    expect(screen.queryByRole("button", { name: "Connect to YouTube" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Connect to Instagram" })).toBeNull();
+  });
+
+  it("submits the existing read-only X connection form rather than the payout settings form", () => {
+    const submit = vi.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(() => undefined);
+    render(<AccountStatusSection accountStatus={status} payoutsPausedBy={null} />);
+    fireEvent.click(screen.getByRole("button", { name: "Connect to X" }));
+    expect(submit).toHaveBeenCalledTimes(1);
+    const form = document.querySelector("form");
+    if (!form) throw new Error("Missing OAuth form");
+    expect(form.method).toBe("post");
+    expect(form.getAttribute("action")).toBe("/users/auth/twitter?state=link_twitter_account&x_auth_access_type=read");
+    expect(form.querySelector<HTMLInputElement>("input[name=authenticity_token]")?.value).toBe("test-csrf");
+    expect(screen.getByText(/Connecting opens your profile afterward/u)).toBeTruthy();
+  });
+
+  it("shows linked accounts and offers enabled unlinked providers using existing routes", () => {
+    const submit = vi.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(() => undefined);
+    render(
+      <AccountStatusSection
+        accountStatus={{
+          ...status,
+          social_connections_for_review: [
+            { provider: "twitter", connected: true },
+            { provider: "youtube", connected: false },
+            { provider: "instagram", connected: false },
+          ],
+        }}
+        payoutsPausedBy="system"
+      />,
+    );
+    expect(screen.getByText("X connected")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Connect to X" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Connect to YouTube" }));
+    const youtubeForm = submit.mock.instances[0];
+    if (!(youtubeForm instanceof HTMLFormElement)) throw new Error("Missing YouTube form");
+    expect(youtubeForm.getAttribute("action")).toBe("/users/auth/youtube");
+    fireEvent.click(screen.getByRole("button", { name: "Connect to Instagram" }));
+    const instagramForm = submit.mock.instances[1];
+    if (!(instagramForm instanceof HTMLFormElement)) throw new Error("Missing Instagram form");
+    expect(instagramForm.getAttribute("action")).toBe("/users/auth/instagram");
+  });
+
+  it("does not render a prompt or social forms when the server excludes the seller", () => {
+    render(
+      <AccountStatusSection
+        accountStatus={{ ...status, social_connections_for_review: null }}
+        payoutsPausedBy="stripe"
+      />,
+    );
+    expect(screen.queryByText("Add social connections (optional)")).toBeNull();
+    expect(document.querySelector("form")).toBeNull();
+    expect(screen.getByRole("link", { name: "Complete verification" })).toBeTruthy();
+  });
+});

--- a/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.test.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.test.tsx
@@ -41,7 +41,9 @@ describe("optional review connections", () => {
   it("keeps the ordinary review and verification paths without requiring a connection", () => {
     render(<AccountStatusSection accountStatus={status} payoutsPausedBy={null} />);
     expect(screen.getByText("Add social connections (optional)")).toBeTruthy();
-    expect(screen.getByText(/Your review can continue without connecting/u)).toBeTruthy();
+    expect(
+      screen.getByText(/share your social account history as additional context for your account review/u),
+    ).toBeTruthy();
     expect(
       screen.getByText(/does not replace identity verification or guarantee approval or a payout date/u),
     ).toBeTruthy();
@@ -78,7 +80,7 @@ describe("optional review connections", () => {
             { provider: "instagram", connected: false },
           ],
         }}
-        payoutsPausedBy="system"
+        payoutsPausedBy={null}
       />,
     );
     expect(screen.getByText("X connected")).toBeTruthy();
@@ -91,6 +93,13 @@ describe("optional review connections", () => {
     const instagramForm = submit.mock.instances[1];
     if (!(instagramForm instanceof HTMLFormElement)) throw new Error("Missing Instagram form");
     expect(instagramForm.getAttribute("action")).toBe("/users/auth/instagram");
+  });
+
+  it("hides the review notice and social prompt while the system payout pause alert is showing", () => {
+    render(<AccountStatusSection accountStatus={status} payoutsPausedBy="system" />);
+    expect(screen.getByText(/Your payouts have been paused for a security review/u)).toBeTruthy();
+    expect(screen.queryByText(status.gumroad_status ?? "")).toBeNull();
+    expect(screen.queryByText("Add social connections (optional)")).toBeNull();
   });
 
   it("does not render a prompt or social forms when the server excludes the seller", () => {

--- a/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
@@ -84,6 +84,9 @@ export default function AccountStatusSection({
 
   const showPayoutPausedAlert = !accountStatus.is_suspended && payoutPausedReason;
 
+  const showReviewNotice =
+    Boolean(accountStatus.gumroad_status) && (!showPayoutPausedAlert || payoutsPausedBy !== "system");
+
   return (
     <section aria-labelledby="account-status-heading" className="flex flex-col gap-4 p-4 md:p-8">
       <h2 id="account-status-heading" className="sr-only">
@@ -168,20 +171,19 @@ export default function AccountStatusSection({
         </Alert>
       ) : null}
 
-      {accountStatus.gumroad_status && (!showPayoutPausedAlert || payoutsPausedBy !== "system") ? (
+      {showReviewNotice ? (
         <Alert role="status" variant="warning">
           {accountStatus.gumroad_status}
           <SupportLink />
         </Alert>
       ) : null}
-      {accountStatus.social_connections_for_review ? (
+      {showReviewNotice && accountStatus.social_connections_for_review ? (
         <Alert role="status" variant="info">
           <div className="flex flex-col gap-3">
             <h3 className="font-bold">Add social connections (optional)</h3>
             <p>
-              You can share your social account history as additional context for your account review. Your review can
-              continue without connecting. This does not replace identity verification or guarantee approval or a payout
-              date.
+              You can share your social account history as additional context for your account review. This does not
+              replace identity verification or guarantee approval or a payout date.
             </p>
             <div className="flex flex-wrap items-center gap-2">
               {accountStatus.social_connections_for_review.map(({ provider, connected }) =>

--- a/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 
+import { SocialAuthButton } from "$app/components/SocialAuthButton";
 import { Alert } from "$app/components/ui/Alert";
+
+const SOCIAL_PROVIDER_NAMES = { twitter: "X", youtube: "YouTube", instagram: "Instagram" };
 
 const SupportLink = () => (
   <>
@@ -31,6 +34,7 @@ export type AccountStatus = {
   compliance_actions: ComplianceAction[];
   needs_id_upload: boolean;
   gumroad_status: string | null;
+  social_connections_for_review: { provider: "twitter" | "youtube" | "instagram"; connected: boolean }[] | null;
   stripe_rejected: boolean;
   stripe_rejected_balance_status: "stripe_hold" | "auto_payout" | "too_small" | "held" | null;
   stripe_rejected_formatted_balance: string | null;
@@ -168,6 +172,45 @@ export default function AccountStatusSection({
         <Alert role="status" variant="warning">
           {accountStatus.gumroad_status}
           <SupportLink />
+        </Alert>
+      ) : null}
+      {accountStatus.social_connections_for_review ? (
+        <Alert role="status" variant="info">
+          <div className="flex flex-col gap-3">
+            <h3 className="font-bold">Add social connections (optional)</h3>
+            <p>
+              You can share your social account history as additional context for your account review. Your review can
+              continue without connecting. This does not replace identity verification or guarantee approval or a payout
+              date.
+            </p>
+            <div className="flex flex-wrap items-center gap-2">
+              {accountStatus.social_connections_for_review.map(({ provider, connected }) =>
+                connected ? (
+                  <span key={provider}>{SOCIAL_PROVIDER_NAMES[provider]} connected</span>
+                ) : (
+                  <SocialAuthButton
+                    key={provider}
+                    provider={provider}
+                    href={
+                      provider === "twitter"
+                        ? Routes.user_twitter_omniauth_authorize_path({
+                            state: "link_twitter_account",
+                            x_auth_access_type: "read",
+                          })
+                        : provider === "youtube"
+                          ? Routes.user_youtube_omniauth_authorize_path()
+                          : Routes.user_instagram_omniauth_authorize_path()
+                    }
+                  >
+                    Connect to {SOCIAL_PROVIDER_NAMES[provider]}
+                  </SocialAuthButton>
+                ),
+              )}
+            </div>
+            <p className="text-sm">
+              Connecting opens your profile afterward. You can return to Payments in Settings at any time.
+            </p>
+          </div>
         </Alert>
       ) : null}
     </section>

--- a/app/javascript/pages/Settings/Payments/Show.test.tsx
+++ b/app/javascript/pages/Settings/Payments/Show.test.tsx
@@ -160,6 +160,7 @@ const pageProps = (userOverrides: Partial<User> = {}, complianceOverrides: Parti
     compliance_actions: [],
     needs_id_upload: false,
     gumroad_status: null,
+    social_connections_for_review: null,
     stripe_rejected: false,
     stripe_rejected_balance_status: null,
     stripe_rejected_formatted_balance: null,

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -567,11 +567,21 @@ class SettingsPresenter
         compliance_actions:,
         needs_id_upload:,
         gumroad_status:,
+        social_connections_for_review: (social_connections_for_review if is_under_review && !is_suspended),
         stripe_rejected:,
         stripe_rejected_balance_status:,
         stripe_rejected_formatted_balance:,
         stripe_rejected_payout_date:,
       }
+    end
+
+    def social_connections_for_review
+      return unless Pundit.policy!(pundit_user, [:settings, :profile]).manage_social_connections?
+
+      connections = [{ provider: "twitter", connected: seller.twitter_user_id.present? }]
+      connections << { provider: "youtube", connected: seller.youtube_identity.present? } if Feature.active?(:youtube_connect, seller)
+      connections << { provider: "instagram", connected: seller.instagram_identity.present? } if Feature.active?(:instagram_connect, seller)
+      connections
     end
 
     def user_details(user_compliance_info)

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -729,6 +729,7 @@ describe SettingsPresenter do
           compliance_actions: [],
           needs_id_upload: false,
           gumroad_status: nil,
+          social_connections_for_review: nil,
           stripe_rejected: false,
           stripe_rejected_balance_status: nil,
           stripe_rejected_formatted_balance: nil,
@@ -1370,6 +1371,7 @@ describe SettingsPresenter do
                                                                          compliance_actions: [{ message: "Complete pending verification requirements via Stripe", href: "/settings/payments/remediation" }],
                                                                          needs_id_upload: true,
                                                                          gumroad_status: "Your account is under review and payouts are on hold until it's resolved.",
+                                                                         social_connections_for_review: [{ provider: "twitter", connected: false }],
                                                                        ),
                                                                      }))
       end
@@ -1404,6 +1406,7 @@ describe SettingsPresenter do
                                                                          compliance_actions: [{ message: "Complete pending verification requirements via Stripe", href: "/settings/payments/remediation" }],
                                                                          needs_id_upload: true,
                                                                          gumroad_status: "Your account is under review and payouts are on hold until it's resolved.",
+                                                                         social_connections_for_review: [{ provider: "twitter", connected: false }],
                                                                        ),
                                                                      }))
       end

--- a/spec/presenters/settings_social_review_spec.rb
+++ b/spec/presenters/settings_social_review_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe SettingsPresenter, "optional social connections for account review" do
+  let(:seller) { create(:named_seller) }
+  let(:user) { seller }
+  let(:presenter) { described_class.new(pundit_user: SellerContext.new(user:, seller:)) }
+
+  def connections
+    presenter.payments_props[:account_status][:social_connections_for_review]
+  end
+
+  before do
+    create(:user_compliance_info, user: seller, country: "United States")
+    Feature.deactivate(:youtube_connect)
+    Feature.deactivate(:instagram_connect)
+  end
+
+  %w[on_probation flagged_for_fraud flagged_for_tos_violation].each do |state|
+    it "offers optional X connection for an owner in #{state}" do
+      seller.update!(user_risk_state: state)
+      expect(connections).to eq([{ provider: "twitter", connected: false }])
+    end
+  end
+
+  %w[not_reviewed compliant suspended_for_fraud suspended_for_tos_violation].each do |state|
+    it "does not offer social connections for #{state}, even with an internal payout pause" do
+      seller.update!(user_risk_state: state, payouts_paused_internally: true)
+      expect(connections).to be_nil
+    end
+  end
+
+  it "does not mistake unrelated Stripe, system, admin or seller pauses for a risk review" do
+    seller.update!(user_risk_state: "compliant")
+    %w[stripe system admin user].each do |source|
+      seller.update!(payouts_paused_internally: source != "user", payouts_paused_by_user: source == "user", payouts_paused_by: source)
+      expect(connections).to be_nil
+    end
+  end
+
+  context "with a team admin" do
+    let(:user) { create(:user) }
+
+    it "keeps payment settings accessible without offering owner-only connections" do
+      create(:team_membership, user:, seller:, role: TeamMembership::ROLE_ADMIN)
+      seller.update!(user_risk_state: "on_probation")
+      expect(Pundit.policy!(SellerContext.new(user:, seller:), [:settings, :payments, seller]).show?).to be true
+      expect(connections).to be_nil
+    end
+  end
+
+  it "uses the current X identity, not a manually entered handle or historical verification" do
+    seller.update!(user_risk_state: "on_probation", twitter_handle: "example_creator")
+    create(:social_connect_verification, user: seller, platform: "twitter", uid: "123")
+    expect(connections).to eq([{ provider: "twitter", connected: false }])
+    seller.update!(twitter_user_id: "123")
+    expect(connections).to eq([{ provider: "twitter", connected: true }])
+    seller.update!(twitter_user_id: nil)
+    expect(connections).to eq([{ provider: "twitter", connected: false }])
+  end
+
+  it "offers only seller-enabled providers and reads current identity associations" do
+    seller.update!(user_risk_state: "on_probation")
+    Feature.activate_user(:youtube_connect, seller)
+    Feature.activate_user(:instagram_connect, seller)
+    expect(connections).to eq([
+                                { provider: "twitter", connected: false },
+                                { provider: "youtube", connected: false },
+                                { provider: "instagram", connected: false },
+                              ])
+    seller.create_youtube_identity!(channel_id: "example_channel", handle: "example_creator")
+    seller.create_instagram_identity!(instagram_user_id: "123", handle: "example_creator")
+    expect(connections.last(2)).to eq([
+                                        { provider: "youtube", connected: true },
+                                        { provider: "instagram", connected: true },
+                                      ])
+    seller.youtube_identity.destroy!
+    seller.instagram_identity.destroy!
+    seller.reload
+    expect(connections.last(2).map { _1[:connected] }).to eq([false, false])
+  end
+
+  it "does not borrow provider availability from another seller" do
+    seller.update!(user_risk_state: "on_probation")
+    other = create(:user)
+    Feature.activate_user(:youtube_connect, other)
+    Feature.activate_user(:instagram_connect, other)
+    expect(connections).to eq([{ provider: "twitter", connected: false }])
+  end
+end

--- a/spec/requests/settings/social_review_spec.rb
+++ b/spec/requests/settings/social_review_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Optional social connections during account review", type: :system, js: true do
+  let(:seller) { create(:named_seller, user_risk_state: "on_probation", twitter_handle: "example_creator") }
+
+  before do
+    create(:user_compliance_info, user: seller, country: "United States")
+    Feature.deactivate(:youtube_connect)
+    Feature.deactivate(:instagram_connect)
+    login_as seller
+  end
+
+  it "offers X despite an unverified handle and leaves normal review available" do
+    visit settings_payments_path
+
+    expect(page).to have_text("Add social connections (optional)")
+    expect(page).to have_button("Connect to X")
+    expect(page).not_to have_button("Connect to YouTube")
+    expect(page).not_to have_button("Connect to Instagram")
+    expect(page).to have_text("Your review can continue without connecting.")
+    within_section "Account status", section_element: :section do
+      expect(page).to have_link("contact support", href: help_center_root_path)
+    end
+    expect(seller.reload.user_risk_state).to eq("on_probation")
+    expect(seller.twitter_user_id).to be_nil
+  end
+
+  it "reflects current connections and removes the prompt when review ends" do
+    seller.update!(twitter_user_id: "123")
+    visit settings_payments_path
+    expect(page).to have_text("X connected")
+    expect(page).not_to have_button("Connect to X")
+
+    seller.update!(twitter_user_id: nil)
+    visit settings_payments_path
+    expect(page).to have_button("Connect to X")
+
+    seller.mark_compliant!(author_name: "test")
+    visit settings_payments_path
+    expect(page).not_to have_text("Add social connections (optional)")
+  end
+end

--- a/spec/requests/settings/social_review_spec.rb
+++ b/spec/requests/settings/social_review_spec.rb
@@ -19,7 +19,7 @@ describe "Optional social connections during account review", type: :system, js:
     expect(page).to have_button("Connect to X")
     expect(page).not_to have_button("Connect to YouTube")
     expect(page).not_to have_button("Connect to Instagram")
-    expect(page).to have_text("Your review can continue without connecting.")
+    expect(page).to have_text("does not replace identity verification or guarantee approval or a payout date")
     within_section "Account status", section_element: :section do
       expect(page).to have_link("contact support", href: help_center_root_path)
     end


### PR DESCRIPTION
## What

Offer optional social connections in Settings → Payments alongside the existing account-review notice. Owners can connect X and seller-enabled YouTube/Instagram using the existing Profile OAuth forms, or continue the normal review without connecting. Current identities determine connected state, not typed handles or historical verification rows.

## Why

The existing review surface (`on_probation? || flagged?`) explains the payout hold but offers no way to add social context. This change reuses that predicate and `Settings::ProfilePolicy#manage_social_connections?`; suspended/compliant/not-reviewed sellers, team admins and unrelated payout pauses get no prompt. It does not change scoring, holds, payout behavior, OAuth callbacks/scopes, credentials, schema or rollout flags.

Independent of #7536: that PR handles getting-started; this one touches only the existing Payments account-status surface. The callback still returns to Profile, explicitly disclosed beside the controls. Automatic return to Payments and provider rollout remain separate decisions; this PR does not claim to complete the broader onboarding journey.

## Before/After

Before: account-review and verification notices only. After: the same notices plus optional connection controls and current connected states. Copy makes no promise of approval, faster review or a payout date.

Hosted preview: https://feat-optional-social-hold-2371.apps.staging.gumroad.org/settings/payments (served `ce287915258a`). Use the standard preview seeded seller login.

Before is the same hosted page with only the new social prop set to null in the browser response, reproducing main’s absent prompt; after is the unmodified server response. No mocked HTML. Desktop/mobile light/dark captures show the complete changed section and unchanged support path. The viewport intentionally shows only the top of the longer Payments form. Videos compare the before and after UI; they do not claim real-provider consent completion.

### Desktop light

![Before](https://github.com/user-attachments/assets/ec0b3e48-367a-43eb-abc4-0a8380d6e213)

![After](https://github.com/user-attachments/assets/bfd5bcc8-9eff-4ae9-8574-6fb3702a2e0e)

### Desktop dark

![Before](https://github.com/user-attachments/assets/324424cd-11e5-473f-808f-b6d15d0e63e8)

![After](https://github.com/user-attachments/assets/7049849b-622f-4798-abd6-450eb2f23e8f)

### Mobile light

![Before](https://github.com/user-attachments/assets/538a4f93-9ddd-4b68-9986-79a05c7d139d)

![After](https://github.com/user-attachments/assets/c7ac2698-ff56-427a-ba5d-a24b5a8296b0)

### Mobile dark

![Before](https://github.com/user-attachments/assets/fbecbbe0-8f35-4ebe-8bb4-e8747c5f04d5)

![After](https://github.com/user-attachments/assets/8fd5d793-3c8f-46ea-9d5d-0c36574d1d30)


## Test Results

- `bundle exec rspec spec/presenters/settings_social_review_spec.rb`: 12 examples, 0 failures. Covers review states, unrelated holds, owner policy, current versus stale identities and seller-scoped provider flags.
- `npx vitest run app/javascript/components/Settings/PaymentsPage/AccountStatusSection.test.tsx app/javascript/pages/Settings/Payments/Show.test.tsx`: 13 passed after installing the lockfile dependencies. Final component-only rerun: 4 passed.
- Ruby lint (4 changed files), JS lint and `npm run typecheck` pass. `git diff --check` passes.
- Local Astra autoreview: clean. Pushed-head Astra+Fable panel clean. Separate final code/spec/comment audit complete; hosted images and extracted video frames inspected.
- `bin/test-confidence`: all 8 selected files passed to its 99% target. Restored direct run of the new presenter tests, existing account-status requests and new browser flows: 21 examples, 0 failures.
- Four guard mutants failed on intended assertions: review targeting (3), owner policy (1), stale X handle (1), provider gate (5); each ran all 12 examples. Original source restored byte-for-byte and verified green.

## QA steps

1. On the hosted preview, sign in as an account owner whose existing account status is under review; open Settings → Payments. Confirm optional wording, the unchanged review/support/verification paths, X, and only seller-enabled additional providers.
2. A typed X handle without `twitter_user_id` must still offer Connect. Current identities show connected; disconnecting makes the offer return on the next Payments visit.
3. Check a team admin and compliant, suspended, not-reviewed, Stripe-paused and seller-paused controls: none gets the prompt unless the owner is in the existing active review population.
4. Check OAuth form targets/CSRF, cancellation and successful connection return behavior. Existing callbacks return to Profile, not Payments. No provider access or rollout changes are included.

Premerge review: clean @ ce287915258ad4e0be750a9dcd48a31ef604a6ca

## Status

Ready for Gianfranco’s review; `working` removed and `awaiting-human` assigned for payout-expectation UI. All 12 uploaded assets verified byte-for-byte through rendered bodyHTML. Current-head CI and Buildkite 22608 pass; hosted prompt QA passed. No actual third-party consent/cancellation was performed in this slice; existing routes, CSRF submission, provider gates and callback destination are covered by tests. Payout-expectation UI: no auto-merge.

---
AI assistance: GPT-6 Astra via OpenRouter. Instructions: add the smallest independent optional social prompt on the existing account-review hold surface, reuse Profile flows/policy/current identities/provider gates, exclude unrelated populations, preserve ordinary review and all money/risk behavior, prove targeting, and leave the onboarding and historical-shadow sibling PRs unchanged.

https://github.com/user-attachments/assets/e1c7eb7f-7d34-4226-ad30-67b0234d41d5

https://github.com/user-attachments/assets/b5bd08c3-24a3-47f2-8526-c5949fdde301

https://github.com/user-attachments/assets/90810a61-49f1-4ba6-ae00-70825106cf64

https://github.com/user-attachments/assets/91eb1a33-bc31-4e79-99ee-2836f34ea1fd