### PR TITLE
Move social connections to a dedicated Settings page and return onboarding to Getting started

### DIFF
--- a/app/controllers/concerns/social_connect_return.rb
+++ b/app/controllers/concerns/social_connect_return.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module SocialConnectReturn
+  extend ActiveSupport::Concern
+
+  RETURN_LIFETIME = 15.minutes
+
+  private
+    def prepare_social_connect_return
+      previous = session.delete(:social_connect_return)
+      return unless params[:social_connect_origin] == "onboarding"
+      return unless logged_in_user == current_seller && policy([:settings, :profile]).manage_social_connections?
+
+      if previous.is_a?(Hash) && previous["user_id"] == logged_in_user.id &&
+          previous["created_at"].is_a?(Integer) && (Time.current.to_i - previous["created_at"]).between?(0, RETURN_LIFETIME.to_i)
+        session[:social_connect_return] = previous
+        return previous["token"]
+      end
+
+      token = SecureRandom.hex(32)
+      session[:social_connect_return] = { "token" => token, "user_id" => logged_in_user.id, "created_at" => Time.current.to_i }
+      token
+    end
+
+    def consume_social_connect_return
+      context = session.delete(:social_connect_return)
+      token = request.env.dig("omniauth.params", "social_connect_return")
+      return false unless context.is_a?(Hash) && token.is_a?(String)
+      return false unless logged_in_user && logged_in_user == current_seller && context["user_id"] == logged_in_user.id
+      return false unless policy([:settings, :profile]).manage_social_connections?
+      return false unless context["created_at"].is_a?(Integer) && (Time.current.to_i - context["created_at"]).between?(0, RETURN_LIFETIME.to_i)
+
+      ActiveSupport::SecurityUtils.secure_compare(context["token"].to_s, token)
+    end
+end

--- a/app/controllers/concerns/social_connect_return.rb
+++ b/app/controllers/concerns/social_connect_return.rb
@@ -9,7 +9,7 @@ module SocialConnectReturn
     def prepare_social_connect_return
       previous = session.delete(:social_connect_return)
       return unless params[:social_connect_origin] == "onboarding"
-      return unless logged_in_user == current_seller && policy([:settings, :profile]).manage_social_connections?
+      return unless logged_in_user == current_seller && policy([:settings, :social_connections]).show?
 
       if previous.is_a?(Hash) && previous["user_id"] == logged_in_user.id &&
           previous["created_at"].is_a?(Integer) && (Time.current.to_i - previous["created_at"]).between?(0, RETURN_LIFETIME.to_i)
@@ -27,7 +27,7 @@ module SocialConnectReturn
       token = request.env.dig("omniauth.params", "social_connect_return")
       return false unless context.is_a?(Hash) && token.is_a?(String)
       return false unless logged_in_user && logged_in_user == current_seller && context["user_id"] == logged_in_user.id
-      return false unless policy([:settings, :profile]).manage_social_connections?
+      return false unless policy([:settings, :social_connections]).show?
       return false unless context["created_at"].is_a?(Integer) && (Time.current.to_i - context["created_at"]).between?(0, RETURN_LIFETIME.to_i)
 
       ActiveSupport::SecurityUtils.secure_compare(context["token"].to_s, token)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -9,6 +9,7 @@ class DashboardController < Sellers::BaseController
 
   def index
     authorize :dashboard
+    session.delete(:social_connect_return)
 
     if current_seller.suspended_for_tos_violation?
       redirect_to products_url

--- a/app/controllers/settings/profile_controller.rb
+++ b/app/controllers/settings/profile_controller.rb
@@ -6,15 +6,13 @@ class Settings::ProfileController < Settings::BaseController
   STALE_PROFILE_MESSAGE = "Your profile was changed somewhere else. Please reload the page and try again."
   private_constant :STALE_PROFILE_MESSAGE
 
-  include SocialConnectReturn
-
   before_action :authorize
 
   def show
     set_meta_tag(title: "Profile settings")
     profile_presenter = ProfilePresenter.new(pundit_user:, seller: current_seller)
 
-    render inertia: "Settings/Profile/Show", props: profile_presenter.profile_settings_props(request:).merge(social_connect_return: prepare_social_connect_return)
+    render inertia: "Settings/Profile/Show", props: profile_presenter.profile_settings_props(request:)
   end
 
   def update

--- a/app/controllers/settings/profile_controller.rb
+++ b/app/controllers/settings/profile_controller.rb
@@ -6,13 +6,15 @@ class Settings::ProfileController < Settings::BaseController
   STALE_PROFILE_MESSAGE = "Your profile was changed somewhere else. Please reload the page and try again."
   private_constant :STALE_PROFILE_MESSAGE
 
+  include SocialConnectReturn
+
   before_action :authorize
 
   def show
     set_meta_tag(title: "Profile settings")
     profile_presenter = ProfilePresenter.new(pundit_user:, seller: current_seller)
 
-    render inertia: "Settings/Profile/Show", props: profile_presenter.profile_settings_props(request:)
+    render inertia: "Settings/Profile/Show", props: profile_presenter.profile_settings_props(request:).merge(social_connect_return: prepare_social_connect_return)
   end
 
   def update

--- a/app/controllers/settings/social_connections_controller.rb
+++ b/app/controllers/settings/social_connections_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Settings::SocialConnectionsController < Settings::BaseController
+  include SocialConnectReturn
+
+  before_action :authorize
+
+  def show
+    set_meta_tag(title: "Social connections")
+    render inertia: "Settings/SocialConnections/Show",
+           props: settings_presenter.social_connections_props.merge(social_connect_return: prepare_social_connect_return)
+  end
+
+  private
+    def authorize
+      super([:settings, :social_connections])
+    end
+end

--- a/app/controllers/user/omniauth_callbacks_controller.rb
+++ b/app/controllers/user/omniauth_callbacks_controller.rb
@@ -211,7 +211,7 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       flash[:alert] = "Couldn't connect #{provider_name}. Please try again."
       redirect_to(logged_in_user.present? ? social_connect_destination : login_path)
     elsif connect_provider == "twitter" && request.env.dig("omniauth.params", REQ_PARAM_STATE) == "link_twitter_account" && logged_in_user.present?
-      flash[:alert] = @return_to_onboarding ? "Couldn't connect X. You can continue without connecting." : "Couldn't connect X. Please try again."
+      flash[:alert] = "Couldn't connect X. Please try again."
       redirect_to social_connect_destination
     elsif params[:error_description].present?
       redirect_to settings_payments_path, notice: params[:error_description]

--- a/app/controllers/user/omniauth_callbacks_controller.rb
+++ b/app/controllers/user/omniauth_callbacks_controller.rb
@@ -237,7 +237,7 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
 
     def social_connect_destination
-      @return_to_onboarding ? dashboard_path : profile_path
+      @return_to_onboarding ? dashboard_path : settings_social_connections_path
     end
 
     def hide_layouts

--- a/app/controllers/user/omniauth_callbacks_controller.rb
+++ b/app/controllers/user/omniauth_callbacks_controller.rb
@@ -210,8 +210,8 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       provider_name = connect_provider == "youtube" ? "YouTube" : "Instagram"
       flash[:alert] = "Couldn't connect #{provider_name}. Please try again."
       redirect_to(logged_in_user.present? ? social_connect_destination : login_path)
-    elsif connect_provider == "twitter" && request.env.dig("omniauth.params", REQ_PARAM_STATE) == "link_twitter_account" && @return_to_onboarding
-      flash[:alert] = "Couldn't connect X. You can continue without connecting."
+    elsif connect_provider == "twitter" && request.env.dig("omniauth.params", REQ_PARAM_STATE) == "link_twitter_account" && logged_in_user.present?
+      flash[:alert] = @return_to_onboarding ? "Couldn't connect X. You can continue without connecting." : "Couldn't connect X. Please try again."
       redirect_to social_connect_destination
     elsif params[:error_description].present?
       redirect_to settings_payments_path, notice: params[:error_description]

--- a/app/controllers/user/omniauth_callbacks_controller.rb
+++ b/app/controllers/user/omniauth_callbacks_controller.rb
@@ -2,6 +2,9 @@
 
 class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   include PageMeta::Base
+  include SocialConnectReturn
+
+  before_action :set_social_connect_destination
 
   skip_before_action :verify_authenticity_token, only: [:apple]
 
@@ -134,7 +137,7 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     unless Feature.active?(:youtube_connect, logged_in_user)
       flash[:alert] = "YouTube connect is not available."
-      return redirect_to profile_path
+      return redirect_to social_connect_destination
     end
 
     begin
@@ -147,7 +150,7 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if channel.blank?
       flash[:alert] = "Couldn't read a YouTube channel for that Google account."
-      return redirect_to profile_path
+      return redirect_to social_connect_destination
     end
 
     begin
@@ -157,10 +160,10 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     rescue StandardError => e
       Rails.logger.error("SocialConnectVerification youtube record failed for user #{logged_in_user.id}: #{e.class}")
       flash[:alert] = "Couldn't save your YouTube connection. Please try again."
-      return redirect_to profile_path
+      return redirect_to social_connect_destination
     end
 
-    redirect_to profile_path
+    redirect_to social_connect_destination
   end
 
   def instagram
@@ -171,7 +174,7 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     unless Feature.active?(:instagram_connect, logged_in_user)
       flash[:alert] = "Instagram connect is not available."
-      return redirect_to profile_path
+      return redirect_to social_connect_destination
     end
 
     token = request.env.dig("omniauth.auth", "credentials", "token")
@@ -179,21 +182,21 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     profile = InstagramProfileFetcher.new(token).fetch
     if profile.blank?
       flash[:alert] = "Couldn't read an Instagram professional account."
-      return redirect_to profile_path
+      return redirect_to social_connect_destination
     end
 
     verification = SocialConnectVerification.record_from_instagram!(logged_in_user, profile.merge("token_user_id" => token_user_id))
     if verification.blank?
       flash[:alert] = "Couldn't save your Instagram connection. Please try again."
-      return redirect_to profile_path
+      return redirect_to social_connect_destination
     end
     identity = logged_in_user.instagram_identity || logged_in_user.build_instagram_identity
     identity.update!(instagram_user_id: verification.uid, handle: verification.handle)
-    redirect_to profile_path
+    redirect_to social_connect_destination
   rescue StandardError => e
     Rails.logger.error("Instagram connect failed for user #{logged_in_user.id}: #{e.class}")
     flash[:alert] = "Couldn't save your Instagram connection. Please try again."
-    redirect_to profile_path
+    redirect_to social_connect_destination
   end
 
   def apple
@@ -206,7 +209,10 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if %w[youtube instagram].include?(connect_provider)
       provider_name = connect_provider == "youtube" ? "YouTube" : "Instagram"
       flash[:alert] = "Couldn't connect #{provider_name}. Please try again."
-      redirect_to(logged_in_user.present? ? profile_path : login_path)
+      redirect_to(logged_in_user.present? ? social_connect_destination : login_path)
+    elsif connect_provider == "twitter" && request.env.dig("omniauth.params", REQ_PARAM_STATE) == "link_twitter_account" && @return_to_onboarding
+      flash[:alert] = "Couldn't connect X. You can continue without connecting."
+      redirect_to social_connect_destination
     elsif params[:error_description].present?
       redirect_to settings_payments_path, notice: params[:error_description]
     elsif params[REQ_PARAM_STATE] != :async_link_twitter_account.to_s
@@ -222,6 +228,18 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   private
+    def set_social_connect_destination
+      provider = action_name == "failure" ? request.env["omniauth.error.strategy"]&.name.to_s : action_name
+      connecting = %w[youtube instagram].include?(provider) ||
+        (provider == "twitter" && request.env.dig("omniauth.params", REQ_PARAM_STATE) == "link_twitter_account")
+      @return_to_onboarding = connecting && consume_social_connect_return
+      session.delete(:social_connect_return) unless connecting || action_name == "failure"
+    end
+
+    def social_connect_destination
+      @return_to_onboarding ? dashboard_path : profile_path
+    end
+
     def hide_layouts
       @hide_layouts = true
     end
@@ -276,6 +294,6 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     def post_link_account
       logged_in_user.save
-      redirect_to profile_path
+      redirect_to social_connect_destination
     end
 end

