### PR TITLE
Avoid repeated cover and avatar variant queries in product cards

### DIFF
--- a/app/controllers/api/v2/links_controller.rb
+++ b/app/controllers/api/v2/links_controller.rb
@@ -3,7 +3,7 @@
 class Api::V2::LinksController < Api::V2::BaseController
   BASE_PRODUCT_ASSOCIATIONS = [
     :preorder_link, :tags, :taxonomy,
-    { display_asset_previews: [:file_attachment, :file_blob] },
+    { display_asset_previews: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } } },
     { bundle_products: [:product, :variant] },
   ].freeze
 

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -895,7 +895,7 @@ class LinksController < ApplicationController
       @product = Link.includes(
         :variant_categories_alive,
         :alive_prices,
-        { display_asset_previews: [:file_attachment, :file_blob] },
+        { display_asset_previews: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } } },
         :alive_third_party_analytics
       ).find(@product.id)
     end

--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -358,9 +358,9 @@ class AssetPreview < ApplicationRecord
 
       enqueue_retina_variant_process
 
-      # Inline workers finish during enqueue. Re-read so this call and the
-      # next one return the same URL.
-      file.blob.variant_records.reset if file.blob.variant_records.loaded?
+      # Inline workers finish during enqueue. Drop the preloaded variant rows and
+      # re-read so this call and the next one return the same URL.
+      file.blob.variant_records.reset
       variant = retina_variant
       if variant && variant_processed?(variant)
         Rails.cache.fetch("attachment_#{file.id}_retina_url") { variant.url }

--- a/app/models/asset_preview.rb
+++ b/app/models/asset_preview.rb
@@ -360,6 +360,7 @@ class AssetPreview < ApplicationRecord
 
       # Inline workers finish during enqueue. Re-read so this call and the
       # next one return the same URL.
+      file.blob.variant_records.reset if file.blob.variant_records.loaded?
       variant = retina_variant
       if variant && variant_processed?(variant)
         Rails.cache.fetch("attachment_#{file.id}_retina_url") { variant.url }
@@ -427,7 +428,12 @@ class AssetPreview < ApplicationRecord
     def variant_processed?(variant)
       return false unless ActiveStorage.track_variants
 
-      variant.blob.variant_records.exists?(variation_digest: variant.variation.digest)
+      records = variant.blob.variant_records
+      if records.loaded?
+        records.any? { |record| record.variation_digest == variant.variation.digest }
+      else
+        records.exists?(variation_digest: variant.variation.digest)
+      end
     end
     alias_method :resized_poster_exists?, :variant_processed?
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -917,7 +917,7 @@ class Purchase < ApplicationRecord
     .not_is_archived_original_subscription_purchase
     .not_rental_expired
     .order(id: :desc)
-    .includes(:preorder, :purchaser, :seller, :subscription, :link, url_redirect: { purchase: { link: [:user, :thumbnail_alive, { display_asset_previews: [:file_attachment, :file_blob] }] } })
+    .includes(:preorder, :purchaser, :seller, :subscription, :link, url_redirect: { purchase: { link: [:user, :thumbnail_alive, { display_asset_previews: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } } }] } })
   }
   scope :for_library, lambda {
     all_success_states

--- a/app/presenters/product_presenter/card.rb
+++ b/app/presenters/product_presenter/card.rb
@@ -9,10 +9,10 @@ class ProductPresenter::Card
     :alive_prices, :product_review_stat, :default_offer_code, :skus,
     {
       tiers: :alive_prices,
-      user: [:avatar_attachment, :avatar_blob, :custom_domain],
+      user: [:custom_domain, { avatar_attachment: { blob: { variant_records: { image_attachment: :blob } } } }],
       variant_categories_alive: :alive_variants,
       thumbnail_alive: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
-      display_asset_previews: [:file_attachment, :file_blob],
+      display_asset_previews: { file_attachment: { blob: { variant_records: { image_attachment: :blob } } } },
       bundle_products: [:variant, { product: [{ variant_categories_alive: :alive_variants }, :tiers] }],
     }
   ]

--- a/spec/models/asset_preview_variant_queries_spec.rb
+++ b/spec/models/asset_preview_variant_queries_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AssetPreview do
+  def preloaded_preview(id)
+    described_class.includes(file_attachment: { blob: { variant_records: { image_attachment: :blob } } }).find(id)
+  end
+
+  it "returns the original and queues processing when the preloaded variants omit the requested size" do
+    preview = create(:asset_preview)
+    preview.file.variant(resize_to_limit: [20, 20]).processed
+    preview = preloaded_preview(preview.id)
+    original = preview.file.url
+
+    expect { expect(preview.url_from_file).to eq(original) }.to change(ProcessAssetPreviewRetinaWorker.jobs, :size).by(1)
+    expect(preview.file.blob.variant_records.reload.map(&:variation_digest)).not_to include(preview.retina_variant.variation.digest)
+  end
+
+  it "returns the newly generated variant when an inline worker fills a preloaded miss" do
+    preview = preloaded_preview(create(:asset_preview).id)
+    expect(preview.file.blob.variant_records).to be_empty
+
+    returned = Sidekiq::Testing.inline! { preview.url_from_file }
+
+    expect(returned).to eq(preview.reload.retina_variant.url)
+    expect(returned).not_to eq(preview.file.url)
+  end
+end

