### PR TITLE
Avoid allocating absent referral slices in analytics cache merges

### DIFF
--- a/app/services/creator_analytics/caching_proxy/formatters/by_referral.rb
+++ b/app/services/creator_analytics/caching_proxy/formatters/by_referral.rb
@@ -19,10 +19,10 @@ module CreatorAnalytics::CachingProxy::Formatters::ByReferral
     days_data.each do |day_data|
       days_count = day_data[:dates_and_months].size
       %i[views sales totals].each do |type|
-        day_data[:by_referral][type].each do |permalink, referrers|
-          referrers.each do |referrer, values|
+        (day_data[:by_referral][type] || {}).each do |permalink, referrers|
+          (referrers || {}).each do |referrer, values|
             series = data[:by_referral][type][permalink][referrer] ||= [0] * dates.size
-            series[total_day_index, days_count] = values
+            series[total_day_index, days_count] = values if values
           end
         end
       end

--- a/app/services/creator_analytics/caching_proxy/formatters/by_referral.rb
+++ b/app/services/creator_analytics/caching_proxy/formatters/by_referral.rb
@@ -11,31 +11,22 @@ module CreatorAnalytics::CachingProxy::Formatters::ByReferral
       day_data[:by_referral].values.map(&:keys)
     end.flatten.uniq
 
-    # Compile referrers by type and product
-    referrers = {}
     %i[views sales totals].each do |type|
-      referrers[type] ||= {}
-      permalinks.each do |permalink|
-        referrers[type][permalink] ||= []
-        days_data.each do |day_data|
-          referrers[type][permalink] += day_data.dig(:by_referral, type, permalink)&.keys || []
-        end
-        referrers[type][permalink].uniq!
-      end
+      permalinks.each { |permalink| data[:by_referral][type][permalink] = {} }
     end
 
-    permalinks.each do |permalink|
-      total_day_index = 0
-      days_data.each do |day_data|
-        %i[views sales totals].each do |type|
-          data[:by_referral][type][permalink] ||= {}
-          referrers[type][permalink].each do |referrer|
-            data[:by_referral][type][permalink][referrer] ||= [0] * dates.size
-            data[:by_referral][type][permalink][referrer][total_day_index .. (total_day_index + day_data[:dates_and_months].size - 1)] = (day_data.dig(:by_referral, type, permalink, referrer) || ([0] * day_data[:dates_and_months].size))
+    total_day_index = 0
+    days_data.each do |day_data|
+      days_count = day_data[:dates_and_months].size
+      %i[views sales totals].each do |type|
+        day_data[:by_referral][type].each do |permalink, referrers|
+          referrers.each do |referrer, values|
+            series = data[:by_referral][type][permalink][referrer] ||= [0] * dates.size
+            series[total_day_index, days_count] = values
           end
         end
-        total_day_index += day_data[:dates_and_months].size
       end
+      total_day_index += days_count
     end
 
     data[:dates_and_months] = D3.date_month_domain(dates.first .. dates.last)

--- a/spec/services/creator_analytics/caching_proxy/formatters/by_referral_spec.rb
+++ b/spec/services/creator_analytics/caching_proxy/formatters/by_referral_spec.rb
@@ -11,6 +11,34 @@ describe CreatorAnalytics::CachingProxy::Formatters::ByReferral do
   end
 
   describe "#merge_data_by_referral" do
