### PR TITLE
Preserve parent receipt when a bundle purchase has no live members

### DIFF
--- a/app/models/concerns/charge/chargeable.rb
+++ b/app/models/concerns/charge/chargeable.rb
@@ -127,7 +127,11 @@ module Charge::Chargeable
   def unbundled_purchases
     @_unbundled_purchases ||=
       successful_purchases.map do |purchase|
-        purchase.is_bundle_purchase? ? purchase.product_purchases : [purchase]
+        if purchase.is_bundle_purchase?
+          purchase.product_purchases.presence || [purchase]
+        else
+          [purchase]
+        end
       end.flatten
   end
 

--- a/app/models/concerns/charge/chargeable.rb
+++ b/app/models/concerns/charge/chargeable.rb
@@ -128,7 +128,7 @@ module Charge::Chargeable
     @_unbundled_purchases ||=
       successful_purchases.map do |purchase|
         if purchase.is_bundle_purchase?
-          purchase.product_purchases.presence || [purchase]
+          purchase.product_purchases.presence || (purchase.purchase_state.in?(Purchase::ALL_SUCCESS_STATES_INCLUDING_TEST) ? [purchase] : [])
         else
           [purchase]
         end

--- a/app/models/concerns/charge/chargeable.rb
+++ b/app/models/concerns/charge/chargeable.rb
@@ -126,13 +126,18 @@ module Charge::Chargeable
 
   def unbundled_purchases
     @_unbundled_purchases ||=
-      successful_purchases.map do |purchase|
-        if purchase.is_bundle_purchase?
-          purchase.product_purchases.presence || (purchase.purchase_state.in?(Purchase::ALL_SUCCESS_STATES_INCLUDING_TEST) ? [purchase] : [])
-        else
+      successful_purchases.flat_map do |purchase|
+        if !purchase.is_bundle_purchase?
           [purchase]
+        elsif purchase.product_purchases.present?
+          purchase.product_purchases
+        elsif purchase.purchase_state.in?(Purchase::ALL_SUCCESS_STATES_INCLUDING_TEST)
+          # Memberless successful bundles still need a receipt line (library does the same).
+          [purchase]
+        else
+          []
         end
-      end.flatten
+      end
   end
 
   # Used by ReceiptPresenter to render a different title for recurring subscription

--- a/app/presenters/receipt_presenter/item_info.rb
+++ b/app/presenters/receipt_presenter/item_info.rb
@@ -115,8 +115,10 @@ class ReceiptPresenter::ItemInfo
     end
 
     # Empty-member bundles still render on the receipt (see Chargeable#unbundled_purchases).
-    # Hide View content only when the download page would also be empty: no live members and
-    # no files/rich content on the parent itself (converted products can keep both).
+    # Hide View content when there are no live members and the parent has no files/rich
+    # content of its own. Do not call Purchase.product_installments here: that path is too
+    # expensive for receipt render. Posts-only download pages stay reachable from the
+    # library row for signed-in buyers.
     def empty_member_bundle_without_content?
       return false unless purchase.is_bundle_purchase?
       return false if purchase.product_purchases.exists?

--- a/app/presenters/receipt_presenter/item_info.rb
+++ b/app/presenters/receipt_presenter/item_info.rb
@@ -111,9 +111,20 @@ class ReceiptPresenter::ItemInfo
       !purchase.is_preorder_authorization &&
       (purchase.url_redirect.present? || purchase.is_commission_completion_purchase?) &&
       purchase.link.native_type != Link::NATIVE_TYPE_COFFEE &&
-      # Empty-member bundles still render on the receipt (see Chargeable#unbundled_purchases),
-      # but their download page has nothing to open. Hide the CTA rather than send buyers there.
-      !(purchase.is_bundle_purchase? && purchase.product_purchases.empty?)
+      !empty_member_bundle_without_content?
+    end
+
+    # Empty-member bundles still render on the receipt (see Chargeable#unbundled_purchases).
+    # Hide View content only when the download page would also be empty: no live members and
+    # no files/rich content on the parent itself (converted products can keep both).
+    def empty_member_bundle_without_content?
+      return false unless purchase.is_bundle_purchase?
+      return false if purchase.product_purchases.exists?
+
+      redirect = purchase.url_redirect
+      return true if redirect.blank?
+
+      redirect.alive_product_files.none? && redirect.rich_content_json.blank?
     end
 
     def license_key

