### PR TITLE
Fix formatting of historical purchase currencies

### DIFF
--- a/app/helpers/currency_helper.rb
+++ b/app/helpers/currency_helper.rb
@@ -10,8 +10,7 @@ module CurrencyHelper
   end
 
   def symbol_for(type = :usd)
-    currency = CURRENCY_CHOICES[type.to_sym] || CURRENCY_CHOICES[:usd]
-    currency[:symbol]
+    MoneyFormatter.symbol_for(type)
   end
 
   def min_price_for(type = :usd)

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -2259,7 +2259,8 @@ class Purchase < ApplicationRecord
 
   def amount_refundable_in_currency
     amount_in_cents = usd_cents_to_currency(displayed_price_currency_type, amount_refundable_cents, rate_converted_to_usd)
-    Money.new(amount_in_cents, displayed_price_currency_type).format(no_cents_if_whole: true, symbol: false)
+    # Sales JSON display path: soft-fail unknown codes via MoneyFormatter.
+    MoneyFormatter.format(amount_in_cents, displayed_price_currency_type, no_cents_if_whole: true, symbol: false)
   end
 
   def amount_refundable_cents_in_currency

--- a/app/modules/money_formatter.rb
+++ b/app/modules/money_formatter.rb
@@ -3,13 +3,59 @@
 module MoneyFormatter
   module_function
 
+  # Soft-fail unknown codes (log + ISO) so one corrupt sale cannot 500 a Sales list.
+  # Do not fall back to USD. Hard-fail callers should build Money::Currency themselves.
   def format(amount, currency_type, opts = {})
     amount ||= 0
-    opts[:symbol] = symbol_for(currency_type) unless opts[:symbol] == false
-    Money.new(amount, currency_type).format(opts)
+    opts = opts.dup
+    with_symbol = opts[:symbol] != false
+    currency = find_currency(currency_type)
+
+    unless currency
+      soft_fail_unknown_currency(currency_type)
+      number = Money.new(amount, "usd").format(opts.merge(symbol: false))
+      iso = iso_code_for(currency_type)
+      return with_symbol && iso.present? ? "#{number} #{iso}" : number
+    end
+
+    opts[:symbol] = pricing_or_registry_symbol(currency_type, currency) if with_symbol
+    Money.new(amount, currency).format(opts)
   end
 
   def symbol_for(currency_type)
-    CURRENCY_CHOICES.dig(currency_type, :symbol) || Money::Currency.new(currency_type).symbol
+    currency = find_currency(currency_type)
+    unless currency
+      soft_fail_unknown_currency(currency_type)
+      return iso_code_for(currency_type)
+    end
+
+    pricing_or_registry_symbol(currency_type, currency)
   end
+
+  def find_currency(currency_type)
+    code = currency_type.to_s.downcase
+    return if code.blank?
+
+    Money::Currency.new(code)
+  rescue Money::Currency::UnknownCurrency
+    nil
+  end
+  private_class_method :find_currency
+
+  def pricing_or_registry_symbol(currency_type, currency)
+    CURRENCY_CHOICES.dig(currency_type.to_s.downcase, :symbol) || currency.symbol
+  end
+  private_class_method :pricing_or_registry_symbol
+
+  def iso_code_for(currency_type)
+    currency_type.to_s.upcase.presence || ""
+  end
+  private_class_method :iso_code_for
+
+  def soft_fail_unknown_currency(currency_type)
+    Rails.logger.warn(
+      "MoneyFormatter: unknown currency #{currency_type.inspect}; displaying ISO code instead of raising"
+    )
+  end
+  private_class_method :soft_fail_unknown_currency
 end

--- a/app/modules/money_formatter.rb
+++ b/app/modules/money_formatter.rb
@@ -5,8 +5,11 @@ module MoneyFormatter
 
   def format(amount, currency_type, opts = {})
     amount ||= 0
-    # use the default symbol unless explicitly stated not to use one
-    opts[:symbol] = CURRENCY_CHOICES[currency_type][:symbol] unless opts[:symbol] == false
+    opts[:symbol] = symbol_for(currency_type) unless opts[:symbol] == false
     Money.new(amount, currency_type).format(opts)
+  end
+
+  def symbol_for(currency_type)
+    CURRENCY_CHOICES.dig(currency_type, :symbol) || Money::Currency.new(currency_type).symbol
   end
 end

--- a/spec/helpers/currency_helper_spec.rb
+++ b/spec/helpers/currency_helper_spec.rb
@@ -30,8 +30,14 @@ describe CurrencyHelper do
       expect(symbol_for(:gbp)).to eq "£"
     end
 