+    it "fills sparse referral series without allocating for every absent day and referrer" do
+      dates = (Date.new(2021, 1, 1) .. Date.new(2021, 12, 31)).to_a
+      days_data = dates.each_with_index.map do |date, index|
+        {
+          dates_and_months: D3.date_month_domain([date]),
+          by_referral: %i[views sales totals].index_with do
+            { "product" => { "source-#{index % 20}.example.com" => [index + 1] } }
+          end
+        }.with_indifferent_access
+      end
+      original = Marshal.dump(days_data)
+      @service.merge_data_by_referral(days_data, dates)
+
+      allocated_before = GC.stat(:total_allocated_objects)
+      result = @service.merge_data_by_referral(days_data, dates)
+      allocations = GC.stat(:total_allocated_objects) - allocated_before
+
+      expect(allocations).to be < 100_000
+      %i[views sales totals].each do |type|
+        expect(result[:by_referral][type]["product"]).to eq(
+          20.times.to_h do |referrer|
+            ["source-#{referrer}.example.com", dates.each_index.map { |index| index % 20 == referrer ? index + 1 : 0 }]
+          end
+        )
+      end
+      expect(Marshal.dump(days_data)).to eq(original)
+    end
+
     it "returns data merged by referral" do
       # notable: without `product` & `profile` and with an array for values for different days
       day_one = {

--- a/spec/services/creator_analytics/caching_proxy/formatters/by_referral_spec.rb
+++ b/spec/services/creator_analytics/caching_proxy/formatters/by_referral_spec.rb
@@ -28,6 +28,7 @@ describe CreatorAnalytics::CachingProxy::Formatters::ByReferral do
       result = @service.merge_data_by_referral(days_data, dates)
       allocations = GC.stat(:total_allocated_objects) - allocated_before
 
+      # Proxy only: exhaustive union merge allocates ~159k on this fixture; sparse stays ~2k.
       expect(allocations).to be < 100_000
       %i[views sales totals].each do |type|
         expect(result[:by_referral][type]["product"]).to eq(
@@ -54,6 +55,71 @@ describe CreatorAnalytics::CachingProxy::Formatters::ByReferral do
         sales: { "product" => { "direct" => [0, 1] }, "empty-product" => {} },
         totals: { "product" => {}, "empty-product" => {} }
       )
+    end
+
+    it "matches the exhaustive-union merge byte-for-byte on deterministic sparse payloads" do
+      rng = Random.new(2464)
+      32.times do
+        date_count = rng.rand(2..8)
+        dates = date_count.times.map { |i| Date.new(2021, 1, 1) + i }
+        chunk_spans = []
+        remaining = date_count
+        while remaining.positive?
+          span = [rng.rand(1..3), remaining].min
+          chunk_spans << span
+          remaining -= span
+        end
+
+        offset = 0
+        days_data = chunk_spans.map do |span|
+          chunk_dates = dates[offset, span]
+          offset += span
+          products = Array.new(rng.rand(1..3)) { |i| "p#{i}" }
+          by_referral = {}
+          %i[views sales totals].each do |type|
+            next if rng.rand < 0.15
+
+            by_referral[type] = products.each_with_object({}) do |permalink, memo|
+              if rng.rand < 0.1
+                memo[permalink] = nil
+                next
+              end
+              referrers = Array.new(rng.rand(0..3)) { |i| "ref-#{i}" }
+              memo[permalink] = referrers.each_with_object({}) do |referrer, refs|
+                refs[referrer] = rng.rand < 0.1 ? nil : Array.new(span) { rng.rand(0..5) }
+              end
+            end
+          end
+          {
+            dates_and_months: D3.date_month_domain(chunk_dates),
+            by_referral: by_referral
+          }.with_indifferent_access
+        end
+
+        expected = exhaustive_union_merge_by_referral(days_data, dates)
+        actual = @service.merge_data_by_referral(days_data, dates)
+        expect(actual[:by_referral].as_json.to_json).to eq(expected.as_json.to_json)
+      end
+    end
+
+    it "copies a length-mismatched chunk the same way range assignment did" do
+      days_data = [
+        {
+          dates_and_months: D3.date_month_domain(@dates.first(2)),
+          by_referral: {
+            views: { "product" => { "short" => [9], "long" => [1, 2, 3] } },
+            sales: {},
+            totals: {}
+          }
+        }.with_indifferent_access
+      ]
+
+      expected = exhaustive_union_merge_by_referral(days_data, @dates.first(2))
+      actual = @service.merge_data_by_referral(days_data, @dates.first(2))
+
+      expect(actual[:by_referral].as_json.to_json).to eq(expected.as_json.to_json)
+      expect(actual[:by_referral][:views]["product"]["short"]).to eq([9])
+      expect(actual[:by_referral][:views]["product"]["long"]).to eq([1, 2, 3])
     end
 
     it "returns data merged by referral" do
@@ -275,4 +341,44 @@ describe CreatorAnalytics::CachingProxy::Formatters::ByReferral do
       )
     end
   end