--- a/app/presenters/receipt_presenter/item_info.rb
+++ b/app/presenters/receipt_presenter/item_info.rb
@@ -110,7 +110,10 @@ class ReceiptPresenter::ItemInfo
       !purchase.is_gift_sender_purchase &&
       !purchase.is_preorder_authorization &&
       (purchase.url_redirect.present? || purchase.is_commission_completion_purchase?) &&
-      purchase.link.native_type != Link::NATIVE_TYPE_COFFEE
+      purchase.link.native_type != Link::NATIVE_TYPE_COFFEE &&
+      # Empty-member bundles still render on the receipt (see Chargeable#unbundled_purchases),
+      # but their download page has nothing to open. Hide the CTA rather than send buyers there.
+      !(purchase.is_bundle_purchase? && purchase.product_purchases.empty?)
     end
 
     def license_key

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -1771,6 +1771,47 @@ describe PurchasesController, :vcr do
         end
       end
 
+      context "when a test purchase is an empty bundle" do
+        let(:product) { create(:product, :bundle, name: "Receipt sample bundle") }
+        let(:purchase) { create(:test_purchase, link: product, email: "buyer@example.com") }
+
+        before do
+          product.bundle_products.each(&:mark_deleted!)
+          order = create(:order, purchases: [purchase])
+          create(:charge, order:, purchases: [purchase], seller: purchase.seller)
+          purchase.create_artifacts_and_send_receipt!
+        end
+
+        it "renders the purchased bundle instead of dropping the only receipt item" do
+          expect(purchase.reload.purchase_state).to eq("test_successful")
+          expect(purchase.charge.successful_purchases).to include(purchase)
+          expect(purchase.product_purchases).to be_empty
+
+          get :receipt, params: { id: purchase.external_id, email: purchase.email }
+
+          expect(response).to be_successful
+          expect(response.body).to include("Receipt sample bundle")
+          expect(response.body).to include("View content")
+        end
+
+        it "does not reveal the bundle when the email does not match" do
+          expect(CustomerMailer).not_to receive(:receipt)
+
+          get :receipt, params: { id: purchase.external_id, email: "wrong@example.com" }
+
+          expect(response).to redirect_to(confirm_receipt_email_purchase_path(purchase.external_id))
+          expect(response.body).not_to include("Receipt sample bundle")
+        end
+
+        it "requires email verification when no email is provided" do
+          expect(CustomerMailer).not_to receive(:receipt)
+
+          get :receipt, params: { id: purchase.external_id }
+
+          expect(response).to redirect_to(confirm_receipt_email_purchase_path(purchase.external_id))
+        end
+      end
+
       context "when the order has no successful purchases" do
         # A charge-backed purchase promotes the receipt's chargeable to its Order;
         # when that Order has no successful purchase, the orderable has no email and

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -1791,7 +1791,8 @@ describe PurchasesController, :vcr do
 
           expect(response).to be_successful
           expect(response.body).to include("Receipt sample bundle")
-          expect(response.body).to include("View content")
+          # No live members to open, so hide View content rather than link to an empty download page.
+          expect(response.body).not_to include("View content")
         end
 
         it "does not reveal the bundle when the email does not match" do

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -1480,6 +1480,24 @@ describe CustomerMailer do
       CustomerMailer.grouped_receipt([purchase.id], recommendations: false).body.decoded
     end
 