-    it "falls back to USD for unknown currency types" do
-      expect(symbol_for(:xyz)).to eq "$"
+    it "uses the registry symbol for historical currencies" do
+      expect(symbol_for(:dkk)).to eq "kr."
+      expect(symbol_for("dkk")).to eq "kr."
+      expect(symbol_for(:aud)).to eq "A$"
+    end
+
+    it "rejects invalid currencies instead of relabeling them as USD" do
+      expect { symbol_for(:xyz) }.to raise_error(Money::Currency::UnknownCurrency)
     end
   end
 
@@ -99,6 +105,7 @@ describe CurrencyHelper do
       expect(format_just_price_in_cents(799, "aud")).to eq("A$7.99")
       expect(format_just_price_in_cents(799, "gbp")).to eq("£7.99")
       expect(format_just_price_in_cents(799, "jpy")).to eq("¥799")
+      expect(format_just_price_in_cents(1250, "dkk")).to eq("12.50 kr.")
     end
   end
 

--- a/spec/helpers/currency_helper_spec.rb
+++ b/spec/helpers/currency_helper_spec.rb
@@ -36,8 +36,21 @@ describe CurrencyHelper do
       expect(symbol_for(:aud)).to eq "A$"
     end
 
-    it "rejects invalid currencies instead of relabeling them as USD" do
-      expect { symbol_for(:xyz) }.to raise_error(Money::Currency::UnknownCurrency)
+    it "soft-fails invalid currencies with the ISO code instead of relabeling them as USD" do
+      expect(Rails.logger).to receive(:warn).with(/unknown currency :xyz/)
+      symbol = symbol_for(:xyz)
+      expect(symbol).to eq("XYZ")
+      expect(symbol).not_to eq("$")
+    end
+
+    it "honors uppercase pricing-choice keys" do
+      expect(symbol_for("AUD")).to eq "A$"
+    end
+
+    it "soft-fails blank currencies without raising" do
+      expect(Rails.logger).to receive(:warn).with(/unknown currency/).twice
+      expect(symbol_for(nil)).to eq ""
+      expect(symbol_for("")).to eq ""
     end
   end
 

--- a/spec/modules/money_formatter_spec.rb
+++ b/spec/modules/money_formatter_spec.rb
@@ -2,6 +2,22 @@
 
 describe MoneyFormatter do
   describe "#format" do
+    it "formats a registered currency absent from product pricing choices" do
+      expect(CURRENCY_CHOICES).not_to have_key(:dkk)
+      expect(MoneyFormatter.format(1250, :dkk)).to eq "12.50 kr."
+      expect(MoneyFormatter.format(1200, "dkk", no_cents_if_whole: true)).to eq "12 kr."
+    end
+
+    it "omits the historical currency symbol only when requested" do
+      expect(MoneyFormatter.format(1250, :dkk, symbol: false)).to eq "12.50"
+      expect(MoneyFormatter.format(1250, :dkk, symbol: true)).to eq "12.50 kr."
+    end
+
+    it "does not relabel an invalid currency as USD" do
+      expect { MoneyFormatter.format(1250, :xyz) }.to raise_error(Money::Currency::UnknownCurrency)
+      expect { MoneyFormatter.format(1250, :xyz, symbol: false) }.to raise_error(Money::Currency::UnknownCurrency)
+    end
+
     describe "usd" do
       it "returns the correct string" do
         expect(MoneyFormatter.format(400, :usd)).to eq "$4.00"

--- a/spec/modules/money_formatter_spec.rb
+++ b/spec/modules/money_formatter_spec.rb
@@ -13,9 +13,17 @@ describe MoneyFormatter do
       expect(MoneyFormatter.format(1250, :dkk, symbol: true)).to eq "12.50 kr."
     end
 
-    it "does not relabel an invalid currency as USD" do
-      expect { MoneyFormatter.format(1250, :xyz) }.to raise_error(Money::Currency::UnknownCurrency)
-      expect { MoneyFormatter.format(1250, :xyz, symbol: false) }.to raise_error(Money::Currency::UnknownCurrency)
+    it "soft-fails unknown currencies with the ISO code instead of relabeling them as USD" do
+      expect(Rails.logger).to receive(:warn).with(/unknown currency :xyz/).at_least(:once)
+      expect(MoneyFormatter.format(1250, :xyz)).to eq "12.50 XYZ"
+      expect(MoneyFormatter.format(1250, :xyz, symbol: false)).to eq "12.50"
+      expect(MoneyFormatter.format(1250, :xyz)).not_to include("$")
+    end
+
+    it "soft-fails blank currencies without raising" do
+      expect(Rails.logger).to receive(:warn).with(/unknown currency/).at_least(:once)
+      expect(MoneyFormatter.format(1250, nil)).to eq "12.50"
+      expect(MoneyFormatter.format(1250, "")).to eq "12.50"
     end
 
     describe "usd" do
