### PR TITLE
Require current linked identities for positive shadow scoring

### DIFF
--- a/app/controllers/api/internal/admin/users_controller.rb
+++ b/app/controllers/api/internal/admin/users_controller.rb
@@ -1013,7 +1013,7 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         platform: verification.platform,
         uid: verification.uid,
         handle: verification.handle,
-        currently_linked: currently_linked?(verification),
+        currently_linked: verification.currently_linked?,
         account_created_at: verification.account_created_at&.iso8601,
         follower_count: verification.follower_count,
         post_count: verification.post_count,
@@ -1021,23 +1021,6 @@ class Api::Internal::Admin::UsersController < Api::Internal::Admin::BaseControll
         last_verified_at: verification.last_verified_at.iso8601,
         shared_identity_user_count: verification.shared_identity_user_ids.size,
       }
-    end
-
-    # Unlinking clears the user's twitter columns but keeps the verification row as evidence,
-    # so the row alone cannot tell a reviewer whether the connection is still live.
-    def currently_linked?(verification)
-      case verification.platform
-      when "twitter"
-        verification.user.twitter_user_id.present? && verification.user.twitter_user_id.to_s == verification.uid.to_s
-      when "youtube"
-        channel_id = verification.user.youtube_identity&.channel_id
-        channel_id.present? && channel_id.to_s == verification.uid.to_s
-      when "instagram"
-        instagram_user_id = verification.user.instagram_identity&.instagram_user_id
-        instagram_user_id.present? && instagram_user_id.to_s == verification.uid.to_s
-      else
-        false
-      end
     end
 
     def build_admin_note(user, content)

--- a/app/models/social_connect_verification.rb
+++ b/app/models/social_connect_verification.rb
@@ -10,6 +10,23 @@ class SocialConnectVerification < ApplicationRecord
   validates :last_verified_at, presence: true
   validates :platform, uniqueness: { scope: :user_id }
 
+  # Unlinking clears the user's twitter columns but keeps the verification row as evidence,
+  # so the row alone cannot tell a reviewer whether the connection is still live.
+  def currently_linked?
+    case platform
+    when "twitter"
+      user.twitter_user_id.present? && user.twitter_user_id.to_s == uid.to_s
+    when "youtube"
+      channel_id = user.youtube_identity&.channel_id
+      channel_id.present? && channel_id.to_s == uid.to_s
+    when "instagram"
+      instagram_user_id = user.instagram_identity&.instagram_user_id
+      instagram_user_id.present? && instagram_user_id.to_s == uid.to_s
+    else
+      false
+    end
+  end
+
   # Other Gumroad accounts vouched for by the same social identity — the
   # dedupe signal risk reviewers check (same precedent as bank/card fingerprints).
   def shared_identity_user_ids

--- a/app/services/social_score_shadow_evaluation_service.rb
+++ b/app/services/social_score_shadow_evaluation_service.rb
@@ -25,18 +25,20 @@ class SocialScoreShadowEvaluationService
   def evaluate
     return nil unless held?
 
-    best = scored_verifications.max_by do |scored|
+    shared_identity_counts = user.social_connect_verifications.to_h { |verification| [verification.id, verification.shared_identity_user_ids.size] }
+    scored = scored_verifications(shared_identity_counts)
+    best = scored.max_by do |scored|
       [scored[:meets_threshold] ? 1 : 0, scored[:score].fdiv(scored[:release_threshold])]
     end
     score = best&.dig(:score) || 0
     # Historical identities remain abuse evidence even when disconnected or stale.
-    shared_identity = user.social_connect_verifications.any? { |verification| verification.shared_identity_user_ids.any? }
+    shared_identity = shared_identity_counts.values.any?(&:positive?)
 
     {
       hold_source:,
       unpaid_balance_cents:,
       score:,
-      would_have_released: scored_verifications.any? { _1[:meets_threshold] } && !shared_identity,
+      would_have_released: scored.any? { _1[:meets_threshold] } && !shared_identity,
       signals: best,
     }
   end
@@ -72,12 +74,12 @@ class SocialScoreShadowEvaluationService
       @_unpaid_balance_cents ||= user.unpaid_balance_cents
     end
 