--- a/spec/presenters/product_presenter/card_spec.rb
+++ b/spec/presenters/product_presenter/card_spec.rb
@@ -132,6 +132,40 @@ describe ProductPresenter::Card do
         queries
       end
 
+      %i[thumbnail cover avatar].each do |source|
+        it "does not query persisted #{source} variants while rendering cards" do
+          products = Array.new(2) do
+            seller = create(:user)
+            product = create(:product, user: seller)
+            case source
+            when :thumbnail
+              create(:thumbnail, product:).thumbnail_variant
+            when :cover
+              create(:asset_preview, link: product).generate_retina_variant!
+            when :avatar
+              seller.avatar.attach(io: File.open(Rails.root.join("spec/support/fixtures/smilie.png")), filename: "smilie.png", content_type: "image/png")
+              seller.avatar_variant
+            end
+            product
+          end
+          expected = products.map do |product|
+            described_class.new(product: product.reload).for_web(compute_description: false, compute_inventory: false)
+          end
+          Rails.cache.clear
+          loaded = Link.where(id: products.map(&:id)).order(:id).includes(*ProductPresenter::ASSOCIATIONS_FOR_CARD).to_a
+          cards = nil
+          queries = capture_queries do
+            ActiveRecord::Base.uncached do
+              cards = loaded.map { |product| described_class.new(product:).for_web(compute_description: false, compute_inventory: false) }
+            end
+          end
+
+          expect(cards).to eq(expected)
+          expect(cards.all? { |card| (source == :avatar ? card.dig(:seller, :avatar_url) : card[:thumbnail_url]).present? }).to eq(true)
+          expect(queries.grep(/FROM `active_storage_/)).to be_empty
+        end
+      end
+
       it "does not issue per-row queries for preloaded associations" do
         # Mix of product shapes: digital, physical (skus), variant categories,
         # rentable. Each exercises a different ASSOCIATIONS branch.

--- a/spec/presenters/product_presenter/card_spec.rb
+++ b/spec/presenters/product_presenter/card_spec.rb
@@ -132,6 +132,8 @@ describe ProductPresenter::Card do
         queries
       end
 
+      # Thumbnail already passed before the cover/avatar preload landed; it stays as a
+      # guard so nobody trims the shared preload graph.
       %i[thumbnail cover avatar].each do |source|
         it "does not query persisted #{source} variants while rendering cards" do
           products = Array.new(2) do


### PR DESCRIPTION
## What

Batch-load the persisted cover and seller-avatar variants that public product cards render. The thumbnail preload already did this; covers and avatars now use the same preload graph. `AssetPreview#variant_processed?` reads the loaded variant rows when they are present and falls back to the database lookup when they are not. After it enqueues variant processing it drops the loaded rows and re-reads, so an inline worker still returns the generated image.

The same preload graph now applies to the other places that render cover URLs from a preloaded product: the API v2 links endpoints, the product page, and the receipts scope on `Purchase`.

## Why

Two-card reproductions with persisted variants and cold URL caches showed where the queries came from. Thumbnails issued no Active Storage queries. Each cover fallback issued eight (existence check, variant, image attachment, blob) and each seller avatar issued six. The existence check used `exists?`, which bypasses the loaded association, and the cover and avatar variant rows were not preloaded at all.

Image processing, avatar storage repair, and card payloads are unchanged.

## Before/After

Active Storage SELECTs during serialization, two cards each with a persisted image:

| Source | Before | After |
| --- | ---: | ---: |
| Thumbnail | 0 | 0 |
| Cover fallback | 8 | 0 |
| Seller avatar | 6 | 0 |

A nine-cover-card probe that includes the preload itself went from 39 Active Storage SELECTs to 6.

Walkthrough video: pending.

## Test Results

- `bundle exec rspec spec/presenters/product_presenter/card_spec.rb spec/models/asset_preview_variant_queries_spec.rb spec/controllers/api/v2/links_controller_spec.rb`: all pass.
- `bundle exec rspec spec/modules/user/posts_spec.rb`: 14 examples fail locally in factory setup, before the changed scope runs. `ProductFile` rejects the local S3 endpoint URL. CI covers them.
- Request specs that render the product page could not run in this worktree: it has no Vite build. CI covers them.
- `bundle exec rubocop` on the changed files: no offenses.
- The cover and avatar card examples fail on `main`. The thumbnail example passes on `main` and stays as a guard for the shared preload graph.
- Removing the `variant_records.reset` makes the inline-worker example fail.
- Autoreview (Codex) on the branch against `origin/main`: clean.

---

AI assistance: OpenAI GPT-6 Astra for the initial change, Claude Fable 5.1 for the review fixes and the follow-up preloads.
