### PR TITLE
Reject malformed signed IDs in thumbnail uploads

### DIFF
--- a/app/controllers/thumbnails_controller.rb
+++ b/app/controllers/thumbnails_controller.rb
@@ -12,8 +12,13 @@ class ThumbnailsController < Sellers::BaseController
 
     thumbnail = @product.thumbnail || @product.build_thumbnail
 
-    if permitted_params[:signed_blob_id].present?
-      thumbnail.file.attach(permitted_params[:signed_blob_id])
+    signed_blob_id = permitted_params[:signed_blob_id]
+    if signed_blob_id.present?
+      unless signed_blob_id.is_a?(String) && (blob = ActiveStorage::Blob.find_signed(signed_blob_id))
+        return render(json: { success: false, error: "Invalid signed_blob_id." }, status: :bad_request)
+      end
+
+      thumbnail.file.attach(blob)
       Timeout.timeout(30) { thumbnail.file.analyze }
       thumbnail.unsplash_url = nil
     end

--- a/test/controllers/thumbnails_controller_test.rb
+++ b/test/controllers/thumbnails_controller_test.rb
@@ -57,6 +57,50 @@ class ThumbnailsControllerTest < ActionController::TestCase
     assert_equal({ "success" => false, "error" => "Invalid thumbnail parameter. Expected signed_blob_id." }, response.parsed_body)
   end
 