-    def scored_verifications
+    def scored_verifications(shared_identity_counts)
       user.social_connect_verifications.filter_map do |verification|
         next unless verification.currently_linked?
         next if verification.last_verified_at.nil? || verification.last_verified_at < MAX_VERIFICATION_AGE.ago
 
-        shared_identity_user_count = verification.shared_identity_user_ids.size
+        shared_identity_user_count = shared_identity_counts.fetch(verification.id)
         components = score_components(verification)
 
         score = components.values.sum

--- a/app/services/social_score_shadow_evaluation_service.rb
+++ b/app/services/social_score_shadow_evaluation_service.rb
@@ -29,9 +29,8 @@ class SocialScoreShadowEvaluationService
       [scored[:meets_threshold] ? 1 : 0, scored[:score].fdiv(scored[:release_threshold])]
     end
     score = best&.dig(:score) || 0
-    # ANY shared identity vetoes, not just the best-scoring verification's —
-    # a fraudster's weakest linked account is still a link.
-    shared_identity = scored_verifications.any? { |scored| scored[:shared_identity_user_count].positive? }
+    # Historical identities remain abuse evidence even when disconnected or stale.
+    shared_identity = user.social_connect_verifications.any? { |verification| verification.shared_identity_user_ids.any? }
 
     {
       hold_source:,
@@ -75,6 +74,7 @@ class SocialScoreShadowEvaluationService
 
     def scored_verifications
       user.social_connect_verifications.filter_map do |verification|
+        next unless verification.currently_linked?
         next if verification.last_verified_at.nil? || verification.last_verified_at < MAX_VERIFICATION_AGE.ago
 
         shared_identity_user_count = verification.shared_identity_user_ids.size

--- a/spec/controllers/connections_controller_spec.rb
+++ b/spec/controllers/connections_controller_spec.rb
@@ -36,6 +36,9 @@ describe ConnectionsController do
 
     it "keeps the social connect verification row while clearing the live twitter identity" do
       verification = create(:social_connect_verification, user: seller, platform: "twitter", uid: "123", handle: "gumroad")
+      seller.update!(user_risk_state: "flagged_for_fraud")
+      allow(seller).to receive(:unpaid_balance_cents).and_return(5000)
+      expect(SocialScoreShadowEvaluationService.new(seller).evaluate).to include(score: 85, would_have_released: true)
 
       post :unlink_twitter
 
@@ -43,6 +46,7 @@ describe ConnectionsController do
       expect(seller.reload.twitter_user_id).to be_nil
       expect(SocialConnectVerification.exists?(id: verification.id)).to be(true)
       expect(verification.reload.uid).to eq("123")
+      expect(SocialScoreShadowEvaluationService.new(seller).evaluate).to include(score: 0, would_have_released: false)
     end
 
     it "responds with an error message if the unlink fails" do

--- a/spec/models/social_connect_verification_spec.rb
+++ b/spec/models/social_connect_verification_spec.rb
@@ -3,6 +3,52 @@
 require "spec_helper"
 
 describe SocialConnectVerification do
+  describe "#currently_linked?" do
+    %w[twitter youtube instagram].each do |platform|
+      it "requires the matching current #{platform} UID" do
+        user = create(:user)
+        verification = create(:social_connect_verification, user:, platform:, uid: "123")
+        expect(verification.currently_linked?).to be(false)
+
+        case platform
+        when "twitter"
+          user.update!(twitter_user_id: "123")
+        when "youtube"
+          create(:user_youtube_identity, user:, channel_id: "123")
+        when "instagram"
+          create(:user_instagram_identity, user:, instagram_user_id: "123")
+        end
+        verification.reload
+        expect(verification.currently_linked?).to be(true)
+
+        verification.uid = "456"
+        expect(verification.currently_linked?).to be(false)
+        verification.uid = nil
+        expect(verification.currently_linked?).to be(false)
+        verification.uid = "123"
+
+        case platform
+        when "twitter"
+          verification.user.update!(twitter_user_id: "")
+        when "youtube"
+          verification.user.youtube_identity.update_columns(channel_id: "")
+        when "instagram"
+          verification.user.instagram_identity.update_columns(instagram_user_id: "")
+        end
+        expect(verification.currently_linked?).to be(false)
+        verification.uid = ""
+        expect(verification.currently_linked?).to be(false)
+      end
+    end
+
+    it "does not consider an unsupported platform linked" do
+      verification = create(:social_connect_verification, platform: "tiktok")
+      verification.user.update!(twitter_user_id: verification.uid)
+
+      expect(verification.currently_linked?).to be(false)
+    end
+  end
+
   describe "validations" do
     it "requires a supported platform" do
       verification = build(:social_connect_verification, platform: "myspace")

--- a/spec/services/social_score_shadow_evaluation_service_spec.rb
+++ b/spec/services/social_score_shadow_evaluation_service_spec.rb
@@ -153,6 +153,16 @@ describe SocialScoreShadowEvaluationService do
       expect(result[:unpaid_balance_cents]).to eq(50_00)
     end
 
+    it "reads each historical identity once per evaluation" do
+      strong_verification
+      create(:social_connect_verification, user:, platform: "youtube")
+      user.social_connect_verifications.reload.each do |verification|
+        expect(verification).to receive(:shared_identity_user_ids).once.and_call_original
+      end
+
+      expect(described_class.new(user).evaluate).to include(score: 85, would_have_released: true)
+    end
+
     it "marks would_have_released for a strong verification above the threshold" do
       strong_verification
 

--- a/spec/services/social_score_shadow_evaluation_service_spec.rb
+++ b/spec/services/social_score_shadow_evaluation_service_spec.rb
@@ -6,8 +6,7 @@ describe SocialScoreShadowEvaluationService do
   let(:user) { create(:user, user_risk_state: "flagged_for_fraud") }
 
   def strong_verification(owner = user)
-    create(
-      :social_connect_verification,
+    linked_verification(
       user: owner,
       account_created_at: 5.years.ago,
       follower_count: 5_000,
@@ -17,24 +16,96 @@ describe SocialScoreShadowEvaluationService do
     )
   end
 
+  def linked_verification(**attributes)
+    verification = create(:social_connect_verification, **attributes)
+    case verification.platform
+    when "twitter"
+      verification.user.update!(twitter_user_id: verification.uid)
+    when "youtube"
+      create(:user_youtube_identity, user: verification.user, channel_id: verification.uid)
+    when "instagram"
+      create(:user_instagram_identity, user: verification.user, instagram_user_id: verification.uid)
+    end
+    verification
+  end
+
   before do
     allow(user).to receive(:unpaid_balance_cents).and_return(50_00)
   end
 
   describe "#evaluate" do
+    %w[twitter youtube instagram].each do |platform|
+      it "scores a currently linked #{platform} identity" do
+        linked_verification(user:, platform:, account_created_at: platform == "instagram" ? nil : 5.years.ago)
+
+        result = described_class.new(user).evaluate
+
+        expect(result[:score]).to eq(platform == "instagram" ? 55 : 85)
+        expect(result[:would_have_released]).to be(true)
+      end
+
+      it "ignores a mismatched #{platform} verification UID" do
+        verification = linked_verification(user:, platform:)
+        verification.update!(uid: "old-identity")
+
+        expect(described_class.new(user).evaluate).to include(score: 0, would_have_released: false, signals: nil)
+      end
+
+      it "ignores a #{platform} verification without a live identity" do
+        create(:social_connect_verification, user:, platform:)
+
+        expect(described_class.new(user).evaluate).to include(score: 0, would_have_released: false, signals: nil)
+      end
+    end
+
+    it "ignores a retained strong Twitter verification after disconnect" do
+      strong_verification
+      user.update!(twitter_user_id: nil)
+
+      expect(described_class.new(user).evaluate).to include(score: 0, would_have_released: false, signals: nil)
+      expect(user.social_connect_verifications.count).to eq(1)
+    end
+
+    it "ignores unsupported platforms even with strong verified signals" do
+      create(:social_connect_verification, user:, platform: "tiktok")
+
+      expect(described_class.new(user).evaluate).to include(score: 0, would_have_released: false, signals: nil)
+    end
+
+    [1.day, 1.year, nil].each do |verification_age|
+      it "retains a disconnected non-best shared identity veto with verification age #{verification_age.inspect}" do
+        strong_verification
+        historical = create(:social_connect_verification, user:, platform: "youtube")
+        historical.update_columns(last_verified_at: verification_age&.ago)
+        create(:social_connect_verification, platform: "youtube", uid: historical.uid)
+
+        expect(described_class.new(user).evaluate).to include(score: 85, would_have_released: false)
+      end
+    end
+
+    it "returns nil for a deleted seller despite strong currently linked signals" do
+      strong_verification
+      user.update_columns(deleted_at: Time.current)
+
+      expect(described_class.new(user).evaluate).to be_nil
+    end
+
     it "returns nil when the user has no held payout" do
+      strong_verification
       user.update!(user_risk_state: "compliant")
 
       expect(described_class.new(user).evaluate).to be_nil
     end
 
     it "returns nil when the held balance is zero" do
+      strong_verification
       allow(user).to receive(:unpaid_balance_cents).and_return(0)
 
       expect(described_class.new(user).evaluate).to be_nil
     end
 
     it "returns nil for suspended users even when payouts are also paused internally" do
+      strong_verification
       # Suspended states are already outside REVIEWABLE_RISK_STATES; the pause is what would
       # otherwise classify this account as held, so it is what proves the suspended guard bites.
       user.update_columns(user_risk_state: "suspended_for_fraud")
@@ -104,8 +175,7 @@ describe SocialScoreShadowEvaluationService do
 
     it "does not release when a weaker, non-best verification carries the shared identity" do
       strong_verification
-      weak = create(
-        :social_connect_verification,
+      weak = linked_verification(
         user:,
         platform: "youtube",
         account_created_at: 1.month.ago,
@@ -123,8 +193,7 @@ describe SocialScoreShadowEvaluationService do
     end
 
     it "does not release on a young account even with a large following" do
-      create(
-        :social_connect_verification,
+      linked_verification(
         user:,
         account_created_at: 3.months.ago,
         follower_count: 100_000,
@@ -139,8 +208,7 @@ describe SocialScoreShadowEvaluationService do
     end
 
     it "prefers a threshold-passing Instagram score over a higher raw score that misses its own threshold" do
-      create(
-        :social_connect_verification,
+      linked_verification(
         user:,
         platform: "twitter",
         account_created_at: 3.months.ago,
@@ -148,8 +216,7 @@ describe SocialScoreShadowEvaluationService do
         post_count: 5_000,
         last_posted_at: 1.day.ago,
       )
-      create(
-        :social_connect_verification,
+      linked_verification(
         user:,
         platform: "instagram",
         account_created_at: nil,
@@ -166,8 +233,7 @@ describe SocialScoreShadowEvaluationService do
     end
 
     it "uses all available Instagram signals instead of requiring an unavailable account age" do
-      create(
-        :social_connect_verification,
+      linked_verification(
         user:,
         platform: "instagram",
         account_created_at: nil,
@@ -184,8 +250,7 @@ describe SocialScoreShadowEvaluationService do
     end
 
     it "does not release an Instagram account without every available signal" do
-      create(
-        :social_connect_verification,
+      linked_verification(
         user:,
         platform: "instagram",
         account_created_at: nil,

--- a/spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb
+++ b/spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb
@@ -26,8 +26,9 @@ describe RecordSocialScoreShadowEvaluationsJob do
       held = create(:user, user_risk_state: "flagged_for_fraud")
       # Deliberately weak signals (young account, no audience) so the recorded verdict is a
       # would-not-release row — the factory default is strong enough to release.
-      create(:social_connect_verification, user: held, account_created_at: 2.months.ago,
-                                           follower_count: 3, post_count: 5, last_posted_at: nil)
+      verification = create(:social_connect_verification, user: held, account_created_at: 2.months.ago,
+                                                          follower_count: 3, post_count: 5, last_posted_at: nil)
+      held.update!(twitter_user_id: verification.uid)
       create(:balance, user: held, merchant_account: create(:merchant_account, user: held), amount_cents: 100_00)
 
       unheld = create(:user, user_risk_state: "compliant")

--- a/spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb
+++ b/spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb
@@ -55,8 +55,9 @@ describe RecordSocialScoreShadowEvaluationsJob do
 
     it "never mutates payout or risk state" do
       held = create(:user, user_risk_state: "flagged_for_fraud")
-      create(:social_connect_verification, user: held, account_created_at: 5.years.ago,
-                                           follower_count: 5_000, post_count: 1_000, last_posted_at: 1.week.ago)
+      verification = create(:social_connect_verification, user: held, account_created_at: 5.years.ago,
+                                                          follower_count: 5_000, post_count: 1_000, last_posted_at: 1.week.ago)
+      held.update!(twitter_user_id: verification.uid)
       create(:balance, user: held, merchant_account: create(:merchant_account, user: held), amount_cents: 100_00)
 
       described_class.new.perform(Date.current.to_s)


### PR DESCRIPTION
## What
Require a matching current X, YouTube, or Instagram identity before its verification contributes positive shadow scoring. Keep historical shared identities able to veto, including disconnected/stale non-best records. No release path, payout/hold changes, thresholds, flags, schema, credentials, or permissions.

Ref antiwork/gumroad-private#2371

## Why
Disconnect retains verification evidence. The scorer previously checked verification age only. The admin API's existing current-UID predicate now lives on `SocialConnectVerification` and is reused unchanged. PR #7534 adds historical readout; this does not duplicate that work or alter #7534/#7536/#7539.

## Before/After
Real base/branch service calls on identical persisted test fixtures (score / would-have-released):

| Fixture | Base | Branch |
| --- | --- | --- |
| Linked X / YouTube | 85 / true | 85 / true |
| Linked Instagram | 55 / true | 55 / true |
| Disconnected X, mismatched YouTube, unsupported platform | 85 / true | 0 / false |
| Strong linked X + stale disconnected shared YouTube | 85 / true | 85 / false |
| Strong linked X + fresh disconnected/weak linked shared YouTube | 85 / false | 85 / false |
| No hold, zero balance, suspended, deleted | nil | nil |

Seller, balance, and verification attributes unchanged across every probe. Backend-only; no rendered UI changed, and no manufactured screenshots.

## Test Results
- Base service regression: 31 examples, 10 intended assertion failures (disconnected X: 85 / true). The actual disconnect-controller regression also fails when the current-link guard is removed.
- Restored current-head model/service/disconnect/job/full admin-controller files plus the real value probe: **482 examples, 0 failures**.
- `bin/test-confidence --strict`: 99% milestone, all five selected files passed; no skipped failures. Separately, full user/risk files plus query probe: 539 examples, 0 failures. The earlier two profile-URL failures were caused by the lane domain override; unsetting only `CUSTOM_DOMAIN` preserves isolated database/Redis and makes both full files pass.
- Six current-head mutations killed: current-link guard (9 failures), historical veto narrowed to scored records (3), each provider UID equality (1 each), unsupported platform (1). Source restored byte-for-byte, then the 482-example suite passed.
- Greptile's repeated-query finding fixed: one linked identity's verification SELECTs fall from 4 to 2, measured through Rails SQL instrumentation. Each historical identity is read once per evaluation; the new regression fails before the fix. No cross-evaluation caching.
- Whole Ruby lint and `git diff --check` pass.
- [x] Local Astra autoreview and regression/value evidence.
- [x] Current-head mutation/restoration and focused checks.
- [x] Current-head Astra+Fable panel: no findings. Separate final code/spec/comments/evidence audit: clean.
- [x] Current-head full CI: `run-all-specs`, Fast/Slow/Minitest/lint and Buildkite #22614 green; 81 successful checks/statuses, 17 intentional skips, none pending or failing.
- [ ] Gianfranco human review: confirm positive eligibility and historical-veto separation. No auto-merge; no merge or production deployment performed.

Premerge review: clean @ 3d324e09da366402e8d2ecac4af64a549c26c78a

QA: run `bundle exec rspec spec/models/social_connect_verification_spec.rb spec/services/social_score_shadow_evaluation_service_spec.rb spec/controllers/connections_controller_spec.rb spec/sidekiq/record_social_score_shadow_evaluations_job_spec.rb` in an isolated test environment. Verify positive controls, mismatched/disconnected rejection, historical vetoes and unchanged state.

---
Built with OpenAI GPT-6 Astra. Instructions: implement only current-link shadow-scoring eligibility; preserve historical abuse vetoes; prove base-red/fixed-green and mutation restoration; do not change money movement or release behavior; obtain human review.