@@ -38,6 +46,34 @@ describe MoneyFormatter do
       it "returns the correct currency symbol" do
         expect(MoneyFormatter.format(400, :aud)).to eq "A$4.00"
       end
+
+      it "honors uppercase pricing-choice keys" do
+        expect(MoneyFormatter.format(400, "AUD")).to eq "A$4.00"
+      end
+    end
+  end
+
+  describe "#symbol_for" do
+    it "uses the pricing override before the registry" do
+      expect(MoneyFormatter.symbol_for(:aud)).to eq "A$"
+      expect(MoneyFormatter.symbol_for("AUD")).to eq "A$"
+    end
+
+    it "uses the registry symbol for historical currencies" do
+      expect(MoneyFormatter.symbol_for(:dkk)).to eq "kr."
+    end
+
+    it "soft-fails unknown currencies with the ISO code instead of relabeling them as USD" do
+      expect(Rails.logger).to receive(:warn).with(/unknown currency :xyz/)
+      symbol = MoneyFormatter.symbol_for(:xyz)
+      expect(symbol).to eq("XYZ")
+      expect(symbol).not_to eq("$")
+    end
+
+    it "soft-fails blank currencies with an empty string" do
+      expect(Rails.logger).to receive(:warn).with(/unknown currency/).twice
+      expect(MoneyFormatter.symbol_for(nil)).to eq ""
+      expect(MoneyFormatter.symbol_for("")).to eq ""
     end
   end
 end

--- a/spec/services/seller_mobile_analytics_service_spec.rb
+++ b/spec/services/seller_mobile_analytics_service_spec.rb
@@ -9,6 +9,22 @@ describe SellerMobileAnalyticsService do
   end
 
   describe "#process" do
+    it "serializes historical currencies in all-time sales without converting the displayed amount" do
+      purchase = create(:purchase, link: @product, price_cents: 200, created_at: 2.years.ago)
+      purchase.update_columns(displayed_price_currency_type: "dkk", displayed_price_cents: 1250)
+      index_model_records(Purchase)
+
+      result = described_class.new(@user, range: "all", fields: [:purchases, :sales_count]).process
+
+      expect(result[:sales_count]).to eq 1
+      expect(result[:revenue]).to eq 200
+      expect(result[:purchases].sole[:price]).to eq "12.50 kr."
+      expect(purchase.reload.formatted_display_price).to eq "12.50 kr."
+      expect(purchase.as_json[:currency_symbol]).to eq "kr."
+      expect(purchase.displayed_price_cents).to eq 1250
+      expect(purchase.price_cents).to eq 200
+    end
+
     it "returns the proper purchase data for all time" do
       valid_purchases = []
       travel_to(1.year.ago) do

--- a/spec/services/seller_mobile_analytics_service_spec.rb
+++ b/spec/services/seller_mobile_analytics_service_spec.rb
@@ -25,6 +25,21 @@ describe SellerMobileAnalyticsService do
       expect(purchase.price_cents).to eq 200
     end
 
+    it "soft-fails unknown purchase currencies in all-time sales instead of 500ing the list" do
+      purchase = create(:purchase, link: @product, price_cents: 200, created_at: 2.years.ago)
+      purchase.update_columns(displayed_price_currency_type: "xyz", displayed_price_cents: 1250)
+      index_model_records(Purchase)
+
+      expect(Rails.logger).to receive(:warn).with(/unknown currency/).at_least(:once)
+      result = described_class.new(@user, range: "all", fields: [:purchases, :sales_count]).process
+
+      expect(result[:sales_count]).to eq 1
+      expect(result[:revenue]).to eq 200
+      expect(result[:purchases].sole[:price]).to eq "12.50 XYZ"
+      expect(purchase.reload.formatted_display_price).to eq "12.50 XYZ"
+      expect(purchase.as_json[:currency_symbol]).to eq "XYZ"
+    end
+
     it "returns the proper purchase data for all time" do
       valid_purchases = []
       travel_to(1.year.ago) do