+  [123, 1.5, true, "123", "invalid-signature"].each do |signed_blob_id|
+    test "POST create rejects malformed signed blob ID #{signed_blob_id.inspect} without changing the thumbnail" do
+      @product.update!(thumbnail: create_thumbnail)
+      thumbnail = @product.thumbnail
+      thumbnail.mark_deleted!
+      original_attributes = thumbnail.reload.attributes
+      original_blob = thumbnail.file.blob
+
+      assert_no_difference [-> { Thumbnail.count }, -> { ActiveStorage::Attachment.count }, -> { ActiveStorage::Blob.count }] do
+        post :create, params: { link_id: @product.unique_permalink, thumbnail: { signed_blob_id: } }, as: :json
+      end
+
+      assert_response :bad_request
+      assert_equal({ "success" => false, "error" => "Invalid signed_blob_id." }, response.parsed_body)
+      assert_equal original_attributes, thumbnail.reload.attributes
+      assert_equal original_blob, thumbnail.file.blob
+    end
+  end
+
+  test "POST create rejects an expired signed blob ID without creating a thumbnail" do
+    signed_blob_id = image_blob.signed_id(expires_in: -1.minute)
+
+    assert_no_difference -> { Thumbnail.count } do
+      post :create, params: { link_id: @product.unique_permalink, thumbnail: { signed_blob_id: } }, as: :json
+    end
+
+    assert_response :bad_request
+    assert_equal false, response.parsed_body["success"]
+    assert_nil @product.reload.thumbnail
+  end
+
+  [nil, "", " ", false].each do |signed_blob_id|
+    test "POST create preserves the existing thumbnail for blank signed blob ID #{signed_blob_id.inspect}" do
+      @product.update!(thumbnail: create_thumbnail)
+      original_blob = @product.thumbnail.file.blob
+
+      post :create, params: { link_id: @product.unique_permalink, thumbnail: { signed_blob_id: } }, as: :json
+
+      assert_response :ok
+      assert_equal true, response.parsed_body["success"]
+      assert_equal original_blob, @product.reload.thumbnail.file.blob
+    end
+  end
+
   test "POST create fails for a thumbnail that is not square" do
     assert_nil @product.thumbnail
     invalid_blob = ActiveStorage::Blob.create_and_upload!(

--- a/test/controllers/thumbnails_controller_test.rb
+++ b/test/controllers/thumbnails_controller_test.rb
@@ -88,8 +88,8 @@ class ThumbnailsControllerTest < ActionController::TestCase
     assert_nil @product.reload.thumbnail
   end
 
-  [nil, "", " ", false].each do |signed_blob_id|
-    test "POST create preserves the existing thumbnail for blank signed blob ID #{signed_blob_id.inspect}" do
+  [nil, "", " ", false, ["invalid"], { value: "invalid" }].each do |signed_blob_id|
+    test "POST create preserves the existing thumbnail for blank or filtered signed blob ID #{signed_blob_id.inspect}" do
       @product.update!(thumbnail: create_thumbnail)
       original_blob = @product.thumbnail.file.blob
 
@@ -98,6 +98,23 @@ class ThumbnailsControllerTest < ActionController::TestCase
       assert_response :ok
       assert_equal true, response.parsed_body["success"]
       assert_equal original_blob, @product.reload.thumbnail.file.blob
+    end
+  end
+
+  test "POST create preserves the thumbnail when signed blob ID is omitted" do
+    @product.update!(thumbnail: create_thumbnail)
+    original_blob = @product.thumbnail.file.blob
+
+    post :create, params: { link_id: @product.unique_permalink, thumbnail: { ignored: "value" } }, as: :json
+
+    assert_response :ok
+    assert_equal true, response.parsed_body["success"]
+    assert_equal original_blob, @product.reload.thumbnail.file.blob
+  end
+
+  test "POST create still requires a nonempty thumbnail parameter" do
+    assert_raises ActionController::ParameterMissing do
+      post :create, params: { link_id: @product.unique_permalink, thumbnail: {} }, as: :json
     end
   end
 


### PR DESCRIPTION
## What / Why
Reject nonblank malformed thumbnail signed IDs before attachment. Strong parameters admit numeric/boolean scalars, but Active Storage requires an attachable or a verified signed string. Resolve strings with `Blob.find_signed` and attach the verified blob; never interpret an integer as a blob ID.

Ref antiwork/gumroad-private#2459. Sentry: https://gumroad-to.sentry.io/issues/7718496952/ (GUMROAD-1JH).

## Before / After
Malformed scalar or invalid/expired signature: uncaught exception → HTTP 400 JSON failure, with existing thumbnail/blob unchanged. Valid signed uploads, thumbnail restoration and blank-value behavior remain unchanged. No UI layout change. The attached real Rails controller walkthrough shows baseline malformed requests failing and the final-head suite passing; final frame inspected for readability and privacy.

## QA / Test Results
- [x] Red first: 26 controller tests, 6 expected errors (numeric/boolean attachable errors and invalid/expired signatures).
- [x] Green: `bundle exec rails test test/controllers/thumbnails_controller_test.rb` — 30 runs, 128 assertions, 0 failures/errors/skips, isolated MySQL database and Redis instance.
- [x] RuboCop: 2 files inspected, no offenses.
- [x] Astra+Fable panel and final QA audit: round 2 clean (both engines, P0–P2). Round 1 array/hash preservation test gap fixed. Code/specs/comments reviewed; no rendered layout delta, controller walkthrough verified.

Premerge review: clean @ e2cdfd3f88641be437698b2e539f80eda9ce53f8
- [x] Final-head controller walkthrough; valid, missing/blank and filtered array/hash semantics verified.
- [x] Full current-head CI passed at `e2cdfd3f88641be437698b2e539f80eda9ce53f8`; checked September 8.
- [x] `bin/test-confidence`: 3 test files passed; 2 system-spec failures reproduced on merge base and skipped by harness (not claimed as passes).

Scope: only seller thumbnail upload validation; no charges, prices, balances, payouts or refund code. Ready for human review; not deployed. No active build lane is claimed.

---
AI disclosure: Built with OpenAI GPT-6 Astra. Prompt: validate malformed thumbnail signed IDs server-side, preserve valid/blank behavior and existing attachments, prove red/green tests, and run panel/QA/CI gates.

https://github.com/user-attachments/assets/ecbe0d6a-eca6-43ba-b919-1571dc0f50b7

## Completion checklist
- [x] Scope — bounded fix described above.
- [x] Design — existing behavior and safety boundaries preserved.
- [x] Build — tests, current-head panel and QA evidence complete.
- [ ] Ship — human review, merge and production verification remain.
- [ ] Market — affected-user follow-up after production verification.
- [ ] Sell — confirm the reported outcome after deployment.