+    it "renders a test-successful empty bundle alongside paid receipts without failed items" do
+      bundle = create(:product, :bundle, name: "Receipt sample bundle", user: seller)
+      bundle.bundle_products.each(&:mark_deleted!)
+      test_purchase = create(:test_purchase, link: bundle, email: "buyer@example.com")
+      order = create(:order, purchases: [test_purchase])
+      create(:charge, order:, purchases: [test_purchase], seller:)
+      test_purchase.create_artifacts_and_send_receipt!
+      failed_purchase = create(:failed_purchase, link: create(:product, name: "Failed receipt item", user: seller))
+      failed_order = create(:order, purchases: [failed_purchase])
+      create(:charge, order: failed_order, purchases: [failed_purchase], seller:)
+
+      mail = CustomerMailer.grouped_receipt(purchases.map(&:id) + [test_purchase.id, failed_purchase.id])
+      body = mail.body.decoded
+
+      receipt_items = Nokogiri::HTML(body).css(".item .product-checkout-cell h4").map(&:text).map(&:strip)
+      expect(receipt_items).to contain_exactly("Receipt sample bundle", product.name, product.name)
+    end
+
     it "skips failed purchases whose charge has no successful purchases" do
       failed_purchase = create(:failed_purchase, link: product, seller:)
       charge = create(:charge, seller:)

--- a/spec/models/concerns/charge/chargeable_spec.rb
+++ b/spec/models/concerns/charge/chargeable_spec.rb
@@ -369,6 +369,24 @@ describe Charge::Chargeable do
       it "keeps the bundle purchase itself instead of dropping it" do
         expect(chargeable.unbundled_purchases).to eq([chargeable])
       end
+
+      it "keeps a test-successful parent for standalone and charge receipts" do
+        chargeable.update!(purchase_state: "test_successful")
+        charge = create(:charge, seller:, purchases: [chargeable])
+
+        expect(charge.successful_purchases).to include(chargeable)
+        expect(chargeable.product_purchases).to be_empty
+        expect(chargeable.unbundled_purchases).to eq([chargeable])
+        expect(charge.unbundled_purchases).to eq([chargeable])
+      end
+
+      it "does not invent a receipt item for a failed standalone bundle" do
+        chargeable.update!(purchase_state: "failed")
+
+        expect(chargeable.successful_purchases).to include(chargeable)
+        expect(chargeable.product_purchases).to be_empty
+        expect(chargeable.unbundled_purchases).to be_empty
+      end
     end
   end
 

--- a/spec/models/concerns/charge/chargeable_spec.rb
+++ b/spec/models/concerns/charge/chargeable_spec.rb
@@ -354,6 +354,22 @@ describe Charge::Chargeable do
         expect(chargeable.unbundled_purchases.second.link).to eq(bundled_product_two.product)
       end
     end
+
+    context "when the bundle purchase has no live member purchases" do
+      let(:product) do
+        create(:product, :bundle, name: "Memberless Bundle", user: seller).tap do |bundle|
+          bundle.bundle_products.each(&:mark_deleted!)
+        end
+      end
+
+      before do
+        chargeable.create_artifacts_and_send_receipt!
+      end
+
+      it "keeps the bundle purchase itself instead of dropping it" do
+        expect(chargeable.unbundled_purchases).to eq([chargeable])
+      end
+    end
   end
 
   describe "#is_recurring_subscription_charge" do

--- a/spec/presenters/receipt_presenter/item_info_spec.rb
+++ b/spec/presenters/receipt_presenter/item_info_spec.rb
@@ -178,9 +178,18 @@ describe ReceiptPresenter::ItemInfo do
               purchase.create_url_redirect!
             end
 
-            it "returns false" do
+            it "returns false when the parent also has nothing to open" do
               expect(purchase.product_purchases).to be_empty
               expect(props[:show_download_button]).to eq(false)
+            end
+
+            context "when the parent still has its own files" do
+              before { create(:product_file, link: product) }
+
+              it "returns true" do
+                expect(purchase.product_purchases).to be_empty
+                expect(props[:show_download_button]).to eq(true)
+              end
             end
           end
         end