+
+  # Mirrors pre-PR exhaustive day*product*referrer union merge for equivalence asserts.
+  def exhaustive_union_merge_by_referral(days_data, dates)
+    data = { views: {}, sales: {}, totals: {} }
+
+    permalinks = days_data.flat_map do |day_data|
+      day_data[:by_referral].values.compact.map { |products| products.keys }
+    end.flatten.uniq
+
+    referrers = {}
+    %i[views sales totals].each do |type|
+      referrers[type] = {}
+      permalinks.each do |permalink|
+        referrers[type][permalink] = []
+        days_data.each do |day_data|
+          referrers[type][permalink] += day_data.dig(:by_referral, type, permalink)&.keys || []
+        end
+        referrers[type][permalink].uniq!
+      end
+    end
+
+    permalinks.each do |permalink|
+      total_day_index = 0
+      days_data.each do |day_data|
+        days_count = day_data[:dates_and_months].size
+        %i[views sales totals].each do |type|
+          data[type][permalink] ||= {}
+          referrers[type][permalink].each do |referrer|
+            data[type][permalink][referrer] ||= [0] * dates.size
+            values = day_data.dig(:by_referral, type, permalink, referrer) || ([0] * days_count)
+            data[type][permalink][referrer][total_day_index, days_count] = values
+          end
+        end
+        total_day_index += days_count
+      end
+    end
+
+    data
+  end
+
 end

--- a/spec/services/creator_analytics/caching_proxy/formatters/by_referral_spec.rb
+++ b/spec/services/creator_analytics/caching_proxy/formatters/by_referral_spec.rb
@@ -39,6 +39,23 @@ describe CreatorAnalytics::CachingProxy::Formatters::ByReferral do
       expect(Marshal.dump(days_data)).to eq(original)
     end
 