--- a/app/javascript/components/Button.test.tsx
+++ b/app/javascript/components/Button.test.tsx
@@ -9,7 +9,7 @@ afterEach(cleanup);
 
 describe("Button brand colors", () => {
   // The YouTube connect and disconnect buttons sit directly beside the X buttons in
-  // Settings > Profile > Social links, so both rows have to read as the same control. Comparing
+  // Settings > Social connections, so both rows have to read as the same control. Comparing
   // against the X button, instead of only asserting bg-black, is what catches a switch back to a
   // provider brand fill such as Google's blue.
   it("fills the YouTube button like the X button", () => {

--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -594,7 +594,9 @@ export const DashboardPage = ({
                       ))}
                     </ul>
                     <div>
-                      <NavigationButton href={Routes.profile_path({ social_connect_origin: "onboarding" })}>
+                      <NavigationButton
+                        href={Routes.settings_social_connections_path({ social_connect_origin: "onboarding" })}
+                      >
                         Manage social connections
                       </NavigationButton>
                     </div>

--- a/app/javascript/components/DashboardPage.tsx
+++ b/app/javascript/components/DashboardPage.tsx
@@ -594,7 +594,9 @@ export const DashboardPage = ({
                       ))}
                     </ul>
                     <div>
-                      <NavigationButton href={Routes.profile_path()}>Manage social connections</NavigationButton>
+                      <NavigationButton href={Routes.profile_path({ social_connect_origin: "onboarding" })}>
+                        Manage social connections
+                      </NavigationButton>
                     </div>
                   </CardContent>
                 </Card>

--- a/app/javascript/components/Settings/Layout.tsx
+++ b/app/javascript/components/Settings/Layout.tsx
@@ -16,6 +16,7 @@ const PAGE_TITLES = {
   billing: "Billing",
   authorized_applications: "Applications",
   password: "Password and authentication",
+  social_connections: "Social connections",
   third_party_analytics: "Third-party analytics",
   advanced: "Advanced",
 };

--- a/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.test.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -25,10 +25,7 @@ beforeEach(() => {
   Object.assign(globalThis, {
     Routes: {
       help_center_root_path: () => "/help",
-      user_twitter_omniauth_authorize_path: (params: Record<string, string>) =>
-        `/users/auth/twitter?${new URLSearchParams(params).toString()}`,
-      user_youtube_omniauth_authorize_path: () => "/users/auth/youtube",
-      user_instagram_omniauth_authorize_path: () => "/users/auth/instagram",
+      settings_social_connections_path: () => "/settings/social_connections",
     },
   });
 });
@@ -55,21 +52,16 @@ describe("optional review connections", () => {
     expect(screen.queryByRole("button", { name: "Connect to Instagram" })).toBeNull();
   });
 
-  it("submits the existing read-only X connection form rather than the payout settings form", () => {
-    const submit = vi.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(() => undefined);
+  it("links to the Social connections settings page instead of starting OAuth on Payments", () => {
     render(<AccountStatusSection accountStatus={status} payoutsPausedBy={null} />);
-    fireEvent.click(screen.getByRole("button", { name: "Connect to X" }));
-    expect(submit).toHaveBeenCalledTimes(1);
-    const form = document.querySelector("form");
-    if (!form) throw new Error("Missing OAuth form");
-    expect(form.method).toBe("post");
-    expect(form.getAttribute("action")).toBe("/users/auth/twitter?state=link_twitter_account&x_auth_access_type=read");
-    expect(form.querySelector<HTMLInputElement>("input[name=authenticity_token]")?.value).toBe("test-csrf");
-    expect(screen.getByText(/Connecting opens your profile afterward/u)).toBeTruthy();
+    expect(screen.getByText("X available to connect")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Manage social connections" }).getAttribute("href")).toBe(
+      "/settings/social_connections",
+    );
+    expect(screen.queryByRole("button", { name: "Connect to X" })).toBeNull();
   });
 
-  it("shows linked accounts and offers enabled unlinked providers using existing routes", () => {
-    const submit = vi.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(() => undefined);
+  it("shows linked accounts and points remaining providers at Settings", () => {
     render(
       <AccountStatusSection
         accountStatus={{
@@ -84,15 +76,12 @@ describe("optional review connections", () => {
       />,
     );
     expect(screen.getByText("X connected")).toBeTruthy();
+    expect(screen.getByText("YouTube available to connect")).toBeTruthy();
+    expect(screen.getByText("Instagram available to connect")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Connect to X" })).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Connect to YouTube" }));
-    const youtubeForm = submit.mock.instances[0];
-    if (!(youtubeForm instanceof HTMLFormElement)) throw new Error("Missing YouTube form");
-    expect(youtubeForm.getAttribute("action")).toBe("/users/auth/youtube");
-    fireEvent.click(screen.getByRole("button", { name: "Connect to Instagram" }));
-    const instagramForm = submit.mock.instances[1];
-    if (!(instagramForm instanceof HTMLFormElement)) throw new Error("Missing Instagram form");
-    expect(instagramForm.getAttribute("action")).toBe("/users/auth/instagram");
+    expect(screen.getByRole("link", { name: "Manage social connections" }).getAttribute("href")).toBe(
+      "/settings/social_connections",
+    );
   });
 
   it("hides the review notice and social prompt while the system payout pause alert is showing", () => {
@@ -102,7 +91,7 @@ describe("optional review connections", () => {
     expect(screen.queryByText("Add social connections (optional)")).toBeNull();
   });
 
-  it("does not render a prompt or social forms when the server excludes the seller", () => {
+  it("does not render a prompt when the server excludes the seller", () => {
     render(
       <AccountStatusSection
         accountStatus={{ ...status, social_connections_for_review: null }}
@@ -110,7 +99,7 @@ describe("optional review connections", () => {
       />,
     );
     expect(screen.queryByText("Add social connections (optional)")).toBeNull();
-    expect(document.querySelector("form")).toBeNull();
+    expect(screen.queryByRole("link", { name: "Manage social connections" })).toBeNull();
     expect(screen.getByRole("link", { name: "Complete verification" })).toBeTruthy();
   });
 });

--- a/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 
-import { SocialAuthButton } from "$app/components/SocialAuthButton";
 import { Alert } from "$app/components/ui/Alert";
 
 const SOCIAL_PROVIDER_NAMES = { twitter: "X", youtube: "YouTube", instagram: "Instagram" };
@@ -190,27 +189,14 @@ export default function AccountStatusSection({
                 connected ? (
                   <span key={provider}>{SOCIAL_PROVIDER_NAMES[provider]} connected</span>
                 ) : (
-                  <SocialAuthButton
-                    key={provider}
-                    provider={provider}
-                    href={
-                      provider === "twitter"
-                        ? Routes.user_twitter_omniauth_authorize_path({
-                            state: "link_twitter_account",
-                            x_auth_access_type: "read",
-                          })
-                        : provider === "youtube"
-                          ? Routes.user_youtube_omniauth_authorize_path()
-                          : Routes.user_instagram_omniauth_authorize_path()
-                    }
-                  >
-                    Connect to {SOCIAL_PROVIDER_NAMES[provider]}
-                  </SocialAuthButton>
+                  <span key={provider}>{SOCIAL_PROVIDER_NAMES[provider]} available to connect</span>
                 ),
               )}
             </div>
-            <p className="text-sm">
-              Connecting opens your profile afterward. You can return to Payments in Settings at any time.
+            <p>
+              <a href={Routes.settings_social_connections_path()} className="underline">
+                Manage social connections
+              </a>
             </p>
           </div>
         </Alert>

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -69,6 +69,7 @@ const FONT_DESCRIPTIONS: Record<string, string> = {
 };
 
 type ProfilePageProps = {
+  social_connect_return?: string | null;
   profile_settings: ProfileSettingsForm;
   editable_profile: ProfileEditorProps;
   profile_version: string;
@@ -89,6 +90,7 @@ type ProfilePageProps = {
 export default function SettingsPage() {
   const {
     creator_profile,
+    social_connect_return,
     profile_settings,
     editable_profile,
     profile_version,
@@ -522,6 +524,7 @@ export default function SettingsPage() {
               {loggedInUser?.policies.settings_profile.manage_social_connections ? (
                 <Fieldset>
                   <FieldsetTitle>Social links</FieldsetTitle>
+                  {social_connect_return ? <p>After connecting, you’ll return to Getting started.</p> : null}
                   {twitter_connected ? (
                     <Button type="button" color="twitter" onClick={handleUnlinkTwitter}>
                       <TwitterX pack="brands" className="size-5" />
@@ -538,6 +541,7 @@ export default function SettingsPage() {
                       <SocialAuthButton
                         provider="twitter"
                         href={Routes.user_twitter_omniauth_authorize_path({
+                          social_connect_return,
                           state: "link_twitter_account",
                           x_auth_access_type: "read",
                         })}
@@ -553,7 +557,10 @@ export default function SettingsPage() {
                       Disconnect {youtube_handle ? `${youtube_handle} from YouTube` : "YouTube"}
                     </Button>
                   ) : youtube_connect_enabled ? (
-                    <SocialAuthButton provider="youtube" href={Routes.user_youtube_omniauth_authorize_path()}>
+                    <SocialAuthButton
+                      provider="youtube"
+                      href={Routes.user_youtube_omniauth_authorize_path({ social_connect_return })}
+                    >
                       <Youtube pack="brands" className="size-5" />
                       Connect to YouTube
                     </SocialAuthButton>
@@ -564,10 +571,18 @@ export default function SettingsPage() {
                       Disconnect {instagram_handle ? `${instagram_handle} from Instagram` : "Instagram"}
                     </Button>
                   ) : instagram_connect_enabled ? (
-                    <SocialAuthButton provider="instagram" href={Routes.user_instagram_omniauth_authorize_path()}>
+                    <SocialAuthButton
+                      provider="instagram"
+                      href={Routes.user_instagram_omniauth_authorize_path({ social_connect_return })}
+                    >
                       <Instagram pack="brands" className="size-5" />
                       Connect to Instagram
                     </SocialAuthButton>
+                  ) : null}
+                  {social_connect_return ? (
+                    <Link href={Routes.dashboard_path()} className="underline">
+                      Continue without connecting
+                    </Link>
                   ) : null}
                 </Fieldset>
               ) : null}

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -1,15 +1,10 @@
-import { FontFamily, Instagram, TwitterX, Youtube } from "@boxicons/react";
+import { FontFamily } from "@boxicons/react";
 import { Link, router, usePage } from "@inertiajs/react";
 import { isEqual } from "lodash-es";
 import * as React from "react";
 import typia from "typia";
 
-import {
-  updateProfileSettings as saveProfileSettings,
-  unlinkInstagram,
-  unlinkTwitter,
-  unlinkYoutube,
-} from "$app/data/profile_settings";
+import { updateProfileSettings as saveProfileSettings } from "$app/data/profile_settings";
 import {
   ProfileSettingsForm,
   changedProfileSettings,
@@ -18,7 +13,6 @@ import {
 } from "$app/pages/Settings/Profile/profileSettingsForm";
 import { CreatorProfile } from "$app/parsers/profile";
 import { classNames } from "$app/utils/classNames";
-import { asyncVoid } from "$app/utils/promise";
 import { assertResponseError } from "$app/utils/request";
 
 import { Button, NavigationButton } from "$app/components/Button";
@@ -36,7 +30,6 @@ import { showAlert } from "$app/components/server-components/Alert";
 import { ToggleSettingRow } from "$app/components/SettingRow";
 import { postToMobileApp } from "$app/components/Settings/Layout";
 import { ShareButtons } from "$app/components/ShareButtons";
-import { SocialAuthButton } from "$app/components/SocialAuthButton";
 import { AgentSupportFallbackNote } from "$app/components/Support/AgentSupportFallbackNote";
 import { Alert } from "$app/components/ui/Alert";
 import { ColorPicker } from "$app/components/ui/ColorPicker";
@@ -69,18 +62,10 @@ const FONT_DESCRIPTIONS: Record<string, string> = {
 };
 
 type ProfilePageProps = {
-  social_connect_return?: string | null;
   profile_settings: ProfileSettingsForm;
   editable_profile: ProfileEditorProps;
   profile_version: string;
   custom_html_pages_enabled: boolean;
-  twitter_connected: boolean;
-  youtube_connect_enabled: boolean;
-  youtube_connected: boolean;
-  youtube_handle: string | null;
-  instagram_connect_enabled: boolean;
-  instagram_connected: boolean;
-  instagram_handle: string | null;
   has_custom_landing_page: boolean;
   seller_fonts_css_source: string;
   username: string;
@@ -90,18 +75,10 @@ type ProfilePageProps = {
 export default function SettingsPage() {
   const {
     creator_profile,
-    social_connect_return,
     profile_settings,
     editable_profile,
     profile_version,
     custom_html_pages_enabled,
-    twitter_connected,
-    youtube_connect_enabled,
-    youtube_connected,
-    youtube_handle,
-    instagram_connect_enabled,
-    instagram_connected,
-    instagram_handle,
     has_custom_landing_page,
     seller_fonts_css_source,
     username,
@@ -275,36 +252,6 @@ export default function SettingsPage() {
   // Pin the chosen background too: #ffffff is a saved theme value, not an instruction to inherit
   // the dashboard's colour scheme. The preview must match the buyer-facing stylesheet.
   const profileColors = profileThemeColors(profileSettings.background_color, profileSettings.highlight_color);
-
-  const handleUnlinkTwitter = asyncVoid(async () => {
-    try {
-      await unlinkTwitter();
-      router.reload();
-    } catch (e) {
-      assertResponseError(e);
-      showAlert(e.message, "error");
-    }
-  });
-
-  const handleUnlinkYoutube = asyncVoid(async () => {
-    try {
-      await unlinkYoutube();
-      router.reload();
-    } catch (e) {
-      assertResponseError(e);
-      showAlert(e.message, "error");
-    }
-  });
-
-  const handleUnlinkInstagram = asyncVoid(async () => {
-    try {
-      await unlinkInstagram();
-      router.reload();
-    } catch (e) {
-      assertResponseError(e);
-      showAlert(e.message, "error");
-    }
-  });
 
   const customLandingPageActive = custom_html_pages_enabled && has_custom_landing_page;
   const showPagesTab = !customLandingPageActive;
@@ -521,71 +468,6 @@ export default function SettingsPage() {
                   from Pages.
                 </FieldsetDescription>
               </Fieldset>
-              {loggedInUser?.policies.settings_profile.manage_social_connections ? (
-                <Fieldset>
-                  <FieldsetTitle>Social links</FieldsetTitle>
-                  {social_connect_return ? <p>After connecting, you’ll return to Getting started.</p> : null}
-                  {twitter_connected ? (
-                    <Button type="button" color="twitter" onClick={handleUnlinkTwitter}>
-                      <TwitterX pack="brands" className="size-5" />
-                      Disconnect {creatorProfile.twitter_handle ? `${creatorProfile.twitter_handle} from X` : "X"}
-                    </Button>
-                  ) : (
-                    <>
-                      {creatorProfile.twitter_handle ? (
-                        <Button type="button" color="twitter" onClick={handleUnlinkTwitter}>
-                          <TwitterX pack="brands" className="size-5" />
-                          Disconnect {creatorProfile.twitter_handle} from X
-                        </Button>
-                      ) : null}
-                      <SocialAuthButton
-                        provider="twitter"
-                        href={Routes.user_twitter_omniauth_authorize_path({
-                          social_connect_return,
-                          state: "link_twitter_account",
-                          x_auth_access_type: "read",
-                        })}
-                      >
-                        <TwitterX pack="brands" className="size-5" />
-                        Connect to X
-                      </SocialAuthButton>
-                    </>
-                  )}
-                  {youtube_connected ? (
-                    <Button type="button" color="youtube" onClick={handleUnlinkYoutube}>
-                      <Youtube pack="brands" className="size-5" />
-                      Disconnect {youtube_handle ? `${youtube_handle} from YouTube` : "YouTube"}
-                    </Button>
-                  ) : youtube_connect_enabled ? (
-                    <SocialAuthButton
-                      provider="youtube"
-                      href={Routes.user_youtube_omniauth_authorize_path({ social_connect_return })}
-                    >
-                      <Youtube pack="brands" className="size-5" />
-                      Connect to YouTube
-                    </SocialAuthButton>
-                  ) : null}
-                  {instagram_connected ? (
-                    <Button type="button" color="instagram" onClick={handleUnlinkInstagram}>
-                      <Instagram pack="brands" className="size-5" />
-                      Disconnect {instagram_handle ? `${instagram_handle} from Instagram` : "Instagram"}
-                    </Button>
-                  ) : instagram_connect_enabled ? (
-                    <SocialAuthButton
-                      provider="instagram"
-                      href={Routes.user_instagram_omniauth_authorize_path({ social_connect_return })}
-                    >
-                      <Instagram pack="brands" className="size-5" />
-                      Connect to Instagram
-                    </SocialAuthButton>
-                  ) : null}
-                  {social_connect_return ? (
-                    <Link href={Routes.dashboard_path()} className="underline">
-                      Continue without connecting
-                    </Link>
-                  ) : null}
-                </Fieldset>
-              ) : null}
             </section>
           ) : tab === "design" ? (
             <section className="grid gap-8 p-4! md:p-8!">

--- a/app/javascript/pages/Settings/SocialConnections/Show.tsx
+++ b/app/javascript/pages/Settings/SocialConnections/Show.tsx
@@ -1,0 +1,157 @@
+import { Instagram, TwitterX, Youtube } from "@boxicons/react";
+import { Link, router, usePage } from "@inertiajs/react";
+import * as React from "react";
+import typia from "typia";
+
+import { unlinkInstagram, unlinkTwitter, unlinkYoutube } from "$app/data/profile_settings";
+import { SettingPage } from "$app/parsers/settings";
+import { asyncVoid } from "$app/utils/promise";
+import { assertResponseError } from "$app/utils/request";
+
+import { Button } from "$app/components/Button";
+import { showAlert } from "$app/components/server-components/Alert";
+import { Layout as SettingsLayout } from "$app/components/Settings/Layout";
+import { SocialAuthButton } from "$app/components/SocialAuthButton";
+import { Fieldset, FieldsetDescription } from "$app/components/ui/Fieldset";
+import { FormSection } from "$app/components/ui/FormSection";
+
+type SocialConnectionsPageProps = {
+  settings_pages: SettingPage[];
+  social_connect_return?: string | null;
+  twitter_connected: boolean;
+  twitter_handle: string | null;
+  youtube_connect_enabled: boolean;
+  youtube_connected: boolean;
+  youtube_handle: string | null;
+  instagram_connect_enabled: boolean;
+  instagram_connected: boolean;
+  instagram_handle: string | null;
+};
+
+const disconnectLabel = (handle: string | null, provider: string) => {
+  const name = handle?.replace(/^@/u, "");
+  return name ? `Disconnect @${name} from ${provider}` : `Disconnect ${provider}`;
+};
+
+export default function SocialConnectionsPage() {
+  const {
+    settings_pages,
+    social_connect_return,
+    twitter_connected,
+    twitter_handle,
+    youtube_connect_enabled,
+    youtube_connected,
+    youtube_handle,
+    instagram_connect_enabled,
+    instagram_connected,
+    instagram_handle,
+  } = typia.assert<SocialConnectionsPageProps>(usePage().props);
+
+  const handleUnlinkTwitter = asyncVoid(async () => {
+    try {
+      await unlinkTwitter();
+      router.reload();
+    } catch (e) {
+      assertResponseError(e);
+      showAlert(e.message, "error");
+    }
+  });
+
+  const handleUnlinkYoutube = asyncVoid(async () => {
+    try {
+      await unlinkYoutube();
+      router.reload();
+    } catch (e) {
+      assertResponseError(e);
+      showAlert(e.message, "error");
+    }
+  });
+
+  const handleUnlinkInstagram = asyncVoid(async () => {
+    try {
+      await unlinkInstagram();
+      router.reload();
+    } catch (e) {
+      assertResponseError(e);
+      showAlert(e.message, "error");
+    }
+  });
+
+  return (
+    <SettingsLayout currentPage="social_connections" pages={settings_pages}>
+      <FormSection
+        header={
+          <>
+            <h2>Social connections</h2>
+            <FieldsetDescription>
+              Connecting is optional and helps verify your account. It never posts for you.
+            </FieldsetDescription>
+          </>
+        }
+      >
+        {social_connect_return ? <p>After connecting, you’ll return to Getting started.</p> : null}
+        <Fieldset>
+          {twitter_connected ? (
+            <Button type="button" color="twitter" onClick={handleUnlinkTwitter}>
+              <TwitterX pack="brands" className="size-5" />
+              {disconnectLabel(twitter_handle, "X")}
+            </Button>
+          ) : (
+            <SocialAuthButton
+              provider="twitter"
+              href={Routes.user_twitter_omniauth_authorize_path({
+                social_connect_return,
+                state: "link_twitter_account",
+                x_auth_access_type: "read",
+              })}
+            >
+              <TwitterX pack="brands" className="size-5" />
+              Connect to X
+            </SocialAuthButton>
+          )}
+        </Fieldset>
+        {youtube_connected ? (
+          <Fieldset>
+            <Button type="button" color="youtube" onClick={handleUnlinkYoutube}>
+              <Youtube pack="brands" className="size-5" />
+              {disconnectLabel(youtube_handle, "YouTube")}
+            </Button>
+          </Fieldset>
+        ) : youtube_connect_enabled ? (
+          <Fieldset>
+            <SocialAuthButton
+              provider="youtube"
+              href={Routes.user_youtube_omniauth_authorize_path({ social_connect_return })}
+            >
+              <Youtube pack="brands" className="size-5" />
+              Connect to YouTube
+            </SocialAuthButton>
+          </Fieldset>
+        ) : null}
+        {instagram_connected ? (
+          <Fieldset>
+            <Button type="button" color="instagram" onClick={handleUnlinkInstagram}>
+              <Instagram pack="brands" className="size-5" />
+              {disconnectLabel(instagram_handle, "Instagram")}
+            </Button>
+          </Fieldset>
+        ) : instagram_connect_enabled ? (
+          <Fieldset>
+            <SocialAuthButton
+              provider="instagram"
+              href={Routes.user_instagram_omniauth_authorize_path({ social_connect_return })}
+            >
+              <Instagram pack="brands" className="size-5" />
+              Connect to Instagram
+            </SocialAuthButton>
+          </Fieldset>
+        ) : null}
+        {social_connect_return ? (
+          <Link href={Routes.dashboard_path()} className="underline">
+            Continue without connecting
+          </Link>
+        ) : null}
+      </FormSection>
+    </SettingsLayout>
+  );
+}

--- a/app/javascript/pages/Settings/SocialConnections/Show.tsx
+++ b/app/javascript/pages/Settings/SocialConnections/Show.tsx
@@ -1,5 +1,5 @@
-import { Instagram, TwitterX, Youtube } from "@boxicons/react";
-import { Link, router, usePage } from "@inertiajs/react";
+import { CheckCircle, Instagram, TwitterX, Youtube } from "@boxicons/react";
+import { router, usePage } from "@inertiajs/react";
 import * as React from "react";
 import typia from "typia";
 
@@ -8,12 +8,13 @@ import { SettingPage } from "$app/parsers/settings";
 import { asyncVoid } from "$app/utils/promise";
 import { assertResponseError } from "$app/utils/request";
 
-import { Button } from "$app/components/Button";
+import { BrandName, Button } from "$app/components/Button";
 import { showAlert } from "$app/components/server-components/Alert";
 import { Layout as SettingsLayout } from "$app/components/Settings/Layout";
 import { SocialAuthButton } from "$app/components/SocialAuthButton";
-import { Fieldset, FieldsetDescription } from "$app/components/ui/Fieldset";
+import { FieldsetDescription } from "$app/components/ui/Fieldset";
 import { FormSection } from "$app/components/ui/FormSection";
+import { Row, RowActions, RowContent, Rows } from "$app/components/ui/Rows";
 
 type SocialConnectionsPageProps = {
   settings_pages: SettingPage[];
@@ -28,9 +29,21 @@ type SocialConnectionsPageProps = {
   instagram_handle: string | null;
 };
 
-const disconnectLabel = (handle: string | null, provider: string) => {
+type Provider = {
+  key: BrandName;
+  name: string;
+  Icon: typeof TwitterX;
+  connected: boolean;
+  handle: string | null;
+  // X only: a hand-typed handle that predates OAuth. Still public, so it stays removable.
+  legacyHandle?: string | null;
+  connectHref: string;
+  disconnect: () => void;
+};
+
+const formatHandle = (handle: string | null) => {
   const name = handle?.replace(/^@/u, "");
-  return name ? `Disconnect @${name} from ${provider}` : `Disconnect ${provider}`;
+  return name ? `@${name}` : null;
 };
 
 export default function SocialConnectionsPage() {
@@ -47,35 +60,59 @@ export default function SocialConnectionsPage() {
     instagram_handle,
   } = typia.assert<SocialConnectionsPageProps>(usePage().props);
 
-  const handleUnlinkTwitter = asyncVoid(async () => {
-    try {
-      await unlinkTwitter();
-      router.reload();
-    } catch (e) {
-      assertResponseError(e);
-      showAlert(e.message, "error");
-    }
-  });
+  const disconnect = (unlink: () => Promise<unknown>) =>
+    asyncVoid(async () => {
+      try {
+        await unlink();
+        router.reload();
+      } catch (e) {
+        assertResponseError(e);
+        showAlert(e.message, "error");
+      }
+    });
 
-  const handleUnlinkYoutube = asyncVoid(async () => {
-    try {
-      await unlinkYoutube();
-      router.reload();
-    } catch (e) {
-      assertResponseError(e);
-      showAlert(e.message, "error");
-    }
-  });
-
-  const handleUnlinkInstagram = asyncVoid(async () => {
-    try {
-      await unlinkInstagram();
-      router.reload();
-    } catch (e) {
-      assertResponseError(e);
-      showAlert(e.message, "error");
-    }
-  });
+  const providers: Provider[] = [
+    {
+      key: "twitter",
+      name: "X",
+      Icon: TwitterX,
+      connected: twitter_connected,
+      handle: twitter_connected ? twitter_handle : null,
+      legacyHandle: twitter_connected ? null : twitter_handle,
+      connectHref: Routes.user_twitter_omniauth_authorize_path({
+        social_connect_return,
+        state: "link_twitter_account",
+        x_auth_access_type: "read",
+      }),
+      disconnect: disconnect(unlinkTwitter),
+    },
+    ...(youtube_connect_enabled || youtube_connected
+      ? [
+          {
+            key: "youtube" as const,
+            name: "YouTube",
+            Icon: Youtube,
+            connected: youtube_connected,
+            handle: youtube_handle,
+            connectHref: Routes.user_youtube_omniauth_authorize_path({ social_connect_return }),
+            disconnect: disconnect(unlinkYoutube),
+          },
+        ]
+      : []),
+    ...(instagram_connect_enabled || instagram_connected
+      ? [
+          {
+            key: "instagram" as const,
+            name: "Instagram",
+            Icon: Instagram,
+            connected: instagram_connected,
+            handle: instagram_handle,
+            connectHref: Routes.user_instagram_omniauth_authorize_path({ social_connect_return }),
+            disconnect: disconnect(unlinkInstagram),
+          },
+        ]
+      : []),
+  ];
 
   return (
     <SettingsLayout currentPage="social_connections" pages={settings_pages}>
@@ -84,73 +121,63 @@ export default function SocialConnectionsPage() {
           <>
             <h2>Social connections</h2>
             <FieldsetDescription>
-              Connecting is optional and helps verify your account. It never posts for you.
+              Connecting a social account is optional. It gives us extra context when we review your account. We only
+              read your public profile, and we never post for you.
             </FieldsetDescription>
           </>
         }
       >
-        {social_connect_return ? <p>After connecting, you’ll return to Getting started.</p> : null}
-        <Fieldset>
-          {twitter_connected ? (
-            <Button type="button" color="twitter" onClick={handleUnlinkTwitter}>
-              <TwitterX pack="brands" className="size-5" />
-              {disconnectLabel(twitter_handle, "X")}
-            </Button>
-          ) : (
-            <SocialAuthButton
-              provider="twitter"
-              href={Routes.user_twitter_omniauth_authorize_path({
-                social_connect_return,
-                state: "link_twitter_account",
-                x_auth_access_type: "read",
-              })}
-            >
-              <TwitterX pack="brands" className="size-5" />
-              Connect to X
-            </SocialAuthButton>
-          )}
-        </Fieldset>
-        {youtube_connected ? (
-          <Fieldset>
-            <Button type="button" color="youtube" onClick={handleUnlinkYoutube}>
-              <Youtube pack="brands" className="size-5" />
-              {disconnectLabel(youtube_handle, "YouTube")}
-            </Button>
-          </Fieldset>
-        ) : youtube_connect_enabled ? (
-          <Fieldset>
-            <SocialAuthButton
-              provider="youtube"
-              href={Routes.user_youtube_omniauth_authorize_path({ social_connect_return })}
-            >
-              <Youtube pack="brands" className="size-5" />
-              Connect to YouTube
-            </SocialAuthButton>
-          </Fieldset>
-        ) : null}
-        {instagram_connected ? (
-          <Fieldset>
-            <Button type="button" color="instagram" onClick={handleUnlinkInstagram}>
-              <Instagram pack="brands" className="size-5" />
-              {disconnectLabel(instagram_handle, "Instagram")}
-            </Button>
-          </Fieldset>
-        ) : instagram_connect_enabled ? (
-          <Fieldset>
-            <SocialAuthButton
-              provider="instagram"
-              href={Routes.user_instagram_omniauth_authorize_path({ social_connect_return })}
-            >
-              <Instagram pack="brands" className="size-5" />
-              Connect to Instagram
-            </SocialAuthButton>
-          </Fieldset>
-        ) : null}
-        {social_connect_return ? (
-          <Link href={Routes.dashboard_path()} className="underline">
-            Continue without connecting
-          </Link>
-        ) : null}
+        <Rows role="list">
+          {providers.map(({ key, name, Icon, connected, handle, legacyHandle, connectHref, disconnect }) => {
+            const displayHandle = formatHandle(handle);
+            const displayLegacyHandle = formatHandle(legacyHandle ?? null);
+            const accountLabel = displayHandle ? `${displayHandle} from ${name}` : name;
+            return (
+              <Row key={key} role="listitem" className="grid-cols-[1fr_auto]">
+                <RowContent className="items-start gap-3">
+                  <Icon pack="brands" className="mt-0.5 size-5 shrink-0" />
+                  <div className="grid gap-1">
+                    <div className="font-bold">{name}</div>
+                    {connected ? (
+                      <FieldsetDescription className="flex items-center gap-1">
+                        {displayHandle ?? "Connected"}
+                        <CheckCircle pack="filled" className="size-4 text-success" aria-label="Connected" />
+                      </FieldsetDescription>
+                    ) : displayLegacyHandle ? (
+                      <FieldsetDescription>
+                        {displayLegacyHandle} was added by hand and is not verified.
+                      </FieldsetDescription>
+                    ) : (
+                      <FieldsetDescription>Not connected</FieldsetDescription>
+                    )}
+                  </div>
+                </RowContent>
+                <RowActions>
+                  {connected ? (
+                    <Button type="button" aria-label={`Disconnect ${accountLabel}`} onClick={disconnect}>
+                      Disconnect
+                    </Button>
+                  ) : (
+                    <>
+                      {displayLegacyHandle ? (
+                        <Button
+                          type="button"
+                          aria-label={`Remove ${displayLegacyHandle} from ${name}`}
+                          onClick={disconnect}
+                        >
+                          Remove
+                        </Button>
+                      ) : null}
+                      <SocialAuthButton provider={key} href={connectHref} aria-label={`Connect to ${name}`}>
+                        Connect
+                      </SocialAuthButton>
+                    </>
+                  )}
+                </RowActions>
+              </Row>
+            );
+          })}
+        </Rows>
       </FormSection>
     </SettingsLayout>
   );

--- a/app/javascript/parsers/settings.ts
+++ b/app/javascript/parsers/settings.ts
@@ -6,5 +6,6 @@ export type SettingPage =
   | "billing"
   | "authorized_applications"
   | "password"
+  | "social_connections"
   | "third_party_analytics"
   | "advanced";

--- a/app/policies/settings/social_connections_policy.rb
+++ b/app/policies/settings/social_connections_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Settings::SocialConnectionsPolicy < ApplicationPolicy
+  def show?
+    user.role_owner_for?(seller)
+  end
+end

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -81,13 +81,6 @@ class ProfilePresenter
         # username feeds the agent prompt. The HTML itself is never sent here - the form never edits
         # it, it only sends "" to reset, so has_custom_landing_page is all the UI needs.
         custom_html_pages_enabled: Feature.active?(:custom_html_pages, seller),
-        twitter_connected: seller.twitter_user_id.present?,
-        youtube_connect_enabled: Feature.active?(:youtube_connect, seller),
-        youtube_connected: seller.youtube_identity.present?,
-        youtube_handle: seller.youtube_identity&.handle,
-        instagram_connect_enabled: Feature.active?(:instagram_connect, seller),
-        instagram_connected: seller.instagram_identity.present?,
-        instagram_handle: seller.instagram_identity&.handle,
         has_custom_landing_page: seller.has_custom_landing_page?,
         username: seller.username,
       }

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -14,6 +14,7 @@ class SettingsPresenter
     billing
     authorized_applications
     password
+    social_connections
     third_party_analytics
     advanced
   ).freeze
@@ -30,7 +31,7 @@ class SettingsPresenter
       case page
       when "main", "payments", "password", "third_party_analytics", "advanced"
         Pundit.policy!(pundit_user, [:settings, page.to_sym, seller]).show?
-      when "billing"
+      when "billing", "social_connections"
         Pundit.policy!(pundit_user, [:settings, page.to_sym]).show?
       when "team"
         Pundit.policy!(pundit_user, [:settings, :team, seller]).show?
@@ -173,6 +174,19 @@ class SettingsPresenter
           code: third_party_analytic.analytics_code,
         }
       end
+    }
+  end
+
+  def social_connections_props
+    {
+      twitter_connected: seller.twitter_user_id.present?,
+      twitter_handle: seller.twitter_handle,
+      youtube_connect_enabled: Feature.active?(:youtube_connect, seller),
+      youtube_connected: seller.youtube_identity.present?,
+      youtube_handle: seller.youtube_identity&.handle,
+      instagram_connect_enabled: Feature.active?(:instagram_connect, seller),
+      instagram_connected: seller.instagram_identity.present?,
+      instagram_handle: seller.instagram_identity&.handle,
     }
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -715,6 +715,7 @@ Rails.application.routes.draw do
         post :resend_confirmation_email
       end
       resource :password, only: %i[show update], controller: "password"
+      resource :social_connections, only: :show, controller: "social_connections"
       resource :totp, only: %i[create destroy], controller: "totp" do
         post :confirm
         post :regenerate_recovery_codes

--- a/lib/omni_auth/strategies/instagram.rb
+++ b/lib/omni_auth/strategies/instagram.rb
@@ -31,18 +31,29 @@ module OmniAuth
       end
 
       def request_phase
-        return redirect(flag_off_redirect) unless instagram_connect_enabled?
+        return unavailable_connection unless instagram_connect_enabled?
 
         super
       end
 
       def callback_phase
-        return redirect(flag_off_redirect) unless instagram_connect_enabled?
+        return unavailable_connection unless instagram_connect_enabled?
 
         super
       end
 
       private
+        def unavailable_connection
+          if session&.dig("omniauth.params", "social_connect_return").present? && on_request_path?
+            env["omniauth.params"] = session.delete("omniauth.params")
+          end
+          if env.dig("omniauth.params", "social_connect_return").present?
+            fail!(:social_connect_unavailable)
+          else
+            redirect(flag_off_redirect)
+          end
+        end
+
         def instagram_connect_enabled?
           Feature.active?(:instagram_connect, instagram_connect_actor)
         end

--- a/lib/omni_auth/strategies/instagram.rb
+++ b/lib/omni_auth/strategies/instagram.rb
@@ -69,7 +69,7 @@ module OmniAuth
         end
 
         def flag_off_redirect
-          instagram_connect_actor.present? ? "/profile" : "/login"
+          instagram_connect_actor.present? ? "/settings/social_connections" : "/login"
         end
     end
   end

--- a/lib/omni_auth/strategies/youtube.rb
+++ b/lib/omni_auth/strategies/youtube.rb
@@ -54,7 +54,7 @@ module OmniAuth
         end
 
         def flag_off_redirect
-          youtube_connect_actor.present? ? "/profile" : "/login"
+          youtube_connect_actor.present? ? "/settings/social_connections" : "/login"
         end
     end
   end

--- a/lib/omni_auth/strategies/youtube.rb
+++ b/lib/omni_auth/strategies/youtube.rb
@@ -14,18 +14,29 @@ module OmniAuth
       option :access_type, "online"
 
       def request_phase
-        return redirect(flag_off_redirect) unless youtube_connect_enabled?
+        return unavailable_connection unless youtube_connect_enabled?
 
         super
       end
 
       def callback_phase
-        return redirect(flag_off_redirect) unless youtube_connect_enabled?
+        return unavailable_connection unless youtube_connect_enabled?
 
         super
       end
 
       private
+        def unavailable_connection
+          if session&.dig("omniauth.params", "social_connect_return").present? && on_request_path?
+            env["omniauth.params"] = session.delete("omniauth.params")
+          end
+          if env.dig("omniauth.params", "social_connect_return").present?
+            fail!(:social_connect_unavailable)
+          else
+            redirect(flag_off_redirect)
+          end
+        end
+
         def youtube_connect_enabled?
           Feature.active?(:youtube_connect, youtube_connect_actor)
         end

--- a/spec/controllers/settings/profile_controller_spec.rb
+++ b/spec/controllers/settings/profile_controller_spec.rb
@@ -16,41 +16,6 @@ describe Settings::ProfileController, :vcr, type: :controller, inertia: true do
   end
 
   describe "GET show" do
-    it "issues a session-bound return token only for the owner entering from onboarding" do
-      sign_in seller
-      get :show, params: { social_connect_origin: "onboarding" }
-      expect(inertia.props[:social_connect_return]).to be_present
-      expect(session[:social_connect_return]).to include("token" => inertia.props[:social_connect_return], "user_id" => seller.id)
-    end
-
-    it "preserves pending intent on an onboarding reload without extending its expiry" do
-      sign_in seller
-      get :show, params: { social_connect_origin: "onboarding" }
-      context = session[:social_connect_return].dup
-      travel 5.minutes do
-        get :show, params: { social_connect_origin: "onboarding" }
-      end
-      expect(session[:social_connect_return]).to eq(context)
-      expect(inertia.props[:social_connect_return]).to eq(context["token"])
-    end
-
-    it "does not issue return intent for team members" do
-      get :show, params: { social_connect_origin: "onboarding" }
-      expect(inertia.props[:social_connect_return]).to be_nil
-      expect(session[:social_connect_return]).to be_nil
-    end
-
-    it "rejects arbitrary origins and clears abandoned intent on a normal Profile visit" do
-      sign_in seller
-      session[:social_connect_return] = { "token" => "abandoned" }
-      get :show, params: { social_connect_origin: "https://example.org" }
-      expect(inertia.props[:social_connect_return]).to be_nil
-      expect(session[:social_connect_return]).to be_nil
-      get :show, params: { social_connect_origin: "onboarding" }
-      get :show
-      expect(session[:social_connect_return]).to be_nil
-    end
-
     it "returns successful response with Inertia page data" do
       get :show
 

--- a/spec/controllers/settings/profile_controller_spec.rb
+++ b/spec/controllers/settings/profile_controller_spec.rb
@@ -16,6 +16,41 @@ describe Settings::ProfileController, :vcr, type: :controller, inertia: true do
   end
 
   describe "GET show" do
+    it "issues a session-bound return token only for the owner entering from onboarding" do
+      sign_in seller
+      get :show, params: { social_connect_origin: "onboarding" }
+      expect(inertia.props[:social_connect_return]).to be_present
+      expect(session[:social_connect_return]).to include("token" => inertia.props[:social_connect_return], "user_id" => seller.id)
+    end
+
+    it "preserves pending intent on an onboarding reload without extending its expiry" do
+      sign_in seller
+      get :show, params: { social_connect_origin: "onboarding" }
+      context = session[:social_connect_return].dup
+      travel 5.minutes do
+        get :show, params: { social_connect_origin: "onboarding" }
+      end
+      expect(session[:social_connect_return]).to eq(context)
+      expect(inertia.props[:social_connect_return]).to eq(context["token"])
+    end
+
+    it "does not issue return intent for team members" do
+      get :show, params: { social_connect_origin: "onboarding" }
+      expect(inertia.props[:social_connect_return]).to be_nil
+      expect(session[:social_connect_return]).to be_nil
+    end
+
+    it "rejects arbitrary origins and clears abandoned intent on a normal Profile visit" do
+      sign_in seller
+      session[:social_connect_return] = { "token" => "abandoned" }
+      get :show, params: { social_connect_origin: "https://example.org" }
+      expect(inertia.props[:social_connect_return]).to be_nil
+      expect(session[:social_connect_return]).to be_nil
+      get :show, params: { social_connect_origin: "onboarding" }
+      get :show
+      expect(session[:social_connect_return]).to be_nil
+    end
+
     it "returns successful response with Inertia page data" do
       get :show
 

--- a/spec/controllers/settings/social_connections_controller_spec.rb
+++ b/spec/controllers/settings/social_connections_controller_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/sellers_base_controller_concern"
+require "shared_examples/authorize_called"
+require "inertia_rails/rspec"
+
+describe Settings::SocialConnectionsController, type: :controller, inertia: true do
+  it_behaves_like "inherits from Sellers::BaseController"
+
+  let(:seller) { create(:named_seller) }
+
+  before { sign_in seller }
+
+  it_behaves_like "authorize called for controller", Settings::SocialConnectionsPolicy do
+    let(:record) { :social_connections }
+  end
+
+  describe "GET show" do
+    it "renders the Social connections page for the owner" do
+      get :show
+
+      expect(response).to be_successful
+      expect(inertia.component).to eq("Settings/SocialConnections/Show")
+      expect(inertia.props[:twitter_connected]).to eq(false)
+      expect(inertia.props[:settings_pages]).to include("social_connections")
+    end
+
+    it "issues a session-bound return token only for the owner entering from onboarding" do
+      get :show, params: { social_connect_origin: "onboarding" }
+      expect(inertia.props[:social_connect_return]).to be_present
+      expect(session[:social_connect_return]).to include("token" => inertia.props[:social_connect_return], "user_id" => seller.id)
+    end
+
+    it "preserves pending intent on an onboarding reload without extending its expiry" do
+      get :show, params: { social_connect_origin: "onboarding" }
+      context = session[:social_connect_return].dup
+      travel 5.minutes do
+        get :show, params: { social_connect_origin: "onboarding" }
+      end
+      expect(session[:social_connect_return]).to eq(context)
+      expect(inertia.props[:social_connect_return]).to eq(context["token"])
+    end
+
+    it "rejects arbitrary origins and clears abandoned intent on a normal visit" do
+      session[:social_connect_return] = { "token" => "abandoned" }
+      get :show, params: { social_connect_origin: "https://example.org" }
+      expect(inertia.props[:social_connect_return]).to be_nil
+      expect(session[:social_connect_return]).to be_nil
+      get :show, params: { social_connect_origin: "onboarding" }
+      get :show
+      expect(session[:social_connect_return]).to be_nil
+    end
+
+    context "as a team admin" do
+      include_context "with user signed in as admin for seller"
+
+      it "redirects unauthorized team members and omits the nav entry" do
+        get :show
+
+        expect(response).to redirect_to(dashboard_url)
+        expect(flash[:alert]).to be_present
+        presenter = SettingsPresenter.new(pundit_user: SellerContext.new(user: user_with_role_for_seller, seller:))
+        expect(presenter.pages).not_to include("social_connections")
+      end
+    end
+  end
+end

--- a/spec/controllers/user/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/user/omniauth_callbacks_controller_spec.rb
@@ -613,7 +613,7 @@ describe User::OmniauthCallbacksController do
 
       post :youtube
 
-      expect(response).to redirect_to profile_path
+      expect(response).to redirect_to settings_social_connections_path
       identity = user.reload.youtube_identity
       expect(identity.channel_id).to eq("UC_x5XG1OV2P6uZZ5FSM9Ttw")
       expect(identity.handle).to eq("googledevelopers")
@@ -647,7 +647,7 @@ describe User::OmniauthCallbacksController do
       expect(YoutubeChannelFetcher).not_to have_received(:new)
       expect(user.reload.youtube_identity).to be_nil
       expect(flash[:alert]).to eq "YouTube connect is not available."
-      expect(response).to redirect_to profile_path
+      expect(response).to redirect_to settings_social_connections_path
     end
 
     it "does not 500 when the channel fetch raises" do
@@ -659,7 +659,7 @@ describe User::OmniauthCallbacksController do
 
       post :youtube
 
-      expect(response).to redirect_to profile_path
+      expect(response).to redirect_to settings_social_connections_path
       expect(flash[:alert]).to eq "Couldn't read a YouTube channel for that Google account."
       expect(user.reload.youtube_identity).to be_nil
     end
@@ -693,7 +693,7 @@ describe User::OmniauthCallbacksController do
 
       post :instagram
 
-      expect(response).to redirect_to profile_path
+      expect(response).to redirect_to settings_social_connections_path
       identity = user.reload.instagram_identity
       expect(identity.instagram_user_id).to eq("17841400000000000")
       expect(identity.handle).to eq("gumroad")
@@ -720,7 +720,7 @@ describe User::OmniauthCallbacksController do
       expect(user.social_connect_verifications.find_by(platform: "instagram")).to be_nil
       expect(user.reload.instagram_identity).to be_nil
       expect(flash[:alert]).to eq "Instagram connect is not available."
-      expect(response).to redirect_to profile_path
+      expect(response).to redirect_to settings_social_connections_path
     end
   end
 
@@ -732,7 +732,7 @@ describe User::OmniauthCallbacksController do
 
       get :failure, params: { error: "access_denied" }
 
-      expect(response).to redirect_to profile_path
+      expect(response).to redirect_to settings_social_connections_path
       expect(flash[:alert]).to eq "Couldn't connect YouTube. Please try again."
     end
 
@@ -743,7 +743,7 @@ describe User::OmniauthCallbacksController do
 
       get :failure, params: { error: "access_denied" }
 
-      expect(response).to redirect_to profile_path
+      expect(response).to redirect_to settings_social_connections_path
       expect(flash[:alert]).to eq "Couldn't connect Instagram. Please try again."
     end
   end

--- a/spec/controllers/user/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/user/omniauth_callbacks_controller_spec.rb
@@ -746,5 +746,17 @@ describe User::OmniauthCallbacksController do
       expect(response).to redirect_to settings_social_connections_path
       expect(flash[:alert]).to eq "Couldn't connect Instagram. Please try again."
     end
+
+    it "returns a cancelled X connection from Settings to Social connections" do
+      user = create(:user)
+      allow(controller).to receive(:logged_in_user).and_return(user)
+      request.env["omniauth.error.strategy"] = instance_double(OmniAuth::Strategies::Twitter, name: "twitter")
+      request.env["omniauth.params"] = { "state" => "link_twitter_account" }
+
+      get :failure, params: { error: "access_denied" }
+
+      expect(response).to redirect_to settings_social_connections_path
+      expect(flash[:alert]).to eq "Couldn't connect X. Please try again."
+    end
   end
 end

--- a/spec/controllers/user/social_connect_return_spec.rb
+++ b/spec/controllers/user/social_connect_return_spec.rb
@@ -50,36 +50,36 @@ describe User::OmniauthCallbacksController do
     expect(seller.reload.instagram_identity.instagram_user_id).to eq("example-id")
   end
 
-  it "preserves the Profile default without a session intent" do
+  it "preserves the Social connections default without a session intent" do
     session.delete(:social_connect_return)
     post :youtube
-    expect(response).to redirect_to profile_path
+    expect(response).to redirect_to settings_social_connections_path
   end
 
   it "does not accept an arbitrary URL as the return token" do
     request.env["omniauth.params"]["social_connect_return"] = "https://example.org/redirect"
     post :youtube
-    expect(response).to redirect_to profile_path
+    expect(response).to redirect_to settings_social_connections_path
     expect(session[:social_connect_return]).to be_nil
   end
 
   it "ignores callback query parameters instead of trusting them as saved request params" do
     request.env["omniauth.params"] = {}
     post :youtube, params: { social_connect_return: token }
-    expect(response).to redirect_to profile_path
+    expect(response).to redirect_to settings_social_connections_path
   end
 
   it "rejects an intent belonging to another user" do
     session[:social_connect_return]["user_id"] = create(:user).id
     post :youtube
-    expect(response).to redirect_to profile_path
+    expect(response).to redirect_to settings_social_connections_path
     expect(session[:social_connect_return]).to be_nil
   end
 
   it "rejects an expired intent" do
     session[:social_connect_return]["created_at"] = 16.minutes.ago.to_i
     post :youtube
-    expect(response).to redirect_to profile_path
+    expect(response).to redirect_to settings_social_connections_path
     expect(session[:social_connect_return]).to be_nil
   end
 
@@ -88,7 +88,7 @@ describe User::OmniauthCallbacksController do
     create(:team_membership, user: seller, seller: other, role: TeamMembership::ROLE_ADMIN)
     cookies.encrypted[:current_seller_id] = other.id
     post :youtube
-    expect(response).to redirect_to profile_path
+    expect(response).to redirect_to settings_social_connections_path
   end
 
   it "does not consume intent on an unrelated OAuth failure" do

--- a/spec/controllers/user/social_connect_return_spec.rb
+++ b/spec/controllers/user/social_connect_return_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe User::OmniauthCallbacksController do
+  let(:seller) { create(:user) }
+  let(:token) { SecureRandom.hex(32) }
+
+  before do
+    request.env["devise.mapping"] = Devise.mappings[:user]
+    sign_in seller
+    session[:social_connect_return] = { "token" => token, "user_id" => seller.id, "created_at" => Time.current.to_i }
+    request.env["omniauth.params"] = { "social_connect_return" => token, "state" => "link_twitter_account" }
+  end
+
+  %w[youtube instagram twitter].each do |provider|
+    it "returns #{provider} cancellation to onboarding and consumes intent" do
+      request.env["omniauth.error.strategy"] = double(name: provider)
+      get :failure
+      expect(response).to redirect_to dashboard_path
+      expect(flash[:alert]).to include("Couldn't connect")
+      expect(session[:social_connect_return]).to be_nil
+    end
+  end
+
+  it "returns successful X linking to onboarding without changing the linking operation" do
+    expect(controller).to receive(:link_twitter_account)
+    post :twitter
+    expect(response).to redirect_to dashboard_path
+    expect(session[:social_connect_return]).to be_nil
+  end
+
+  it "returns a successful YouTube connection to onboarding" do
+    Feature.activate_user(:youtube_connect, seller)
+    request.env["omniauth.auth"] = OmniAuth::AuthHash.new(credentials: { token: "test-token" })
+    channel = { "id" => "example-channel", "handle" => "example" }
+    allow(YoutubeChannelFetcher).to receive(:new).and_return(instance_double(YoutubeChannelFetcher, fetch: channel))
+    post :youtube
+    expect(response).to redirect_to dashboard_path
+    expect(seller.reload.youtube_identity.channel_id).to eq("example-channel")
+  end
+
+  it "returns a successful Instagram connection to onboarding" do
+    Feature.activate_user(:instagram_connect, seller)
+    request.env["omniauth.auth"] = OmniAuth::AuthHash.new(uid: "example-id", credentials: { token: "test-token" })
+    profile = { "user_id" => "example-id", "username" => "example" }
+    allow(InstagramProfileFetcher).to receive(:new).and_return(instance_double(InstagramProfileFetcher, fetch: profile))
+    post :instagram
+    expect(response).to redirect_to dashboard_path
+    expect(seller.reload.instagram_identity.instagram_user_id).to eq("example-id")
+  end
+
+  it "preserves the Profile default without a session intent" do
+    session.delete(:social_connect_return)
+    post :youtube
+    expect(response).to redirect_to profile_path
+  end
+
+  it "does not accept an arbitrary URL as the return token" do
+    request.env["omniauth.params"]["social_connect_return"] = "https://example.org/redirect"
+    post :youtube
+    expect(response).to redirect_to profile_path
+    expect(session[:social_connect_return]).to be_nil
+  end
+
+  it "ignores callback query parameters instead of trusting them as saved request params" do
+    request.env["omniauth.params"] = {}
+    post :youtube, params: { social_connect_return: token }
+    expect(response).to redirect_to profile_path
+  end
+
+  it "rejects an intent belonging to another user" do
+    session[:social_connect_return]["user_id"] = create(:user).id
+    post :youtube
+    expect(response).to redirect_to profile_path
+    expect(session[:social_connect_return]).to be_nil
+  end
+
+  it "rejects an expired intent" do
+    session[:social_connect_return]["created_at"] = 16.minutes.ago.to_i
+    post :youtube
+    expect(response).to redirect_to profile_path
+    expect(session[:social_connect_return]).to be_nil
+  end
+
+  it "rejects an intent after switching to another seller" do
+    other = create(:user)
+    create(:team_membership, user: seller, seller: other, role: TeamMembership::ROLE_ADMIN)
+    cookies.encrypted[:current_seller_id] = other.id
+    post :youtube
+    expect(response).to redirect_to profile_path
+  end
+
+  it "does not consume intent on an unrelated OAuth failure" do
+    request.env["omniauth.error.strategy"] = double(name: "google_oauth2")
+    get :failure, params: { error_description: "Unrelated failure" }
+    expect(response).to redirect_to settings_payments_path
+    expect(session[:social_connect_return]["token"]).to eq(token)
+  end
+
+  it "preserves login for a signed-out callback" do
+    sign_out seller
+    post :youtube
+    expect(response).to redirect_to login_path
+    expect(session[:social_connect_return]).to be_nil
+  end
+
+  it "does not alter Google sign-in referral behavior" do
+    allow(User).to receive(:find_or_create_for_google_oauth2).and_return(seller)
+    request.env["omniauth.params"]["referer"] = balance_path
+    post :google_oauth2
+    expect(response).to redirect_to balance_path
+    expect(session[:social_connect_return]).to be_nil
+  end
+end

--- a/spec/lib/omni_auth/strategies/instagram_spec.rb
+++ b/spec/lib/omni_auth/strategies/instagram_spec.rb
@@ -38,13 +38,13 @@ describe OmniAuth::Strategies::Instagram do
   end
 
   describe "#request_phase" do
-    it "redirects to profile when the flag is off for a signed-in user" do
+    it "redirects to Social connections when the flag is off for a signed-in user" do
       assign_env(create(:user))
 
       status, headers, = strategy.request_phase
 
       expect(status).to eq(302)
-      expect(headers["Location"]).to eq("/profile")
+      expect(headers["Location"]).to eq("/settings/social_connections")
     end
 
     it "redirects to login when the flag is off and no user is signed in" do

--- a/spec/lib/omni_auth/strategies/social_connect_return_spec.rb
+++ b/spec/lib/omni_auth/strategies/social_connect_return_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+[OmniAuth::Strategies::Youtube, OmniAuth::Strategies::Instagram].each do |strategy_class|
+  describe strategy_class do
+    let(:strategy) { described_class.new(->(_env) { [200, {}, ["ok"]] }) }
+    let(:user) { create(:user) }
+    let(:token) { "test-navigation-token" }
+
+    %w[request callback].each do |phase|
+      it "routes a gated onboarding #{phase} through the existing failure endpoint with saved intent" do
+        env = Rack::MockRequest.env_for("/users/auth/#{strategy.options.name}#{phase == 'callback' ? '/callback' : ''}")
+        env["warden"] = instance_double(Warden::Proxy, user:)
+        env["rack.session"] = phase == "request" ? { "omniauth.params" => { "social_connect_return" => token } } : {}
+        env["omniauth.params"] = { "social_connect_return" => token } if phase == "callback"
+        strategy.instance_variable_set(:@env, env)
+        expect(strategy).to receive(:fail!).with(:social_connect_unavailable) do
+          expect(env["omniauth.params"]).to eq("social_connect_return" => token)
+          [302, { "Location" => "/dashboard" }, []]
+        end
+        strategy.public_send("#{phase}_phase")
+        expect(env["rack.session"]["omniauth.params"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/omni_auth/strategies/youtube_spec.rb
+++ b/spec/lib/omni_auth/strategies/youtube_spec.rb
@@ -38,13 +38,13 @@ describe OmniAuth::Strategies::Youtube do
   end
 
   describe "#request_phase" do
-    it "redirects to profile when the flag is off for a signed-in user" do
+    it "redirects to Social connections when the flag is off for a signed-in user" do
       assign_env(create(:user))
 
       status, headers, = strategy.request_phase
 
       expect(status).to eq(302)
-      expect(headers["Location"]).to eq("/profile")
+      expect(headers["Location"]).to eq("/settings/social_connections")
     end
 
     it "redirects to login when the flag is off and no user is signed in" do

--- a/spec/policies/settings/social_connections_policy_spec.rb
+++ b/spec/policies/settings/social_connections_policy_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Settings::SocialConnectionsPolicy do
+  subject { described_class }
+
+  let(:seller) { create(:named_seller) }
+  let(:admin_for_seller) { create(:user) }
+
+  before do
+    create(:team_membership, user: admin_for_seller, seller:, role: TeamMembership::ROLE_ADMIN)
+  end
+
+  permissions :show? do
+    it "grants access to the owner" do
+      expect(subject).to permit(SellerContext.new(user: seller, seller:), nil)
+    end
+
+    it "denies access to team members" do
+      expect(subject).not_to permit(SellerContext.new(user: admin_for_seller, seller:), nil)
+    end
+  end
+end

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -52,38 +52,12 @@ describe ProfilePresenter do
     end
 
 
-    it "includes the YouTube channel id on the public profile and the handle only on settings props" do
+    it "includes the YouTube channel id on the public profile without the handle" do
       create(:user_youtube_identity, user: seller, channel_id: "UC123", handle: "googledevelopers")
       seller.reload
 
       expect(described_class.new(pundit_user: SellerContext.logged_out, seller:).creator_profile).not_to have_key(:youtube_handle)
       expect(described_class.new(pundit_user: SellerContext.logged_out, seller:).creator_profile[:youtube_channel_id]).to eq("UC123")
-      expect(described_class.new(pundit_user:, seller:).profile_settings_props(request:)[:youtube_handle]).to eq("googledevelopers")
-      expect(described_class.new(pundit_user:, seller:).profile_settings_props(request:)[:youtube_connected]).to eq(true)
-    end
-
-    it "reports X connected from the current link rather than a manually entered handle" do
-      seller.update!(twitter_handle: "example_creator")
-      expect(described_class.new(pundit_user:, seller:).profile_settings_props(request:)[:twitter_connected]).to eq(false)
-
-      seller.update!(twitter_user_id: "example-social-id")
-      expect(described_class.new(pundit_user:, seller:).profile_settings_props(request:)[:twitter_connected]).to eq(true)
-    end
-
-    it "reports Instagram connected from the live identity, not a dormant verification row" do
-      create(:social_connect_verification, user: seller, platform: "instagram", uid: "17841400000000000", handle: "oldhandle")
-      seller.reload
-
-      props = described_class.new(pundit_user:, seller:).profile_settings_props(request:)
-      expect(props[:instagram_connected]).to eq(false)
-      expect(props[:instagram_handle]).to be_nil
-
-      create(:user_instagram_identity, user: seller, instagram_user_id: "17841400000000000", handle: "gumroad")
-      seller.reload
-
-      props = described_class.new(pundit_user:, seller:).profile_settings_props(request:)
-      expect(props[:instagram_connected]).to eq(true)
-      expect(props[:instagram_handle]).to eq("gumroad")
     end
 
     it "includes hide_follow_form when the seller has turned it on" do
@@ -330,13 +304,6 @@ describe ProfilePresenter do
           seller_fonts_css_source: SellerProfile.seller_fonts_css_source,
           email_confirmation: nil,
           custom_html_pages_enabled: false,
-          twitter_connected: false,
-          youtube_connect_enabled: false,
-          youtube_connected: false,
-          youtube_handle: nil,
-          instagram_connect_enabled: false,
-          instagram_connected: false,
-          instagram_handle: nil,
           has_custom_landing_page: false,
           username: seller.username,
           # seller_analytics is only added to the public profile_props — the settings

--- a/spec/presenters/settings_presenter_spec.rb
+++ b/spec/presenters/settings_presenter_spec.rb
@@ -15,7 +15,7 @@ describe SettingsPresenter do
     context "with owner as logged in user" do
       it "returns correct pages" do
         expect(presenter.pages).to eq(
-          %w(main team payments billing password third_party_analytics advanced)
+          %w(main team payments billing password social_connections third_party_analytics advanced)
         )
       end
 
@@ -364,7 +364,7 @@ describe SettingsPresenter do
   end
 
   describe "#password_props" do
-    let(:settings_pages) { %w(main team payments billing password third_party_analytics advanced) }
+    let(:settings_pages) { %w(main team payments billing password social_connections third_party_analytics advanced) }
 
     context "when seller is registered using a social provider" do
       before do
@@ -395,6 +395,40 @@ describe SettingsPresenter do
     end
   end
 
+  describe "#social_connections_props" do
+    it "reports X connected from the current link rather than a manually entered handle" do
+      seller.update!(twitter_handle: "example_creator")
+      expect(presenter.social_connections_props[:twitter_connected]).to eq(false)
+      expect(presenter.social_connections_props[:twitter_handle]).to eq("example_creator")
+
+      seller.update!(twitter_user_id: "example-social-id")
+      expect(presenter.social_connections_props[:twitter_connected]).to eq(true)
+    end
+
+    it "includes the YouTube handle only when connected" do
+      expect(presenter.social_connections_props[:youtube_connected]).to eq(false)
+      create(:user_youtube_identity, user: seller, channel_id: "UC123", handle: "googledevelopers")
+      seller.reload
+      props = described_class.new(pundit_user:).social_connections_props
+      expect(props[:youtube_connected]).to eq(true)
+      expect(props[:youtube_handle]).to eq("googledevelopers")
+    end
+
+    it "reports Instagram connected from the live identity, not a dormant verification row" do
+      create(:social_connect_verification, user: seller, platform: "instagram", uid: "17841400000000000", handle: "oldhandle")
+      seller.reload
+      props = described_class.new(pundit_user:).social_connections_props
+      expect(props[:instagram_connected]).to eq(false)
+      expect(props[:instagram_handle]).to be_nil
+
+      create(:user_instagram_identity, user: seller, instagram_user_id: "17841400000000000", handle: "gumroad")
+      seller.reload
+      props = described_class.new(pundit_user:).social_connections_props
+      expect(props[:instagram_connected]).to eq(true)
+      expect(props[:instagram_handle]).to eq("gumroad")
+    end
+  end
+
   describe "#authorized_applications_props" do
     context "when some applications have no access grants" do
       let(:oauth_application1) { create(:oauth_application, owner: seller) }
@@ -415,7 +449,7 @@ describe SettingsPresenter do
                                                                   scopes: oauth_application1.scopes,
                                                                   id: oauth_application1.external_id,
                                                                 }],
-                                                                settings_pages: %w(main team payments billing authorized_applications password third_party_analytics advanced),
+                                                                settings_pages: %w(main team payments billing authorized_applications password social_connections third_party_analytics advanced),
                                                               })
       end
     end
@@ -438,7 +472,7 @@ describe SettingsPresenter do
                                                                   scopes: oauth_application1.scopes,
                                                                   id: oauth_application1.external_id,
                                                                 }],
-                                                                settings_pages: %w(main team payments billing authorized_applications password third_party_analytics advanced),
+                                                                settings_pages: %w(main team payments billing authorized_applications password social_connections third_party_analytics advanced),
                                                               })
       end
     end
@@ -474,7 +508,7 @@ describe SettingsPresenter do
                                                                 scopes: oauth_application1.scopes,
                                                                 id: oauth_application1.external_id,
                                                               }],
-                                                              settings_pages: %w(main team payments billing authorized_applications password third_party_analytics advanced),
+                                                              settings_pages: %w(main team payments billing authorized_applications password social_connections third_party_analytics advanced),
                                                             })
     end
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -81,7 +81,7 @@ describe "Dashboard", js: true, type: :system do
       expect(page).not_to have_text("YouTube: Available to connect")
       expect(page).not_to have_text("Instagram: Available to connect")
       click_on "Manage social connections"
-      expect(page).to have_current_path(profile_path)
+      expect(page).to have_current_path(profile_path(social_connect_origin: "onboarding"))
       expect(page).to have_text("Social links")
       expect(page).to have_button("Connect to X")
       expect(page).to have_button("Disconnect example_creator from X")

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -70,7 +70,7 @@ describe "Dashboard", js: true, type: :system do
   end
 
   describe "Getting started" do
-    it "offers optional social connections and opens the existing settings controls" do
+    it "offers optional social connections and opens the Social connections settings page" do
       Feature.deactivate(:youtube_connect)
       Feature.deactivate(:instagram_connect)
       seller.update!(twitter_handle: "example_creator")
@@ -81,15 +81,10 @@ describe "Dashboard", js: true, type: :system do
       expect(page).not_to have_text("YouTube: Available to connect")
       expect(page).not_to have_text("Instagram: Available to connect")
       click_on "Manage social connections"
-      expect(page).to have_current_path(profile_path(social_connect_origin: "onboarding"))
-      expect(page).to have_text("Social links")
+      expect(page).to have_current_path(settings_social_connections_path(social_connect_origin: "onboarding"))
+      expect(page).to have_text("Social connections")
       expect(page).to have_button("Connect to X")
-      expect(page).to have_button("Disconnect example_creator from X")
-
-      click_on "Disconnect example_creator from X"
-      expect(page).not_to have_button("Disconnect example_creator from X")
-      expect(page).to have_button("Connect to X")
-      expect(seller.reload.twitter_handle).to be_nil
+      expect(page).not_to have_button("Disconnect @example_creator from X")
     end
 
     it "shows a connected account without making social connections required for checklist completion" do

--- a/spec/requests/settings/social_connections_spec.rb
+++ b/spec/requests/settings/social_connections_spec.rb
@@ -16,14 +16,14 @@ describe "Settings social connections page", type: :system, js: true do
     OmniAuth.config.mock_auth.delete(:twitter)
   end
 
-  it "renders connect controls for the owner and keeps Connect ahead of Continue" do
+  it "renders connect controls for the owner and carries the onboarding return token" do
     visit settings_social_connections_path(social_connect_origin: "onboarding")
 
     expect(page).to have_text("Social connections")
-    expect(page).to have_text("Connecting is optional and helps verify your account")
+    expect(page).to have_text("Connecting a social account is optional")
     expect(page).to have_button("Connect to X")
-    expect(page).to have_link("Continue without connecting", href: dashboard_path)
-    expect(page.text.index("Connect to X")).to be < page.text.index("Continue without connecting")
+    expect(page).to have_text("Not connected")
+    expect(page).to have_css("form[action*='social_connect_return=']", visible: :all)
   end
 
   it "saves a connected or disconnected X account" do
@@ -36,12 +36,27 @@ describe "Settings social connections page", type: :system, js: true do
     end
     click_on "Connect to X"
     expect(page).to have_button("Disconnect @squidarth from X")
+    expect(page).to have_text("@squidarth")
+    expect(page).not_to have_text("Not connected")
     expect(seller.reload.twitter_handle).not_to be_nil
     click_on "Disconnect @#{seller.twitter_handle} from X"
     wait_for_ajax
     expect(seller.reload.twitter_handle).to be_nil
     expect(page).to have_button("Connect to X")
     OmniAuth.config.before_callback_phase = nil
+  end
+
+  it "lets the owner remove a legacy hand-typed X handle and still offers Connect" do
+    seller.update!(twitter_handle: "old_handle", twitter_user_id: nil)
+    visit settings_social_connections_path
+
+    expect(page).to have_text("@old_handle was added by hand and is not verified.")
+    expect(page).to have_button("Connect to X")
+    expect(page).not_to have_button("Disconnect @old_handle from X")
+    click_on "Remove @old_handle from X"
+    wait_for_ajax
+    expect(seller.reload.twitter_handle).to be_nil
+    expect(page).to have_text("Not connected")
   end
 
   it "shows Connect to YouTube when the youtube_connect flag is on" do

--- a/spec/requests/settings/social_connections_spec.rb
+++ b/spec/requests/settings/social_connections_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Settings social connections page", type: :system, js: true do
+  let(:seller) { create(:named_seller) }
+
+  before do
+    @previous_test_mode = OmniAuth.config.test_mode
+    OmniAuth.config.test_mode = true
+    login_as seller
+  end
+
+  after do
+    OmniAuth.config.test_mode = @previous_test_mode
+    OmniAuth.config.mock_auth.delete(:twitter)
+  end
+
+  it "renders connect controls for the owner and keeps Connect ahead of Continue" do
+    visit settings_social_connections_path(social_connect_origin: "onboarding")
+
+    expect(page).to have_text("Social connections")
+    expect(page).to have_text("Connecting is optional and helps verify your account")
+    expect(page).to have_button("Connect to X")
+    expect(page).to have_link("Continue without connecting", href: dashboard_path)
+    expect(page.text.index("Connect to X")).to be < page.text.index("Continue without connecting")
+    expect(page).to have_link("Social connections")
+  end
+
+  it "saves a connected or disconnected X account" do
+    visit settings_social_connections_path
+    expect(page).to have_button("Connect to X")
+    expect(page).not_to have_button("Connect to YouTube")
+    OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new JSON.parse(File.open("#{Rails.root}/spec/support/fixtures/twitter_omniauth.json").read)
+    OmniAuth.config.before_callback_phase do |env|
+      env["omniauth.params"] = { "state" => "link_twitter_account" }
+    end
+    click_on "Connect to X"
+    expect(page).to have_button("Disconnect @squidarth from X")
+    expect(seller.reload.twitter_handle).not_to be_nil
+    click_on "Disconnect @#{seller.twitter_handle} from X"
+    wait_for_ajax
+    expect(seller.reload.twitter_handle).to be_nil
+    expect(page).to have_button("Connect to X")
+    OmniAuth.config.before_callback_phase = nil
+  end
+
+  it "shows Connect to YouTube when the youtube_connect flag is on" do
+    Feature.activate_user(:youtube_connect, seller)
+    visit settings_social_connections_path
+
+    expect(page).to have_button("Connect to YouTube")
+  end
+
+  it "shows Connect to Instagram when the instagram_connect flag is on" do
+    Feature.activate_user(:instagram_connect, seller)
+    visit settings_social_connections_path
+
+    expect(page).to have_button("Connect to Instagram")
+  end
+
+  context "when logged user has role admin" do
+    include_context "with switching account to user as admin for seller"
+
+    it "does not show social connection controls" do
+      visit settings_social_connections_path
+
+      expect(page).to have_current_path(dashboard_path)
+      expect(page).not_to have_link("Social connections")
+      expect(page).not_to have_button("Connect to X")
+    end
+  end
+end

--- a/spec/requests/settings/social_connections_spec.rb
+++ b/spec/requests/settings/social_connections_spec.rb
@@ -24,7 +24,6 @@ describe "Settings social connections page", type: :system, js: true do
     expect(page).to have_button("Connect to X")
     expect(page).to have_link("Continue without connecting", href: dashboard_path)
     expect(page.text.index("Connect to X")).to be < page.text.index("Continue without connecting")
-    expect(page).to have_link("Social connections")
   end
 
   it "saves a connected or disconnected X account" do
@@ -57,17 +56,5 @@ describe "Settings social connections page", type: :system, js: true do
     visit settings_social_connections_path
 
     expect(page).to have_button("Connect to Instagram")
-  end
-
-  context "when logged user has role admin" do
-    include_context "with switching account to user as admin for seller"
-
-    it "does not show social connection controls" do
-      visit settings_social_connections_path
-
-      expect(page).to have_current_path(dashboard_path)
-      expect(page).not_to have_link("Social connections")
-      expect(page).not_to have_button("Connect to X")
-    end
   end
 end

--- a/spec/requests/settings/social_review_spec.rb
+++ b/spec/requests/settings/social_review_spec.rb
@@ -12,11 +12,13 @@ describe "Optional social connections during account review", type: :system, js:
     login_as seller
   end
 
-  it "offers X despite an unverified handle and leaves normal review available" do
+  it "offers a link to Social connections and leaves normal review available" do
     visit settings_payments_path
 
     expect(page).to have_text("Add social connections (optional)")
-    expect(page).to have_button("Connect to X")
+    expect(page).to have_link("Manage social connections", href: settings_social_connections_path)
+    expect(page).to have_text("X available to connect")
+    expect(page).not_to have_button("Connect to X")
     expect(page).not_to have_button("Connect to YouTube")
     expect(page).not_to have_button("Connect to Instagram")
     expect(page).to have_text("does not replace identity verification or guarantee approval or a payout date")
@@ -35,7 +37,7 @@ describe "Optional social connections during account review", type: :system, js:
 
     seller.update!(twitter_user_id: nil)
     visit settings_payments_path
-    expect(page).to have_button("Connect to X")
+    expect(page).to have_text("X available to connect")
 
     seller.mark_compliant!(author_name: "test")
     visit settings_payments_path

--- a/spec/requests/social_connect_return_spec.rb
+++ b/spec/requests/social_connect_return_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# These exercise Gumroad's browser/OAuth navigation boundary, not vendor consent.
+describe "Onboarding social connection return", js: true, type: :system do
+  let(:seller) { create(:named_seller) }
+
+  before do
+    @previous_test_mode = OmniAuth.config.test_mode
+    OmniAuth.config.test_mode = true
+    login_as seller
+  end
+
+  after do
+    OmniAuth.config.test_mode = @previous_test_mode
+    OmniAuth.config.mock_auth.delete(:twitter)
+    OmniAuth.config.mock_auth.delete(:youtube)
+    OmniAuth.config.mock_auth.delete(:instagram)
+  end
+
+  it "lets the seller skip connecting and clears the Profile continuation" do
+    visit dashboard_path
+    click_on "Manage social connections"
+    expect(page).to have_current_path(profile_path(social_connect_origin: "onboarding"))
+    expect(page).to have_button("Connect to X")
+    expect(page).to have_link("Continue without connecting", href: dashboard_path)
+    connect_index = page.text.index("Connect to X")
+    skip_index = page.text.index("Continue without connecting")
+    expect(connect_index).to be < skip_index
+    click_on "Continue without connecting"
+    expect(page).to have_current_path(dashboard_path)
+    expect(page).to have_text("X: Available to connect")
+    visit profile_path
+    expect(page).not_to have_link("Continue without connecting")
+  end
+
+  %w[twitter youtube instagram].each do |provider|
+    it "returns from #{provider} cancellation to Getting started" do
+      Feature.activate_user(:"#{provider}_connect", seller) unless provider == "twitter"
+      OmniAuth.config.mock_auth[provider.to_sym] = :access_denied
+      visit dashboard_path
+      click_on "Manage social connections"
+      click_on "Connect to #{ { 'twitter' => 'X', 'youtube' => 'YouTube', 'instagram' => 'Instagram' }.fetch(provider)}"
+      expect(page).to have_current_path(dashboard_path)
+      expect(page).to have_text("Couldn't connect")
+      expect(page).to have_link("Manage social connections")
+      expect(seller.reload.twitter_user_id).to be_nil
+      expect(seller.youtube_identity).to be_nil
+      expect(seller.instagram_identity).to be_nil
+    end
+  end
+
+  %w[youtube instagram].each do |provider|
+    it "returns to onboarding when #{provider} becomes unavailable before authorization" do
+      OmniAuth.config.test_mode = false
+      Feature.activate_user(:"#{provider}_connect", seller)
+      visit dashboard_path
+      click_on "Manage social connections"
+      Feature.deactivate_user(:"#{provider}_connect", seller)
+      click_on "Connect to #{provider == 'youtube' ? 'YouTube' : 'Instagram'}"
+      expect(page).to have_current_path(dashboard_path)
+      expect(page).to have_text("Couldn't connect")
+      expect(seller.reload.youtube_identity).to be_nil
+      expect(seller.instagram_identity).to be_nil
+      visit profile_path
+      expect(page).not_to have_link("Continue without connecting")
+    end
+  end
+
+  it "returns from successful X linking and displays the current connection" do
+    auth = JSON.parse(File.read(Rails.root.join("spec/support/fixtures/twitter_omniauth.json")))
+    OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new(auth)
+    visit dashboard_path
+    click_on "Manage social connections"
+    click_on "Connect to X"
+    expect(page).to have_current_path(dashboard_path)
+    expect(page).to have_text("X: Connected")
+    expect(seller.reload.twitter_user_id).to be_present
+  end
+end

--- a/spec/requests/social_connect_return_spec.rb
+++ b/spec/requests/social_connect_return_spec.rb
@@ -19,10 +19,10 @@ describe "Onboarding social connection return", js: true, type: :system do
     OmniAuth.config.mock_auth.delete(:instagram)
   end
 
-  it "lets the seller skip connecting and clears the Profile continuation" do
+  it "lets the seller skip connecting and clears the continuation" do
     visit dashboard_path
     click_on "Manage social connections"
-    expect(page).to have_current_path(profile_path(social_connect_origin: "onboarding"))
+    expect(page).to have_current_path(settings_social_connections_path(social_connect_origin: "onboarding"))
     expect(page).to have_button("Connect to X")
     expect(page).to have_link("Continue without connecting", href: dashboard_path)
     connect_index = page.text.index("Connect to X")
@@ -31,7 +31,7 @@ describe "Onboarding social connection return", js: true, type: :system do
     click_on "Continue without connecting"
     expect(page).to have_current_path(dashboard_path)
     expect(page).to have_text("X: Available to connect")
-    visit profile_path
+    visit settings_social_connections_path
     expect(page).not_to have_link("Continue without connecting")
   end
 
@@ -63,7 +63,7 @@ describe "Onboarding social connection return", js: true, type: :system do
       expect(page).to have_text("Couldn't connect")
       expect(seller.reload.youtube_identity).to be_nil
       expect(seller.instagram_identity).to be_nil
-      visit profile_path
+      visit settings_social_connections_path
       expect(page).not_to have_link("Continue without connecting")
     end
   end

--- a/spec/requests/social_connect_return_spec.rb
+++ b/spec/requests/social_connect_return_spec.rb
@@ -19,20 +19,16 @@ describe "Onboarding social connection return", js: true, type: :system do
     OmniAuth.config.mock_auth.delete(:instagram)
   end
 
-  it "lets the seller skip connecting and clears the continuation" do
+  it "clears the continuation when the seller leaves without connecting" do
     visit dashboard_path
     click_on "Manage social connections"
     expect(page).to have_current_path(settings_social_connections_path(social_connect_origin: "onboarding"))
     expect(page).to have_button("Connect to X")
-    expect(page).to have_link("Continue without connecting", href: dashboard_path)
-    connect_index = page.text.index("Connect to X")
-    skip_index = page.text.index("Continue without connecting")
-    expect(connect_index).to be < skip_index
-    click_on "Continue without connecting"
-    expect(page).to have_current_path(dashboard_path)
+    expect(page).to have_css("form[action*='social_connect_return=']", visible: :all)
+    visit dashboard_path
     expect(page).to have_text("X: Available to connect")
     visit settings_social_connections_path
-    expect(page).not_to have_link("Continue without connecting")
+    expect(page).not_to have_css("form[action*='social_connect_return=']", visible: :all)
   end
 
   %w[twitter youtube instagram].each do |provider|
@@ -64,7 +60,7 @@ describe "Onboarding social connection return", js: true, type: :system do
       expect(seller.reload.youtube_identity).to be_nil
       expect(seller.instagram_identity).to be_nil
       visit settings_social_connections_path
-      expect(page).not_to have_link("Continue without connecting")
+      expect(page).not_to have_css("form[action*='social_connect_return=']", visible: :all)
     end
   end
 

--- a/spec/requests/user/settings_spec.rb
+++ b/spec/requests/user/settings_spec.rb
@@ -132,52 +132,5 @@ describe "User profile settings page", type: :system, js: true do
       end
       expect(page).to have_alert(text: "Invalid file type.")
     end
-
-    it "saves connected or disconnected Twitter account" do
-      visit profile_path
-      expect(page).to have_button("Connect to X")
-      expect(page).not_to have_button("Connect to YouTube")
-      OmniAuth.config.test_mode = true
-      OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new JSON.parse(File.open("#{Rails.root}/spec/support/fixtures/twitter_omniauth.json").read)
-      OmniAuth.config.before_callback_phase do |env|
-        env["omniauth.params"] = { "state" => "link_twitter_account" }
-      end
-      click_on "Connect to X"
-      expect(page).to have_button("Disconnect squidarth from X")
-      expect(@user.reload.twitter_handle).not_to be_nil
-      click_on "Disconnect #{@user.twitter_handle} from X"
-      wait_for_ajax
-      expect(@user.reload.twitter_handle).to be_nil
-      expect(page).to have_button("Connect to X")
-      # Reset the before_callback_phase to avoid making other X tests flaky.
-      OmniAuth.config.before_callback_phase = nil
-    end
-
-    it "shows Connect to YouTube when the youtube_connect flag is on" do
-      Feature.activate_user(:youtube_connect, @user)
-      visit profile_path
-
-      expect(page).to have_button("Connect to YouTube")
-    end
-
-    it "shows Connect to Instagram when the instagram_connect flag is on" do
-      Feature.activate_user(:instagram_connect, @user)
-      visit profile_path
-
-      expect(page).to have_button("Connect to Instagram")
-    end
-
-    context "when logged user has role admin" do
-      include_context "with switching account to user as admin for seller" do
-        let(:seller) { @user }
-      end
-
-      it "does not show social links" do
-        visit profile_path
-
-        expect(page).not_to have_text("Social links")
-        expect(page).not_to have_link("Connect to X", href: user_twitter_omniauth_authorize_path(state: "link_twitter_account", x_auth_access_type: "read"))
-      end
-    end
   end
 end


### PR DESCRIPTION
## What

OAuth connect and disconnect for X, YouTube, and Instagram now live on Settings → Social connections (`/settings/social_connections`). Profile no longer hosts those controls. Getting started and the account-review prompt link to the new page. Onboarding still returns to Getting started via the existing owner-bound, session-bound 15-minute nonce. Ordinary callbacks return to Social connections.

The page lists one row per available provider, using the same `Rows` list as Passkeys and Applications. Each row names the provider, shows the connected handle with a success check or "Not connected", and ends in a short Connect or Disconnect button. The accessible name of each button keeps the provider and handle.

A hand-typed legacy X handle is not a connection. Its row says the handle was added by hand and is not verified, and offers Remove next to Connect, so the handle can be cleared without pretending it was authenticated.

A signed-in seller who cancels at X now returns to Social connections, or to Getting started during onboarding. Before, only the onboarding path had a return branch and a plain cancel landed on the login page. YouTube and Instagram already returned to Social connections.

Tracker: antiwork/gumroad-private#2494

## Why

Sahil, Sept 9:

> I think we should separate out from social links. One is about verification via oauth, can live there. This is about adding a dictionary of URLs whihc we don't need as we now have custom html.

> We can move it outside of profile settings.

Public links stay on custom HTML. This page is only OAuth verification.

The rows layout replaces buttons whose label carried the state ("Connect to X" versus "Disconnect @handle from X"). A button is an action, not a status, and the handle made every button a different width. Status now lives in text next to the provider name.

The copy says what connecting is for: extra context during account review. The earlier "helps verify your account" read like identity verification, which the Payments page says this does not replace. The onboarding skip link and return note are gone. This is a settings page, and the sidebar already leads back to Getting started.

## Before / After

Before = Profile "Social links" fieldset on `main`. After = Settings → Social connections with `youtube_connect` and `instagram_connect` on.

### Before

![Baseline desktop light](https://github.com/user-attachments/assets/ba73d5fe-46ca-45ce-b520-63f10881ed97)

![Baseline mobile light](https://github.com/user-attachments/assets/6847e6aa-e270-4a24-aef4-452ee52c47e4)

### After

![Social connections, desktop, light](https://github.com/user-attachments/assets/3183c45f-c1ee-4ceb-814b-81f14f88bfeb)

![Social connections, desktop, dark](https://github.com/user-attachments/assets/30ad338e-310f-4da5-bf1c-b1475084b48d)

![Social connections, mobile, light](https://github.com/user-attachments/assets/a4ed3a2c-33e4-4577-b504-a12f4418c100)

![Social connections, mobile, dark](https://github.com/user-attachments/assets/9e9f68f8-4588-4a0f-bfcb-9e2f80dc9dc5)

![All three accounts connected](https://github.com/user-attachments/assets/9606d0bf-ec5e-488f-9a57-91decad628f9)

![Legacy hand-typed X handle with Remove and Connect](https://github.com/user-attachments/assets/b7187866-b7f8-446f-8f54-5445d5dfa2d7)

## Test results

Head `8971a1814036754cfa99c229077c3b62352ff787` on current `main`:

- `bin/rspec spec/requests/settings/social_connections_spec.rb spec/requests/social_connect_return_spec.rb spec/requests/dashboard_spec.rb -e social`: 14 examples, 0 failures
- `bin/rspec spec/presenters/settings_presenter_spec.rb -e social_connections spec/controllers/user/omniauth_callbacks_controller_spec.rb -e "#failure" spec/controllers/user/social_connect_return_spec.rb spec/controllers/settings/social_connections_controller_spec.rb`: 0 failures
- `npx tsc --noEmit`, eslint, prettier on touched frontend files: clean
- `bundle exec rubocop` on touched Ruby files: clean
- `/autoreview` (Codex) on the branch against `main`: clean after one accepted P2 (legacy handle shown as connected), fixed as described above

## QA steps

1. Sign in on the branch preview with the seeded seller and complete two-factor (`000000` in non-production).
2. Open Settings. Confirm a "Social connections" nav entry. Open it. Confirm one row for X, and rows for YouTube and Instagram only when those flags are on. Each row shows "Not connected" and a Connect button. Confirm Profile has no Social links fieldset.
3. Connect X. Confirm the row shows the handle with a check and a Disconnect button. Disconnect. Confirm the row returns to "Not connected".
4. Start a connect and cancel at the provider. Confirm you land back on Social connections with an alert, not on the login page.
5. From Dashboard → Getting started → Manage social connections, land on Social connections with `social_connect_origin=onboarding`. Connect an account and confirm you return to Getting started.
6. Open Settings → Payments while under review. The optional social prompt links to Social connections.
7. Repeat steps 2 and 3 at mobile width, in light and dark mode.

## Completion checklist

- [x] Scope: move OAuth connection management outside Profile; no URL directory.
- [x] Design: dedicated Social connections Settings page with one row per provider; owner-only nav; onboarding return unchanged.
- [x] Build: page, policy, presenter, routes, tests, rebased on `main`.
- [x] QA: captures at this head, desktop and mobile, light and dark.
- [ ] Ship: human auth review by Gianfranco.
- [ ] Market: not applicable.
- [ ] Sell: verify production onboarding after the first named release.

---
AI assistance: xAI grok-4.6 (executor) for the original page; Claude Fable 5.1 for the rebase, rows layout, copy, and the callback fix.