--- a/spec/presenters/receipt_presenter/item_info_spec.rb
+++ b/spec/presenters/receipt_presenter/item_info_spec.rb
@@ -159,6 +159,30 @@ describe ReceiptPresenter::ItemInfo do
               expect(props[:show_download_button]).to eq(false)
             end
           end
+
+          context "when the purchase is an empty-member bundle" do
+            let(:product) { create(:product, :bundle, user: seller) }
+            let(:purchase) do
+              create(
+                :purchase,
+                link: product,
+                seller:,
+                merchant_account:,
+                price_cents: 1_499,
+                is_bundle_purchase: true
+              )
+            end
+
+            before do
+              product.bundle_products.each(&:mark_deleted!)
+              purchase.create_url_redirect!
+            end
+
+            it "returns false" do
+              expect(purchase.product_purchases).to be_empty
+              expect(props[:show_download_button]).to eq(false)
+            end
+          end
         end
       end
     end

--- a/spec/presenters/receipt_presenter/mail_subject_spec.rb
+++ b/spec/presenters/receipt_presenter/mail_subject_spec.rb
@@ -9,6 +9,24 @@ describe ReceiptPresenter::MailSubject, :vcr do
   let(:mail_subject) { described_class.build(chargeable) }
 
   describe ".build" do
+    describe "with a memberless bundle purchase" do
+      let(:product_one) do
+        create(:product, :bundle, name: "Memberless Bundle").tap do |bundle|
+          bundle.bundle_products.each(&:mark_deleted!)
+        end
+      end
+      let(:purchase_one) { create(:purchase, link: product_one) }
+      let(:chargeable) { purchase_one }
+
+      before do
+        purchase_one.create_artifacts_and_send_receipt!
+      end
+
+      it "renders the bundle itself instead of crashing on an empty collection" do
+        expect(mail_subject).to eq("You bought Memberless Bundle!")
+      end
+    end
+
     describe "with one purchase" do
       RSpec.shared_examples "one purchase mail subject" do
         it "returns expected subject" do


### PR DESCRIPTION
## What
Preserve successful empty bundle parents in receipt expansion, shared by Purchase and Charge. Ref antiwork/gumroad-private#2461.

## Why
An empty bundle expands to no receipt items: the standalone receipt subject crashes and grouped receipts omit the bundle. Fall back to the parent only for `ALL_SUCCESS_STATES_INCLUDING_TEST`; standalone `successful_purchases` does not filter state. Populated bundles still expand to their children. No controller authorization, charge selection or money movement changes.

## Before/After
Real Rails receipt request, synthetic test-successful purchase with a Charge and zero bundle members: before HTTP 500; after HTTP 200 with the parent item. At current head `2802cd061cd7892f95e91d1c45c394605b0433ba`, empty-member parents without files or rich content hide View content. Wrong email remains HTTP 302 without rendering the receipt. No email sent and no production data used.

NEW after stills below were captured at `2802cd061` (empty-member CTA hide). Earlier after stills at `2fc42670bb6521f58faa7614adff5cd8138f3523` that still showed View content are kept and labeled superseded / before-CTA-hide. Before HTTP 500 stills are unchanged.

## Test Results
- [x] State restriction: unconditional fallback gives 3 examples, 1 failure (failed standalone); fixed gives 3 examples, 0 failures.
- [x] Real controller + grouped mailer regression: original expansion gives 4 examples, 2 failures (nil.link_name and missing parent item); fixed gives 4 examples, 0 failures. Wrong/missing-email controls pass in both.
- [x] Full GET receipt authorization context, chargeable, subject, presenter and receipt-job suites: 128 examples, 0 failures.
- [x] Populated bundle, grouped receipt and multi-item paid mailer controls: 16 examples, 0 failures. Mixed grouped receipt asserts the exact purchased-item list, not recommendations.
- [x] Ruby lint clean; original commit retained.
- [x] Astra + Fable panel: no findings at the earlier reviewed head.
- [x] Separate later Astra + Fable QA audit: code, specs, comments and rendered evidence reviewed at the earlier reviewed head; no accepted findings.
- [x] Full earlier-head CI passed at `2fc42670bb6521f58faa7614adff5cd8138f3523`; checked September 8.