+    it "preserves zeros and empty products for missing cached types and nil referral values" do
+      days_data = [
+        { by_referral: { views: { "product" => { "direct" => [2], "empty" => nil }, "empty-product" => nil } } },
+        { by_referral: { sales: { "product" => { "direct" => [1] } } } }
+      ].map.with_index do |data, index|
+        data.merge(dates_and_months: D3.date_month_domain([@dates[index]])).with_indifferent_access
+      end
+
+      result = @service.merge_data_by_referral(days_data, @dates.first(2))
+
+      expect(result[:by_referral]).to eq(
+        views: { "product" => { "direct" => [2, 0], "empty" => [0, 0] }, "empty-product" => {} },
+        sales: { "product" => { "direct" => [0, 1] }, "empty-product" => {} },
+        totals: { "product" => {}, "empty-product" => {} }
+      )
+    end
+
     it "returns data merged by referral" do
       # notable: without `product` & `profile` and with an array for values for different days
       day_one = {

--- a/spec/services/creator_analytics/caching_proxy/formatters/by_referral_spec.rb
+++ b/spec/services/creator_analytics/caching_proxy/formatters/by_referral_spec.rb
@@ -85,8 +85,8 @@ describe CreatorAnalytics::CachingProxy::Formatters::ByReferral do
                 next
               end
               referrers = Array.new(rng.rand(0..3)) { |i| "ref-#{i}" }
-              memo[permalink] = referrers.each_with_object({}) do |referrer, refs|
-                refs[referrer] = rng.rand < 0.1 ? nil : Array.new(span) { rng.rand(0..5) }
+              memo[permalink] = referrers.index_with do |referrer|
+                rng.rand < 0.1 ? nil : Array.new(span) { rng.rand(0..5) }
               end
             end
           end
@@ -380,5 +380,4 @@ describe CreatorAnalytics::CachingProxy::Formatters::ByReferral do
 
     data
   end
-
 end


### PR DESCRIPTION
## What
Merge cached referral analytics by copying only populated product/referrer slices into zero-filled series. All-time remains available; response fields, key order, values, and date range are unchanged.

## Why
The old merge visits every day × product × all-time referrer even when that referrer has no activity on the day. Each miss allocates temporary arrays and performs recursive indifferent-access lookups. A CPU profile of the actual formatter attributed 79.4% of samples to garbage collection; the corresponding allocation profile concentrated in these lookups and zero-slice writes.

This fixes a reproduced allocation bottleneck, not a verified explanation of a particular production timeout. The production seller's cardinalities and post-deploy latency still need measurement. No query/index changes, caps, rescues, or UI removal.

## Before-After
Synthetic fixture: 1,424 days, 20 products, 60 rotating referrers per product; one active referrer per product/day. Same current-code cache inputs, warmed once then three measurements per implementation. Process CPU is reported separately from wall time because this is a shared host.

| Cache merge | Before | After |
| --- | ---: | ---: |
| Median process CPU | 12.613026 s | 0.093655 s |
| Median allocated objects | 36,226,441 | 58,141 |
| JSON response bytes | 10,504,598 | 10,504,598 |

All three runs assert byte-for-byte JSON equality. A further 101 deterministic randomized cases cover mixed single/multi-day spans, missing types, nil products/referrer values, empty products, product order, negative totals, and input nonmutation. No rendered layout/copy changes; the existing analytics walkthrough remains owed before ready: the documented seeded seller login was rejected on the new preview.

## Test Results
- Focused formatter suite: 5 examples, 0 failures with in-process merchant seeds in the leased test database; schema reload disabled with an explicit pending-migration check.
- Full controller/render probe on the synthetic long-range cache: HTTP 200, 1,424 dates, 10,504,598 response bytes exactly equal to baseline JSON, 3.216 s locally; external cache-read source stubbed, actual proxy merge and controller serialization exercised.
- Storage/source suites: 22 examples, 0 failures (ComputedSalesAnalyticsDay and ProductPageViews).
- Full-suite CI at current head: 79 successful checks, 17 skipped/noop checks, no failures or pending check runs (96 enumerated and verified). Preview deployment is tracked separately.
- RuboCop: 2 files, no offenses.
- Current-code profiling separately measured cache compilation, merge, live Web transformation, and ActiveSupport JSON encoding.
- Baseline formatter control: 5 examples, 1 failure; exactly the allocation regression fails (170,316 objects vs 100,000 ceiling). First-head control: exactly the new nil-payload compatibility case fails. Current-head relevant analytics suite: 90 examples, 0 failures (formatter, caching proxy, Web, Sales, and analytics controller). Runs require TZ=UTC and warmed Vite assets for untouched layout specs.
- `bin/test-confidence` was exercised but is not evidence: it reported 99% with zero passing tests and six unverified skips. Direct suite runs are the gate instead.
- Development autoreview clean. Final panel round 1 found nil-payload compatibility; reproduced and corrected with a regression test. Round 2 Astra+Fable panel clean at current head (zero findings). Separate QA audit passed code/spec/comment review; evidence audit remains blocked by authenticated preview access.

### QA steps
Run the formatter and caching-proxy specs. On a seeded preview, choose Analytics → All-time and compare referral totals and date series with the baseline; verify there are no missing products/referrers or date-range restrictions. This preview walkthrough could not be performed because the documented seed login was rejected. Use a working preview seller session, then verify All time and attach the walkthrough with `gh --attach`.

Prior premerge review: clean @ a32192fd7680576114fb4ec996f0e053b138823d (not a verdict on the later human commits).

---
Built with OpenAI GPT-6 Astra. Instructions: profile all-time referral CPU/allocations/merge/serialization on synthetic size-shaped fixtures; retain all-time; make only the smallest proven improvement and prove exact response equivalence.


### Remaining verification
Earlier-head deployment [6328877693](https://github.com/antiwork/gumroad/deployments) now serves https://perf-referral-profile-2464.apps.staging.gumroad.org with x-revision a32192fd7680. The initial TLS provisioning delay has cleared; a real browser login attempt using the documented preview seller credentials returned to `/login?next=%2Fdashboard`. The authenticated analytics walkthrough could not run; no screenshots/video were attached. The authenticated preview login did not reach Analytics; no completed walkthrough is claimed. Full CI is green at current head c9b033a0b5372e9deea3f8dced2537fee1fc90d1; the recorded Astra+Fable panel predates Gianfranco’s two later test commits. The earlier review does not cover those test changes, and authenticated visual verification remains incomplete. No auto-merge is armed.

## Completion checklist
- [x] Scope — reduce sparse referral-merge allocations.
- [x] Design — preserve response equivalence.
- [ ] Build — current-head panel verification after the later test changes.
- [ ] Ship — authenticated preview evidence and production verification.
- [ ] Market — no production speed claim from synthetic timing.
- [ ] Sell — verify production outcome.