--- a/spec/services/seller_mobile_analytics_service_spec.rb
+++ b/spec/services/seller_mobile_analytics_service_spec.rb
@@ -37,7 +37,10 @@ describe SellerMobileAnalyticsService do
       expect(result[:revenue]).to eq 200
       expect(result[:purchases].sole[:price]).to eq "12.50 XYZ"
       expect(purchase.reload.formatted_display_price).to eq "12.50 XYZ"
-      expect(purchase.as_json[:currency_symbol]).to eq "XYZ"
+      json = purchase.as_json
+      expect(json[:currency_symbol]).to eq "XYZ"
+      expect(json[:amount_refundable_in_currency]).to eq purchase.amount_refundable_in_currency
+      expect(json[:amount_refundable_in_currency]).not_to include("$")
     end
 
     it "returns the proper purchase data for all time" do


### PR DESCRIPTION
## What
Use Money's currency registry when a historical sale has no product-pricing symbol override. Share lookup with purchase JSON. Unknown or corrupt codes soft-fail on public Sales / creator-app display paths: log and show the ISO code so one bad sale cannot 500 a list. Do not relabel them as USD.

## Why
Product-pricing choices are not a historical currency registry. A retired currency caused a nil dereference during seller analytics serialization. Raising on corrupt codes would still 500 paginated Sales JSON. Soft-fail keeps the list up and surfaces the bad code. No currency conversion, stored amount changes, or new pricing currencies. Ref antiwork/gumroad-private#2463.

## Before/After
Live synthetic-fixture walkthrough: https://github.com/user-attachments/assets/2063716d-b89c-4fd3-b6e8-cfed28ff5024

The same all-time sale raises with the base formatter, then renders `12.50 kr.` with this formatter. JSON reports `kr.`; displayed minor units and USD revenue are unchanged. The recording also verifies `symbol: false`, the supported AUD override, and invalid-code soft-fail (ISO display, not USD). Uploaded video read back byte-identically; final frame inspected.

## QA
- [x] Red-first formatter/helper and actual mobile analytics → Purchase serialization regression.
- [x] Complete relevant spec files, expanded presentment/presenter tests, scoped Ruby lint, and live walkthrough.
- [x] Astra+Fable code/spec/comment/evidence audit at prior head; Astra pack-autoreview clean after soft-fail follow-up.
- [x] Full current-head CI passed at `af0f470959bbf85787ac5937d9946e9a7fe86a4e`; checked September 8.
- [x] CI passed; ready for Gianfranco’s human review. No auto-merge.

## Test Results
- Formatter, currency helper, seller mobile analytics: 48 examples, 0 failures.
- Buyer-local helpers/presenter, receipt item/payment and invoice order presenters, purchase/charge presentment: 271 examples, 0 failures.
- Scoped RuboCop: 5 files, no offenses. All current pricing currencies match pre-fix formatting for zero, fractional and negative amounts, with/without symbols and whole-unit formatting.
- Local tests use isolated MySQL/Redis, a namespaced Elasticsearch setup, and test merchant-account seed. Red-first mobile test: 1 example, 1 failure at the exact formatter stack; live before/after demo: 1 example, 0 failures.
- `bin/test-confidence` was attempted but stopped during environment-failure baseline retries; its inferred confidence is not a passing-suite claim. The direct complete-file runs above are verified; full CI remains required.

Premerge review: clean @ af0f470959bbf85787ac5937d9946e9a7fe86a4e

Soft-fail follow-up: public Sales JSON logs unknown currencies and shows the ISO code (including refundable amount display). Astra pack-autoreview clean @ 8790a85e9ba084764c826306a96dbc58c63fb789.

Round 2: Astra + Fable clean. Round 1 assumed plain symbol-keyed choices; the real initializer uses `HashWithIndifferentAccess`. Actual Rails probes and the initializer disproved that finding; string and symbol AUD both retain `A$`.

Owner: Gianfranco for final human review after completed CI and QA. Money-path-capable shared formatter: human review by gianfrancopiana after all gates, no auto-merge.

---
AI disclosure: Built with OpenAI GPT-6 Astra; reviewed with GPT-6 Astra and Claude Fable 5. Prompt: fix historical-currency rendering without changing amounts, defaulting unknown codes to USD, or expanding new-product pricing; test formatter, helper and mobile serialization and require human review.


## Completion checklist
- [x] Scope — bounded fix described above.
- [x] Design — existing behavior and safety boundaries preserved.
- [x] Build — tests, current-head panel and QA evidence complete.
- [ ] Ship — human review, merge and production verification remain.
- [ ] Market — affected-user follow-up after production verification.
- [ ] Sell — confirm the reported outcome after deployment.