Prior premerge review: clean @ 2fc42670bb6521f58faa7614adff5cd8138f3523 (superseded by later commits; not a current-head verdict).

## QA
1. Create a bundle with its live member records removed, then a test purchase with an order and charge; run `create_artifacts_and_send_receipt!`. Verify the charge's successful collection contains the parent and `product_purchases` is empty.
2. Open its receipt with the matching email: the parent bundle must render and View content must be absent when the parent has no files or rich content. Wrong or missing email must redirect to email confirmation without rendering the mailer.
3. Confirm populated bundles still show their member purchases, mixed grouped receipts show only successful purchased items, and a failed standalone empty bundle has no `unbundled_purchases`. Keep View content when an empty-member parent still has its own files or rich content.

Gianfranco owns the follow-up changes. Current head `2802cd061cd7892f95e91d1c45c394605b0433ba` hides View content for memberless parents without files/rich content, unlike the superseded earlier after stills below. Gianfranco explicitly accepted the posts-only tradeoff in [review](https://github.com/antiwork/gumroad/pull/7544#discussion_r3960514996): receipt visibility remains files+rich-content only, with no installment probe. Posts-only content remains reachable through the library for signed-in buyers; signed-out buyers do not receive a View content link for that case. This is an accepted limitation, not a fixed defect or an outstanding product decision. No code change is needed for the ruling. Current-head full CI passed (Tests run 34247041926); prior panel and separate QA audit results apply only to the earlier head. No automerge; current-head panel/QA validation and final review remain with Gianfranco. Private tracker remains open until production deployment is verified.

---
AI disclosure: OpenAI GPT-6 Astra recovered the existing draft and added success-state/authorization coverage; reviewed by GPT-6 Astra and Claude Fable 5. Prompt: preserve the existing commit, restrict the empty-bundle fallback to successful states, prove receipt authorization and populated/paid controls, render synthetic evidence, and complete panel/QA/CI without automerge.

![Before desktop: real receipt HTTP 500](https://github.com/user-attachments/assets/f58d17d9-0b6a-4721-9468-e885c273553a)

![NEW after desktop @ 2802cd061: empty-member bundle, no View content](https://github.com/user-attachments/assets/6e597aa7-e780-425b-a2b3-3e3fd18b54af)

![NEW after mobile @ 2802cd061: empty-member bundle, no View content](https://github.com/user-attachments/assets/521cf85a-5662-4d50-a751-f10216c098bb)

![Before mobile: real receipt HTTP 500](https://github.com/user-attachments/assets/703afae9-1c80-4fbb-94ca-112615cdff14)

![Superseded after desktop @ 2fc42670 (before-CTA-hide; still shows View content)](https://github.com/user-attachments/assets/5518d819-1719-4458-8ce0-ea2e24b16534)

![Superseded after mobile @ 2fc42670 (before-CTA-hide; still shows View content)](https://github.com/user-attachments/assets/955688fe-71bd-4efc-89da-84f4eb7077d2)

![Desktop dark preference: email retains light styling (superseded head)](https://github.com/user-attachments/assets/74281075-1445-4afa-93c7-1ce8ca1718b0)

![Mobile dark preference: email retains light styling (superseded head)](https://github.com/user-attachments/assets/c4118c28-52a7-4602-827c-9d788f9ee156)

https://github.com/user-attachments/assets/d245d14f-0623-4f60-b90c-92c1e2ecc1da

## Completion checklist
- [x] Scope — bounded fix described above.
- [x] Design — existing behavior and safety boundaries preserved.
- [ ] Build — original fallback validated; latest human changes require current-head validation.
- [ ] Ship — human review, merge and production verification remain.
- [ ] Market — affected-user follow-up after production verification.
- [ ] Sell — confirm the reported outcome after deployment.
