### PR TITLE
Keep refunds committed when fee retention fails; skip BGN transfer reversals

### DIFF
--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -763,7 +763,13 @@ class StripeChargeProcessor
     destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
                                                                           stripe_account: stripe_account_id)
     holding_abs = destination_balance_transaction.net.abs
-    persist_refund_fee_holding_debit!(refund, holding_abs) if refund.present?
+    if refund.present?
+      persist_refund_fee_holding_debit!(
+        refund,
+        holding_abs,
+        currency: credit.merchant_account.currency
+      )
+    end
     holding_abs
   end
   private_class_method :resume_transfer_reversal_for_refund_fee
@@ -797,7 +803,9 @@ class StripeChargeProcessor
                   when Currency::EUR then eur_amount_cents
                   when BGN then (BigDecimal(eur_amount_cents) * BGN_PER_EUR).round
                   end
-    persist_refund_fee_holding_debit!(refund, holding_abs) if refund.present? && holding_abs.present?
+    if refund.present? && holding_abs.present?
+      persist_refund_fee_holding_debit!(refund, holding_abs, currency: credit.merchant_account.currency)
+    end
     holding_abs
   end
 
@@ -815,7 +823,7 @@ class StripeChargeProcessor
                                                    stripe_account: stripe_account_id)
       holding_abs = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
                                                         stripe_account: stripe_account_id).net.abs
-      persist_refund_fee_holding_debit!(refund, holding_abs)
+      persist_refund_fee_holding_debit!(refund, holding_abs, currency: credit.merchant_account.currency)
       holding_abs
     when FEE_DEBIT_OP_EUR_DEBIT
       eur_amount_cents = refund.refund_fee_eur_debit_cents
@@ -825,11 +833,11 @@ class StripeChargeProcessor
                     when Currency::EUR then eur_amount_cents.to_i
                     when BGN then (BigDecimal(eur_amount_cents) * BGN_PER_EUR).round
                     end
-      persist_refund_fee_holding_debit!(refund, holding_abs) if holding_abs.present?
+      persist_refund_fee_holding_debit!(refund, holding_abs, currency: credit.merchant_account.currency) if holding_abs.present?
       holding_abs
     when FEE_DEBIT_OP_US_DEBIT
       holding_abs = credit.amount_cents.abs
-      persist_refund_fee_holding_debit!(refund, holding_abs)
+      persist_refund_fee_holding_debit!(refund, holding_abs, currency: Currency::USD)
       holding_abs
     end
   rescue StandardError => e
@@ -843,12 +851,16 @@ class StripeChargeProcessor
   end
   private_class_method :record_refund_fee_debit_marker!
 
-  def self.persist_refund_fee_holding_debit!(refund, holding_debit_cents)
+  def self.persist_refund_fee_holding_debit!(refund, holding_debit_cents, currency: nil)
     return if refund.blank? || holding_debit_cents.blank?
-    return if refund.refund_fee_holding_debit_cents.to_i == holding_debit_cents.to_i
+    currency = currency.to_s.downcase.presence
+    return if refund.refund_fee_holding_debit_cents.to_i == holding_debit_cents.to_i &&
+      (currency.blank? || refund.refund_fee_holding_debit_currency.to_s.casecmp?(currency))
 
     ActiveRecord::Base.transaction(requires_new: true) do
-      refund.update!(refund_fee_holding_debit_cents: holding_debit_cents.to_i)
+      attrs = { refund_fee_holding_debit_cents: holding_debit_cents.to_i }
+      attrs[:refund_fee_holding_debit_currency] = currency if currency.present?
+      refund.update!(attrs)
     end
   end
   private_class_method :persist_refund_fee_holding_debit!

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -811,23 +811,29 @@ class StripeChargeProcessor
     refund = credit.fee_retention_refund
     # Reuse the first requested EUR amount so a stable idempotency key never pairs with a
     # different FX-converted amount on retry (Stripe rejects parameter changes).
-    eur_amount_cents = refund&.refund_fee_eur_debit_cents.presence || usd_cents_to_currency(Currency::EUR, usd_amount_cents)
+    proposed_eur_amount_cents = refund&.refund_fee_eur_debit_cents.presence || usd_cents_to_currency(Currency::EUR, usd_amount_cents)
     if refund.present?
       claimed = Credit.persist_refund_fee_debit_choice!(refund,
                   operation: FEE_DEBIT_OP_EUR_DEBIT,
-                  amount_cents: eur_amount_cents)
+                  amount_cents: proposed_eur_amount_cents)
       unless claimed
         return debit_stripe_account_for_refund_fee(credit:)
       end
+      # Immutable amount selected under the refund lock (also mirrored on eur_debit_cents).
+      eur_amount_cents = refund.reload.refund_fee_debit_amount_cents.presence ||
+        refund.refund_fee_eur_debit_cents.presence ||
+        proposed_eur_amount_cents
       if refund.refund_fee_eur_debit_cents.blank?
         ActiveRecord::Base.transaction(requires_new: true) do
           refund.update!(refund_fee_eur_debit_cents: eur_amount_cents)
         end
       end
+    else
+      eur_amount_cents = proposed_eur_amount_cents
     end
     transfer_options = { stripe_account: credit.merchant_account.charge_processor_merchant_id }
     transfer_options[:idempotency_key] = "refund_fee_eur_debit_#{refund.external_id}" if refund&.id.present?
-    transfer = Stripe::Transfer.create({ amount: eur_amount_cents, currency: Currency::EUR, destination: STRIPE_PLATFORM_ACCOUNT_ID },
+    transfer = Stripe::Transfer.create({ amount: eur_amount_cents.to_i, currency: Currency::EUR, destination: STRIPE_PLATFORM_ACCOUNT_ID },
                                        transfer_options)
     record_refund_fee_debit_marker!(refund, transfer.id) if refund.present?
 

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -843,10 +843,14 @@ class StripeChargeProcessor
       unless claimed
         return debit_stripe_account_for_refund_fee(credit:)
       end
-      # Immutable amount selected under the refund lock (also mirrored on eur_debit_cents).
-      eur_amount_cents = refund.reload.refund_fee_debit_amount_cents.presence ||
+      # Use in-memory sticky fields from the claim we just won. Do not reload: a concurrent
+      # InvalidRequest release can replace them with another generation/operation.
+      return debit_stripe_account_for_refund_fee(credit:) unless refund.refund_fee_debit_operation == FEE_DEBIT_OP_EUR_DEBIT
+
+      eur_amount_cents = refund.refund_fee_debit_amount_cents.presence ||
         refund.refund_fee_eur_debit_cents.presence ||
         proposed_eur_amount_cents
+      attempted_generation = refund.refund_fee_debit_generation.to_i
       if refund.refund_fee_eur_debit_cents.blank?
         ActiveRecord::Base.transaction(requires_new: true) do
           refund.update!(refund_fee_eur_debit_cents: eur_amount_cents)
@@ -854,9 +858,9 @@ class StripeChargeProcessor
       end
     else
       eur_amount_cents = proposed_eur_amount_cents
+      attempted_generation = 0
     end
     transfer_options = { stripe_account: credit.merchant_account.charge_processor_merchant_id }
-    attempted_generation = refund&.refund_fee_debit_generation.to_i
     if refund&.id.present?
       transfer_options[:idempotency_key] = if attempted_generation.zero?
         "refund_fee_eur_debit_#{refund.external_id}"

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -856,11 +856,23 @@ class StripeChargeProcessor
       eur_amount_cents = proposed_eur_amount_cents
     end
     transfer_options = { stripe_account: credit.merchant_account.charge_processor_merchant_id }
-    transfer_options[:idempotency_key] = "refund_fee_eur_debit_#{refund.external_id}" if refund&.id.present?
-    transfer = Stripe::Transfer.create(
-      { amount: eur_amount_cents.to_i, currency: Currency::EUR, destination: STRIPE_PLATFORM_ACCOUNT_ID },
-      transfer_options
-    )
+    attempted_generation = refund&.refund_fee_debit_generation.to_i
+    if refund&.id.present?
+      transfer_options[:idempotency_key] = if attempted_generation.zero?
+        "refund_fee_eur_debit_#{refund.external_id}"
+      else
+        "refund_fee_eur_debit_#{refund.external_id}_g#{attempted_generation}"
+      end
+    end
+    begin
+      transfer = Stripe::Transfer.create(
+        { amount: eur_amount_cents.to_i, currency: Currency::EUR, destination: STRIPE_PLATFORM_ACCOUNT_ID },
+        transfer_options
+      )
+    rescue Stripe::InvalidRequestError
+      Credit.release_sticky_refund_fee_debit_choice!(refund, generation: attempted_generation) if refund.present?
+      raise
+    end
     record_refund_fee_debit_marker!(refund, transfer.id) if refund.present?
 
     holding_abs = case credit.merchant_account.currency.to_s.downcase

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -762,12 +762,12 @@ class StripeChargeProcessor
     return if transfer_id.blank? || amount_cents.blank?
 
     reversal_opts = {}
+    attempted_generation = refund&.refund_fee_debit_generation.to_i
     if refund&.id.present?
-      generation = refund.refund_fee_debit_generation.to_i
-      reversal_opts[:idempotency_key] = if generation.zero?
+      reversal_opts[:idempotency_key] = if attempted_generation.zero?
         "refund_fee_reversal_#{refund.external_id}"
       else
-        "refund_fee_reversal_#{refund.external_id}_g#{generation}"
+        "refund_fee_reversal_#{refund.external_id}_g#{attempted_generation}"
       end
     end
     begin
@@ -775,7 +775,9 @@ class StripeChargeProcessor
     rescue Stripe::InvalidRequestError
       # Stripe confirmed no reversal was created (e.g. depleted transfer). Release the sticky
       # choice so a retry can select another eligible transfer; keep sticky on timeouts.
-      Credit.release_sticky_refund_fee_debit_choice!(refund) if refund.present?
+      if refund.present?
+        Credit.release_sticky_refund_fee_debit_choice!(refund, generation: attempted_generation)
+      end
       raise
     end
     # Persist the reversal id before follow-up retrieves. If those lookups fail, pending_retry

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -33,6 +33,11 @@ class StripeChargeProcessor
   # https://docs.stripe.com/currencies#zero-decimal
   ZERO_DECIMAL_CURRENCIES = %w[bif clp djf gnf jpy kmf krw mga pyg rwf ugx vnd vuv xaf xof xpf].freeze
 
+  # Bulgaria's retired currency: Stripe still reports historical transfers in it but no
+  # longer accepts reversals in it. The conversion rate to the euro is fixed and irrevocable.
+  BGN = "bgn"
+  BGN_PER_EUR = BigDecimal("1.95583")
+
   # Currencies Stripe only accepts in amounts evenly divisible by 100 (e.g. NT$310.50 is
   # rejected); unrounded FX-quoted amounts cannot guarantee that.
   # https://docs.stripe.com/currencies#special-cases
@@ -640,6 +645,20 @@ class StripeChargeProcessor
     # raw USD figure in a foreign currency, debiting the creator the wrong amount.
     amount_to_reverse_for = ->(transfer) { usd_cents_to_currency(transfer.currency, usd_amount_cents) }
 
+    # Stripe rejects transfer reversals in BGN since Bulgaria adopted the euro, so a
+    # BGN-settled transfer can never be the one reversed here. Check the currency before
+    # the amount so no BGN rate lookup is made, and remember that one was seen: when
+    # nothing else is eligible the fee is recovered with a EUR debit instead (below).
+    bgn_transfer_seen = false
+    reversible = lambda do |transfer|
+      if transfer.currency.to_s.casecmp?(BGN)
+        bgn_transfer_seen = true
+        next false
+      end
+
+      transfer.amount - transfer.amount_reversed > amount_to_reverse_for.call(transfer)
+    end
+
     # First, try and reverse an internal transfer made from gumroad platform account
     # to the connect account, if possible.
     transfer_ids = credit.user.payments.completed
@@ -648,7 +667,7 @@ class StripeChargeProcessor
                          .pluck(:stripe_internal_transfer_id)
     transfer = transfer_ids.compact_blank.lazy
                            .filter_map { |tr_id| Stripe::Transfer.retrieve(tr_id) rescue nil }
-                           .find { |tr| tr.amount - tr.amount_reversed > amount_to_reverse_for.call(tr) }
+                           .find { |tr| reversible.call(tr) }
     if transfer.present?
       transfer_reversal = Stripe::Transfer.create_reversal(transfer.id, { amount: amount_to_reverse_for.call(transfer) })
       refund = credit.fee_retention_refund
@@ -665,9 +684,7 @@ class StripeChargeProcessor
     # Try and find a transfer older than 120 days. As disputes and refunds are not allowed after 120 days, it's safe to
     # reverse these transfers.
     transfers = Stripe::Transfer.list(destination: stripe_account_id, created: { 'lt': 120.days.ago.to_i }, limit: 100)
-    transfer = transfers.find do |tr|
-      tr.present? && (tr.amount - tr.amount_reversed > amount_to_reverse_for.call(tr))
-    end
+    transfer = transfers.find { |tr| tr.present? && reversible.call(tr) }
     if transfer.present?
       transfer_reversal = Stripe::Transfer.create_reversal(transfer.id, { amount: amount_to_reverse_for.call(transfer) })
       refund = credit.fee_retention_refund
@@ -677,7 +694,28 @@ class StripeChargeProcessor
 
       destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
                                                                             stripe_account: stripe_account_id)
-      destination_balance_transaction.net.abs
+      return destination_balance_transaction.net.abs
+    end
+
+    return unless bgn_transfer_seen
+
+    debit_stripe_account_in_eur_for_refund_fee(credit:, usd_amount_cents:)
+  end
+
+  # Recovery for accounts whose only reversible history settled in BGN: per Stripe's guidance
+  # for those accounts, debit them directly with a EUR transfer to the platform instead.
+  # Returns the debited amount in the merchant account's holding currency; a ledger still
+  # held in BGN (account not yet switched to EUR) gets the exact fixed-rate conversion.
+  def self.debit_stripe_account_in_eur_for_refund_fee(credit:, usd_amount_cents:)
+    eur_amount_cents = usd_cents_to_currency(Currency::EUR, usd_amount_cents)
+    transfer = Stripe::Transfer.create({ amount: eur_amount_cents, currency: Currency::EUR, destination: STRIPE_PLATFORM_ACCOUNT_ID },
+                                       { stripe_account: credit.merchant_account.charge_processor_merchant_id })
+    refund = credit.fee_retention_refund
+    refund.update!(debited_stripe_transfer: transfer.id) if refund.present?
+
+    case credit.merchant_account.currency.to_s.downcase
+    when Currency::EUR then eur_amount_cents
+    when BGN then (BigDecimal(eur_amount_cents) * BGN_PER_EUR).round
     end
   end
 

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -735,10 +735,14 @@ class StripeChargeProcessor
   # reuse the same Stripe idempotency key and parameters.
   def self.perform_transfer_reversal_for_refund_fee(credit:, refund:, stripe_account_id:, transfer_id:, amount_cents:)
     if refund.present?
-      Credit.persist_refund_fee_debit_choice!(refund,
+      claimed = Credit.persist_refund_fee_debit_choice!(refund,
                   operation: FEE_DEBIT_OP_TRANSFER_REVERSAL,
                   transfer_id:,
                   amount_cents:)
+      unless claimed
+        # Another caller already persisted a different sticky route; resume that one.
+        return debit_stripe_account_for_refund_fee(credit:)
+      end
     end
     resume_transfer_reversal_for_refund_fee(credit:, refund:, stripe_account_id:,
                                             transfer_id:, amount_cents:)
@@ -804,9 +808,12 @@ class StripeChargeProcessor
     # different FX-converted amount on retry (Stripe rejects parameter changes).
     eur_amount_cents = refund&.refund_fee_eur_debit_cents.presence || usd_cents_to_currency(Currency::EUR, usd_amount_cents)
     if refund.present?
-      Credit.persist_refund_fee_debit_choice!(refund,
+      claimed = Credit.persist_refund_fee_debit_choice!(refund,
                   operation: FEE_DEBIT_OP_EUR_DEBIT,
                   amount_cents: eur_amount_cents)
+      unless claimed
+        return debit_stripe_account_for_refund_fee(credit:)
+      end
       if refund.refund_fee_eur_debit_cents.blank?
         ActiveRecord::Base.transaction(requires_new: true) do
           refund.update!(refund_fee_eur_debit_cents: eur_amount_cents)

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -735,10 +735,12 @@ class StripeChargeProcessor
   # reuse the same Stripe idempotency key and parameters.
   def self.perform_transfer_reversal_for_refund_fee(credit:, refund:, stripe_account_id:, transfer_id:, amount_cents:)
     if refund.present?
-      claimed = Credit.persist_refund_fee_debit_choice!(refund,
-                  operation: FEE_DEBIT_OP_TRANSFER_REVERSAL,
-                  transfer_id:,
-                  amount_cents:)
+      claimed = Credit.persist_refund_fee_debit_choice!(
+        refund,
+        operation: FEE_DEBIT_OP_TRANSFER_REVERSAL,
+        transfer_id:,
+        amount_cents:
+      )
       unless claimed
         # Another caller already persisted a different sticky route; resume that one.
         return debit_stripe_account_for_refund_fee(credit:)
@@ -766,11 +768,15 @@ class StripeChargeProcessor
     # must not erase proof the creator was already debited (idempotency keys expire).
     record_refund_fee_debit_marker!(refund, transfer_reversal.id) if refund.present?
 
-    destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
-                                                 stripe_account: stripe_account_id)
+    destination_refund = Stripe::Refund.retrieve(
+      transfer_reversal.destination_payment_refund,
+      stripe_account: stripe_account_id
+    )
 
-    destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
-                                                                          stripe_account: stripe_account_id)
+    destination_balance_transaction = Stripe::BalanceTransaction.retrieve(
+      destination_refund.balance_transaction,
+      stripe_account: stripe_account_id
+    )
     # Stripe reports the destination balance currency, which can differ from
     # merchant_account.currency (e.g. EUR proceeds while the ledger is still BGN).
     holding_abs = holding_amount_in_merchant_currency(
@@ -813,9 +819,11 @@ class StripeChargeProcessor
     # different FX-converted amount on retry (Stripe rejects parameter changes).
     proposed_eur_amount_cents = refund&.refund_fee_eur_debit_cents.presence || usd_cents_to_currency(Currency::EUR, usd_amount_cents)
     if refund.present?
-      claimed = Credit.persist_refund_fee_debit_choice!(refund,
-                  operation: FEE_DEBIT_OP_EUR_DEBIT,
-                  amount_cents: proposed_eur_amount_cents)
+      claimed = Credit.persist_refund_fee_debit_choice!(
+        refund,
+        operation: FEE_DEBIT_OP_EUR_DEBIT,
+        amount_cents: proposed_eur_amount_cents
+      )
       unless claimed
         return debit_stripe_account_for_refund_fee(credit:)
       end
@@ -833,14 +841,16 @@ class StripeChargeProcessor
     end
     transfer_options = { stripe_account: credit.merchant_account.charge_processor_merchant_id }
     transfer_options[:idempotency_key] = "refund_fee_eur_debit_#{refund.external_id}" if refund&.id.present?
-    transfer = Stripe::Transfer.create({ amount: eur_amount_cents.to_i, currency: Currency::EUR, destination: STRIPE_PLATFORM_ACCOUNT_ID },
-                                       transfer_options)
+    transfer = Stripe::Transfer.create(
+      { amount: eur_amount_cents.to_i, currency: Currency::EUR, destination: STRIPE_PLATFORM_ACCOUNT_ID },
+      transfer_options
+    )
     record_refund_fee_debit_marker!(refund, transfer.id) if refund.present?
 
     holding_abs = case credit.merchant_account.currency.to_s.downcase
                   when Currency::EUR then eur_amount_cents
                   when BGN then (BigDecimal(eur_amount_cents) * BGN_PER_EUR).round
-                  end
+    end
     if refund.present? && holding_abs.present?
       persist_refund_fee_holding_debit!(refund, holding_abs, currency: credit.merchant_account.currency)
     end
@@ -857,10 +867,14 @@ class StripeChargeProcessor
       return if transfer_id.blank? || reversal_id.blank?
 
       transfer_reversal = Stripe::Transfer.retrieve(transfer_id).reversals.retrieve(reversal_id)
-      destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
-                                                   stripe_account: stripe_account_id)
-      destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
-                                                                            stripe_account: stripe_account_id)
+      destination_refund = Stripe::Refund.retrieve(
+        transfer_reversal.destination_payment_refund,
+        stripe_account: stripe_account_id
+      )
+      destination_balance_transaction = Stripe::BalanceTransaction.retrieve(
+        destination_refund.balance_transaction,
+        stripe_account: stripe_account_id
+      )
       holding_abs = holding_amount_in_merchant_currency(
         destination_balance_transaction.net.abs,
         from_currency: destination_balance_transaction.currency,
@@ -875,7 +889,7 @@ class StripeChargeProcessor
       holding_abs = case credit.merchant_account.currency.to_s.downcase
                     when Currency::EUR then eur_amount_cents.to_i
                     when BGN then (BigDecimal(eur_amount_cents) * BGN_PER_EUR).round
-                    end
+      end
       persist_refund_fee_holding_debit!(refund, holding_abs, currency: credit.merchant_account.currency) if holding_abs.present?
       holding_abs
     when FEE_DEBIT_OP_US_DEBIT
@@ -887,6 +901,7 @@ class StripeChargeProcessor
     Rails.logger.error("Failed to finish fee debit holding lookup for refund #{refund.id}: #{e.class}: #{e.message}")
     nil
   end
+
   def self.record_refund_fee_debit_marker!(refund, marker)
     ActiveRecord::Base.transaction(requires_new: true) do
       refund.update!(debited_stripe_transfer: marker)

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -744,8 +744,8 @@ class StripeChargeProcessor
         return debit_stripe_account_for_refund_fee(credit:)
       end
     end
-    resume_transfer_reversal_for_refund_fee(credit:, refund:, stripe_account_id:,
-                                            transfer_id:, amount_cents:)
+    # Always resume from the persisted sticky fields (immutable once claimed).
+    resume_transfer_reversal_for_refund_fee(credit:, refund:, stripe_account_id:)
   end
   private_class_method :perform_transfer_reversal_for_refund_fee
 

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -630,7 +630,8 @@ class StripeChargeProcessor
     return unless credit.merchant_account&.charge_processor_merchant_id.present?
     return unless credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE
     return if credit.merchant_account.country == Compliance::Countries::USA.alpha2
-    return if credit.fee_retention_refund&.debited_stripe_transfer.present?
+    refund = credit.fee_retention_refund
+    return if refund&.debited_stripe_transfer.present? && refund.debited_stripe_transfer != Credit::FEE_DEBIT_PENDING_RETRY
 
     stripe_account_id = credit.merchant_account.charge_processor_merchant_id
     usd_amount_cents = credit.amount_cents.abs
@@ -669,9 +670,10 @@ class StripeChargeProcessor
                            .filter_map { |tr_id| Stripe::Transfer.retrieve(tr_id) rescue nil }
                            .find { |tr| reversible.call(tr) }
     if transfer.present?
-      transfer_reversal = Stripe::Transfer.create_reversal(transfer.id, { amount: amount_to_reverse_for.call(transfer) })
-      refund = credit.fee_retention_refund
-      refund.update!(debited_stripe_transfer: transfer_reversal.id) if refund.present?
+      reversal_opts = {}
+      reversal_opts[:idempotency_key] = "refund_fee_reversal_#{refund.external_id}" if refund&.id.present?
+      transfer_reversal = Stripe::Transfer.create_reversal(transfer.id, { amount: amount_to_reverse_for.call(transfer) }, reversal_opts)
+      record_refund_fee_debit_marker!(refund, transfer_reversal.id) if refund.present?
       destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
                                                    stripe_account: stripe_account_id)
 
@@ -686,9 +688,10 @@ class StripeChargeProcessor
     transfers = Stripe::Transfer.list(destination: stripe_account_id, created: { 'lt': 120.days.ago.to_i }, limit: 100)
     transfer = transfers.find { |tr| tr.present? && reversible.call(tr) }
     if transfer.present?
-      transfer_reversal = Stripe::Transfer.create_reversal(transfer.id, { amount: amount_to_reverse_for.call(transfer) })
-      refund = credit.fee_retention_refund
-      refund.update!(debited_stripe_transfer: transfer_reversal.id) if refund.present?
+      reversal_opts = {}
+      reversal_opts[:idempotency_key] = "refund_fee_reversal_#{refund.external_id}" if refund&.id.present?
+      transfer_reversal = Stripe::Transfer.create_reversal(transfer.id, { amount: amount_to_reverse_for.call(transfer) }, reversal_opts)
+      record_refund_fee_debit_marker!(refund, transfer_reversal.id) if refund.present?
       destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
                                                    stripe_account: stripe_account_id)
 
@@ -708,20 +711,32 @@ class StripeChargeProcessor
   # held in BGN (account not yet switched to EUR) gets the exact fixed-rate conversion.
   def self.debit_stripe_account_in_eur_for_refund_fee(credit:, usd_amount_cents:)
     refund = credit.fee_retention_refund
-    eur_amount_cents = usd_cents_to_currency(Currency::EUR, usd_amount_cents)
-    # Stable per-refund key: if Stripe accepts the transfer but we lose the response
-    # before recording debited_stripe_transfer, a retry must not create a second debit.
+    # Reuse the first requested EUR amount so a stable idempotency key never pairs with a
+    # different FX-converted amount on retry (Stripe rejects parameter changes).
+    eur_amount_cents = refund&.refund_fee_eur_debit_cents.presence || usd_cents_to_currency(Currency::EUR, usd_amount_cents)
+    if refund.present? && refund.refund_fee_eur_debit_cents.blank?
+      ActiveRecord::Base.transaction(requires_new: true) do
+        refund.update!(refund_fee_eur_debit_cents: eur_amount_cents)
+      end
+    end
     transfer_options = { stripe_account: credit.merchant_account.charge_processor_merchant_id }
     transfer_options[:idempotency_key] = "refund_fee_eur_debit_#{refund.external_id}" if refund&.id.present?
     transfer = Stripe::Transfer.create({ amount: eur_amount_cents, currency: Currency::EUR, destination: STRIPE_PLATFORM_ACCOUNT_ID },
                                        transfer_options)
-    refund.update!(debited_stripe_transfer: transfer.id) if refund.present?
+    record_refund_fee_debit_marker!(refund, transfer.id) if refund.present?
 
     case credit.merchant_account.currency.to_s.downcase
     when Currency::EUR then eur_amount_cents
     when BGN then (BigDecimal(eur_amount_cents) * BGN_PER_EUR).round
     end
   end
+
+  def self.record_refund_fee_debit_marker!(refund, marker)
+    ActiveRecord::Base.transaction(requires_new: true) do
+      refund.update!(debited_stripe_transfer: marker)
+    end
+  end
+  private_class_method :record_refund_fee_debit_marker!
 
   def self.debit_stripe_account_for_australia_backtaxes(credit:)
     return unless credit.present?

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -649,15 +649,19 @@ class StripeChargeProcessor
     # Resume that same operation — never re-select a different recovery route (reversal vs EUR),
     # which would use a different idempotency key and double-debit. After Stripe's idempotency
     # window, refuse automatic resubmit rather than risk a second debit.
-    if refund.present? && refund.debited_stripe_transfer == Credit::FEE_DEBIT_PENDING_RETRY &&
+    if refund.present? &&
+        refund.refund_fee_debit_operation.present? &&
+        (refund.debited_stripe_transfer.blank? || refund.debited_stripe_transfer == Credit::FEE_DEBIT_PENDING_RETRY) &&
         Credit.fee_debit_idempotency_window_expired?(refund)
       Rails.logger.error("Refusing automatic fee debit resubmit for refund #{refund.id}: Stripe idempotency window elapsed")
       ErrorNotifier.notify(
-        "Refund fee debit pending_retry outside Stripe idempotency window",
+        "Refund fee debit outside Stripe idempotency window",
         context: {
           refund_id: refund.id,
           purchase_id: refund.purchase_id,
-          operation: refund.refund_fee_debit_operation
+          operation: refund.refund_fee_debit_operation,
+          submitted_at: refund.refund_fee_debit_submitted_at,
+          debited_stripe_transfer: refund.debited_stripe_transfer
         }
       )
       return refund.refund_fee_holding_debit_cents.presence&.to_i
@@ -832,8 +836,6 @@ class StripeChargeProcessor
     Rails.logger.error("Failed to finish fee debit holding lookup for refund #{refund.id}: #{e.class}: #{e.message}")
     nil
   end
-  private_class_method :finish_holding_lookup_for_recorded_fee_debit
-
   def self.record_refund_fee_debit_marker!(refund, marker)
     ActiveRecord::Base.transaction(requires_new: true) do
       refund.update!(debited_stripe_transfer: marker)

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -707,10 +707,14 @@ class StripeChargeProcessor
   # Returns the debited amount in the merchant account's holding currency; a ledger still
   # held in BGN (account not yet switched to EUR) gets the exact fixed-rate conversion.
   def self.debit_stripe_account_in_eur_for_refund_fee(credit:, usd_amount_cents:)
-    eur_amount_cents = usd_cents_to_currency(Currency::EUR, usd_amount_cents)
-    transfer = Stripe::Transfer.create({ amount: eur_amount_cents, currency: Currency::EUR, destination: STRIPE_PLATFORM_ACCOUNT_ID },
-                                       { stripe_account: credit.merchant_account.charge_processor_merchant_id })
     refund = credit.fee_retention_refund
+    eur_amount_cents = usd_cents_to_currency(Currency::EUR, usd_amount_cents)
+    # Stable per-refund key: if Stripe accepts the transfer but we lose the response
+    # before recording debited_stripe_transfer, a retry must not create a second debit.
+    transfer_options = { stripe_account: credit.merchant_account.charge_processor_merchant_id }
+    transfer_options[:idempotency_key] = "refund_fee_eur_debit_#{refund.external_id}" if refund&.id.present?
+    transfer = Stripe::Transfer.create({ amount: eur_amount_cents, currency: Currency::EUR, destination: STRIPE_PLATFORM_ACCOUNT_ID },
+                                       transfer_options)
     refund.update!(debited_stripe_transfer: transfer.id) if refund.present?
 
     case credit.merchant_account.currency.to_s.downcase

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -635,18 +635,34 @@ class StripeChargeProcessor
     return unless credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE
     return if credit.merchant_account.country == Compliance::Countries::USA.alpha2
     refund = credit.fee_retention_refund
-    if refund&.debited_stripe_transfer.present? && refund.debited_stripe_transfer != Credit::FEE_DEBIT_PENDING_RETRY
-      # Debit already succeeded; return any persisted holding amount so retries can still
-      # reconcile the ledger estimate without submitting another Stripe operation.
-      return refund.refund_fee_holding_debit_cents.presence&.to_i
-    end
-
     stripe_account_id = credit.merchant_account.charge_processor_merchant_id
     usd_amount_cents = credit.amount_cents.abs
 
+    if refund&.debited_stripe_transfer.present? && refund.debited_stripe_transfer != Credit::FEE_DEBIT_PENDING_RETRY
+      # Debit already succeeded. Prefer the persisted holding amount; if follow-up Stripe
+      # lookups failed earlier, finish those retrieves without submitting another debit.
+      return refund.refund_fee_holding_debit_cents.presence&.to_i ||
+        finish_holding_lookup_for_recorded_fee_debit(credit:, refund:, stripe_account_id:)
+    end
+
     # A prior attempt may have submitted to Stripe and timed out after recording pending_retry.
     # Resume that same operation — never re-select a different recovery route (reversal vs EUR),
-    # which would use a different idempotency key and double-debit.
+    # which would use a different idempotency key and double-debit. After Stripe's idempotency
+    # window, refuse automatic resubmit rather than risk a second debit.
+    if refund.present? && refund.debited_stripe_transfer == Credit::FEE_DEBIT_PENDING_RETRY &&
+        Credit.fee_debit_idempotency_window_expired?(refund)
+      Rails.logger.error("Refusing automatic fee debit resubmit for refund #{refund.id}: Stripe idempotency window elapsed")
+      ErrorNotifier.notify(
+        "Refund fee debit pending_retry outside Stripe idempotency window",
+        context: {
+          refund_id: refund.id,
+          purchase_id: refund.purchase_id,
+          operation: refund.refund_fee_debit_operation
+        }
+      )
+      return refund.refund_fee_holding_debit_cents.presence&.to_i
+    end
+
     case refund&.refund_fee_debit_operation
     when FEE_DEBIT_OP_TRANSFER_REVERSAL
       return resume_transfer_reversal_for_refund_fee(credit:, refund:, stripe_account_id:)
@@ -780,6 +796,43 @@ class StripeChargeProcessor
     persist_refund_fee_holding_debit!(refund, holding_abs) if refund.present? && holding_abs.present?
     holding_abs
   end
+
+  # Marker is already set but the destination balance-transaction retrieve failed earlier.
+  # Finish that lookup so holding reconcile can run; never create another debit.
+  def self.finish_holding_lookup_for_recorded_fee_debit(credit:, refund:, stripe_account_id:)
+    case refund.refund_fee_debit_operation
+    when FEE_DEBIT_OP_TRANSFER_REVERSAL
+      transfer_id = refund.refund_fee_debit_transfer_id
+      reversal_id = refund.debited_stripe_transfer
+      return if transfer_id.blank? || reversal_id.blank?
+
+      transfer_reversal = Stripe::Transfer.retrieve(transfer_id).reversals.retrieve(reversal_id)
+      destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
+                                                   stripe_account: stripe_account_id)
+      holding_abs = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
+                                                        stripe_account: stripe_account_id).net.abs
+      persist_refund_fee_holding_debit!(refund, holding_abs)
+      holding_abs
+    when FEE_DEBIT_OP_EUR_DEBIT
+      eur_amount_cents = refund.refund_fee_eur_debit_cents
+      return if eur_amount_cents.blank?
+
+      holding_abs = case credit.merchant_account.currency.to_s.downcase
+                    when Currency::EUR then eur_amount_cents.to_i
+                    when BGN then (BigDecimal(eur_amount_cents) * BGN_PER_EUR).round
+                    end
+      persist_refund_fee_holding_debit!(refund, holding_abs) if holding_abs.present?
+      holding_abs
+    when FEE_DEBIT_OP_US_DEBIT
+      holding_abs = credit.amount_cents.abs
+      persist_refund_fee_holding_debit!(refund, holding_abs)
+      holding_abs
+    end
+  rescue StandardError => e
+    Rails.logger.error("Failed to finish fee debit holding lookup for refund #{refund.id}: #{e.class}: #{e.message}")
+    nil
+  end
+  private_class_method :finish_holding_lookup_for_recorded_fee_debit
 
   def self.record_refund_fee_debit_marker!(refund, marker)
     ActiveRecord::Base.transaction(requires_new: true) do

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -762,8 +762,22 @@ class StripeChargeProcessor
     return if transfer_id.blank? || amount_cents.blank?
 
     reversal_opts = {}
-    reversal_opts[:idempotency_key] = "refund_fee_reversal_#{refund.external_id}" if refund&.id.present?
-    transfer_reversal = Stripe::Transfer.create_reversal(transfer_id, { amount: amount_cents.to_i }, reversal_opts)
+    if refund&.id.present?
+      generation = refund.refund_fee_debit_generation.to_i
+      reversal_opts[:idempotency_key] = if generation.zero?
+        "refund_fee_reversal_#{refund.external_id}"
+      else
+        "refund_fee_reversal_#{refund.external_id}_g#{generation}"
+      end
+    end
+    begin
+      transfer_reversal = Stripe::Transfer.create_reversal(transfer_id, { amount: amount_cents.to_i }, reversal_opts)
+    rescue Stripe::InvalidRequestError
+      # Stripe confirmed no reversal was created (e.g. depleted transfer). Release the sticky
+      # choice so a retry can select another eligible transfer; keep sticky on timeouts.
+      Credit.release_sticky_refund_fee_debit_choice!(refund) if refund.present?
+      raise
+    end
     # Persist the reversal id before follow-up retrieves. If those lookups fail, pending_retry
     # must not erase proof the creator was already debited (idempotency keys expire).
     record_refund_fee_debit_marker!(refund, transfer_reversal.id) if refund.present?

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -744,8 +744,13 @@ class StripeChargeProcessor
         return debit_stripe_account_for_refund_fee(credit:)
       end
     end
-    # Always resume from the persisted sticky fields (immutable once claimed).
-    resume_transfer_reversal_for_refund_fee(credit:, refund:, stripe_account_id:)
+    # Prefer persisted sticky fields when present; otherwise forward the selected params
+    # (credits without fee_retention_refund still need to reverse).
+    resume_transfer_reversal_for_refund_fee(
+      credit:, refund:, stripe_account_id:,
+      transfer_id: refund&.refund_fee_debit_transfer_id.presence || transfer_id,
+      amount_cents: refund&.refund_fee_debit_amount_cents.presence || amount_cents
+    )
   end
   private_class_method :perform_transfer_reversal_for_refund_fee
 

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -635,7 +635,11 @@ class StripeChargeProcessor
     return unless credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE
     return if credit.merchant_account.country == Compliance::Countries::USA.alpha2
     refund = credit.fee_retention_refund
-    return if refund&.debited_stripe_transfer.present? && refund.debited_stripe_transfer != Credit::FEE_DEBIT_PENDING_RETRY
+    if refund&.debited_stripe_transfer.present? && refund.debited_stripe_transfer != Credit::FEE_DEBIT_PENDING_RETRY
+      # Debit already succeeded; return any persisted holding amount so retries can still
+      # reconcile the ledger estimate without submitting another Stripe operation.
+      return refund.refund_fee_holding_debit_cents.presence&.to_i
+    end
 
     stripe_account_id = credit.merchant_account.charge_processor_merchant_id
     usd_amount_cents = credit.amount_cents.abs
@@ -729,13 +733,17 @@ class StripeChargeProcessor
     reversal_opts = {}
     reversal_opts[:idempotency_key] = "refund_fee_reversal_#{refund.external_id}" if refund&.id.present?
     transfer_reversal = Stripe::Transfer.create_reversal(transfer_id, { amount: amount_cents.to_i }, reversal_opts)
+    # Persist the reversal id before follow-up retrieves. If those lookups fail, pending_retry
+    # must not erase proof the creator was already debited (idempotency keys expire).
+    record_refund_fee_debit_marker!(refund, transfer_reversal.id) if refund.present?
+
     destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
                                                  stripe_account: stripe_account_id)
 
     destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
                                                                           stripe_account: stripe_account_id)
     holding_abs = destination_balance_transaction.net.abs
-    record_refund_fee_debit_marker!(refund, transfer_reversal.id, holding_debit_cents: holding_abs) if refund.present?
+    persist_refund_fee_holding_debit!(refund, holding_abs) if refund.present?
     holding_abs
   end
   private_class_method :resume_transfer_reversal_for_refund_fee
@@ -763,23 +771,32 @@ class StripeChargeProcessor
     transfer_options[:idempotency_key] = "refund_fee_eur_debit_#{refund.external_id}" if refund&.id.present?
     transfer = Stripe::Transfer.create({ amount: eur_amount_cents, currency: Currency::EUR, destination: STRIPE_PLATFORM_ACCOUNT_ID },
                                        transfer_options)
+    record_refund_fee_debit_marker!(refund, transfer.id) if refund.present?
 
     holding_abs = case credit.merchant_account.currency.to_s.downcase
                   when Currency::EUR then eur_amount_cents
                   when BGN then (BigDecimal(eur_amount_cents) * BGN_PER_EUR).round
                   end
-    record_refund_fee_debit_marker!(refund, transfer.id, holding_debit_cents: holding_abs) if refund.present?
+    persist_refund_fee_holding_debit!(refund, holding_abs) if refund.present? && holding_abs.present?
     holding_abs
   end
 
-  def self.record_refund_fee_debit_marker!(refund, marker, holding_debit_cents: nil)
+  def self.record_refund_fee_debit_marker!(refund, marker)
     ActiveRecord::Base.transaction(requires_new: true) do
-      refund.debited_stripe_transfer = marker
-      refund.refund_fee_holding_debit_cents = holding_debit_cents if holding_debit_cents.present?
-      refund.save!
+      refund.update!(debited_stripe_transfer: marker)
     end
   end
   private_class_method :record_refund_fee_debit_marker!
+
+  def self.persist_refund_fee_holding_debit!(refund, holding_debit_cents)
+    return if refund.blank? || holding_debit_cents.blank?
+    return if refund.refund_fee_holding_debit_cents.to_i == holding_debit_cents.to_i
+
+    ActiveRecord::Base.transaction(requires_new: true) do
+      refund.update!(refund_fee_holding_debit_cents: holding_debit_cents.to_i)
+    end
+  end
+  private_class_method :persist_refund_fee_holding_debit!
 
   def self.debit_stripe_account_for_australia_backtaxes(credit:)
     return unless credit.present?

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -624,6 +624,10 @@ class StripeChargeProcessor
     raise ChargeProcessorUnavailableError.new("Stripe error while refunding a charge: #{e.message}", original_error: e)
   end
 
+  FEE_DEBIT_OP_TRANSFER_REVERSAL = "transfer_reversal"
+  FEE_DEBIT_OP_EUR_DEBIT = "eur_debit"
+  FEE_DEBIT_OP_US_DEBIT = "us_debit"
+
   def self.debit_stripe_account_for_refund_fee(credit:)
     return unless credit.present?
     return if credit.amount_cents == 0
@@ -635,6 +639,16 @@ class StripeChargeProcessor
 
     stripe_account_id = credit.merchant_account.charge_processor_merchant_id
     usd_amount_cents = credit.amount_cents.abs
+
+    # A prior attempt may have submitted to Stripe and timed out after recording pending_retry.
+    # Resume that same operation — never re-select a different recovery route (reversal vs EUR),
+    # which would use a different idempotency key and double-debit.
+    case refund&.refund_fee_debit_operation
+    when FEE_DEBIT_OP_TRANSFER_REVERSAL
+      return resume_transfer_reversal_for_refund_fee(credit:, refund:, stripe_account_id:)
+    when FEE_DEBIT_OP_EUR_DEBIT
+      return debit_stripe_account_in_eur_for_refund_fee(credit:, usd_amount_cents:)
+    end
 
     # The fee being recovered (credit.amount_cents) is always in USD cents, but Stripe
     # transfer reversals are denominated in the transfer's own currency. Internal payout
@@ -670,16 +684,10 @@ class StripeChargeProcessor
                            .filter_map { |tr_id| Stripe::Transfer.retrieve(tr_id) rescue nil }
                            .find { |tr| reversible.call(tr) }
     if transfer.present?
-      reversal_opts = {}
-      reversal_opts[:idempotency_key] = "refund_fee_reversal_#{refund.external_id}" if refund&.id.present?
-      transfer_reversal = Stripe::Transfer.create_reversal(transfer.id, { amount: amount_to_reverse_for.call(transfer) }, reversal_opts)
-      record_refund_fee_debit_marker!(refund, transfer_reversal.id) if refund.present?
-      destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
-                                                   stripe_account: stripe_account_id)
-
-      destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
-                                                                            stripe_account: stripe_account_id)
-      return destination_balance_transaction.net.abs
+      return perform_transfer_reversal_for_refund_fee(
+        credit:, refund:, stripe_account_id:,
+        transfer_id: transfer.id, amount_cents: amount_to_reverse_for.call(transfer)
+      )
     end
 
     # If no eligible internal transfer was available, reverse a transfer associated with an old purchase.
@@ -688,22 +696,49 @@ class StripeChargeProcessor
     transfers = Stripe::Transfer.list(destination: stripe_account_id, created: { 'lt': 120.days.ago.to_i }, limit: 100)
     transfer = transfers.find { |tr| tr.present? && reversible.call(tr) }
     if transfer.present?
-      reversal_opts = {}
-      reversal_opts[:idempotency_key] = "refund_fee_reversal_#{refund.external_id}" if refund&.id.present?
-      transfer_reversal = Stripe::Transfer.create_reversal(transfer.id, { amount: amount_to_reverse_for.call(transfer) }, reversal_opts)
-      record_refund_fee_debit_marker!(refund, transfer_reversal.id) if refund.present?
-      destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
-                                                   stripe_account: stripe_account_id)
-
-      destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
-                                                                            stripe_account: stripe_account_id)
-      return destination_balance_transaction.net.abs
+      return perform_transfer_reversal_for_refund_fee(
+        credit:, refund:, stripe_account_id:,
+        transfer_id: transfer.id, amount_cents: amount_to_reverse_for.call(transfer)
+      )
     end
 
     return unless bgn_transfer_seen
 
     debit_stripe_account_in_eur_for_refund_fee(credit:, usd_amount_cents:)
   end
+
+  # Persist the chosen transfer + amount, then reverse. Retries with the same sticky choice
+  # reuse the same Stripe idempotency key and parameters.
+  def self.perform_transfer_reversal_for_refund_fee(credit:, refund:, stripe_account_id:, transfer_id:, amount_cents:)
+    if refund.present?
+      Credit.persist_refund_fee_debit_choice!(refund,
+                  operation: FEE_DEBIT_OP_TRANSFER_REVERSAL,
+                  transfer_id:,
+                  amount_cents:)
+    end
+    resume_transfer_reversal_for_refund_fee(credit:, refund:, stripe_account_id:,
+                                            transfer_id:, amount_cents:)
+  end
+  private_class_method :perform_transfer_reversal_for_refund_fee
+
+  def self.resume_transfer_reversal_for_refund_fee(credit:, refund:, stripe_account_id:, transfer_id: nil, amount_cents: nil)
+    transfer_id = transfer_id.presence || refund&.refund_fee_debit_transfer_id
+    amount_cents = amount_cents.presence || refund&.refund_fee_debit_amount_cents
+    return if transfer_id.blank? || amount_cents.blank?
+
+    reversal_opts = {}
+    reversal_opts[:idempotency_key] = "refund_fee_reversal_#{refund.external_id}" if refund&.id.present?
+    transfer_reversal = Stripe::Transfer.create_reversal(transfer_id, { amount: amount_cents.to_i }, reversal_opts)
+    destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
+                                                 stripe_account: stripe_account_id)
+
+    destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
+                                                                          stripe_account: stripe_account_id)
+    holding_abs = destination_balance_transaction.net.abs
+    record_refund_fee_debit_marker!(refund, transfer_reversal.id, holding_debit_cents: holding_abs) if refund.present?
+    holding_abs
+  end
+  private_class_method :resume_transfer_reversal_for_refund_fee
 
   # Recovery for accounts whose only reversible history settled in BGN: per Stripe's guidance
   # for those accounts, debit them directly with a EUR transfer to the platform instead.
@@ -714,26 +749,34 @@ class StripeChargeProcessor
     # Reuse the first requested EUR amount so a stable idempotency key never pairs with a
     # different FX-converted amount on retry (Stripe rejects parameter changes).
     eur_amount_cents = refund&.refund_fee_eur_debit_cents.presence || usd_cents_to_currency(Currency::EUR, usd_amount_cents)
-    if refund.present? && refund.refund_fee_eur_debit_cents.blank?
-      ActiveRecord::Base.transaction(requires_new: true) do
-        refund.update!(refund_fee_eur_debit_cents: eur_amount_cents)
+    if refund.present?
+      Credit.persist_refund_fee_debit_choice!(refund,
+                  operation: FEE_DEBIT_OP_EUR_DEBIT,
+                  amount_cents: eur_amount_cents)
+      if refund.refund_fee_eur_debit_cents.blank?
+        ActiveRecord::Base.transaction(requires_new: true) do
+          refund.update!(refund_fee_eur_debit_cents: eur_amount_cents)
+        end
       end
     end
     transfer_options = { stripe_account: credit.merchant_account.charge_processor_merchant_id }
     transfer_options[:idempotency_key] = "refund_fee_eur_debit_#{refund.external_id}" if refund&.id.present?
     transfer = Stripe::Transfer.create({ amount: eur_amount_cents, currency: Currency::EUR, destination: STRIPE_PLATFORM_ACCOUNT_ID },
                                        transfer_options)
-    record_refund_fee_debit_marker!(refund, transfer.id) if refund.present?
 
-    case credit.merchant_account.currency.to_s.downcase
-    when Currency::EUR then eur_amount_cents
-    when BGN then (BigDecimal(eur_amount_cents) * BGN_PER_EUR).round
-    end
+    holding_abs = case credit.merchant_account.currency.to_s.downcase
+                  when Currency::EUR then eur_amount_cents
+                  when BGN then (BigDecimal(eur_amount_cents) * BGN_PER_EUR).round
+                  end
+    record_refund_fee_debit_marker!(refund, transfer.id, holding_debit_cents: holding_abs) if refund.present?
+    holding_abs
   end
 
-  def self.record_refund_fee_debit_marker!(refund, marker)
+  def self.record_refund_fee_debit_marker!(refund, marker, holding_debit_cents: nil)
     ActiveRecord::Base.transaction(requires_new: true) do
-      refund.update!(debited_stripe_transfer: marker)
+      refund.debited_stripe_transfer = marker
+      refund.refund_fee_holding_debit_cents = holding_debit_cents if holding_debit_cents.present?
+      refund.save!
     end
   end
   private_class_method :record_refund_fee_debit_marker!

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -762,7 +762,13 @@ class StripeChargeProcessor
 
     destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
                                                                           stripe_account: stripe_account_id)
-    holding_abs = destination_balance_transaction.net.abs
+    # Stripe reports the destination balance currency, which can differ from
+    # merchant_account.currency (e.g. EUR proceeds while the ledger is still BGN).
+    holding_abs = holding_amount_in_merchant_currency(
+      destination_balance_transaction.net.abs,
+      from_currency: destination_balance_transaction.currency,
+      merchant_currency: credit.merchant_account.currency
+    )
     if refund.present?
       persist_refund_fee_holding_debit!(
         refund,
@@ -773,6 +779,20 @@ class StripeChargeProcessor
     holding_abs
   end
   private_class_method :resume_transfer_reversal_for_refund_fee
+
+  def self.holding_amount_in_merchant_currency(amount_cents, from_currency:, merchant_currency:)
+    from_currency = from_currency.to_s.downcase
+    merchant_currency = merchant_currency.to_s.downcase
+    return amount_cents.to_i if from_currency == merchant_currency
+
+    if [from_currency, merchant_currency].sort == [BGN, Currency::EUR].sort
+      return from_currency == Currency::EUR ? (BigDecimal(amount_cents) * BGN_PER_EUR).round : (BigDecimal(amount_cents) / BGN_PER_EUR).round
+    end
+
+    usd = get_usd_cents(from_currency, amount_cents)
+    usd_cents_to_currency(merchant_currency, usd)
+  end
+  private_class_method :holding_amount_in_merchant_currency
 
   # Recovery for accounts whose only reversible history settled in BGN: per Stripe's guidance
   # for those accounts, debit them directly with a EUR transfer to the platform instead.
@@ -821,8 +841,13 @@ class StripeChargeProcessor
       transfer_reversal = Stripe::Transfer.retrieve(transfer_id).reversals.retrieve(reversal_id)
       destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
                                                    stripe_account: stripe_account_id)
-      holding_abs = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
-                                                        stripe_account: stripe_account_id).net.abs
+      destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
+                                                                            stripe_account: stripe_account_id)
+      holding_abs = holding_amount_in_merchant_currency(
+        destination_balance_transaction.net.abs,
+        from_currency: destination_balance_transaction.currency,
+        merchant_currency: credit.merchant_account.currency
+      )
       persist_refund_fee_holding_debit!(refund, holding_abs, currency: credit.merchant_account.currency)
       holding_abs
     when FEE_DEBIT_OP_EUR_DEBIT

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -188,17 +188,19 @@ class Charge < ApplicationRecord
   end
 
   def refund_and_save!(refunding_user_id, reason: nil)
-    transaction do
-      refunded_all_purchases = true
-      lock_successful_purchases_in_id_order!.each do |purchase|
-        refunded = purchase.refund_and_save!(refunding_user_id, reason:)
-        unless refunded
-          copy_refund_errors_from(purchase)
-          refunded_all_purchases = false
-        end
+    # No wrapping transaction: each purchase.refund_and_save! commits its own local refund
+    # before the next starts. A later purchase failure must not erase an earlier
+    # processor-successful refund (and its fee markers) via outer rollback (#7549).
+    # Per-purchase lock order (purchase then balance) still holds inside each call.
+    refunded_all_purchases = true
+    successful_purchases.sort_by(&:id).each do |purchase|
+      refunded = purchase.refund_and_save!(refunding_user_id, reason:)
+      unless refunded
+        copy_refund_errors_from(purchase)
+        refunded_all_purchases = false
       end
-      refunded_all_purchases
     end
+    refunded_all_purchases
   end
 
   def refund_gumroad_taxes!(refunding_user_id:, note: nil, business_vat_id: nil)
@@ -325,28 +327,11 @@ class Charge < ApplicationRecord
       )
     end
 
-    # Combined-charge refunds update every purchase in the charge plus the shared
-    # seller balance inside one transaction. Each Purchase#refund_purchase! locks
-    # its purchase row and then the balance, so without this pre-pass the
-    # transaction's acquisition sequence is purchase₁ → balance → purchase₂ → …:
-    # it holds the balance while waiting for later purchase rows. A concurrent
-    # failed-refund reversal (Purchase::HandleFailedRefundService) that already
-    # holds one of those later purchases and is waiting for the same balance
-    # completes a deadlock cycle. Taking every purchase lock up front, in id
-    # order, before any refund work keeps this path inside the global
-    # purchase-first lock order established for single-purchase refunds (#5917).
-    #
-    # Returns the locked instances; callers must iterate THESE, not re-query
-    # successful_purchases. Under REPEATABLE READ a re-query would read the
-    # transaction snapshot taken before the locks were acquired, so refundable
-    # amounts computed from it could be stale relative to a reversal that
-    # committed while this pre-pass was waiting for a lock. lock!'s FOR UPDATE
-    # re-read makes these instances reflect committed state at lock time.
-    #
-    # reload before lock!: reading any json_data-backed attribute on a row whose
-    # json_data column is NULL dirties the record in memory, and lock! raises on
-    # dirty records. Reloading discards that phantom change; lock! reloads again
-    # under FOR UPDATE.
+    # Pre-lock successful purchases in id order for callers that still wrap multi-
+    # purchase balance work in one transaction (tax refunds, fraud block). Without
+    # this, purchase₁ → balance → purchase₂ can deadlock with HandleFailedRefundService.
+    # Callers must iterate THESE locked instances (not re-query) under REPEATABLE READ.
+    # reload before lock!: NULL json_data dirties the record and lock! raises on dirty.
     def lock_successful_purchases_in_id_order!
       successful_purchases.sort_by(&:id).each { _1.reload.lock! }
     end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -188,13 +188,14 @@ class Charge < ApplicationRecord
   end
 
   def refund_and_save!(refunding_user_id, reason: nil)
-    # No wrapping transaction: each purchase.refund_and_save! commits its own local refund
-    # before the next starts. A later purchase failure must not erase an earlier
-    # processor-successful refund (and its fee markers) via outer rollback (#7549).
-    # Per-purchase lock order (purchase then balance) still holds inside each call.
+    # One purchase at a time: with_lock serializes concurrent charge refunds on the same
+    # purchase (eligibility is checked before Stripe), then commits before the next starts
+    # so a later failure cannot erase an earlier processor-successful refund (#7549).
     refunded_all_purchases = true
     successful_purchases.sort_by(&:id).each do |purchase|
-      refunded = purchase.refund_and_save!(refunding_user_id, reason:)
+      refunded = purchase.with_lock do
+        purchase.refund_and_save!(refunding_user_id, reason:)
+      end
       unless refunded
         copy_refund_errors_from(purchase)
         refunded_all_purchases = false

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -311,7 +311,8 @@ class Credit < ApplicationRecord
       # Scope by user_id so MySQL can use index_credits_on_user_id_and_created_at_and_id
       # (there is no index on fee_retention_refund_id alone). Lock the row so concurrent
       # retries serialize on the same retention credit.
-      existing_credit = where(user_id: purchase.seller_id, fee_retention_refund: refund, failed_refund_id: nil).lock.first
+      existing_credit = where(user_id: purchase.seller_id, fee_retention_refund: refund, failed_refund_id: nil).first
+      existing_credit = where(id: existing_credit.id).lock.first if existing_credit
       if existing_credit.present?
         # Pre-patch US retention completed Stripe transfers without recording
         # debited_stripe_transfer. Blank marker + ledger means legacy-complete — do not
@@ -428,7 +429,8 @@ class Credit < ApplicationRecord
         clear_refund_fee_retention_pending!(refund)
         return
       end
-      existing_credit = where(user_id: purchase.seller_id, fee_retention_refund: refund, failed_refund_id: nil).lock.first
+      existing_credit = where(user_id: purchase.seller_id, fee_retention_refund: refund, failed_refund_id: nil).first
+      existing_credit = where(id: existing_credit.id).lock.first if existing_credit
       if existing_credit.present?
         # Another concurrent attempt booked the credit (possibly with an FX estimate) while
         # this attempt obtained the actual Stripe debit. Reconcile before returning.
@@ -595,13 +597,14 @@ class Credit < ApplicationRecord
 
   # Stripe confirmed the sticky reversal did not happen (InvalidRequest). Drop the choice
   # so a retry can pick another transfer; bump generation for a fresh idempotency key.
-  def self.release_sticky_refund_fee_debit_choice!(refund)
+  def self.release_sticky_refund_fee_debit_choice!(refund, generation:)
     return if refund.blank?
 
     refund.reload
     refund.with_lock do
       refund.reload
       return if refund.debited_stripe_transfer.present? && refund.debited_stripe_transfer != FEE_DEBIT_PENDING_RETRY
+      return if refund.refund_fee_debit_generation.to_i != generation.to_i
 
       transaction(requires_new: true) do
         refund.refund_fee_debit_operation = nil

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -321,7 +321,14 @@ class Credit < ApplicationRecord
           # Debit helper returns nil once the success marker is set; still reconcile from the
           # persisted actual when a prior attempt booked only the FX estimate.
           actual_holding ||= refund.refund_fee_holding_debit_cents
-          reconcile_fee_retention_holding_amount!(existing_credit, actual_holding)
+          begin
+            reconcile_fee_retention_holding_amount!(existing_credit, actual_holding)
+          rescue StandardError => e
+            # Keep any Stripe success marker written in requires_new savepoints: re-raising
+            # would roll back this purchase.with_lock transaction and erase proof of debit.
+            Rails.logger.error("Failed to reconcile fee retention holding for refund #{refund.id}: #{e.class}: #{e.message}")
+            ErrorNotifier.notify(e, context: { refund_id: refund.id, credit_id: existing_credit.id })
+          end
         end
         return existing_credit
       end
@@ -539,17 +546,27 @@ class Credit < ApplicationRecord
 
   def self.persist_refund_fee_debit_choice!(refund, operation:, transfer_id: nil, amount_cents: nil)
     return if refund.blank?
-    already = refund.refund_fee_debit_operation == operation &&
-      (transfer_id.blank? || refund.refund_fee_debit_transfer_id == transfer_id) &&
-      (amount_cents.blank? || refund.refund_fee_debit_amount_cents.to_i == amount_cents.to_i)
-    return if already && refund.refund_fee_debit_submitted_at.present?
 
-    transaction(requires_new: true) do
-      refund.refund_fee_debit_operation = operation
-      refund.refund_fee_debit_transfer_id = transfer_id if transfer_id.present?
-      refund.refund_fee_debit_amount_cents = amount_cents if amount_cents.present?
-      refund.refund_fee_debit_submitted_at ||= Time.current.utc.iso8601
-      refund.save!
+    # Under the refund lock: if another caller already chose an operation, keep theirs so
+    # concurrent retries resume one sticky route instead of overwriting with a second debit.
+    refund.with_lock do
+      refund.reload
+      if refund.refund_fee_debit_operation.present? && refund.refund_fee_debit_operation != operation
+        return false
+      end
+      already = refund.refund_fee_debit_operation == operation &&
+        (transfer_id.blank? || refund.refund_fee_debit_transfer_id == transfer_id) &&
+        (amount_cents.blank? || refund.refund_fee_debit_amount_cents.to_i == amount_cents.to_i)
+      return true if already && refund.refund_fee_debit_submitted_at.present?
+
+      transaction(requires_new: true) do
+        refund.refund_fee_debit_operation = operation
+        refund.refund_fee_debit_transfer_id = transfer_id if transfer_id.present?
+        refund.refund_fee_debit_amount_cents = amount_cents if amount_cents.present?
+        refund.refund_fee_debit_submitted_at ||= Time.current.utc.iso8601
+        refund.save!
+      end
+      true
     end
   end
 

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -298,7 +298,14 @@ class Credit < ApplicationRecord
   def self.create_for_refund_fee_retention!(refund:)
     existing_credit = where(fee_retention_refund: refund, failed_refund_id: nil).first
     if existing_credit.present?
-      debit_stripe_account_for_retained_fee(existing_credit)
+      # Pre-patch US retention completed Stripe transfers without recording
+      # debited_stripe_transfer. Re-debiting those would charge the seller twice.
+      # Skip the Stripe call for US credits that already have a ledger and no marker;
+      # non-US retries still finish an outstanding debit.
+      us_legacy_complete = existing_credit.merchant_account&.country == Compliance::Countries::USA.alpha2 &&
+        refund.debited_stripe_transfer.blank? &&
+        existing_credit.balance_id.present?
+      debit_stripe_account_for_retained_fee(existing_credit) unless us_legacy_complete
       return existing_credit
     end
 
@@ -319,7 +326,10 @@ class Credit < ApplicationRecord
       credit.merchant_account = MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id)
       credit.fee_retention_refund = refund
 
-      transaction do
+      # requires_new: callers (Charge#refund_and_save!, processor webhook with_lock) may
+      # still hold an open transaction. A nested join would let an outer rescue commit a
+      # half-written credit if balance creation failed after credit.save!.
+      transaction(requires_new: true) do
         credit.save!
 
         balance_transaction_amount = BalanceTransaction::Amount.new(
@@ -367,7 +377,8 @@ class Credit < ApplicationRecord
     net_amount_on_stripe_in_holding_currency = debit_stripe_account_for_retained_fee(credit)
     reversed_amount_cents_in_holding_currency = -net_amount_on_stripe_in_holding_currency if net_amount_on_stripe_in_holding_currency.present?
 
-    transaction do
+    # requires_new: see Connect branch above — isolate ledger writes from any outer txn.
+    transaction(requires_new: true) do
       credit.save!
 
       refund.retained_fee_cents = credit.amount_cents.abs
@@ -413,8 +424,10 @@ class Credit < ApplicationRecord
     if merchant_account.country == Compliance::Countries::USA.alpha2
       # For gumroad-controlled Stripe accounts from the US, we can make new debit transfers.
       # So we transfer the retained fee back to Gumroad's Stripe platform account.
+      transfer_options = { stripe_account: merchant_account.charge_processor_merchant_id }
+      transfer_options[:idempotency_key] = "refund_fee_us_debit_#{refund.external_id}" if refund.id.present?
       transfer = Stripe::Transfer.create({ amount: credit.amount_cents.abs, currency: "usd", destination: Stripe::Account.retrieve.id, },
-                                         { stripe_account: merchant_account.charge_processor_merchant_id })
+                                         transfer_options)
       refund.update!(debited_stripe_transfer: transfer.id)
       nil
     else

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -296,7 +296,9 @@ class Credit < ApplicationRecord
   # The ledger rows are booked in one transaction, so an existing retention credit means the
   # only thing that can still be outstanding is the Stripe debit.
   def self.create_for_refund_fee_retention!(refund:)
-    existing_credit = where(fee_retention_refund: refund, failed_refund_id: nil).first
+    # Scope by user_id so MySQL can use index_credits_on_user_id_and_created_at_and_id
+    # (there is no index on fee_retention_refund_id alone).
+    existing_credit = where(user_id: refund.purchase.seller_id, fee_retention_refund: refund, failed_refund_id: nil).first
     if existing_credit.present?
       # Pre-patch US retention completed Stripe transfers without recording
       # debited_stripe_transfer. Blank marker + ledger means legacy-complete — do not
@@ -306,6 +308,9 @@ class Credit < ApplicationRecord
         existing_credit.balance_id.present?
       unless us_legacy_complete
         actual_holding = debit_stripe_account_for_retained_fee(existing_credit)
+        # Debit helper returns nil once the success marker is set; still reconcile from the
+        # persisted actual when a prior attempt booked only the FX estimate.
+        actual_holding ||= refund.refund_fee_holding_debit_cents
         reconcile_fee_retention_holding_amount!(existing_credit, actual_holding)
       end
       return existing_credit
@@ -430,7 +435,9 @@ class Credit < ApplicationRecord
     merchant_account = credit.merchant_account
     refund = credit.fee_retention_refund
     return unless merchant_account.holder_of_funds == HolderOfFunds::STRIPE
-    return if refund.debited_stripe_transfer.present? && !fee_debit_pending_retry?(refund)
+    if refund.debited_stripe_transfer.present? && !fee_debit_pending_retry?(refund)
+      return refund.refund_fee_holding_debit_cents.presence&.to_i
+    end
 
     if merchant_account.country == Compliance::Countries::USA.alpha2
       # For gumroad-controlled Stripe accounts from the US, we can make new debit transfers.
@@ -441,8 +448,9 @@ class Credit < ApplicationRecord
       transfer_options[:idempotency_key] = "refund_fee_us_debit_#{refund.external_id}" if refund.id.present?
       transfer = Stripe::Transfer.create({ amount: credit.amount_cents.abs, currency: "usd", destination: Stripe::Account.retrieve.id, },
                                          transfer_options)
-      record_fee_debit_marker!(refund, transfer.id, holding_debit_cents: credit.amount_cents.abs)
-      nil
+      record_fee_debit_marker!(refund, transfer.id)
+      persist_refund_fee_holding_on_credit!(refund, credit.amount_cents.abs)
+      credit.amount_cents.abs
     else
       # For non-US gumroad-controlled Stripe accounts, we cannot make debit transfers.
       # So we try and reverse the retained fee amount from one of the old transfers made to that Stripe account.
@@ -467,14 +475,22 @@ class Credit < ApplicationRecord
   # enclosing transaction must commit that transaction even when later ledger work fails
   # (see Purchase#debit_processor_fee_from_merchant_account!), otherwise the savepoint is
   # rolled back and a retry can debit Stripe again after the idempotency window.
-  def self.record_fee_debit_marker!(refund, marker, holding_debit_cents: nil)
+  def self.record_fee_debit_marker!(refund, marker)
     transaction(requires_new: true) do
-      refund.debited_stripe_transfer = marker
-      refund.refund_fee_holding_debit_cents = holding_debit_cents if holding_debit_cents.present?
-      refund.save!
+      refund.update!(debited_stripe_transfer: marker)
     end
   end
   private_class_method :record_fee_debit_marker!
+
+  def self.persist_refund_fee_holding_on_credit!(refund, holding_debit_cents)
+    return if refund.blank? || holding_debit_cents.blank?
+    return if refund.refund_fee_holding_debit_cents.to_i == holding_debit_cents.to_i
+
+    transaction(requires_new: true) do
+      refund.update!(refund_fee_holding_debit_cents: holding_debit_cents.to_i)
+    end
+  end
+  private_class_method :persist_refund_fee_holding_on_credit!
 
   # Persist the chosen Stripe recovery route before submit so a timed-out response cannot
   # be retried as a different operation (e.g. transfer reversal → EUR debit).

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -695,15 +695,15 @@ class Credit < ApplicationRecord
           holding_currency:,
           state: "unpaid"
         ).order(date: :asc).first
-        unpaid ||= Balance.create!(
-          user: credit.user,
-          merchant_account: credit.merchant_account,
-          currency: bt.issued_amount_currency,
-          holding_currency:,
-          date: credit.created_at.to_date,
-          amount_cents: 0,
-          holding_amount_cents: 0
-        )
+        # Do not invent a zero-USD / negative-holding unpaid balance: payout validation
+        # rejects that as DESTINATION_LEDGER_NEGATIVE. Leave unreconciled until an unpaid
+        # balance exists to absorb the correction.
+        if unpaid.blank?
+          Rails.logger.error(
+            "Skipping fee retention holding reconcile for refund #{refund&.id}: "             "original balance immutable and no unpaid #{holding_currency} balance"
+          )
+          next
+        end
 
         unpaid.with_lock do
           unpaid.increment(:holding_amount_cents, adjusted_delta)

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -486,12 +486,13 @@ class Credit < ApplicationRecord
         credit.balance = balance_transaction.balance
         credit.save!
 
-        # Fold into refund fee columns only when the credit lands on the same unpaid
-        # balance as the refund. Cross-payout retention leaves retained_fee_cents unset so
-        # the later payout export can show the debit credit instead of mis-attributing it.
+        # Fold into refund fee columns when the refund's balance is still unpaid (same
+        # payout cohort, even across multiple unpaid balances). If the refund already
+        # left unpaid, leave retained_fee_cents unset so the later payout shows the credit.
         if credit.balance&.unpaid?
-          refund_balance_ids = refund.balance_transactions.map(&:balance_id)
-          if refund_balance_ids.blank? || refund_balance_ids.include?(credit.balance_id)
+          refund_still_unpaid = refund.balance_transactions.none? ||
+            refund.balance_transactions.joins(:balance).where(balances: { state: "unpaid" }).exists?
+          if refund_still_unpaid
             refund.retained_fee_cents = credit.amount_cents.abs
             refund.save!
           end

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -296,9 +296,17 @@ class Credit < ApplicationRecord
   # The ledger rows are booked in one transaction, so an existing retention credit means the
   # only thing that can still be outstanding is the Stripe debit.
   def self.create_for_refund_fee_retention!(refund:)
+    purchase = refund.purchase
+    # Same purchase → refund lock order as HandleFailedRefundService / the Purchase wrapper.
+    # Refuse to retain (or re-retain) a fee after the refund's balance was reversed on failure.
+    purchase.with_lock do
+      refund.lock!
+      return if refund.balance_reversed_on_failure
+    end
+
     # Scope by user_id so MySQL can use index_credits_on_user_id_and_created_at_and_id
     # (there is no index on fee_retention_refund_id alone).
-    existing_credit = where(user_id: refund.purchase.seller_id, fee_retention_refund: refund, failed_refund_id: nil).first
+    existing_credit = where(user_id: purchase.seller_id, fee_retention_refund: refund, failed_refund_id: nil).first
     if existing_credit.present?
       # Pre-patch US retention completed Stripe transfers without recording
       # debited_stripe_transfer. Blank marker + ledger means legacy-complete — do not
@@ -383,7 +391,12 @@ class Credit < ApplicationRecord
     # instead of debiting the account twice.
     net_amount_on_stripe_in_holding_currency = debit_stripe_account_for_retained_fee(credit)
     if refund.refund_fee_holding_debit_cents.present?
-      reversed_amount_cents_in_holding_currency = -refund.refund_fee_holding_debit_cents.to_i
+      holding_abs = convert_fee_holding_cents(
+        refund.refund_fee_holding_debit_cents,
+        from_currency: refund.refund_fee_holding_debit_currency.presence || credit.merchant_account.currency,
+        to_currency: credit.merchant_account.currency
+      )
+      reversed_amount_cents_in_holding_currency = -holding_abs if holding_abs.present?
     elsif net_amount_on_stripe_in_holding_currency.present?
       reversed_amount_cents_in_holding_currency = -net_amount_on_stripe_in_holding_currency
     end
@@ -552,7 +565,14 @@ class Credit < ApplicationRecord
     return if refund&.refund_fee_holding_reconciled_cents.to_i == actual_in_bt_currency
 
     target = -actual_in_bt_currency
-    delta = target - bt.holding_amount_net_cents
+    previously_reconciled = refund&.refund_fee_holding_reconciled_cents
+    delta = if previously_reconciled.present?
+      # Adjust from the last applied amount, not the immutable BT estimate, so FX churn
+      # cannot re-apply the full estimate delta.
+      (-actual_in_bt_currency) - (-previously_reconciled.to_i)
+    else
+      target - bt.holding_amount_net_cents
+    end
 
     if delta.zero?
       transaction(requires_new: true) do
@@ -609,31 +629,21 @@ class Credit < ApplicationRecord
   end
   private_class_method :reconcile_fee_retention_holding_amount!
 
-  # Convert a fee debit's holding amount into the currency of the original retention
-  # BalanceTransaction. BGN↔EUR uses Stripe's fixed rate; other pairs go through USD rates.
+  # Convert a fee debit's holding amount into another currency. BGN↔EUR uses Stripe's fixed
+  # rate; other pairs go through CurrencyHelper so zero-decimal currencies stay correct.
   def self.convert_fee_holding_cents(amount_cents, from_currency:, to_currency:)
     from_currency = from_currency.to_s.downcase
     to_currency = to_currency.to_s.downcase
     return amount_cents.to_i if from_currency == to_currency
 
-    amount = BigDecimal(amount_cents.to_i)
+    amount = amount_cents.to_i
     bgn = StripeChargeProcessor::BGN
     if [from_currency, to_currency].sort == [bgn, Currency::EUR].sort
-      return from_currency == Currency::EUR ? (amount * StripeChargeProcessor::BGN_PER_EUR).round : (amount / StripeChargeProcessor::BGN_PER_EUR).round
+      return from_currency == Currency::EUR ? (BigDecimal(amount) * StripeChargeProcessor::BGN_PER_EUR).round : (BigDecimal(amount) / StripeChargeProcessor::BGN_PER_EUR).round
     end
 
-    usd = if from_currency == Currency::USD
-      amount
-    else
-      rate = BigDecimal(StripeChargeProcessor.get_rate(from_currency).to_s)
-      return if rate.zero?
-      amount / rate
-    end
-    return usd.round if to_currency == Currency::USD
-
-    rate = BigDecimal(StripeChargeProcessor.get_rate(to_currency).to_s)
-    return if rate.zero?
-    (usd * rate).round
+    usd = StripeChargeProcessor.get_usd_cents(from_currency, amount)
+    StripeChargeProcessor.usd_cents_to_currency(to_currency, usd)
   end
   private_class_method :convert_fee_holding_cents
 

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -416,7 +416,22 @@ class Credit < ApplicationRecord
     credit.fee_retention_refund = refund
 
     reversed_amount_cents_in_usd = credit.amount_cents
-    reversed_amount_cents_in_holding_currency = credit.usd_cents_to_currency(credit.merchant_account.currency, credit.amount_cents)
+    # Prefer a persisted Stripe holding amount. For BGN ledgers, estimate via EUR and the
+    # fixed BGN_PER_EUR rate — never get_rate("bgn"), which is often missing and aborts retries.
+    reversed_amount_cents_in_holding_currency = if refund.refund_fee_holding_debit_cents.present?
+      holding_abs = convert_fee_holding_cents(
+        refund.refund_fee_holding_debit_cents,
+        from_currency: refund.refund_fee_holding_debit_currency.presence || credit.merchant_account.currency,
+        to_currency: credit.merchant_account.currency
+      )
+      holding_abs.present? ? -holding_abs : nil
+    elsif credit.merchant_account.currency.to_s.casecmp?(StripeChargeProcessor::BGN)
+      eur_abs = StripeChargeProcessor.usd_cents_to_currency(Currency::EUR, credit.amount_cents.abs)
+      bgn_abs = (BigDecimal(eur_abs) * StripeChargeProcessor::BGN_PER_EUR).round
+      -bgn_abs
+    else
+      credit.usd_cents_to_currency(credit.merchant_account.currency, credit.amount_cents)
+    end
 
     # Debit Stripe before booking the ledger rows: the debit records its transfer id on the
     # refund the moment it succeeds, so a retry after a failed ledger write skips Stripe
@@ -828,9 +843,29 @@ class Credit < ApplicationRecord
           next
         end
 
+        absorbed = false
         unpaid.with_lock do
-          unpaid.increment(:holding_amount_cents, adjusted_delta)
-          unpaid.save!
+          projected_holding = unpaid.holding_amount_cents + adjusted_delta
+          # Same DESTINATION_LEDGER_NEGATIVE shape payout validation rejects: negative holding
+          # with a non-negative USD ledger. Keep reconcile pending instead of finalizing that.
+          if projected_holding.negative? && !unpaid.amount_cents.negative?
+            Rails.logger.error(
+              "Skipping fee retention holding reconcile for refund #{refund&.id}: "               "unpaid balance #{unpaid.id} cannot absorb holding delta #{adjusted_delta}"
+            )
+          else
+            unpaid.increment(:holding_amount_cents, adjusted_delta)
+            unpaid.save!
+            absorbed = true
+          end
+        end
+        unless absorbed
+          if refund.present?
+            refund.update!(
+              refund_fee_holding_reconcile_pending: true,
+              fee_retention_retry_at: 15.minutes.from_now
+            )
+          end
+          next
         end
       end
 

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -291,7 +291,17 @@ class Credit < ApplicationRecord
     credit
   end
 
+  # Idempotent: runs after the refund has committed (the processor has already returned the
+  # buyer's money), so it must be safe to call again when an earlier attempt failed part way.
+  # The ledger rows are booked in one transaction, so an existing retention credit means the
+  # only thing that can still be outstanding is the Stripe debit.
   def self.create_for_refund_fee_retention!(refund:)
+    existing_credit = where(fee_retention_refund: refund, failed_refund_id: nil).first
+    if existing_credit.present?
+      debit_stripe_account_for_retained_fee(existing_credit)
+      return existing_credit
+    end
+
     # We retain the payment processor fee (2.9% + 30c) and the Gumroad fee (10% + any discover fee) in case of refunds.
     # For Stripe Connect sales, the application fee includes the Gumroad fee, the VAT/sales tax,
     # and the affiliate credit. We debit connected accounts for the full application fee, so we add a positive credit
@@ -308,23 +318,26 @@ class Credit < ApplicationRecord
       credit.amount_cents = (application_fee_refundable_portion * (refund.amount_cents.to_f / purchase.price_cents)).round
       credit.merchant_account = MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id)
       credit.fee_retention_refund = refund
-      credit.save!
 
-      balance_transaction_amount = BalanceTransaction::Amount.new(
-        currency: Currency::USD,
-        gross_cents: credit.amount_cents,
-        net_cents: credit.amount_cents
-      )
-      balance_transaction = BalanceTransaction.create!(
-        user: credit.user,
-        merchant_account: credit.merchant_account,
-        credit:,
-        issued_amount: balance_transaction_amount,
-        holding_amount: balance_transaction_amount
-      )
+      transaction do
+        credit.save!
 
-      credit.balance = balance_transaction.balance
-      credit.save!
+        balance_transaction_amount = BalanceTransaction::Amount.new(
+          currency: Currency::USD,
+          gross_cents: credit.amount_cents,
+          net_cents: credit.amount_cents
+        )
+        balance_transaction = BalanceTransaction.create!(
+          user: credit.user,
+          merchant_account: credit.merchant_account,
+          credit:,
+          issued_amount: balance_transaction_amount,
+          holding_amount: balance_transaction_amount
+        )
+
+        credit.balance = balance_transaction.balance
+        credit.save!
+      end
 
       return credit
     end
@@ -344,51 +357,77 @@ class Credit < ApplicationRecord
     end
     credit.merchant_account = refund.purchase.merchant_account
     credit.fee_retention_refund = refund
-    credit.save!
-
-    refund.retained_fee_cents = credit.amount_cents.abs
-    refund.save!
 
     reversed_amount_cents_in_usd = credit.amount_cents
     reversed_amount_cents_in_holding_currency = credit.usd_cents_to_currency(credit.merchant_account.currency, credit.amount_cents)
 
-    # For Stripe sales that use a gumroad-managed custom connect account, we debit the Stripe account for the fee amount.
-    if credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE && credit.merchant_account.country == Compliance::Countries::USA.alpha2
-      # For gumroad-controlled Stripe accounts from the US, we can make new debit transfers.
-      # So we transfer the retained fee back to Gumroad's Stripe platform account.
-      Stripe::Transfer.create({ amount: credit.amount_cents.abs, currency: "usd", destination: Stripe::Account.retrieve.id, },
-                              { stripe_account: credit.merchant_account.charge_processor_merchant_id })
-    elsif credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE
-      # For non-US gumroad-controlled Stripe accounts, we cannot make debit transfers.
-      # So we try and reverse the retained fee amount from one of the old transfers made to that Stripe account.
-      net_amount_on_stripe_in_holding_currency = StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:)
-      reversed_amount_cents_in_holding_currency = -net_amount_on_stripe_in_holding_currency if net_amount_on_stripe_in_holding_currency.present?
+    # Debit Stripe before booking the ledger rows: the debit records its transfer id on the
+    # refund the moment it succeeds, so a retry after a failed ledger write skips Stripe
+    # instead of debiting the account twice.
+    net_amount_on_stripe_in_holding_currency = debit_stripe_account_for_retained_fee(credit)
+    reversed_amount_cents_in_holding_currency = -net_amount_on_stripe_in_holding_currency if net_amount_on_stripe_in_holding_currency.present?
+
+    transaction do
+      credit.save!
+
+      refund.retained_fee_cents = credit.amount_cents.abs
+      refund.save!
+
+      balance_transaction_amount = BalanceTransaction::Amount.new(
+        currency: Currency::USD,
+        gross_cents: reversed_amount_cents_in_usd,
+        net_cents: reversed_amount_cents_in_usd
+      )
+
+      balance_transaction_holding_amount = BalanceTransaction::Amount.new(
+        currency: credit.merchant_account.currency,
+        gross_cents: reversed_amount_cents_in_holding_currency,
+        net_cents: reversed_amount_cents_in_holding_currency
+      )
+
+      balance_transaction = BalanceTransaction.create!(
+        user: credit.user,
+        merchant_account: credit.merchant_account,
+        credit:,
+        issued_amount: balance_transaction_amount,
+        holding_amount: balance_transaction_holding_amount
+      )
+
+      credit.balance = balance_transaction.balance
+      credit.save!
     end
-
-    balance_transaction_amount = BalanceTransaction::Amount.new(
-      currency: Currency::USD,
-      gross_cents: reversed_amount_cents_in_usd,
-      net_cents: reversed_amount_cents_in_usd
-    )
-
-    balance_transaction_holding_amount = BalanceTransaction::Amount.new(
-      currency: credit.merchant_account.currency,
-      gross_cents: reversed_amount_cents_in_holding_currency,
-      net_cents: reversed_amount_cents_in_holding_currency
-    )
-
-    balance_transaction = BalanceTransaction.create!(
-      user: credit.user,
-      merchant_account: credit.merchant_account,
-      credit:,
-      issued_amount: balance_transaction_amount,
-      holding_amount: balance_transaction_holding_amount
-    )
-
-    credit.balance = balance_transaction.balance
-    credit.save!
     credit
   end
+
+  # For Stripe sales that use a gumroad-managed custom connect account, pull the retained fee
+  # out of that Stripe account. Best effort: the ledger is booked whether or not this
+  # succeeds, a failure is reported and left for a retry, and the transfer id recorded on
+  # the refund makes a second call a no-op. Returns the amount taken from the Stripe balance
+  # in the account's currency, or nil when the ledger has to fall back to the converted fee.
+  def self.debit_stripe_account_for_retained_fee(credit)
+    merchant_account = credit.merchant_account
+    refund = credit.fee_retention_refund
+    return unless merchant_account.holder_of_funds == HolderOfFunds::STRIPE
+    return if refund.debited_stripe_transfer.present?
+
+    if merchant_account.country == Compliance::Countries::USA.alpha2
+      # For gumroad-controlled Stripe accounts from the US, we can make new debit transfers.
+      # So we transfer the retained fee back to Gumroad's Stripe platform account.
+      transfer = Stripe::Transfer.create({ amount: credit.amount_cents.abs, currency: "usd", destination: Stripe::Account.retrieve.id, },
+                                         { stripe_account: merchant_account.charge_processor_merchant_id })
+      refund.update!(debited_stripe_transfer: transfer.id)
+      nil
+    else
+      # For non-US gumroad-controlled Stripe accounts, we cannot make debit transfers.
+      # So we try and reverse the retained fee amount from one of the old transfers made to that Stripe account.
+      StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:)
+    end
+  rescue StandardError => e
+    Rails.logger.error("Failed to debit Stripe account for the retained fee of refund #{refund.id}: #{e.class}: #{e.message}")
+    ErrorNotifier.notify(e, context: { refund_id: refund.id, purchase_id: refund.purchase_id, merchant_account_id: merchant_account.id })
+    nil
+  end
+  private_class_method :debit_stripe_account_for_retained_fee
 
   # Give back the fee that create_for_refund_fee_retention! retained, because the
   # refund it was retained for later FAILED (async bank-transfer refunds can be

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -503,7 +503,7 @@ class Credit < ApplicationRecord
   rescue StandardError => e
     # Persist a retryable sentinel so US failures are not mistaken for legacy-complete
     # blank-marker retentions on the next attempt.
-    record_fee_debit_marker!(refund, FEE_DEBIT_PENDING_RETRY) if refund.present? && refund.debited_stripe_transfer.blank?
+    record_pending_fee_debit_retry!(refund)
     Rails.logger.error("Failed to debit Stripe account for the retained fee of refund #{refund.id}: #{e.class}: #{e.message}")
     ErrorNotifier.notify(e, context: { refund_id: refund.id, purchase_id: refund.purchase_id, merchant_account_id: merchant_account.id })
     nil
@@ -525,6 +525,24 @@ class Credit < ApplicationRecord
     end
   end
   private_class_method :record_fee_debit_marker!
+
+  # pending_retry must not overwrite a success marker another concurrent attempt just
+  # committed. Reload under the refund lock before the blank-to-pending transition.
+  def self.record_pending_fee_debit_retry!(refund)
+    return if refund.blank?
+
+    refund.reload
+    refund.with_lock do
+      refund.reload
+      return if refund.debited_stripe_transfer.present? && refund.debited_stripe_transfer != FEE_DEBIT_PENDING_RETRY
+      return if refund.debited_stripe_transfer == FEE_DEBIT_PENDING_RETRY
+
+      transaction(requires_new: true) do
+        refund.update!(debited_stripe_transfer: FEE_DEBIT_PENDING_RETRY)
+      end
+    end
+  end
+  private_class_method :record_pending_fee_debit_retry!
 
   def self.persist_refund_fee_holding_on_credit!(refund, holding_debit_cents, currency: nil)
     return if refund.blank? || holding_debit_cents.blank?

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -458,7 +458,7 @@ class Credit < ApplicationRecord
       transfer = Stripe::Transfer.create({ amount: credit.amount_cents.abs, currency: "usd", destination: Stripe::Account.retrieve.id, },
                                          transfer_options)
       record_fee_debit_marker!(refund, transfer.id)
-      persist_refund_fee_holding_on_credit!(refund, credit.amount_cents.abs)
+      persist_refund_fee_holding_on_credit!(refund, credit.amount_cents.abs, currency: Currency::USD)
       credit.amount_cents.abs
     else
       # For non-US gumroad-controlled Stripe accounts, we cannot make debit transfers.
@@ -491,12 +491,16 @@ class Credit < ApplicationRecord
   end
   private_class_method :record_fee_debit_marker!
 
-  def self.persist_refund_fee_holding_on_credit!(refund, holding_debit_cents)
+  def self.persist_refund_fee_holding_on_credit!(refund, holding_debit_cents, currency: nil)
     return if refund.blank? || holding_debit_cents.blank?
-    return if refund.refund_fee_holding_debit_cents.to_i == holding_debit_cents.to_i
+    currency = currency.to_s.downcase.presence
+    return if refund.refund_fee_holding_debit_cents.to_i == holding_debit_cents.to_i &&
+      (currency.blank? || refund.refund_fee_holding_debit_currency.to_s.casecmp?(currency))
 
     transaction(requires_new: true) do
-      refund.update!(refund_fee_holding_debit_cents: holding_debit_cents.to_i)
+      attrs = { refund_fee_holding_debit_cents: holding_debit_cents.to_i }
+      attrs[:refund_fee_holding_debit_currency] = currency if currency.present?
+      refund.update!(attrs)
     end
   end
   private_class_method :persist_refund_fee_holding_on_credit!
@@ -533,26 +537,29 @@ class Credit < ApplicationRecord
 
     actual = actual_holding_abs_cents.to_i.abs
     refund = credit.fee_retention_refund
-    # Idempotent: once this actual has been applied, do not subtract the BT-estimate
-    # delta again on later retries.
-    return if refund&.refund_fee_holding_reconciled_cents.to_i == actual
-
-    target = -actual
     bt = credit.balance_transaction
     return if bt.blank?
 
+    actual_currency = (refund&.refund_fee_holding_debit_currency.presence || credit.merchant_account.currency).to_s.downcase
+    actual_in_bt_currency = convert_fee_holding_cents(
+      actual,
+      from_currency: actual_currency,
+      to_currency: bt.holding_amount_currency.to_s.downcase
+    )
+    return if actual_in_bt_currency.blank?
+
+    # Idempotent against the BT-currency amount we applied.
+    return if refund&.refund_fee_holding_reconciled_cents.to_i == actual_in_bt_currency
+
+    target = -actual_in_bt_currency
     delta = target - bt.holding_amount_net_cents
-    if refund.present? && refund.refund_fee_holding_debit_cents.to_i != actual
-      transaction(requires_new: true) do
-        refund.update!(refund_fee_holding_debit_cents: actual)
-      end
-    end
 
     if delta.zero?
       transaction(requires_new: true) do
         refund.update!(
           refund_fee_holding_debit_cents: actual,
-          refund_fee_holding_reconciled_cents: actual
+          refund_fee_holding_debit_currency: actual_currency,
+          refund_fee_holding_reconciled_cents: actual_in_bt_currency
         ) if refund.present?
       end
       return
@@ -577,7 +584,15 @@ class Credit < ApplicationRecord
           holding_currency: bt.holding_amount_currency,
           state: "unpaid"
         ).order(date: :asc).first
-        raise if unpaid.blank?
+        unpaid ||= Balance.create!(
+          user: credit.user,
+          merchant_account: credit.merchant_account,
+          currency: bt.issued_amount_currency,
+          holding_currency: bt.holding_amount_currency,
+          date: credit.created_at.to_date,
+          amount_cents: 0,
+          holding_amount_cents: 0
+        )
 
         unpaid.with_lock do
           unpaid.increment(:holding_amount_cents, delta)
@@ -587,11 +602,40 @@ class Credit < ApplicationRecord
 
       refund.update!(
         refund_fee_holding_debit_cents: actual,
-        refund_fee_holding_reconciled_cents: actual
+        refund_fee_holding_debit_currency: actual_currency,
+        refund_fee_holding_reconciled_cents: actual_in_bt_currency
       ) if refund.present?
     end
   end
   private_class_method :reconcile_fee_retention_holding_amount!
+
+  # Convert a fee debit's holding amount into the currency of the original retention
+  # BalanceTransaction. BGN↔EUR uses Stripe's fixed rate; other pairs go through USD rates.
+  def self.convert_fee_holding_cents(amount_cents, from_currency:, to_currency:)
+    from_currency = from_currency.to_s.downcase
+    to_currency = to_currency.to_s.downcase
+    return amount_cents.to_i if from_currency == to_currency
+
+    amount = BigDecimal(amount_cents.to_i)
+    bgn = StripeChargeProcessor::BGN
+    if [from_currency, to_currency].sort == [bgn, Currency::EUR].sort
+      return from_currency == Currency::EUR ? (amount * StripeChargeProcessor::BGN_PER_EUR).round : (amount / StripeChargeProcessor::BGN_PER_EUR).round
+    end
+
+    usd = if from_currency == Currency::USD
+      amount
+    else
+      rate = BigDecimal(StripeChargeProcessor.get_rate(from_currency).to_s)
+      return if rate.zero?
+      amount / rate
+    end
+    return usd.round if to_currency == Currency::USD
+
+    rate = BigDecimal(StripeChargeProcessor.get_rate(to_currency).to_s)
+    return if rate.zero?
+    (usd * rate).round
+  end
+  private_class_method :convert_fee_holding_cents
 
   def self.fee_debit_idempotency_window_expired?(refund)
     raw = refund&.refund_fee_debit_submitted_at

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -577,6 +577,12 @@ class Credit < ApplicationRecord
     return if refund.blank?
     refund.reload
     return unless refund.refund_fee_retention_pending
+    # Keep the flag while Stripe debit or holding reconciliation is still outstanding so
+    # the recurring job can finish finish_holding_lookup / reconcile after a crash.
+    return if fee_debit_pending_retry?(refund)
+    if refund.debited_stripe_transfer.present? && refund.refund_fee_holding_debit_cents.blank?
+      return
+    end
 
     transaction(requires_new: true) do
       refund.update!(refund_fee_retention_pending: false)

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -818,15 +818,7 @@ class Credit < ApplicationRecord
             applied = true
           end
         end
-        unless applied
-          if refund.present?
-            refund.update!(
-              refund_fee_holding_reconcile_pending: true,
-              fee_retention_retry_at: 15.minutes.from_now
-            )
-          end
-          next
-        end
+        raise ActiveRecord::RecordInvalid.new(balance) unless applied
       rescue ActiveRecord::RecordInvalid
         holding_currency = credit.merchant_account.currency.to_s.downcase
         adjusted_delta = convert_fee_holding_cents(
@@ -842,7 +834,7 @@ class Credit < ApplicationRecord
           currency: bt.issued_amount_currency,
           holding_currency:,
           state: "unpaid"
-        ).order(date: :asc).first
+        ).where.not(id: balance.id).order(date: :asc).first
         # Do not invent a zero-USD / negative-holding unpaid balance: payout validation
         # rejects that as DESTINATION_LEDGER_NEGATIVE. Leave unreconciled until an unpaid
         # balance exists to absorb the correction.

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -462,13 +462,6 @@ class Credit < ApplicationRecord
       transaction(requires_new: true) do
         credit.save!
 
-        # Only attribute retained_fee_cents when this credit landed on an unpaid balance.
-        # Delayed retention after payout must not rewrite the paid payout's refund export.
-        if credit.balance&.unpaid?
-          refund.retained_fee_cents = credit.amount_cents.abs
-          refund.save!
-        end
-
         balance_transaction_amount = BalanceTransaction::Amount.new(
           currency: Currency::USD,
           gross_cents: reversed_amount_cents_in_usd,
@@ -491,6 +484,13 @@ class Credit < ApplicationRecord
 
         credit.balance = balance_transaction.balance
         credit.save!
+
+        # Attribute retained fee only after balance is linked — unpaid balances need the
+        # cents for payout/reporting; paid balances already settled without this marker.
+        if credit.balance&.unpaid?
+          refund.retained_fee_cents = credit.amount_cents.abs
+          refund.save!
+        end
       end
     end
     clear_refund_fee_retention_pending!(refund)

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -442,6 +442,14 @@ class Credit < ApplicationRecord
     if merchant_account.country == Compliance::Countries::USA.alpha2
       # For gumroad-controlled Stripe accounts from the US, we can make new debit transfers.
       # So we transfer the retained fee back to Gumroad's Stripe platform account.
+      if fee_debit_pending_retry?(refund) && fee_debit_idempotency_window_expired?(refund)
+        Rails.logger.error("Refusing automatic US fee debit resubmit for refund #{refund.id}: Stripe idempotency window elapsed")
+        ErrorNotifier.notify(
+          "Refund fee debit pending_retry outside Stripe idempotency window",
+          context: { refund_id: refund.id, purchase_id: refund.purchase_id, operation: StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT }
+        )
+        return refund.refund_fee_holding_debit_cents.presence&.to_i
+      end
       persist_refund_fee_debit_choice!(refund, operation: StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT,
                                               amount_cents: credit.amount_cents.abs)
       transfer_options = { stripe_account: merchant_account.charge_processor_merchant_id }
@@ -494,16 +502,23 @@ class Credit < ApplicationRecord
 
   # Persist the chosen Stripe recovery route before submit so a timed-out response cannot
   # be retried as a different operation (e.g. transfer reversal → EUR debit).
+  # Stripe documents a 24-hour idempotency key retention window. Refuse automatic
+  # resubmits after this slightly shorter window so a timed-out fee debit cannot be
+  # posted twice once Stripe has forgotten the original key.
+  FEE_DEBIT_IDEMPOTENCY_WINDOW = 23.hours
+
   def self.persist_refund_fee_debit_choice!(refund, operation:, transfer_id: nil, amount_cents: nil)
     return if refund.blank?
-    return if refund.refund_fee_debit_operation == operation &&
+    already = refund.refund_fee_debit_operation == operation &&
       (transfer_id.blank? || refund.refund_fee_debit_transfer_id == transfer_id) &&
       (amount_cents.blank? || refund.refund_fee_debit_amount_cents.to_i == amount_cents.to_i)
+    return if already && refund.refund_fee_debit_submitted_at.present?
 
     transaction(requires_new: true) do
       refund.refund_fee_debit_operation = operation
       refund.refund_fee_debit_transfer_id = transfer_id if transfer_id.present?
       refund.refund_fee_debit_amount_cents = amount_cents if amount_cents.present?
+      refund.refund_fee_debit_submitted_at ||= Time.current.utc.iso8601
       refund.save!
     end
   end
@@ -515,28 +530,79 @@ class Credit < ApplicationRecord
   def self.reconcile_fee_retention_holding_amount!(credit, actual_holding_abs_cents)
     return if credit.blank? || actual_holding_abs_cents.blank?
 
-    target = -actual_holding_abs_cents.to_i.abs
+    actual = actual_holding_abs_cents.to_i.abs
+    refund = credit.fee_retention_refund
+    # Idempotent: once this actual has been applied, do not subtract the BT-estimate
+    # delta again on later retries.
+    return if refund&.refund_fee_holding_reconciled_cents.to_i == actual
+
+    target = -actual
     bt = credit.balance_transaction
     return if bt.blank?
 
     delta = target - bt.holding_amount_net_cents
-    refund = credit.fee_retention_refund
-    if refund.present? && refund.refund_fee_holding_debit_cents.to_i != actual_holding_abs_cents.to_i.abs
+    if refund.present? && refund.refund_fee_holding_debit_cents.to_i != actual
       transaction(requires_new: true) do
-        refund.update!(refund_fee_holding_debit_cents: actual_holding_abs_cents.to_i.abs)
+        refund.update!(refund_fee_holding_debit_cents: actual)
       end
     end
-    return if delta.zero?
+
+    if delta.zero?
+      mark_fee_retention_holding_reconciled!(refund, actual)
+      return
+    end
 
     balance = credit.balance || bt.balance
     return if balance.blank?
 
-    balance.with_lock do
-      balance.increment(:holding_amount_cents, delta)
-      balance.save!
+    begin
+      balance.with_lock do
+        balance.increment(:holding_amount_cents, delta)
+        balance.save!
+      end
+    rescue ActiveRecord::RecordInvalid
+      # Original retention balance may already be processing/paid. Book the correction
+      # onto an unpaid balance for the same merchant account when possible.
+      unpaid = Balance.where(
+        user: credit.user,
+        merchant_account: credit.merchant_account,
+        currency: bt.issued_amount_currency,
+        holding_currency: bt.holding_amount_currency,
+        state: "unpaid"
+      ).order(date: :asc).first
+      raise if unpaid.blank?
+
+      unpaid.with_lock do
+        unpaid.increment(:holding_amount_cents, delta)
+        unpaid.save!
+      end
     end
+
+    mark_fee_retention_holding_reconciled!(refund, actual)
   end
   private_class_method :reconcile_fee_retention_holding_amount!
+
+  def self.mark_fee_retention_holding_reconciled!(refund, actual)
+    return if refund.blank?
+
+    transaction(requires_new: true) do
+      refund.update!(
+        refund_fee_holding_debit_cents: actual,
+        refund_fee_holding_reconciled_cents: actual
+      )
+    end
+  end
+  private_class_method :mark_fee_retention_holding_reconciled!
+
+  def self.fee_debit_idempotency_window_expired?(refund)
+    raw = refund&.refund_fee_debit_submitted_at
+    return false if raw.blank?
+
+    submitted_at = Time.zone.parse(raw.to_s)
+    submitted_at.present? && submitted_at < FEE_DEBIT_IDEMPOTENCY_WINDOW.ago
+  rescue ArgumentError, TypeError
+    false
+  end
 
   # Give back the fee that create_for_refund_fee_retention! retained, because the
   # refund it was retained for later FAILED (async bank-transfer refunds can be

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -319,7 +319,9 @@ class Credit < ApplicationRecord
         # re-debit. New failures record FEE_DEBIT_PENDING_RETRY so retries still run.
         us_legacy_complete = existing_credit.merchant_account&.country == Compliance::Countries::USA.alpha2 &&
           refund.debited_stripe_transfer.blank? &&
-          existing_credit.balance_id.present?
+          existing_credit.balance_id.present? &&
+          refund.refund_fee_debit_generation.to_i.zero? &&
+          refund.refund_fee_debit_submitted_at.blank?
       end
     end
 
@@ -622,8 +624,9 @@ class Credit < ApplicationRecord
         refund.refund_fee_debit_operation = nil
         refund.refund_fee_debit_transfer_id = nil
         refund.refund_fee_debit_amount_cents = nil
+        refund.refund_fee_debit_submitted_at = nil
         refund.refund_fee_debit_generation = refund.refund_fee_debit_generation.to_i + 1
-        refund.debited_stripe_transfer = nil if refund.debited_stripe_transfer == FEE_DEBIT_PENDING_RETRY
+        refund.debited_stripe_transfer = FEE_DEBIT_PENDING_RETRY
         refund.save!
       end
     end

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -486,12 +486,13 @@ class Credit < ApplicationRecord
         credit.balance = balance_transaction.balance
         credit.save!
 
-        # Fold into refund fee columns when the refund's balance is still unpaid (same
-        # payout cohort, even across multiple unpaid balances). If the refund already
-        # left unpaid, leave retained_fee_cents unset so the later payout shows the credit.
+        # Fold into refund fee columns when the seller's refund balance is still unpaid
+        # (same payout cohort). Ignore affiliate BTs — an unpaid affiliate balance must
+        # not fold a fee that later lands on the seller's next payout.
         if credit.balance&.unpaid?
-          refund_still_unpaid = refund.balance_transactions.none? ||
-            refund.balance_transactions.joins(:balance).where(balances: { state: "unpaid" }).exists?
+          seller_refund_bts = refund.balance_transactions.where(user_id: refund.seller_id)
+          refund_still_unpaid = seller_refund_bts.none? ||
+            seller_refund_bts.joins(:balance).where(balances: { state: "unpaid" }).exists?
           if refund_still_unpaid
             refund.retained_fee_cents = credit.amount_cents.abs
             refund.save!

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -301,6 +301,8 @@ class Credit < ApplicationRecord
     # Refuse to retain (or re-retain) a fee after the refund's balance was reversed on failure.
     # reload before lock!: callers may have read a json_data accessor on a NULL column,
     # which dirties the in-memory record and makes lock! raise.
+    existing_credit = nil
+    us_legacy_complete = false
     purchase.with_lock do
       refund.reload.lock!
       return if refund.balance_reversed_on_failure
@@ -316,22 +318,23 @@ class Credit < ApplicationRecord
         us_legacy_complete = existing_credit.merchant_account&.country == Compliance::Countries::USA.alpha2 &&
           refund.debited_stripe_transfer.blank? &&
           existing_credit.balance_id.present?
-        unless us_legacy_complete
-          actual_holding = debit_stripe_account_for_retained_fee(existing_credit)
-          # Debit helper returns nil once the success marker is set; still reconcile from the
-          # persisted actual when a prior attempt booked only the FX estimate.
-          actual_holding ||= refund.refund_fee_holding_debit_cents
-          begin
-            reconcile_fee_retention_holding_amount!(existing_credit, actual_holding)
-          rescue StandardError => e
-            # Keep any Stripe success marker written in requires_new savepoints: re-raising
-            # would roll back this purchase.with_lock transaction and erase proof of debit.
-            Rails.logger.error("Failed to reconcile fee retention holding for refund #{refund.id}: #{e.class}: #{e.message}")
-            ErrorNotifier.notify(e, context: { refund_id: refund.id, credit_id: existing_credit.id })
-          end
-        end
-        return existing_credit
       end
+    end
+
+    if existing_credit.present?
+      unless us_legacy_complete
+        # Stripe + durable markers run outside the lock transaction so requires_new writes
+        # are real commits if this process dies mid-flight.
+        actual_holding = debit_stripe_account_for_retained_fee(existing_credit)
+        actual_holding ||= refund.reload.refund_fee_holding_debit_cents
+        begin
+          reconcile_fee_retention_holding_amount!(existing_credit, actual_holding)
+        rescue StandardError => e
+          Rails.logger.error("Failed to reconcile fee retention holding for refund #{refund.id}: #{e.class}: #{e.message}")
+          ErrorNotifier.notify(e, context: { refund_id: refund.id, credit_id: existing_credit.id })
+        end
+      end
+      return existing_credit
     end
 
     # We retain the payment processor fee (2.9% + 30c) and the Gumroad fee (10% + any discover fee) in case of refunds.

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -299,8 +299,10 @@ class Credit < ApplicationRecord
     purchase = refund.purchase
     # Same purchase → refund lock order as HandleFailedRefundService / the Purchase wrapper.
     # Refuse to retain (or re-retain) a fee after the refund's balance was reversed on failure.
+    # reload before lock!: callers may have read a json_data accessor on a NULL column,
+    # which dirties the in-memory record and makes lock! raise.
     purchase.with_lock do
-      refund.lock!
+      refund.reload.lock!
       return if refund.balance_reversed_on_failure
     end
 
@@ -561,36 +563,54 @@ class Credit < ApplicationRecord
     )
     return if actual_in_bt_currency.blank?
 
-    # Idempotent against the BT-currency amount we applied.
-    return if refund&.refund_fee_holding_reconciled_cents.to_i == actual_in_bt_currency
+    apply_fee_retention_holding_reconcile!(
+      credit:,
+      refund:,
+      bt:,
+      actual:,
+      actual_currency:,
+      actual_in_bt_currency:
+    )
+  end
+  private_class_method :reconcile_fee_retention_holding_amount!
 
-    target = -actual_in_bt_currency
-    previously_reconciled = refund&.refund_fee_holding_reconciled_cents
-    delta = if previously_reconciled.present?
-      # Adjust from the last applied amount, not the immutable BT estimate, so FX churn
-      # cannot re-apply the full estimate delta.
-      (-actual_in_bt_currency) - (-previously_reconciled.to_i)
-    else
-      target - bt.holding_amount_net_cents
+  def self.apply_fee_retention_holding_reconcile!(credit:, refund:, bt:, actual:, actual_currency:, actual_in_bt_currency:)
+    # Serialize marker read/write with the balance correction so concurrent retries cannot
+    # both apply the same delta after both observing an unreconciled refund.
+    lock_refund = ->(&block) do
+      if refund.present?
+        refund.with_lock do
+          refund.reload
+          block.call
+        end
+      else
+        block.call
+      end
     end
 
-    if delta.zero?
-      transaction(requires_new: true) do
+    lock_refund.call do
+      return if refund&.refund_fee_holding_reconciled_cents.to_i == actual_in_bt_currency
+
+      target = -actual_in_bt_currency
+      previously_reconciled = refund&.refund_fee_holding_reconciled_cents
+      delta = if previously_reconciled.present?
+        (-actual_in_bt_currency) - (-previously_reconciled.to_i)
+      else
+        target - bt.holding_amount_net_cents
+      end
+
+      if delta.zero?
         refund.update!(
           refund_fee_holding_debit_cents: actual,
           refund_fee_holding_debit_currency: actual_currency,
           refund_fee_holding_reconciled_cents: actual_in_bt_currency
         ) if refund.present?
+        next
       end
-      return
-    end
 
-    balance = credit.balance || bt.balance
-    return if balance.blank?
+      balance = credit.balance || bt.balance
+      return if balance.blank?
 
-    # Keep the balance correction and reconciliation marker in one savepoint so a failed
-    # marker write cannot leave a committed delta that the next retry would apply again.
-    transaction(requires_new: true) do
       begin
         balance.with_lock do
           balance.increment(:holding_amount_cents, delta)
@@ -627,7 +647,7 @@ class Credit < ApplicationRecord
       ) if refund.present?
     end
   end
-  private_class_method :reconcile_fee_retention_holding_amount!
+  private_class_method :apply_fee_retention_holding_reconcile!
 
   # Convert a fee debit's holding amount into another currency. BGN↔EUR uses Stripe's fixed
   # rate; other pairs go through CurrencyHelper so zero-decimal currencies stay correct.

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -547,17 +547,17 @@ class Credit < ApplicationRecord
   def self.persist_refund_fee_debit_choice!(refund, operation:, transfer_id: nil, amount_cents: nil)
     return if refund.blank?
 
-    # Under the refund lock: if another caller already chose an operation, keep theirs so
-    # concurrent retries resume one sticky route instead of overwriting with a second debit.
+    # reload before with_lock: a json_data accessor on NULL dirties the record, and Rails
+    # lock!s before yielding — the inner reload would never run.
+    refund.reload
+    # Under the refund lock: the first complete choice is immutable. Concurrent callers
+    # either resume that same operation or bail so debit_stripe_account_for_refund_fee can
+    # resume the persisted route.
     refund.with_lock do
       refund.reload
-      if refund.refund_fee_debit_operation.present? && refund.refund_fee_debit_operation != operation
-        return false
+      if refund.refund_fee_debit_operation.present?
+        return refund.refund_fee_debit_operation == operation
       end
-      already = refund.refund_fee_debit_operation == operation &&
-        (transfer_id.blank? || refund.refund_fee_debit_transfer_id == transfer_id) &&
-        (amount_cents.blank? || refund.refund_fee_debit_amount_cents.to_i == amount_cents.to_i)
-      return true if already && refund.refund_fee_debit_submitted_at.present?
 
       transaction(requires_new: true) do
         refund.refund_fee_debit_operation = operation

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -356,33 +356,43 @@ class Credit < ApplicationRecord
         return
       end
 
-      credit = new
-      credit.user = purchase.seller
-      credit.amount_cents = (application_fee_refundable_portion * (refund.amount_cents.to_f / purchase.price_cents)).round
-      credit.merchant_account = MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id)
-      credit.fee_retention_refund = refund
+      credit = nil
+      purchase.with_lock do
+        refund.reload.lock!
+        return if refund.balance_reversed_on_failure
 
-      # requires_new: callers (Charge#refund_and_save!, processor webhook with_lock) may
-      # still hold an open transaction. A nested join would let an outer rescue commit a
-      # half-written credit if balance creation failed after credit.save!.
-      transaction(requires_new: true) do
-        credit.save!
+        existing = where(user_id: purchase.seller_id, fee_retention_refund: refund, failed_refund_id: nil).first
+        if existing
+          clear_refund_fee_retention_pending!(refund)
+          return existing
+        end
 
-        balance_transaction_amount = BalanceTransaction::Amount.new(
-          currency: Currency::USD,
-          gross_cents: credit.amount_cents,
-          net_cents: credit.amount_cents
-        )
-        balance_transaction = BalanceTransaction.create!(
-          user: credit.user,
-          merchant_account: credit.merchant_account,
-          credit:,
-          issued_amount: balance_transaction_amount,
-          holding_amount: balance_transaction_amount
-        )
+        credit = new
+        credit.user = purchase.seller
+        credit.amount_cents = (application_fee_refundable_portion * (refund.amount_cents.to_f / purchase.price_cents)).round
+        credit.merchant_account = MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id)
+        credit.fee_retention_refund = refund
 
-        credit.balance = balance_transaction.balance
-        credit.save!
+        # requires_new: isolate ledger writes from any outer txn held by the caller.
+        transaction(requires_new: true) do
+          credit.save!
+
+          balance_transaction_amount = BalanceTransaction::Amount.new(
+            currency: Currency::USD,
+            gross_cents: credit.amount_cents,
+            net_cents: credit.amount_cents
+          )
+          balance_transaction = BalanceTransaction.create!(
+            user: credit.user,
+            merchant_account: credit.merchant_account,
+            credit:,
+            issued_amount: balance_transaction_amount,
+            holding_amount: balance_transaction_amount
+          )
+
+          credit.balance = balance_transaction.balance
+          credit.save!
+        end
       end
 
       clear_refund_fee_retention_pending!(refund)

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -420,7 +420,20 @@ class Credit < ApplicationRecord
       refund.reload.lock!
       return if refund.balance_reversed_on_failure
       existing_credit = where(user_id: purchase.seller_id, fee_retention_refund: refund, failed_refund_id: nil).lock.first
-      return existing_credit if existing_credit.present?
+      if existing_credit.present?
+        # Another concurrent attempt booked the credit (possibly with an FX estimate) while
+        # this attempt obtained the actual Stripe debit. Reconcile before returning.
+        begin
+          reconcile_fee_retention_holding_amount!(
+            existing_credit,
+            refund.refund_fee_holding_debit_cents.presence || net_amount_on_stripe_in_holding_currency
+          )
+        rescue StandardError => e
+          Rails.logger.error("Failed to reconcile concurrent fee retention for refund #{refund.id}: #{e.class}: #{e.message}")
+          ErrorNotifier.notify(e, context: { refund_id: refund.id, credit_id: existing_credit.id })
+        end
+        return existing_credit
+      end
 
       # requires_new: see Connect branch above — isolate ledger writes from any outer txn.
       transaction(requires_new: true) do

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -304,26 +304,27 @@ class Credit < ApplicationRecord
     purchase.with_lock do
       refund.reload.lock!
       return if refund.balance_reversed_on_failure
-    end
 
-    # Scope by user_id so MySQL can use index_credits_on_user_id_and_created_at_and_id
-    # (there is no index on fee_retention_refund_id alone).
-    existing_credit = where(user_id: purchase.seller_id, fee_retention_refund: refund, failed_refund_id: nil).first
-    if existing_credit.present?
-      # Pre-patch US retention completed Stripe transfers without recording
-      # debited_stripe_transfer. Blank marker + ledger means legacy-complete — do not
-      # re-debit. New failures record FEE_DEBIT_PENDING_RETRY so retries still run.
-      us_legacy_complete = existing_credit.merchant_account&.country == Compliance::Countries::USA.alpha2 &&
-        refund.debited_stripe_transfer.blank? &&
-        existing_credit.balance_id.present?
-      unless us_legacy_complete
-        actual_holding = debit_stripe_account_for_retained_fee(existing_credit)
-        # Debit helper returns nil once the success marker is set; still reconcile from the
-        # persisted actual when a prior attempt booked only the FX estimate.
-        actual_holding ||= refund.refund_fee_holding_debit_cents
-        reconcile_fee_retention_holding_amount!(existing_credit, actual_holding)
+      # Scope by user_id so MySQL can use index_credits_on_user_id_and_created_at_and_id
+      # (there is no index on fee_retention_refund_id alone). Lock the row so concurrent
+      # retries serialize on the same retention credit.
+      existing_credit = where(user_id: purchase.seller_id, fee_retention_refund: refund, failed_refund_id: nil).lock.first
+      if existing_credit.present?
+        # Pre-patch US retention completed Stripe transfers without recording
+        # debited_stripe_transfer. Blank marker + ledger means legacy-complete — do not
+        # re-debit. New failures record FEE_DEBIT_PENDING_RETRY so retries still run.
+        us_legacy_complete = existing_credit.merchant_account&.country == Compliance::Countries::USA.alpha2 &&
+          refund.debited_stripe_transfer.blank? &&
+          existing_credit.balance_id.present?
+        unless us_legacy_complete
+          actual_holding = debit_stripe_account_for_retained_fee(existing_credit)
+          # Debit helper returns nil once the success marker is set; still reconcile from the
+          # persisted actual when a prior attempt booked only the FX estimate.
+          actual_holding ||= refund.refund_fee_holding_debit_cents
+          reconcile_fee_retention_holding_amount!(existing_credit, actual_holding)
+        end
+        return existing_credit
       end
-      return existing_credit
     end
 
     # We retain the payment processor fee (2.9% + 30c) and the Gumroad fee (10% + any discover fee) in case of refunds.
@@ -403,35 +404,44 @@ class Credit < ApplicationRecord
       reversed_amount_cents_in_holding_currency = -net_amount_on_stripe_in_holding_currency
     end
 
-    # requires_new: see Connect branch above — isolate ledger writes from any outer txn.
-    transaction(requires_new: true) do
-      credit.save!
+    # Re-take locks after Stripe: a failed-refund reversal or concurrent retention may have
+    # landed while the debit ran without holding the rows.
+    purchase.with_lock do
+      refund.reload.lock!
+      return if refund.balance_reversed_on_failure
+      existing_credit = where(user_id: purchase.seller_id, fee_retention_refund: refund, failed_refund_id: nil).lock.first
+      return existing_credit if existing_credit.present?
 
-      refund.retained_fee_cents = credit.amount_cents.abs
-      refund.save!
+      # requires_new: see Connect branch above — isolate ledger writes from any outer txn.
+      transaction(requires_new: true) do
+        credit.save!
 
-      balance_transaction_amount = BalanceTransaction::Amount.new(
-        currency: Currency::USD,
-        gross_cents: reversed_amount_cents_in_usd,
-        net_cents: reversed_amount_cents_in_usd
-      )
+        refund.retained_fee_cents = credit.amount_cents.abs
+        refund.save!
 
-      balance_transaction_holding_amount = BalanceTransaction::Amount.new(
-        currency: credit.merchant_account.currency,
-        gross_cents: reversed_amount_cents_in_holding_currency,
-        net_cents: reversed_amount_cents_in_holding_currency
-      )
+        balance_transaction_amount = BalanceTransaction::Amount.new(
+          currency: Currency::USD,
+          gross_cents: reversed_amount_cents_in_usd,
+          net_cents: reversed_amount_cents_in_usd
+        )
 
-      balance_transaction = BalanceTransaction.create!(
-        user: credit.user,
-        merchant_account: credit.merchant_account,
-        credit:,
-        issued_amount: balance_transaction_amount,
-        holding_amount: balance_transaction_holding_amount
-      )
+        balance_transaction_holding_amount = BalanceTransaction::Amount.new(
+          currency: credit.merchant_account.currency,
+          gross_cents: reversed_amount_cents_in_holding_currency,
+          net_cents: reversed_amount_cents_in_holding_currency
+        )
 
-      credit.balance = balance_transaction.balance
-      credit.save!
+        balance_transaction = BalanceTransaction.create!(
+          user: credit.user,
+          merchant_account: credit.merchant_account,
+          credit:,
+          issued_amount: balance_transaction_amount,
+          holding_amount: balance_transaction_holding_amount
+        )
+
+        credit.balance = balance_transaction.balance
+        credit.save!
+      end
     end
     credit
   end
@@ -581,10 +591,12 @@ class Credit < ApplicationRecord
       if refund.present?
         refund.with_lock do
           refund.reload
-          block.call
+          # Isolate from an enclosing retention transaction so a later marker failure
+          # cannot commit the balance delta without its reconciliation marker.
+          transaction(requires_new: true) { block.call }
         end
       else
-        block.call
+        transaction(requires_new: true) { block.call }
       end
     end
 
@@ -617,25 +629,33 @@ class Credit < ApplicationRecord
           balance.save!
         end
       rescue ActiveRecord::RecordInvalid
+        holding_currency = credit.merchant_account.currency.to_s.downcase
+        adjusted_delta = convert_fee_holding_cents(
+          delta,
+          from_currency: bt.holding_amount_currency,
+          to_currency: holding_currency
+        )
+        adjusted_delta = delta if adjusted_delta.blank?
+
         unpaid = Balance.where(
           user: credit.user,
           merchant_account: credit.merchant_account,
           currency: bt.issued_amount_currency,
-          holding_currency: bt.holding_amount_currency,
+          holding_currency:,
           state: "unpaid"
         ).order(date: :asc).first
         unpaid ||= Balance.create!(
           user: credit.user,
           merchant_account: credit.merchant_account,
           currency: bt.issued_amount_currency,
-          holding_currency: bt.holding_amount_currency,
+          holding_currency:,
           date: credit.created_at.to_date,
           amount_cents: 0,
           holding_amount_cents: 0
         )
 
         unpaid.with_lock do
-          unpaid.increment(:holding_amount_cents, delta)
+          unpaid.increment(:holding_amount_cents, adjusted_delta)
           unpaid.save!
         end
       end

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -526,9 +526,8 @@ class Credit < ApplicationRecord
         operation: StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT,
         amount_cents: debit_amount_cents
       )
-      return debit_stripe_account_for_retained_fee(credit) unless claimed
-      # In-memory sticky fields from the claim we just won — do not reload.
-      return debit_stripe_account_for_retained_fee(credit) unless refund.refund_fee_debit_operation == StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT
+      # Resume only the US claim we hold in memory; do not reload or recurse.
+      return unless claimed && refund.refund_fee_debit_operation == StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT
 
       debit_amount_cents = refund.refund_fee_debit_amount_cents.presence || debit_amount_cents
       attempted_generation = refund.refund_fee_debit_generation.to_i

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -304,7 +304,10 @@ class Credit < ApplicationRecord
       us_legacy_complete = existing_credit.merchant_account&.country == Compliance::Countries::USA.alpha2 &&
         refund.debited_stripe_transfer.blank? &&
         existing_credit.balance_id.present?
-      debit_stripe_account_for_retained_fee(existing_credit) unless us_legacy_complete
+      unless us_legacy_complete
+        actual_holding = debit_stripe_account_for_retained_fee(existing_credit)
+        reconcile_fee_retention_holding_amount!(existing_credit, actual_holding)
+      end
       return existing_credit
     end
 
@@ -374,7 +377,11 @@ class Credit < ApplicationRecord
     # refund the moment it succeeds, so a retry after a failed ledger write skips Stripe
     # instead of debiting the account twice.
     net_amount_on_stripe_in_holding_currency = debit_stripe_account_for_retained_fee(credit)
-    reversed_amount_cents_in_holding_currency = -net_amount_on_stripe_in_holding_currency if net_amount_on_stripe_in_holding_currency.present?
+    if refund.refund_fee_holding_debit_cents.present?
+      reversed_amount_cents_in_holding_currency = -refund.refund_fee_holding_debit_cents.to_i
+    elsif net_amount_on_stripe_in_holding_currency.present?
+      reversed_amount_cents_in_holding_currency = -net_amount_on_stripe_in_holding_currency
+    end
 
     # requires_new: see Connect branch above — isolate ledger writes from any outer txn.
     transaction(requires_new: true) do
@@ -428,11 +435,13 @@ class Credit < ApplicationRecord
     if merchant_account.country == Compliance::Countries::USA.alpha2
       # For gumroad-controlled Stripe accounts from the US, we can make new debit transfers.
       # So we transfer the retained fee back to Gumroad's Stripe platform account.
+      persist_refund_fee_debit_choice!(refund, operation: StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT,
+                                              amount_cents: credit.amount_cents.abs)
       transfer_options = { stripe_account: merchant_account.charge_processor_merchant_id }
       transfer_options[:idempotency_key] = "refund_fee_us_debit_#{refund.external_id}" if refund.id.present?
       transfer = Stripe::Transfer.create({ amount: credit.amount_cents.abs, currency: "usd", destination: Stripe::Account.retrieve.id, },
                                          transfer_options)
-      record_fee_debit_marker!(refund, transfer.id)
+      record_fee_debit_marker!(refund, transfer.id, holding_debit_cents: credit.amount_cents.abs)
       nil
     else
       # For non-US gumroad-controlled Stripe accounts, we cannot make debit transfers.
@@ -454,15 +463,64 @@ class Credit < ApplicationRecord
   end
   private_class_method :fee_debit_pending_retry?
 
-  # Commit the debit marker in its own transaction so a later ledger failure (or an
-  # enclosing retention transaction rollback) cannot erase proof that Stripe already
-  # took the money.
-  def self.record_fee_debit_marker!(refund, marker)
+  # Write the debit marker in a requires_new savepoint. Callers that wrap retention in an
+  # enclosing transaction must commit that transaction even when later ledger work fails
+  # (see Purchase#debit_processor_fee_from_merchant_account!), otherwise the savepoint is
+  # rolled back and a retry can debit Stripe again after the idempotency window.
+  def self.record_fee_debit_marker!(refund, marker, holding_debit_cents: nil)
     transaction(requires_new: true) do
-      refund.update!(debited_stripe_transfer: marker)
+      refund.debited_stripe_transfer = marker
+      refund.refund_fee_holding_debit_cents = holding_debit_cents if holding_debit_cents.present?
+      refund.save!
     end
   end
   private_class_method :record_fee_debit_marker!
+
+  # Persist the chosen Stripe recovery route before submit so a timed-out response cannot
+  # be retried as a different operation (e.g. transfer reversal → EUR debit).
+  def self.persist_refund_fee_debit_choice!(refund, operation:, transfer_id: nil, amount_cents: nil)
+    return if refund.blank?
+    return if refund.refund_fee_debit_operation == operation &&
+      (transfer_id.blank? || refund.refund_fee_debit_transfer_id == transfer_id) &&
+      (amount_cents.blank? || refund.refund_fee_debit_amount_cents.to_i == amount_cents.to_i)
+
+    transaction(requires_new: true) do
+      refund.refund_fee_debit_operation = operation
+      refund.refund_fee_debit_transfer_id = transfer_id if transfer_id.present?
+      refund.refund_fee_debit_amount_cents = amount_cents if amount_cents.present?
+      refund.save!
+    end
+  end
+
+  # When the first Stripe attempt fails, the ledger books an estimated holding amount. A
+  # later successful retry returns the actual Stripe debit; adjust the unpaid balance's
+  # holding total so payout math matches Stripe. The immutable BalanceTransaction row keeps
+  # its original estimate; refund_fee_holding_debit_cents records the actual.
+  def self.reconcile_fee_retention_holding_amount!(credit, actual_holding_abs_cents)
+    return if credit.blank? || actual_holding_abs_cents.blank?
+
+    target = -actual_holding_abs_cents.to_i.abs
+    bt = credit.balance_transaction
+    return if bt.blank?
+
+    delta = target - bt.holding_amount_net_cents
+    refund = credit.fee_retention_refund
+    if refund.present? && refund.refund_fee_holding_debit_cents.to_i != actual_holding_abs_cents.to_i.abs
+      transaction(requires_new: true) do
+        refund.update!(refund_fee_holding_debit_cents: actual_holding_abs_cents.to_i.abs)
+      end
+    end
+    return if delta.zero?
+
+    balance = credit.balance || bt.balance
+    return if balance.blank?
+
+    balance.with_lock do
+      balance.increment(:holding_amount_cents, delta)
+      balance.save!
+    end
+  end
+  private_class_method :reconcile_fee_retention_holding_amount!
 
   # Give back the fee that create_for_refund_fee_retention! retained, because the
   # refund it was retained for later FAILED (async bank-transfer refunds can be

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -299,9 +299,8 @@ class Credit < ApplicationRecord
     existing_credit = where(fee_retention_refund: refund, failed_refund_id: nil).first
     if existing_credit.present?
       # Pre-patch US retention completed Stripe transfers without recording
-      # debited_stripe_transfer. Re-debiting those would charge the seller twice.
-      # Skip the Stripe call for US credits that already have a ledger and no marker;
-      # non-US retries still finish an outstanding debit.
+      # debited_stripe_transfer. Blank marker + ledger means legacy-complete — do not
+      # re-debit. New failures record FEE_DEBIT_PENDING_RETRY so retries still run.
       us_legacy_complete = existing_credit.merchant_account&.country == Compliance::Countries::USA.alpha2 &&
         refund.debited_stripe_transfer.blank? &&
         existing_credit.balance_id.present?
@@ -410,6 +409,11 @@ class Credit < ApplicationRecord
     credit
   end
 
+  # Sentinel written when a Stripe fee debit fails after we already intend to book the
+  # local ledger. Distinguishes a retryable new failure from a pre-patch US retention
+  # that completed without recording debited_stripe_transfer.
+  FEE_DEBIT_PENDING_RETRY = "pending_retry"
+
   # For Stripe sales that use a gumroad-managed custom connect account, pull the retained fee
   # out of that Stripe account. Best effort: the ledger is booked whether or not this
   # succeeds, a failure is reported and left for a retry, and the transfer id recorded on
@@ -419,7 +423,7 @@ class Credit < ApplicationRecord
     merchant_account = credit.merchant_account
     refund = credit.fee_retention_refund
     return unless merchant_account.holder_of_funds == HolderOfFunds::STRIPE
-    return if refund.debited_stripe_transfer.present?
+    return if refund.debited_stripe_transfer.present? && !fee_debit_pending_retry?(refund)
 
     if merchant_account.country == Compliance::Countries::USA.alpha2
       # For gumroad-controlled Stripe accounts from the US, we can make new debit transfers.
@@ -428,7 +432,7 @@ class Credit < ApplicationRecord
       transfer_options[:idempotency_key] = "refund_fee_us_debit_#{refund.external_id}" if refund.id.present?
       transfer = Stripe::Transfer.create({ amount: credit.amount_cents.abs, currency: "usd", destination: Stripe::Account.retrieve.id, },
                                          transfer_options)
-      refund.update!(debited_stripe_transfer: transfer.id)
+      record_fee_debit_marker!(refund, transfer.id)
       nil
     else
       # For non-US gumroad-controlled Stripe accounts, we cannot make debit transfers.
@@ -436,11 +440,29 @@ class Credit < ApplicationRecord
       StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:)
     end
   rescue StandardError => e
+    # Persist a retryable sentinel so US failures are not mistaken for legacy-complete
+    # blank-marker retentions on the next attempt.
+    record_fee_debit_marker!(refund, FEE_DEBIT_PENDING_RETRY) if refund.present? && refund.debited_stripe_transfer.blank?
     Rails.logger.error("Failed to debit Stripe account for the retained fee of refund #{refund.id}: #{e.class}: #{e.message}")
     ErrorNotifier.notify(e, context: { refund_id: refund.id, purchase_id: refund.purchase_id, merchant_account_id: merchant_account.id })
     nil
   end
   private_class_method :debit_stripe_account_for_retained_fee
+
+  def self.fee_debit_pending_retry?(refund)
+    refund.debited_stripe_transfer == FEE_DEBIT_PENDING_RETRY
+  end
+  private_class_method :fee_debit_pending_retry?
+
+  # Commit the debit marker in its own transaction so a later ledger failure (or an
+  # enclosing retention transaction rollback) cannot erase proof that Stripe already
+  # took the money.
+  def self.record_fee_debit_marker!(refund, marker)
+    transaction(requires_new: true) do
+      refund.update!(debited_stripe_transfer: marker)
+    end
+  end
+  private_class_method :record_fee_debit_marker!
 
   # Give back the fee that create_for_refund_fee_retention! retained, because the
   # refund it was retained for later FAILED (async bank-transfer refunds can be

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -521,12 +521,16 @@ class Credit < ApplicationRecord
         return refund.refund_fee_holding_debit_cents.presence&.to_i
       end
       debit_amount_cents = refund.refund_fee_debit_amount_cents.presence || credit.amount_cents.abs
-      persist_refund_fee_debit_choice!(
+      claimed = persist_refund_fee_debit_choice!(
         refund,
         operation: StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT,
         amount_cents: debit_amount_cents
       )
-      debit_amount_cents = refund.reload.refund_fee_debit_amount_cents.presence || debit_amount_cents
+      return debit_stripe_account_for_retained_fee(credit) unless claimed
+      # In-memory sticky fields from the claim we just won — do not reload.
+      return debit_stripe_account_for_retained_fee(credit) unless refund.refund_fee_debit_operation == StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT
+
+      debit_amount_cents = refund.refund_fee_debit_amount_cents.presence || debit_amount_cents
       attempted_generation = refund.refund_fee_debit_generation.to_i
       transfer_options = { stripe_account: merchant_account.charge_processor_merchant_id }
       if refund.id.present?

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -515,12 +515,24 @@ class Credit < ApplicationRecord
         amount_cents: debit_amount_cents
       )
       debit_amount_cents = refund.reload.refund_fee_debit_amount_cents.presence || debit_amount_cents
+      attempted_generation = refund.refund_fee_debit_generation.to_i
       transfer_options = { stripe_account: merchant_account.charge_processor_merchant_id }
-      transfer_options[:idempotency_key] = "refund_fee_us_debit_#{refund.external_id}" if refund.id.present?
-      transfer = Stripe::Transfer.create(
-        { amount: debit_amount_cents.to_i, currency: "usd", destination: Stripe::Account.retrieve.id },
-        transfer_options
-      )
+      if refund.id.present?
+        transfer_options[:idempotency_key] = if attempted_generation.zero?
+          "refund_fee_us_debit_#{refund.external_id}"
+        else
+          "refund_fee_us_debit_#{refund.external_id}_g#{attempted_generation}"
+        end
+      end
+      begin
+        transfer = Stripe::Transfer.create(
+          { amount: debit_amount_cents.to_i, currency: "usd", destination: Stripe::Account.retrieve.id },
+          transfer_options
+        )
+      rescue Stripe::InvalidRequestError
+        release_sticky_refund_fee_debit_choice!(refund, generation: attempted_generation)
+        raise
+      end
       record_fee_debit_marker!(refund, transfer.id)
       persist_refund_fee_holding_on_credit!(refund, debit_amount_cents.to_i, currency: Currency::USD)
       debit_amount_cents.to_i

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -303,7 +303,10 @@ class Credit < ApplicationRecord
     us_legacy_complete = false
     purchase.with_lock do
       refund.reload.lock!
-      return if refund.balance_reversed_on_failure
+      if refund.balance_reversed_on_failure
+        clear_refund_fee_retention_pending!(refund)
+        return
+      end
 
       # Scope by user_id so MySQL can use index_credits_on_user_id_and_created_at_and_id
       # (there is no index on fee_retention_refund_id alone). Lock the row so concurrent
@@ -332,6 +335,7 @@ class Credit < ApplicationRecord
           ErrorNotifier.notify(e, context: { refund_id: refund.id, credit_id: existing_credit.id })
         end
       end
+      clear_refund_fee_retention_pending!(refund)
       return existing_credit
     end
 
@@ -344,7 +348,10 @@ class Credit < ApplicationRecord
     unless refund.purchase.charged_using_gumroad_merchant_account?
       purchase = refund.purchase
       application_fee_refundable_portion = purchase.gumroad_tax_cents + purchase.affiliate_credit_cents
-      return if application_fee_refundable_portion.zero?
+      if application_fee_refundable_portion.zero?
+        clear_refund_fee_retention_pending!(refund)
+        return
+      end
 
       credit = new
       credit.user = purchase.seller
@@ -375,6 +382,7 @@ class Credit < ApplicationRecord
         credit.save!
       end
 
+      clear_refund_fee_retention_pending!(refund)
       return credit
     end
 
@@ -416,7 +424,10 @@ class Credit < ApplicationRecord
     # landed while the debit ran without holding the rows.
     purchase.with_lock do
       refund.reload.lock!
-      return if refund.balance_reversed_on_failure
+      if refund.balance_reversed_on_failure
+        clear_refund_fee_retention_pending!(refund)
+        return
+      end
       existing_credit = where(user_id: purchase.seller_id, fee_retention_refund: refund, failed_refund_id: nil).lock.first
       if existing_credit.present?
         # Another concurrent attempt booked the credit (possibly with an FX estimate) while
@@ -464,6 +475,7 @@ class Credit < ApplicationRecord
         credit.save!
       end
     end
+    clear_refund_fee_retention_pending!(refund)
     credit
   end
 
@@ -514,9 +526,14 @@ class Credit < ApplicationRecord
       StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:)
     end
   rescue StandardError => e
-    # Persist a retryable sentinel so US failures are not mistaken for legacy-complete
-    # blank-marker retentions on the next attempt.
-    record_pending_fee_debit_retry!(refund)
+    # pending_retry for blank-marker failures. If the debit already succeeded and only a
+    # follow-up holding lookup failed, keep the success marker and schedule a retry.
+    refund&.reload
+    if refund.present? && refund.debited_stripe_transfer.present? && !fee_debit_pending_retry?(refund)
+      RetryRefundFeeRetentionJob.perform_in(1.minute, refund.id) if refund.id.present?
+    else
+      record_pending_fee_debit_retry!(refund)
+    end
     Rails.logger.error("Failed to debit Stripe account for the retained fee of refund #{refund.id}: #{e.class}: #{e.message}")
     ErrorNotifier.notify(e, context: { refund_id: refund.id, purchase_id: refund.purchase_id, merchant_account_id: merchant_account.id })
     nil
@@ -555,6 +572,17 @@ class Credit < ApplicationRecord
     RetryRefundFeeRetentionJob.perform_in(1.minute, refund.id) if refund.id.present?
   end
   private_class_method :record_pending_fee_debit_retry!
+
+  def self.clear_refund_fee_retention_pending!(refund)
+    return if refund.blank?
+    refund.reload
+    return unless refund.refund_fee_retention_pending
+
+    transaction(requires_new: true) do
+      refund.update!(refund_fee_retention_pending: false)
+    end
+  end
+  private_class_method :clear_refund_fee_retention_pending!
 
   def self.persist_refund_fee_holding_on_credit!(refund, holding_debit_cents, currency: nil)
     return if refund.blank? || holding_debit_cents.blank?

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -455,6 +455,7 @@ class Credit < ApplicationRecord
           Rails.logger.error("Failed to reconcile concurrent fee retention for refund #{refund.id}: #{e.class}: #{e.message}")
           ErrorNotifier.notify(e, context: { refund_id: refund.id, credit_id: existing_credit.id })
         end
+        clear_refund_fee_retention_pending!(refund)
         return existing_credit
       end
 
@@ -485,11 +486,15 @@ class Credit < ApplicationRecord
         credit.balance = balance_transaction.balance
         credit.save!
 
-        # Attribute retained fee only after balance is linked — unpaid balances need the
-        # cents for payout/reporting; paid balances already settled without this marker.
+        # Fold into refund fee columns only when the credit lands on the same unpaid
+        # balance as the refund. Cross-payout retention leaves retained_fee_cents unset so
+        # the later payout export can show the debit credit instead of mis-attributing it.
         if credit.balance&.unpaid?
-          refund.retained_fee_cents = credit.amount_cents.abs
-          refund.save!
+          refund_balance_ids = refund.balance_transactions.map(&:balance_id)
+          if refund_balance_ids.blank? || refund_balance_ids.include?(credit.balance_id)
+            refund.retained_fee_cents = credit.amount_cents.abs
+            refund.save!
+          end
         end
       end
     end
@@ -601,7 +606,10 @@ class Credit < ApplicationRecord
       return if refund.debited_stripe_transfer == FEE_DEBIT_PENDING_RETRY
 
       transaction(requires_new: true) do
-        refund.update!(debited_stripe_transfer: FEE_DEBIT_PENDING_RETRY)
+        refund.update!(
+          debited_stripe_transfer: FEE_DEBIT_PENDING_RETRY,
+          fee_retention_retry_at: 1.minute.from_now
+        )
       end
     end
     RetryRefundFeeRetentionJob.perform_in(1.minute, refund.id) if refund.id.present?
@@ -611,7 +619,8 @@ class Credit < ApplicationRecord
   def self.clear_refund_fee_retention_pending!(refund)
     return if refund.blank?
     refund.reload
-    return unless refund.refund_fee_retention_pending
+    return unless refund.refund_fee_retention_pending || refund.fee_retention_retry_at.present? ||
+      refund.refund_fee_holding_reconcile_pending
     # Keep the flag while Stripe debit or holding reconciliation is still outstanding so
     # the recurring job can finish finish_holding_lookup / reconcile after a crash.
     return if fee_debit_pending_retry?(refund)
@@ -619,12 +628,24 @@ class Credit < ApplicationRecord
       return if refund.refund_fee_holding_debit_cents.blank?
       return if refund.refund_fee_holding_reconciled_cents.blank?
     end
+    return if refund.refund_fee_holding_reconcile_pending
 
     transaction(requires_new: true) do
-      refund.update!(refund_fee_retention_pending: false)
+      refund.update!(
+        refund_fee_retention_pending: false,
+        fee_retention_retry_at: nil,
+        refund_fee_holding_reconcile_pending: false
+      )
     end
   end
   private_class_method :clear_refund_fee_retention_pending!
+
+  # Enqueue-eligible marker for the indexed recurring retry scan.
+  def self.schedule_fee_retention_retry!(refund, run_at: Time.current)
+    return if refund.blank?
+    refund.update!(fee_retention_retry_at: run_at)
+  end
+  private_class_method :schedule_fee_retention_retry!
 
   # Stripe confirmed the sticky reversal did not happen (InvalidRequest). Drop the choice
   # so a retry can pick another transfer; bump generation for a fresh idempotency key.
@@ -756,7 +777,8 @@ class Credit < ApplicationRecord
         refund.update!(
           refund_fee_holding_debit_cents: actual,
           refund_fee_holding_debit_currency: actual_currency,
-          refund_fee_holding_reconciled_cents: actual_in_bt_currency
+          refund_fee_holding_reconciled_cents: actual_in_bt_currency,
+          refund_fee_holding_reconcile_pending: false
         ) if refund.present?
         next
       end
@@ -792,6 +814,15 @@ class Credit < ApplicationRecord
           Rails.logger.error(
             "Skipping fee retention holding reconcile for refund #{refund&.id}: "             "original balance immutable and no unpaid #{holding_currency} balance"
           )
+          # Keep retry eligibility until an unpaid balance can absorb the correction —
+          # without this marker the debit is done and retention_pending is clear, so the
+          # recurring job would never revisit the outstanding holding delta.
+          if refund.present?
+            refund.update!(
+              refund_fee_holding_reconcile_pending: true,
+              fee_retention_retry_at: 15.minutes.from_now
+            )
+          end
           next
         end
 
@@ -804,7 +835,8 @@ class Credit < ApplicationRecord
       refund.update!(
         refund_fee_holding_debit_cents: actual,
         refund_fee_holding_debit_currency: actual_currency,
-        refund_fee_holding_reconciled_cents: actual_in_bt_currency
+        refund_fee_holding_reconciled_cents: actual_in_bt_currency,
+        refund_fee_holding_reconcile_pending: false
       ) if refund.present?
     end
   end

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -331,11 +331,15 @@ class Credit < ApplicationRecord
         # are real commits if this process dies mid-flight.
         actual_holding = debit_stripe_account_for_retained_fee(existing_credit)
         actual_holding ||= refund.reload.refund_fee_holding_debit_cents
-        begin
-          reconcile_fee_retention_holding_amount!(existing_credit, actual_holding)
-        rescue StandardError => e
-          Rails.logger.error("Failed to reconcile fee retention holding for refund #{refund.id}: #{e.class}: #{e.message}")
-          ErrorNotifier.notify(e, context: { refund_id: refund.id, credit_id: existing_credit.id })
+        if existing_credit.balance_transaction.blank?
+          finish_incomplete_fee_retention_ledger!(existing_credit, refund:, holding_net_cents: actual_holding)
+        else
+          begin
+            reconcile_fee_retention_holding_amount!(existing_credit, actual_holding)
+          rescue StandardError => e
+            Rails.logger.error("Failed to reconcile fee retention holding for refund #{refund.id}: #{e.class}: #{e.message}")
+            ErrorNotifier.notify(e, context: { refund_id: refund.id, credit_id: existing_credit.id })
+          end
         end
       end
       clear_refund_fee_retention_pending!(refund)
@@ -407,13 +411,18 @@ class Credit < ApplicationRecord
     # and in both those cases transactions are always in USD.
     # If purchase.processor_fee_cents is not present for some reason (rare case), we calculate the fee amount,
     # that is to be retained, using the fee percentage used in Purchase#calculate_fees.
-    credit.amount_cents = if refund.purchase.processor_fee_cents.present? && refund.purchase.processor_fee_cents_currency == "usd"
+    credit.amount_cents = if refund.refund_fee_retention_usd_cents.present?
+      -refund.refund_fee_retention_usd_cents.to_i.abs
+    elsif refund.purchase.processor_fee_cents.present? && refund.purchase.processor_fee_cents_currency == "usd"
       -(refund.purchase.processor_fee_cents * (refund.amount_cents.to_f / refund.purchase.price_cents)).round
     else
       -(refund.amount_cents * Purchase::PROCESSOR_FEE_PER_THOUSAND / 1000.0 + (Purchase::PROCESSOR_FIXED_FEE_CENTS * refund.amount_cents.to_f / refund.purchase.price_cents)).round
     end
     credit.merchant_account = refund.purchase.merchant_account
     credit.fee_retention_refund = refund
+    if refund.refund_fee_retention_usd_cents.blank?
+      refund.update!(refund_fee_retention_usd_cents: credit.amount_cents.abs)
+    end
 
     reversed_amount_cents_in_usd = credit.amount_cents
     # Prefer a persisted Stripe holding amount. For BGN ledgers, estimate via EUR and the
@@ -460,15 +469,17 @@ class Credit < ApplicationRecord
       existing_credit = where(id: existing_credit.id).lock.first if existing_credit
       if existing_credit.present?
         # Another concurrent attempt booked the credit (possibly with an FX estimate) while
-        # this attempt obtained the actual Stripe debit. Reconcile before returning.
-        begin
-          reconcile_fee_retention_holding_amount!(
-            existing_credit,
-            refund.refund_fee_holding_debit_cents.presence || net_amount_on_stripe_in_holding_currency
-          )
-        rescue StandardError => e
-          Rails.logger.error("Failed to reconcile concurrent fee retention for refund #{refund.id}: #{e.class}: #{e.message}")
-          ErrorNotifier.notify(e, context: { refund_id: refund.id, credit_id: existing_credit.id })
+        # this attempt obtained the actual Stripe debit. Finish or reconcile before returning.
+        holding = refund.refund_fee_holding_debit_cents.presence || net_amount_on_stripe_in_holding_currency
+        if existing_credit.balance_transaction.blank?
+          finish_incomplete_fee_retention_ledger!(existing_credit, refund:, holding_net_cents: holding)
+        else
+          begin
+            reconcile_fee_retention_holding_amount!(existing_credit, holding)
+          rescue StandardError => e
+            Rails.logger.error("Failed to reconcile concurrent fee retention for refund #{refund.id}: #{e.class}: #{e.message}")
+            ErrorNotifier.notify(e, context: { refund_id: refund.id, credit_id: existing_credit.id })
+          end
         end
         clear_refund_fee_retention_pending!(refund)
         return existing_credit
@@ -701,6 +712,62 @@ class Credit < ApplicationRecord
     end
   end
   private_class_method :persist_refund_fee_holding_on_credit!
+
+  # Completes a retention credit that was persisted without its BalanceTransaction (crash
+  # between save and ledger). Uses sticky USD + holding debit amounts when present.
+  def self.finish_incomplete_fee_retention_ledger!(credit, refund:, holding_net_cents: nil)
+    return credit if credit.blank? || credit.balance_transaction.present?
+
+    usd = credit.amount_cents
+    holding = if refund.refund_fee_holding_debit_cents.present?
+      -convert_fee_holding_cents(
+        refund.refund_fee_holding_debit_cents,
+        from_currency: refund.refund_fee_holding_debit_currency.presence || credit.merchant_account.currency,
+        to_currency: credit.merchant_account.currency
+      )
+    elsif holding_net_cents.present?
+      -holding_net_cents.to_i.abs
+    else
+      credit.usd_cents_to_currency(credit.merchant_account.currency, usd)
+    end
+
+    purchase = refund.purchase
+    purchase.with_lock do
+      refund.reload.lock!
+      return credit if refund.balance_reversed_on_failure
+      credit = where(id: credit.id).lock.first
+      return credit if credit.blank? || credit.balance_transaction.present?
+
+      transaction(requires_new: true) do
+        balance_transaction = BalanceTransaction.create!(
+          user: credit.user,
+          merchant_account: credit.merchant_account,
+          credit:,
+          issued_amount: BalanceTransaction::Amount.new(currency: Currency::USD, gross_cents: usd, net_cents: usd),
+          holding_amount: BalanceTransaction::Amount.new(
+            currency: credit.merchant_account.currency,
+            gross_cents: holding,
+            net_cents: holding
+          )
+        )
+        credit.balance = balance_transaction.balance
+        credit.save!
+
+        if credit.balance&.unpaid?
+          seller_refund_bts = refund.balance_transactions.where(user_id: refund.seller_id)
+          refund_still_unpaid = seller_refund_bts.none? ||
+            seller_refund_bts.joins(:balance).where(balances: { state: "unpaid" }).exists?
+          if refund_still_unpaid
+            refund.retained_fee_cents = credit.amount_cents.abs
+            refund.save!
+          end
+        end
+      end
+    end
+    credit
+  end
+  private_class_method :finish_incomplete_fee_retention_ledger!
+
 
   # Sticky recovery route before Stripe submit so a timed-out response cannot be retried as
   # a different operation. Refuse automatic resubmits after this window (under Stripe's 24h

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -462,8 +462,12 @@ class Credit < ApplicationRecord
       transaction(requires_new: true) do
         credit.save!
 
-        refund.retained_fee_cents = credit.amount_cents.abs
-        refund.save!
+        # Only attribute retained_fee_cents when this credit landed on an unpaid balance.
+        # Delayed retention after payout must not rewrite the paid payout's refund export.
+        if credit.balance&.unpaid?
+          refund.retained_fee_cents = credit.amount_cents.abs
+          refund.save!
+        end
 
         balance_transaction_amount = BalanceTransaction::Amount.new(
           currency: Currency::USD,

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -291,10 +291,8 @@ class Credit < ApplicationRecord
     credit
   end
 
-  # Idempotent: runs after the refund has committed (the processor has already returned the
-  # buyer's money), so it must be safe to call again when an earlier attempt failed part way.
-  # The ledger rows are booked in one transaction, so an existing retention credit means the
-  # only thing that can still be outstanding is the Stripe debit.
+  # Idempotent after the processor refund: safe to re-run when an earlier attempt failed part
+  # way. An existing retention credit means only the Stripe debit can still be outstanding.
   def self.create_for_refund_fee_retention!(refund:)
     purchase = refund.purchase
     # Same purchase → refund lock order as HandleFailedRefundService / the Purchase wrapper.
@@ -469,16 +467,13 @@ class Credit < ApplicationRecord
     credit
   end
 
-  # Sentinel written when a Stripe fee debit fails after we already intend to book the
-  # local ledger. Distinguishes a retryable new failure from a pre-patch US retention
-  # that completed without recording debited_stripe_transfer.
+  # Retryable Stripe fee-debit failure. Distinguishes new failures from pre-patch US
+  # retentions that completed without recording debited_stripe_transfer.
   FEE_DEBIT_PENDING_RETRY = "pending_retry"
 
-  # For Stripe sales that use a gumroad-managed custom connect account, pull the retained fee
-  # out of that Stripe account. Best effort: the ledger is booked whether or not this
-  # succeeds, a failure is reported and left for a retry, and the transfer id recorded on
-  # the refund makes a second call a no-op. Returns the amount taken from the Stripe balance
-  # in the account's currency, or nil when the ledger has to fall back to the converted fee.
+  # Best-effort Stripe debit of the retained fee from a gumroad-managed Connect account.
+  # Records the transfer id for idempotency; failures become pending_retry for the job.
+  # Returns holding-currency cents taken, or nil when the ledger falls back to the estimate.
   def self.debit_stripe_account_for_retained_fee(credit)
     merchant_account = credit.merchant_account
     refund = credit.fee_retention_refund
@@ -499,12 +494,17 @@ class Credit < ApplicationRecord
         refuse_expired_fee_debit_resubmit!(refund, StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT)
         return refund.refund_fee_holding_debit_cents.presence&.to_i
       end
-      persist_refund_fee_debit_choice!(refund, operation: StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT,
-                                              amount_cents: credit.amount_cents.abs)
+      persist_refund_fee_debit_choice!(
+        refund,
+        operation: StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT,
+        amount_cents: credit.amount_cents.abs
+      )
       transfer_options = { stripe_account: merchant_account.charge_processor_merchant_id }
       transfer_options[:idempotency_key] = "refund_fee_us_debit_#{refund.external_id}" if refund.id.present?
-      transfer = Stripe::Transfer.create({ amount: credit.amount_cents.abs, currency: "usd", destination: Stripe::Account.retrieve.id, },
-                                         transfer_options)
+      transfer = Stripe::Transfer.create(
+        { amount: credit.amount_cents.abs, currency: "usd", destination: Stripe::Account.retrieve.id },
+        transfer_options
+      )
       record_fee_debit_marker!(refund, transfer.id)
       persist_refund_fee_holding_on_credit!(refund, credit.amount_cents.abs, currency: Currency::USD)
       credit.amount_cents.abs
@@ -528,10 +528,8 @@ class Credit < ApplicationRecord
   end
   private_class_method :fee_debit_pending_retry?
 
-  # Write the debit marker in a requires_new savepoint. Callers that wrap retention in an
-  # enclosing transaction must commit that transaction even when later ledger work fails
-  # (see Purchase#debit_processor_fee_from_merchant_account!), otherwise the savepoint is
-  # rolled back and a retry can debit Stripe again after the idempotency window.
+  # requires_new so the marker can commit even if later ledger work fails inside an
+  # enclosing retention transaction (otherwise a retry can debit Stripe twice).
   def self.record_fee_debit_marker!(refund, marker)
     transaction(requires_new: true) do
       refund.update!(debited_stripe_transfer: marker)
@@ -554,6 +552,7 @@ class Credit < ApplicationRecord
         refund.update!(debited_stripe_transfer: FEE_DEBIT_PENDING_RETRY)
       end
     end
+    RetryRefundFeeRetentionJob.perform_in(1.minute, refund.id) if refund.id.present?
   end
   private_class_method :record_pending_fee_debit_retry!
 
@@ -571,11 +570,9 @@ class Credit < ApplicationRecord
   end
   private_class_method :persist_refund_fee_holding_on_credit!
 
-  # Persist the chosen Stripe recovery route before submit so a timed-out response cannot
-  # be retried as a different operation (e.g. transfer reversal → EUR debit).
-  # Stripe documents a 24-hour idempotency key retention window. Refuse automatic
-  # resubmits after this slightly shorter window so a timed-out fee debit cannot be
-  # posted twice once Stripe has forgotten the original key.
+  # Sticky recovery route before Stripe submit so a timed-out response cannot be retried as
+  # a different operation. Refuse automatic resubmits after this window (under Stripe's 24h
+  # idempotency retention) so a forgotten key cannot double-post a timed-out debit.
   FEE_DEBIT_IDEMPOTENCY_WINDOW = 23.hours
 
   def self.persist_refund_fee_debit_choice!(refund, operation:, transfer_id: nil, amount_cents: nil)

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -828,23 +828,20 @@ class Credit < ApplicationRecord
         )
         adjusted_delta = delta if adjusted_delta.blank?
 
-        unpaid = Balance.where(
+        unpaid_balances = Balance.where(
           user: credit.user,
           merchant_account: credit.merchant_account,
           currency: bt.issued_amount_currency,
           holding_currency:,
           state: "unpaid"
-        ).where.not(id: balance.id).order(date: :asc).first
+        ).where.not(id: balance.id).order(date: :asc).to_a
         # Do not invent a zero-USD / negative-holding unpaid balance: payout validation
         # rejects that as DESTINATION_LEDGER_NEGATIVE. Leave unreconciled until an unpaid
         # balance exists to absorb the correction.
-        if unpaid.blank?
+        if unpaid_balances.blank?
           Rails.logger.error(
             "Skipping fee retention holding reconcile for refund #{refund&.id}: "             "original balance immutable and no unpaid #{holding_currency} balance"
           )
-          # Keep retry eligibility until an unpaid balance can absorb the correction —
-          # without this marker the debit is done and retention_pending is clear, so the
-          # recurring job would never revisit the outstanding holding delta.
           if refund.present?
             refund.update!(
               refund_fee_holding_reconcile_pending: true,
@@ -855,21 +852,22 @@ class Credit < ApplicationRecord
         end
 
         absorbed = false
-        unpaid.with_lock do
-          projected_holding = unpaid.holding_amount_cents + adjusted_delta
-          # Same DESTINATION_LEDGER_NEGATIVE shape payout validation rejects: negative holding
-          # with a non-negative USD ledger. Keep reconcile pending instead of finalizing that.
-          if projected_holding.negative? && !unpaid.amount_cents.negative?
-            Rails.logger.error(
-              "Skipping fee retention holding reconcile for refund #{refund&.id}: "               "unpaid balance #{unpaid.id} cannot absorb holding delta #{adjusted_delta}"
-            )
-          else
+        unpaid_balances.each do |unpaid|
+          unpaid.with_lock do
+            projected_holding = unpaid.holding_amount_cents + adjusted_delta
+            # Same DESTINATION_LEDGER_NEGATIVE shape payout validation rejects.
+            next if projected_holding.negative? && !unpaid.amount_cents.negative?
+
             unpaid.increment(:holding_amount_cents, adjusted_delta)
             unpaid.save!
             absorbed = true
           end
+          break if absorbed
         end
         unless absorbed
+          Rails.logger.error(
+            "Skipping fee retention holding reconcile for refund #{refund&.id}: "             "no unpaid #{holding_currency} balance can absorb holding delta #{adjusted_delta}"
+          )
           if refund.present?
             refund.update!(
               refund_fee_holding_reconcile_pending: true,

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -506,20 +506,22 @@ class Credit < ApplicationRecord
         refuse_expired_fee_debit_resubmit!(refund, StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT)
         return refund.refund_fee_holding_debit_cents.presence&.to_i
       end
+      debit_amount_cents = refund.refund_fee_debit_amount_cents.presence || credit.amount_cents.abs
       persist_refund_fee_debit_choice!(
         refund,
         operation: StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT,
-        amount_cents: credit.amount_cents.abs
+        amount_cents: debit_amount_cents
       )
+      debit_amount_cents = refund.reload.refund_fee_debit_amount_cents.presence || debit_amount_cents
       transfer_options = { stripe_account: merchant_account.charge_processor_merchant_id }
       transfer_options[:idempotency_key] = "refund_fee_us_debit_#{refund.external_id}" if refund.id.present?
       transfer = Stripe::Transfer.create(
-        { amount: credit.amount_cents.abs, currency: "usd", destination: Stripe::Account.retrieve.id },
+        { amount: debit_amount_cents.to_i, currency: "usd", destination: Stripe::Account.retrieve.id },
         transfer_options
       )
       record_fee_debit_marker!(refund, transfer.id)
-      persist_refund_fee_holding_on_credit!(refund, credit.amount_cents.abs, currency: Currency::USD)
-      credit.amount_cents.abs
+      persist_refund_fee_holding_on_credit!(refund, debit_amount_cents.to_i, currency: Currency::USD)
+      debit_amount_cents.to_i
     else
       # For non-US gumroad-controlled Stripe accounts, we cannot make debit transfers.
       # So we try and reverse the retained fee amount from one of the old transfers made to that Stripe account.
@@ -580,8 +582,9 @@ class Credit < ApplicationRecord
     # Keep the flag while Stripe debit or holding reconciliation is still outstanding so
     # the recurring job can finish finish_holding_lookup / reconcile after a crash.
     return if fee_debit_pending_retry?(refund)
-    if refund.debited_stripe_transfer.present? && refund.refund_fee_holding_debit_cents.blank?
-      return
+    if refund.debited_stripe_transfer.present?
+      return if refund.refund_fee_holding_debit_cents.blank?
+      return if refund.refund_fee_holding_reconciled_cents.blank?
     end
 
     transaction(requires_new: true) do

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -530,6 +530,7 @@ class Credit < ApplicationRecord
     merchant_account = credit.merchant_account
     refund = credit.fee_retention_refund
     return unless merchant_account.holder_of_funds == HolderOfFunds::STRIPE
+    return 0 if credit.amount_cents.to_i.zero?
     if refund.debited_stripe_transfer.present? && !fee_debit_pending_retry?(refund)
       return refund.refund_fee_holding_debit_cents.presence&.to_i ||
         StripeChargeProcessor.finish_holding_lookup_for_recorded_fee_debit(
@@ -804,9 +805,27 @@ class Credit < ApplicationRecord
       return if balance.blank?
 
       begin
+        applied = false
         balance.with_lock do
-          balance.increment(:holding_amount_cents, delta)
-          balance.save!
+          projected_holding = balance.holding_amount_cents + delta
+          if projected_holding.negative? && !balance.amount_cents.negative?
+            Rails.logger.error(
+              "Skipping fee retention holding reconcile for refund #{refund&.id}: "               "balance #{balance.id} cannot absorb holding delta #{delta}"
+            )
+          else
+            balance.increment(:holding_amount_cents, delta)
+            balance.save!
+            applied = true
+          end
+        end
+        unless applied
+          if refund.present?
+            refund.update!(
+              refund_fee_holding_reconcile_pending: true,
+              fee_retention_retry_at: 15.minutes.from_now
+            )
+          end
+          next
         end
       rescue ActiveRecord::RecordInvalid
         holding_currency = credit.merchant_account.currency.to_s.downcase

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -593,6 +593,27 @@ class Credit < ApplicationRecord
   end
   private_class_method :clear_refund_fee_retention_pending!
 
+  # Stripe confirmed the sticky reversal did not happen (InvalidRequest). Drop the choice
+  # so a retry can pick another transfer; bump generation for a fresh idempotency key.
+  def self.release_sticky_refund_fee_debit_choice!(refund)
+    return if refund.blank?
+
+    refund.reload
+    refund.with_lock do
+      refund.reload
+      return if refund.debited_stripe_transfer.present? && refund.debited_stripe_transfer != FEE_DEBIT_PENDING_RETRY
+
+      transaction(requires_new: true) do
+        refund.refund_fee_debit_operation = nil
+        refund.refund_fee_debit_transfer_id = nil
+        refund.refund_fee_debit_amount_cents = nil
+        refund.refund_fee_debit_generation = refund.refund_fee_debit_generation.to_i + 1
+        refund.debited_stripe_transfer = nil if refund.debited_stripe_transfer == FEE_DEBIT_PENDING_RETRY
+        refund.save!
+      end
+    end
+  end
+
   def self.persist_refund_fee_holding_on_credit!(refund, holding_debit_cents, currency: nil)
     return if refund.blank? || holding_debit_cents.blank?
     currency = currency.to_s.downcase.presence

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -436,18 +436,19 @@ class Credit < ApplicationRecord
     refund = credit.fee_retention_refund
     return unless merchant_account.holder_of_funds == HolderOfFunds::STRIPE
     if refund.debited_stripe_transfer.present? && !fee_debit_pending_retry?(refund)
-      return refund.refund_fee_holding_debit_cents.presence&.to_i
+      return refund.refund_fee_holding_debit_cents.presence&.to_i ||
+        StripeChargeProcessor.finish_holding_lookup_for_recorded_fee_debit(
+          credit:,
+          refund:,
+          stripe_account_id: merchant_account.charge_processor_merchant_id
+        )
     end
 
     if merchant_account.country == Compliance::Countries::USA.alpha2
       # For gumroad-controlled Stripe accounts from the US, we can make new debit transfers.
       # So we transfer the retained fee back to Gumroad's Stripe platform account.
-      if fee_debit_pending_retry?(refund) && fee_debit_idempotency_window_expired?(refund)
-        Rails.logger.error("Refusing automatic US fee debit resubmit for refund #{refund.id}: Stripe idempotency window elapsed")
-        ErrorNotifier.notify(
-          "Refund fee debit pending_retry outside Stripe idempotency window",
-          context: { refund_id: refund.id, purchase_id: refund.purchase_id, operation: StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT }
-        )
+      if fee_debit_submitted_without_success_marker?(refund) && fee_debit_idempotency_window_expired?(refund)
+        refuse_expired_fee_debit_resubmit!(refund, StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT)
         return refund.refund_fee_holding_debit_cents.presence&.to_i
       end
       persist_refund_fee_debit_choice!(refund, operation: StripeChargeProcessor::FEE_DEBIT_OP_US_DEBIT,
@@ -548,51 +549,49 @@ class Credit < ApplicationRecord
     end
 
     if delta.zero?
-      mark_fee_retention_holding_reconciled!(refund, actual)
+      transaction(requires_new: true) do
+        refund.update!(
+          refund_fee_holding_debit_cents: actual,
+          refund_fee_holding_reconciled_cents: actual
+        ) if refund.present?
+      end
       return
     end
 
     balance = credit.balance || bt.balance
     return if balance.blank?
 
-    begin
-      balance.with_lock do
-        balance.increment(:holding_amount_cents, delta)
-        balance.save!
-      end
-    rescue ActiveRecord::RecordInvalid
-      # Original retention balance may already be processing/paid. Book the correction
-      # onto an unpaid balance for the same merchant account when possible.
-      unpaid = Balance.where(
-        user: credit.user,
-        merchant_account: credit.merchant_account,
-        currency: bt.issued_amount_currency,
-        holding_currency: bt.holding_amount_currency,
-        state: "unpaid"
-      ).order(date: :asc).first
-      raise if unpaid.blank?
-
-      unpaid.with_lock do
-        unpaid.increment(:holding_amount_cents, delta)
-        unpaid.save!
-      end
-    end
-
-    mark_fee_retention_holding_reconciled!(refund, actual)
-  end
-  private_class_method :reconcile_fee_retention_holding_amount!
-
-  def self.mark_fee_retention_holding_reconciled!(refund, actual)
-    return if refund.blank?
-
+    # Keep the balance correction and reconciliation marker in one savepoint so a failed
+    # marker write cannot leave a committed delta that the next retry would apply again.
     transaction(requires_new: true) do
+      begin
+        balance.with_lock do
+          balance.increment(:holding_amount_cents, delta)
+          balance.save!
+        end
+      rescue ActiveRecord::RecordInvalid
+        unpaid = Balance.where(
+          user: credit.user,
+          merchant_account: credit.merchant_account,
+          currency: bt.issued_amount_currency,
+          holding_currency: bt.holding_amount_currency,
+          state: "unpaid"
+        ).order(date: :asc).first
+        raise if unpaid.blank?
+
+        unpaid.with_lock do
+          unpaid.increment(:holding_amount_cents, delta)
+          unpaid.save!
+        end
+      end
+
       refund.update!(
         refund_fee_holding_debit_cents: actual,
         refund_fee_holding_reconciled_cents: actual
-      )
+      ) if refund.present?
     end
   end
-  private_class_method :mark_fee_retention_holding_reconciled!
+  private_class_method :reconcile_fee_retention_holding_amount!
 
   def self.fee_debit_idempotency_window_expired?(refund)
     raw = refund&.refund_fee_debit_submitted_at
@@ -603,6 +602,32 @@ class Credit < ApplicationRecord
   rescue ArgumentError, TypeError
     false
   end
+
+  # Sticky choice was written (and usually submitted) but no durable success transfer id yet.
+  # pending_retry is one such state; a crash before the rescue leaves a blank marker too.
+  def self.fee_debit_submitted_without_success_marker?(refund)
+    return false if refund.blank?
+    return false if refund.refund_fee_debit_operation.blank?
+    return false if refund.debited_stripe_transfer.present? && !fee_debit_pending_retry?(refund)
+
+    true
+  end
+  private_class_method :fee_debit_submitted_without_success_marker?
+
+  def self.refuse_expired_fee_debit_resubmit!(refund, operation)
+    Rails.logger.error("Refusing automatic fee debit resubmit for refund #{refund.id}: Stripe idempotency window elapsed")
+    ErrorNotifier.notify(
+      "Refund fee debit outside Stripe idempotency window",
+      context: {
+        refund_id: refund.id,
+        purchase_id: refund.purchase_id,
+        operation:,
+        submitted_at: refund.refund_fee_debit_submitted_at,
+        debited_stripe_transfer: refund.debited_stripe_transfer
+      }
+    )
+  end
+  private_class_method :refuse_expired_fee_debit_resubmit!
 
   # Give back the fee that create_for_refund_fee_retention! retained, because the
   # refund it was retained for later FAILED (async bank-transfer refunds can be

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -156,7 +156,12 @@ class Payment < ApplicationRecord
   end
 
   def credit_amount_cents
-    credits.where(fee_retention_refund_id: nil).sum("amount_cents")
+    ordinary = credits.where(fee_retention_refund_id: nil).sum("amount_cents")
+    separate_retention = credits.where.not(fee_retention_refund_id: nil)
+      .joins("INNER JOIN refunds ON refunds.id = credits.fee_retention_refund_id")
+      .where("COALESCE(refunds.json_data->'$.retained_fee_cents', 0) = 0")
+      .sum("amount_cents")
+    ordinary + separate_retention
   end
 
   def send_deposit_email

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -98,6 +98,9 @@ class Refund < ApplicationRecord
   # Stripe transfer id and amount (in that transfer's currency) for a sticky transfer_reversal.
   attr_json_data_accessor :refund_fee_debit_transfer_id
   attr_json_data_accessor :refund_fee_debit_amount_cents
+  # Bumped when a definitive Stripe InvalidRequest clears the sticky choice so the next
+  # attempt can use a fresh idempotency key without colliding with the rejected one.
+  attr_json_data_accessor :refund_fee_debit_generation
   # EUR cents requested for the BGN-fallback platform debit; reused on retry so the
   # Stripe idempotency key always pairs with the same amount parameters.
   attr_json_data_accessor :refund_fee_eur_debit_cents

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -115,6 +115,8 @@ class Refund < ApplicationRecord
   # UTC time the sticky fee-debit operation was first submitted to Stripe (ISO 8601).
   # Used to refuse automatic resubmits after Stripe's idempotency window.
   attr_json_data_accessor :refund_fee_debit_submitted_at
+  # Canonical USD cents retained for this refund; reused if ledger booking retries after debit.
+  attr_json_data_accessor :refund_fee_retention_usd_cents
   attr_json_data_accessor :retained_fee_cents
   attr_json_data_accessor :presentment_currency
   attr_json_data_accessor :presentment_amount_cents

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -90,6 +90,12 @@ class Refund < ApplicationRecord
   attr_json_data_accessor :refund_fee_eur_debit_cents
   # Holding-currency cents actually taken from Stripe for this fee debit, when known.
   attr_json_data_accessor :refund_fee_holding_debit_cents
+  # Holding cents already applied to balances.holding_amount_cents for this fee debit;
+  # keeps reconcile_fee_retention_holding_amount! from subtracting the same delta twice.
+  attr_json_data_accessor :refund_fee_holding_reconciled_cents
+  # UTC time the sticky fee-debit operation was first submitted to Stripe (ISO 8601).
+  # Used to refuse automatic resubmits after Stripe's idempotency window.
+  attr_json_data_accessor :refund_fee_debit_submitted_at
   attr_json_data_accessor :retained_fee_cents
   attr_json_data_accessor :presentment_currency
   attr_json_data_accessor :presentment_amount_cents

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -79,6 +79,9 @@ class Refund < ApplicationRecord
   attr_json_data_accessor :note
   attr_json_data_accessor :business_vat_id
   attr_json_data_accessor :debited_stripe_transfer
+  # EUR cents requested for the BGN-fallback platform debit; reused on retry so the
+  # Stripe idempotency key always pairs with the same amount parameters.
+  attr_json_data_accessor :refund_fee_eur_debit_cents
   attr_json_data_accessor :retained_fee_cents
   attr_json_data_accessor :presentment_currency
   attr_json_data_accessor :presentment_amount_cents

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -79,6 +79,12 @@ class Refund < ApplicationRecord
   attr_json_data_accessor :note
   attr_json_data_accessor :business_vat_id
   attr_json_data_accessor :debited_stripe_transfer
+
+  # Stripe fee debit failed transiently; retry jobs revisit these within the idempotency window.
+  scope :pending_fee_debit_retry, -> {
+    where("refunds.json_data->>'$.debited_stripe_transfer' = ?", Credit::FEE_DEBIT_PENDING_RETRY)
+  }
+
   # Sticky recovery route chosen before the Stripe submit (transfer_reversal / eur_debit /
   # us_debit). Retries must resume this route instead of selecting a new one.
   attr_json_data_accessor :refund_fee_debit_operation

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -79,10 +79,17 @@ class Refund < ApplicationRecord
   attr_json_data_accessor :note
   attr_json_data_accessor :business_vat_id
   attr_json_data_accessor :debited_stripe_transfer
+  # True until Credit.create_for_refund_fee_retention! finishes (or is waived). Survives process
+  # death between refund commit and after_commit fee retention.
+  attr_json_data_accessor :refund_fee_retention_pending
 
-  # Stripe fee debit failed transiently; retry jobs revisit these within the idempotency window.
+  # Fee retention still outstanding (set when the refund commits; cleared when retention finishes)
+  # or Stripe debit left in pending_retry. Retry jobs revisit these within the idempotency window.
   scope :pending_fee_debit_retry, -> {
-    where("refunds.json_data->>'$.debited_stripe_transfer' = ?", Credit::FEE_DEBIT_PENDING_RETRY)
+    where(
+      "refunds.json_data->>'$.debited_stripe_transfer' = ? OR COALESCE(refunds.json_data->>'$.refund_fee_retention_pending', 'false') = 'true'",
+      Credit::FEE_DEBIT_PENDING_RETRY
+    )
   }
 
   # Sticky recovery route chosen before the Stripe submit (transfer_reversal / eur_debit /

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -79,9 +79,17 @@ class Refund < ApplicationRecord
   attr_json_data_accessor :note
   attr_json_data_accessor :business_vat_id
   attr_json_data_accessor :debited_stripe_transfer
+  # Sticky recovery route chosen before the Stripe submit (transfer_reversal / eur_debit /
+  # us_debit). Retries must resume this route instead of selecting a new one.
+  attr_json_data_accessor :refund_fee_debit_operation
+  # Stripe transfer id and amount (in that transfer's currency) for a sticky transfer_reversal.
+  attr_json_data_accessor :refund_fee_debit_transfer_id
+  attr_json_data_accessor :refund_fee_debit_amount_cents
   # EUR cents requested for the BGN-fallback platform debit; reused on retry so the
   # Stripe idempotency key always pairs with the same amount parameters.
   attr_json_data_accessor :refund_fee_eur_debit_cents
+  # Holding-currency cents actually taken from Stripe for this fee debit, when known.
+  attr_json_data_accessor :refund_fee_holding_debit_cents
   attr_json_data_accessor :retained_fee_cents
   attr_json_data_accessor :presentment_currency
   attr_json_data_accessor :presentment_amount_cents

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -90,6 +90,8 @@ class Refund < ApplicationRecord
   attr_json_data_accessor :refund_fee_eur_debit_cents
   # Holding-currency cents actually taken from Stripe for this fee debit, when known.
   attr_json_data_accessor :refund_fee_holding_debit_cents
+  # Currency of refund_fee_holding_debit_cents (merchant account currency at debit time).
+  attr_json_data_accessor :refund_fee_holding_debit_currency
   # Holding cents already applied to balances.holding_amount_cents for this fee debit;
   # keeps reconcile_fee_retention_holding_amount! from subtracting the same delta twice.
   attr_json_data_accessor :refund_fee_holding_reconciled_cents

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -83,14 +83,15 @@ class Refund < ApplicationRecord
   # death between refund commit and after_commit fee retention.
   attr_json_data_accessor :refund_fee_retention_pending
 
-  # Fee retention still outstanding (set when the refund commits; cleared when retention finishes)
-  # or Stripe debit left in pending_retry. Retry jobs revisit these within the idempotency window.
+  # Indexed queue for outstanding fee retention / debit / holding-reconcile work.
+  # fee_retention_retry_at is set while work remains and cleared when finished — the
+  # recurring job selects on this column so MySQL does not scan refund JSON history.
   scope :pending_fee_debit_retry, -> {
-    where(
-      "refunds.json_data->>'$.debited_stripe_transfer' = ? OR COALESCE(refunds.json_data->>'$.refund_fee_retention_pending', 'false') = 'true'",
-      Credit::FEE_DEBIT_PENDING_RETRY
-    )
+    where.not(fee_retention_retry_at: nil)
   }
+
+  # True while holding-amount reconcile could not land (immutable balance, no unpaid).
+  attr_json_data_accessor :refund_fee_holding_reconcile_pending
 
   # Sticky recovery route chosen before the Stripe submit (transfer_reversal / eur_debit /
   # us_debit). Retries must resume this route instead of selecting a new one.

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -688,16 +688,18 @@ class Purchase
       return if refund.blank?
 
       # Serialize against HandleFailedRefundService (same purchase → refund lock order).
-      # A failure webhook can reverse the refund between this method's outer commit and
-      # the fee booking; re-check under the locks so we never retain a fee for a reversed
-      # failure.
+      # Only the eligibility check holds the locks: wrapping Stripe + ledger here would
+      # roll back debited_stripe_transfer when ledger creation failed after a successful
+      # Stripe debit, and a retry would debit the seller again.
+      fee_reversed = false
       transaction do
         reload.lock!
         refund.reload.lock!
-        unless refund.balance_reversed_on_failure
-          Credit.create_for_refund_fee_retention!(refund:)
-        end
+        fee_reversed = refund.balance_reversed_on_failure.present?
       end
+      return if fee_reversed
+
+      Credit.create_for_refund_fee_retention!(refund:)
     rescue StandardError => e
       logger.error "Failed to retain the fee for refund #{refund.id} of purchase #{id}: #{e.class}: #{e.message}"
       ErrorNotifier.notify(

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -334,6 +334,9 @@ class Purchase
       refund.note = note if note.present?
       refunds << refund
       self.is_refund_chargeback_fee_waived = !charged_using_gumroad_merchant_account? || is_for_fraud
+      unless is_refund_chargeback_fee_waived || chargedback_not_reversed?
+        refund.refund_fee_retention_pending = true
+      end
       mark_giftee_purchase_as_refunded(is_partially_refunded: self.stripe_partially_refunded?) if is_gift_sender_purchase
       subscription.cancel_immediately_if_pending_cancellation! if subscription.present?
       decrement_balance_for_refund_or_chargeback!(flow_of_funds, refund:) unless chargedback_not_reversed?
@@ -414,6 +417,9 @@ class Purchase
 
       if refund.present?
         refund.processor_refund_id = processor_refund_id
+        unless is_refund_chargeback_fee_waived
+          refund.refund_fee_retention_pending = true
+        end
         refunds << refund
       end
       save!

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -290,12 +290,11 @@ class Purchase
     # the fallback is unreachable there and a presentment amount can never be booked as canonical.
     funds_refunded = canonical_gross_refund_cents || flow_of_funds.issued_amount.cents.abs
     refund = nil
-    ActiveRecord::Base.transaction do
+    refunded_locally = ActiveRecord::Base.transaction do
       # Failed-refund reversals lock the purchase before their refund and balance rows.
       # Use the same order here so a single-purchase refund cannot hold a balance while
-      # waiting for a purchase row that a reversal already holds. (Combined-charge
-      # refunds take all their purchase locks up front in id order — see
-      # Charge#refund_and_save! — so they follow the same purchase-first order.)
+      # waiting for a purchase row that a reversal already holds. Combined-charge refunds
+      # process purchases in id order without one wrapping transaction (#7549).
       # reload first: reading any json_data-backed attribute on a row whose json_data
       # column is NULL dirties the record in memory, and lock! raises on dirty records.
       # Reloading discards that phantom change; lock! reloads again under FOR UPDATE.
@@ -368,27 +367,34 @@ class Purchase
       end
 
       true
-    end.tap do |refunded|
-      next unless refunded
-
-      # After this method's transaction returns: ChargeProcessor.refund! has already moved
-      # the money. Fee ledger writes use requires_new so an outer Charge/webhook transaction
-      # cannot commit a half-written credit if retention fails mid-way. Neither a failed fee
-      # debit nor a failed license write may roll back the refund rows.
-      debit_processor_fee_from_merchant_account!(refund) unless is_refund_chargeback_fee_waived || chargedback_not_reversed?
-      disable_attached_license_if_fully_refunded!(for_fraud: is_for_fraud)
     end
+
+    # Fee retention / license disable wait for the outermost commit. `.tap` still runs under
+    # Charge#refund_and_save! or webhook with_lock, where requires_new markers are savepoints
+    # an outer rollback can erase after Stripe already moved money.
+    if refunded_locally
+      refund_id = refund.id
+      should_debit_fee = !is_refund_chargeback_fee_waived && !chargedback_not_reversed?
+      for_fraud = is_for_fraud
+      after_commit do
+        refund_record = Refund.find_by(id: refund_id)
+        next if refund_record.blank?
+
+        debit_processor_fee_from_merchant_account!(refund_record) if should_debit_fee
+        disable_attached_license_if_fully_refunded!(for_fraud: for_fraud)
+      end
+    end
+
+    refunded_locally
   end
 
   def refund_partial_purchase!(gross_refund_amount_cents, refunding_user_id, processor_refund_id: nil)
     refund = nil
-    ActiveRecord::Base.transaction do
-      # Same purchase-first lock order as refund_purchase!: take the purchase row
-      # lock before touching refund or balance rows, so this path cannot hold a
-      # balance while a failed-refund reversal holds the purchase. reload first
-      # because reading a json_data-backed attribute on a row whose json_data is
-      # NULL dirties the record, and lock! raises on dirty records. Read the
-      # partial-refund flag only after the lock so it reflects committed state.
+    refunded_locally = ActiveRecord::Base.transaction do
+      # Same purchase-first lock order as refund_purchase!: purchase before refund/
+      # balance so this path cannot hold a balance while a failed-refund reversal
+      # holds the purchase. reload before lock! (NULL json_data dirties the record).
+      # Read the partial-refund flag only after the lock so it reflects committed state.
       reload.lock!
       partially_refunded_previously = self.stripe_partially_refunded
       if (gross_amount_refunded_cents + gross_refund_amount_cents) >= total_transaction_cents
@@ -418,12 +424,19 @@ class Purchase
       # is committed/visible and would miss it.
       CustomerMailer.partial_refund(email, link.id, id, gross_refund_amount_cents, formatted_refund_state, refund&.presentment_amount_cents, refund&.presentment_currency).deliver_later(queue: "critical")
       true
-    end.tap do |refunded|
-      next unless refunded
-
-      debit_processor_fee_from_merchant_account!(refund) unless is_refund_chargeback_fee_waived
-      disable_attached_license_if_fully_refunded!
     end
+
+    if refunded_locally
+      refund_id = refund&.id
+      should_debit_fee = !is_refund_chargeback_fee_waived
+      after_commit do
+        refund_record = refund_id.present? ? Refund.find_by(id: refund_id) : nil
+        debit_processor_fee_from_merchant_account!(refund_record) if should_debit_fee && refund_record.present?
+        disable_attached_license_if_fully_refunded!
+      end
+    end
+
+    refunded_locally
   end
 
   def refund_gumroad_taxes!(refunding_user_id:, note: nil, business_vat_id: nil)
@@ -680,19 +693,12 @@ class Purchase
       Stripe::Transfer.create_reversal(transfer.id, { amount: amount_refundable_cents }) if transfer.present?
     end
 
-    # Runs after the refund transaction commits: the processor has already returned the
-    # money, so a failure here is reported and left for a retry rather than allowed to
-    # unwind the refund. Credit.create_for_refund_fee_retention! is idempotent, so calling
-    # it again for the same refund finishes whatever the first attempt did not.
+    # After-commit only: never let fee retention unwind a processor-successful refund.
+    # Idempotent: re-running finishes an outstanding Stripe debit. Serialize eligibility
+    # against HandleFailedRefundService, then release before Stripe so markers are commits.
     def debit_processor_fee_from_merchant_account!(refund)
       return if refund.blank?
 
-      # Intentionally after the refund transaction has committed: fee retention must never
-      # roll back a processor-successful buyer refund (private issue 2460). Serialize
-      # eligibility against HandleFailedRefundService (same purchase → refund lock order),
-      # then release before Stripe so sticky debit choices and success markers are real
-      # commits rather than savepoints. A crash here leaves a committed refund and a
-      # retryable fee; that is the accepted recovery model, not a missing atomic intent.
       fee_reversed = false
       transaction do
         reload.lock!
@@ -715,6 +721,7 @@ class Purchase
             error: e.message,
           }
         )
+        RetryRefundFeeRetentionJob.perform_in(1.minute, refund.id) if refund.id.present?
       end
     end
 

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -335,6 +335,7 @@ class Purchase
       self.is_refund_chargeback_fee_waived = !charged_using_gumroad_merchant_account? || is_for_fraud
       unless is_refund_chargeback_fee_waived || chargedback_not_reversed?
         refund.refund_fee_retention_pending = true
+        refund.fee_retention_retry_at = Time.current
       end
       refunds << refund
       mark_giftee_purchase_as_refunded(is_partially_refunded: self.stripe_partially_refunded?) if is_gift_sender_purchase
@@ -419,6 +420,7 @@ class Purchase
         refund.processor_refund_id = processor_refund_id
         unless is_refund_chargeback_fee_waived
           refund.refund_fee_retention_pending = true
+          refund.fee_retention_retry_at = Time.current
         end
         refunds << refund
       end

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -687,31 +687,33 @@ class Purchase
     def debit_processor_fee_from_merchant_account!(refund)
       return if refund.blank?
 
-      # Serialize against HandleFailedRefundService (same purchase → refund lock order)
-      # through local ledger booking. Nested requires_new marker writes are only savepoints,
-      # so a ledger failure must be handled inside this transaction: re-raising would roll
-      # back the enclosing txn and erase proof Stripe already debited. Swallowing lets this
-      # txn commit and keeps the marker for an idempotent retry.
+      # Serialize eligibility against HandleFailedRefundService (same purchase → refund
+      # lock order), then release before Stripe. Sticky debit choices and success markers
+      # must be real commits — nested requires_new is only a savepoint while this
+      # transaction is open, and a crash after Stripe accepts a debit would otherwise
+      # lose that proof.
+      fee_reversed = false
       transaction do
         reload.lock!
         refund.reload.lock!
-        next if refund.balance_reversed_on_failure
+        fee_reversed = refund.balance_reversed_on_failure.present?
+      end
+      return if fee_reversed
 
-        begin
-          Credit.create_for_refund_fee_retention!(refund:)
-        rescue StandardError => e
-          logger.error "Failed to retain the fee for refund #{refund.id} of purchase #{id}: #{e.class}: #{e.message}"
-          ErrorNotifier.notify(
-            "Failed to retain refund fee after refund",
-            context: {
-              purchase_id: id,
-              purchase_external_id: external_id,
-              refund_id: refund.id,
-              error_class: e.class.name,
-              error: e.message,
-            }
-          )
-        end
+      begin
+        Credit.create_for_refund_fee_retention!(refund:)
+      rescue StandardError => e
+        logger.error "Failed to retain the fee for refund #{refund.id} of purchase #{id}: #{e.class}: #{e.message}"
+        ErrorNotifier.notify(
+          "Failed to retain refund fee after refund",
+          context: {
+            purchase_id: id,
+            purchase_external_id: external_id,
+            refund_id: refund.id,
+            error_class: e.class.name,
+            error: e.message,
+          }
+        )
       end
     end
 

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -289,6 +289,7 @@ class Purchase
     # purchase the block above always sets `canonical_gross_refund_cents` (or returns false), so
     # the fallback is unreachable there and a presentment amount can never be booked as canonical.
     funds_refunded = canonical_gross_refund_cents || flow_of_funds.issued_amount.cents.abs
+    refund = nil
     ActiveRecord::Base.transaction do
       # Failed-refund reversals lock the purchase before their refund and balance rows.
       # Use the same order here so a single-purchase refund cannot hold a balance while
@@ -341,7 +342,6 @@ class Purchase
       save!
       reverse_the_transfer_made_for_dispute_win! if chargedback? && chargeback_reversed
       reverse_excess_amount_from_stripe_transfer(refund:) if stripe_partially_refunded && vat_already_refunded
-      debit_processor_fee_from_merchant_account!(refund) unless is_refund_chargeback_fee_waived || chargedback_not_reversed?
       Credit.create_for_vat_exclusive_refund!(refund:) if (paypal_order_id.present? || merchant_account&.is_a_stripe_connect_account?) && !chargedback_not_reversed?
       subscription.original_purchase.update!(should_exclude_product_review: true) if subscription&.should_exclude_product_review_on_charge_reversal?
       send_refunded_notification_webhook
@@ -369,13 +369,17 @@ class Purchase
 
       true
     end.tap do |refunded|
-      # After commit: ChargeProcessor.refund! has already moved the money.
-      # A failed license write must not roll back stripe_refunded.
-      disable_attached_license_if_fully_refunded!(for_fraud: is_for_fraud) if refunded
+      next unless refunded
+
+      # After commit: ChargeProcessor.refund! has already moved the money. Neither a failed
+      # fee debit nor a failed license write may roll back the refund rows.
+      debit_processor_fee_from_merchant_account!(refund) unless is_refund_chargeback_fee_waived || chargedback_not_reversed?
+      disable_attached_license_if_fully_refunded!(for_fraud: is_for_fraud)
     end
   end
 
   def refund_partial_purchase!(gross_refund_amount_cents, refunding_user_id, processor_refund_id: nil)
+    refund = nil
     ActiveRecord::Base.transaction do
       # Same purchase-first lock order as refund_purchase!: take the purchase row
       # lock before touching refund or balance rows, so this path cannot hold a
@@ -406,7 +410,6 @@ class Purchase
       end
       save!
       Credit.create_for_vat_exclusive_refund!(refund:) if paypal_order_id.present? || merchant_account&.is_a_stripe_connect_account?
-      debit_processor_fee_from_merchant_account!(refund) unless is_refund_chargeback_fee_waived
       # refund can be nil here (build_partial_full_refund may return nothing). Pass the
       # refund's buyer-currency amount as plain values (not the Refund id): this enqueue
       # happens inside the transaction, so the mailer job could run before the Refund row
@@ -414,7 +417,10 @@ class Purchase
       CustomerMailer.partial_refund(email, link.id, id, gross_refund_amount_cents, formatted_refund_state, refund&.presentment_amount_cents, refund&.presentment_currency).deliver_later(queue: "critical")
       true
     end.tap do |refunded|
-      disable_attached_license_if_fully_refunded! if refunded
+      next unless refunded
+
+      debit_processor_fee_from_merchant_account!(refund) unless is_refund_chargeback_fee_waived
+      disable_attached_license_if_fully_refunded!
     end
   end
 
@@ -672,8 +678,26 @@ class Purchase
       Stripe::Transfer.create_reversal(transfer.id, { amount: amount_refundable_cents }) if transfer.present?
     end
 
+    # Runs after the refund transaction commits: the processor has already returned the
+    # money, so a failure here is reported and left for a retry rather than allowed to
+    # unwind the refund. Credit.create_for_refund_fee_retention! is idempotent, so calling
+    # it again for the same refund finishes whatever the first attempt did not.
     def debit_processor_fee_from_merchant_account!(refund)
+      return if refund.blank?
+
       Credit.create_for_refund_fee_retention!(refund:)
+    rescue StandardError => e
+      logger.error "Failed to retain the fee for refund #{refund.id} of purchase #{id}: #{e.class}: #{e.message}"
+      ErrorNotifier.notify(
+        "Failed to retain refund fee after refund",
+        context: {
+          purchase_id: id,
+          purchase_external_id: external_id,
+          refund_id: refund.id,
+          error_class: e.class.name,
+          error: e.message,
+        }
+      )
     end
 
     def insufficient_funds_refund_error_message

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -687,19 +687,16 @@ class Purchase
     def debit_processor_fee_from_merchant_account!(refund)
       return if refund.blank?
 
-      # Serialize against HandleFailedRefundService (same purchase → refund lock order).
-      # Only the eligibility check holds the locks: wrapping Stripe + ledger here would
-      # roll back debited_stripe_transfer when ledger creation failed after a successful
-      # Stripe debit, and a retry would debit the seller again.
-      fee_reversed = false
+      # Serialize against HandleFailedRefundService (same purchase → refund lock order)
+      # through local ledger booking. Debit markers are written in requires_new
+      # transactions, so a ledger failure here cannot erase proof Stripe already debited.
       transaction do
         reload.lock!
         refund.reload.lock!
-        fee_reversed = refund.balance_reversed_on_failure.present?
+        unless refund.balance_reversed_on_failure
+          Credit.create_for_refund_fee_retention!(refund:)
+        end
       end
-      return if fee_reversed
-
-      Credit.create_for_refund_fee_retention!(refund:)
     rescue StandardError => e
       logger.error "Failed to retain the fee for refund #{refund.id} of purchase #{id}: #{e.class}: #{e.message}"
       ErrorNotifier.notify(

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -687,11 +687,12 @@ class Purchase
     def debit_processor_fee_from_merchant_account!(refund)
       return if refund.blank?
 
-      # Serialize eligibility against HandleFailedRefundService (same purchase → refund
-      # lock order), then release before Stripe. Sticky debit choices and success markers
-      # must be real commits — nested requires_new is only a savepoint while this
-      # transaction is open, and a crash after Stripe accepts a debit would otherwise
-      # lose that proof.
+      # Intentionally after the refund transaction has committed: fee retention must never
+      # roll back a processor-successful buyer refund (private issue 2460). Serialize
+      # eligibility against HandleFailedRefundService (same purchase → refund lock order),
+      # then release before Stripe so sticky debit choices and success markers are real
+      # commits rather than savepoints. A crash here leaves a committed refund and a
+      # retryable fee; that is the accepted recovery model, not a missing atomic intent.
       fee_reversed = false
       transaction do
         reload.lock!

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -688,27 +688,31 @@ class Purchase
       return if refund.blank?
 
       # Serialize against HandleFailedRefundService (same purchase → refund lock order)
-      # through local ledger booking. Debit markers are written in requires_new
-      # transactions, so a ledger failure here cannot erase proof Stripe already debited.
+      # through local ledger booking. Nested requires_new marker writes are only savepoints,
+      # so a ledger failure must be handled inside this transaction: re-raising would roll
+      # back the enclosing txn and erase proof Stripe already debited. Swallowing lets this
+      # txn commit and keeps the marker for an idempotent retry.
       transaction do
         reload.lock!
         refund.reload.lock!
-        unless refund.balance_reversed_on_failure
+        next if refund.balance_reversed_on_failure
+
+        begin
           Credit.create_for_refund_fee_retention!(refund:)
+        rescue StandardError => e
+          logger.error "Failed to retain the fee for refund #{refund.id} of purchase #{id}: #{e.class}: #{e.message}"
+          ErrorNotifier.notify(
+            "Failed to retain refund fee after refund",
+            context: {
+              purchase_id: id,
+              purchase_external_id: external_id,
+              refund_id: refund.id,
+              error_class: e.class.name,
+              error: e.message,
+            }
+          )
         end
       end
-    rescue StandardError => e
-      logger.error "Failed to retain the fee for refund #{refund.id} of purchase #{id}: #{e.class}: #{e.message}"
-      ErrorNotifier.notify(
-        "Failed to retain refund fee after refund",
-        context: {
-          purchase_id: id,
-          purchase_external_id: external_id,
-          refund_id: refund.id,
-          error_class: e.class.name,
-          error: e.message,
-        }
-      )
     end
 
     def insufficient_funds_refund_error_message

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -371,8 +371,10 @@ class Purchase
     end.tap do |refunded|
       next unless refunded
 
-      # After commit: ChargeProcessor.refund! has already moved the money. Neither a failed
-      # fee debit nor a failed license write may roll back the refund rows.
+      # After this method's transaction returns: ChargeProcessor.refund! has already moved
+      # the money. Fee ledger writes use requires_new so an outer Charge/webhook transaction
+      # cannot commit a half-written credit if retention fails mid-way. Neither a failed fee
+      # debit nor a failed license write may roll back the refund rows.
       debit_processor_fee_from_merchant_account!(refund) unless is_refund_chargeback_fee_waived || chargedback_not_reversed?
       disable_attached_license_if_fully_refunded!(for_fraud: is_for_fraud)
     end
@@ -685,7 +687,17 @@ class Purchase
     def debit_processor_fee_from_merchant_account!(refund)
       return if refund.blank?
 
-      Credit.create_for_refund_fee_retention!(refund:)
+      # Serialize against HandleFailedRefundService (same purchase → refund lock order).
+      # A failure webhook can reverse the refund between this method's outer commit and
+      # the fee booking; re-check under the locks so we never retain a fee for a reversed
+      # failure.
+      transaction do
+        reload.lock!
+        refund.reload.lock!
+        unless refund.balance_reversed_on_failure
+          Credit.create_for_refund_fee_retention!(refund:)
+        end
+      end
     rescue StandardError => e
       logger.error "Failed to retain the fee for refund #{refund.id} of purchase #{id}: #{e.class}: #{e.message}"
       ErrorNotifier.notify(

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -332,11 +332,11 @@ class Purchase
       # Free-text explanation of why the refund happened (e.g. "Buyer was charged twice").
       # Shown to the creator in the notification email when a team member issued the refund.
       refund.note = note if note.present?
-      refunds << refund
       self.is_refund_chargeback_fee_waived = !charged_using_gumroad_merchant_account? || is_for_fraud
       unless is_refund_chargeback_fee_waived || chargedback_not_reversed?
         refund.refund_fee_retention_pending = true
       end
+      refunds << refund
       mark_giftee_purchase_as_refunded(is_partially_refunded: self.stripe_partially_refunded?) if is_gift_sender_purchase
       subscription.cancel_immediately_if_pending_cancellation! if subscription.present?
       decrement_balance_for_refund_or_chargeback!(flow_of_funds, refund:) unless chargedback_not_reversed?

--- a/app/modules/user/stats.rb
+++ b/app/modules/user/stats.rb
@@ -305,7 +305,7 @@ module User::Stats
   def credits_cents_for_balances(balance_ids)
     scope = credits
       .where(financing_paydown_purchase_id: nil)
-      .where("json_data->>'$.stripe_loan_paydown_id' IS NULL")
+      .where("credits.json_data->>'$.stripe_loan_paydown_id' IS NULL")
       .where(balance_id: balance_ids)
 
     ordinary = scope.where(fee_retention_refund_id: nil).sum("amount_cents")

--- a/app/modules/user/stats.rb
+++ b/app/modules/user/stats.rb
@@ -303,12 +303,18 @@ module User::Stats
   end
 
   def credits_cents_for_balances(balance_ids)
-    credits
+    scope = credits
       .where(financing_paydown_purchase_id: nil)
       .where("json_data->>'$.stripe_loan_paydown_id' IS NULL")
-      .where(fee_retention_refund_id: nil)
       .where(balance_id: balance_ids)
+
+    ordinary = scope.where(fee_retention_refund_id: nil).sum("amount_cents")
+    # Separately booked fee retention (not folded into refund.retained_fee_cents).
+    separate_retention = scope.where.not(fee_retention_refund_id: nil)
+      .joins("INNER JOIN refunds ON refunds.id = credits.fee_retention_refund_id")
+      .where("COALESCE(refunds.json_data->'$.retained_fee_cents', 0) = 0")
       .sum("amount_cents")
+    ordinary + separate_retention
   end
 
   def loan_repayment_cents_for_balances(balance_ids)

--- a/app/services/exports/payouts/base.rb
+++ b/app/services/exports/payouts/base.rb
@@ -85,16 +85,16 @@ class Exports::Payouts::Base
         end
 
         Credit.where(balance: bal).find_each do |credit|
-          # Fee-retention debits are normally folded into the refund rows' fee columns
-          # (via retained_fee_cents), so the negative credit row is skipped to avoid
-          # double-counting. When the refund FAILED and was reversed, its refund rows
-          # are excluded above — show the retention debit and its give-back explicitly
-          # instead, so the pair is visible and nets to zero.
+          # Fee-retention debits on the same payout as the refund are folded into the
+          # refund rows' fee columns via retained_fee_cents; skip those credit rows to
+          # avoid double-counting. Cross-payout retention leaves retained_fee_cents blank
+          # so this later balance can show the debit. Reversed failures always show both.
           retention_refund = credit.fee_retention_refund
           reversed_failure = retention_refund.present? &&
             retention_refund.terminally_failed? &&
             retention_refund.balance_reversed_on_failure.present?
-          next if retention_refund.present? && credit.amount_cents <= 0 && !reversed_failure
+          folded_into_refund = retention_refund&.retained_fee_cents.present?
+          next if retention_refund.present? && credit.amount_cents <= 0 && !reversed_failure && folded_into_refund
 
           credit_type = if reversed_failure
             credit.failed_refund_id.present? ? "Failed Refund Fee Returned" : "Failed Refund Fee Retained"

--- a/app/sidekiq/retry_pending_refund_fee_debits_job.rb
+++ b/app/sidekiq/retry_pending_refund_fee_debits_job.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# Safety net for outstanding fee retention / pending_retry markers when the per-refund
-# enqueue was lost. Dispatches RetryRefundFeeRetentionJob. Bounded to recently updated
-# refunds so MySQL is not forced to examine the entire refunds history every run.
+# Safety net for outstanding fee retention / pending_retry / holding-reconcile work when
+# the per-refund enqueue was lost. Dispatches RetryRefundFeeRetentionJob via the indexed
+# fee_retention_retry_at queue (no JSON history scan).
 class RetryPendingRefundFeeDebitsJob
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :default, lock: :until_executed
@@ -10,11 +10,9 @@ class RetryPendingRefundFeeDebitsJob
   include RecurringLockTtl
   recurring_lock_ttl max_attempt: 5.minutes
 
-  LOOKBACK = 30.days
-
   def perform
     Refund.pending_fee_debit_retry
-          .where("refunds.updated_at > ?", LOOKBACK.ago)
+          .where("refunds.fee_retention_retry_at <= ?", Time.current)
           .find_each do |refund|
       next if refund.balance_reversed_on_failure
 

--- a/app/sidekiq/retry_pending_refund_fee_debits_job.rb
+++ b/app/sidekiq/retry_pending_refund_fee_debits_job.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # Safety net for outstanding fee retention / pending_retry markers when the per-refund
-# enqueue was lost. Dispatches RetryRefundFeeRetentionJob; create_for_refund_fee_retention!
-# refuses expired Stripe resubmits but still finishes holding lookups for confirmed debits.
+# enqueue was lost. Dispatches RetryRefundFeeRetentionJob. Bounded to recently updated
+# refunds so MySQL is not forced to examine the entire refunds history every run.
 class RetryPendingRefundFeeDebitsJob
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :default, lock: :until_executed
@@ -10,8 +10,12 @@ class RetryPendingRefundFeeDebitsJob
   include RecurringLockTtl
   recurring_lock_ttl max_attempt: 5.minutes
 
+  LOOKBACK = 30.days
+
   def perform
-    Refund.pending_fee_debit_retry.find_each do |refund|
+    Refund.pending_fee_debit_retry
+          .where("refunds.updated_at > ?", LOOKBACK.ago)
+          .find_each do |refund|
       next if refund.balance_reversed_on_failure
 
       RetryRefundFeeRetentionJob.perform_async(refund.id)

--- a/app/sidekiq/retry_pending_refund_fee_debits_job.rb
+++ b/app/sidekiq/retry_pending_refund_fee_debits_job.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# Safety net for refund fee debits left pending when the per-refund enqueue was lost.
-# Only considers refunds still inside the Stripe idempotency window and dispatches the
-# per-refund job rather than doing Stripe work inline.
+# Safety net for outstanding fee retention / pending_retry markers when the per-refund
+# enqueue was lost. Dispatches RetryRefundFeeRetentionJob; create_for_refund_fee_retention!
+# refuses expired Stripe resubmits but still finishes holding lookups for confirmed debits.
 class RetryPendingRefundFeeDebitsJob
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :default, lock: :until_executed
@@ -11,9 +11,7 @@ class RetryPendingRefundFeeDebitsJob
   recurring_lock_ttl max_attempt: 5.minutes
 
   def perform
-    Refund.pending_fee_debit_retry
-          .where("refunds.created_at > ?", Credit::FEE_DEBIT_IDEMPOTENCY_WINDOW.ago)
-          .find_each do |refund|
+    Refund.pending_fee_debit_retry.find_each do |refund|
       next if refund.balance_reversed_on_failure
 
       RetryRefundFeeRetentionJob.perform_async(refund.id)

--- a/app/sidekiq/retry_pending_refund_fee_debits_job.rb
+++ b/app/sidekiq/retry_pending_refund_fee_debits_job.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# Safety net for refund fee debits left in pending_retry when the per-refund enqueue was
-# lost. Runs inside the Stripe idempotency window so create_for_refund_fee_retention!
-# can still finish the debit.
+# Safety net for refund fee debits left pending when the per-refund enqueue was lost.
+# Only considers refunds still inside the Stripe idempotency window and dispatches the
+# per-refund job rather than doing Stripe work inline.
 class RetryPendingRefundFeeDebitsJob
   include Sidekiq::Job
   sidekiq_options retry: 5, queue: :default, lock: :until_executed
@@ -11,13 +11,12 @@ class RetryPendingRefundFeeDebitsJob
   recurring_lock_ttl max_attempt: 5.minutes
 
   def perform
-    Refund.pending_fee_debit_retry.find_each do |refund|
+    Refund.pending_fee_debit_retry
+          .where("refunds.created_at > ?", Credit::FEE_DEBIT_IDEMPOTENCY_WINDOW.ago)
+          .find_each do |refund|
       next if refund.balance_reversed_on_failure
 
-      Credit.create_for_refund_fee_retention!(refund:)
-    rescue StandardError => e
-      Rails.logger.error("Failed pending refund fee debit retry for refund #{refund.id}: #{e.class}: #{e.message}")
-      ErrorNotifier.notify(e, context: { refund_id: refund.id, purchase_id: refund.purchase_id })
+      RetryRefundFeeRetentionJob.perform_async(refund.id)
     end
   end
 end

--- a/app/sidekiq/retry_pending_refund_fee_debits_job.rb
+++ b/app/sidekiq/retry_pending_refund_fee_debits_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Safety net for refund fee debits left in pending_retry when the per-refund enqueue was
+# lost. Runs inside the Stripe idempotency window so create_for_refund_fee_retention!
+# can still finish the debit.
+class RetryPendingRefundFeeDebitsJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5, queue: :default, lock: :until_executed
+
+  include RecurringLockTtl
+  recurring_lock_ttl max_attempt: 5.minutes
+
+  def perform
+    Refund.pending_fee_debit_retry.find_each do |refund|
+      next if refund.balance_reversed_on_failure
+
+      Credit.create_for_refund_fee_retention!(refund:)
+    rescue StandardError => e
+      Rails.logger.error("Failed pending refund fee debit retry for refund #{refund.id}: #{e.class}: #{e.message}")
+      ErrorNotifier.notify(e, context: { refund_id: refund.id, purchase_id: refund.purchase_id })
+    end
+  end
+end

--- a/app/sidekiq/retry_refund_fee_retention_job.rb
+++ b/app/sidekiq/retry_refund_fee_retention_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Retries Credit.create_for_refund_fee_retention! for one refund after a transient Stripe
+# fee-debit failure (pending_retry). Idempotent; refuses automatic resubmit after the
+# Stripe idempotency window.
+class RetryRefundFeeRetentionJob
+  include Sidekiq::Job
+  sidekiq_options retry: 10, queue: :default, lock: :until_executed
+
+  def perform(refund_id)
+    refund = Refund.find_by(id: refund_id)
+    return if refund.blank?
+    return if refund.balance_reversed_on_failure
+
+    Credit.create_for_refund_fee_retention!(refund:)
+  end
+end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -14,6 +14,10 @@ dispatch_pending_failed_refund_exceptions:
   cron: "* * * * *" # Every minute
   class: DispatchPendingFailedRefundExceptionsJob
   description: Re-enqueues notifications for durable failed-refund exception records
+retry_pending_refund_fee_debits:
+  cron: "*/15 * * * *" # Every 15 minutes, inside the 23h Stripe fee-debit idempotency window
+  class: RetryPendingRefundFeeDebitsJob
+  description: Retries Stripe refund fee debits left in pending_retry after transient failures
 update_purchase_healthcheck_threshold:
   cron: "* * * * *" # Every minute — the threshold carries a 1h TTL, so the healthcheck fails closed if this stalls
   class: UpdatePurchaseHealthcheckThresholdJob

--- a/db/migrate/20261211140000_add_fee_retention_retry_at_to_refunds.rb
+++ b/db/migrate/20261211140000_add_fee_retention_retry_at_to_refunds.rb
@@ -5,7 +5,9 @@
 # work remains and cleared when retention + holding reconcile are finished.
 class AddFeeRetentionRetryAtToRefunds < ActiveRecord::Migration[7.1]
   def change
-    add_column :refunds, :fee_retention_retry_at, :datetime, precision: nil
-    add_index :refunds, :fee_retention_retry_at, name: "index_refunds_on_fee_retention_retry_at"
+    change_table :refunds, bulk: true do |t|
+      t.datetime :fee_retention_retry_at, precision: nil
+      t.index :fee_retention_retry_at, name: "index_refunds_on_fee_retention_retry_at"
+    end
   end
 end

--- a/db/migrate/20261211140000_add_fee_retention_retry_at_to_refunds.rb
+++ b/db/migrate/20261211140000_add_fee_retention_retry_at_to_refunds.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Indexed dispatch for outstanding refund fee retention / debit retry work.
+# JSON markers alone force a history scan; this nullable timestamp is set while
+# work remains and cleared when retention + holding reconcile are finished.
+class AddFeeRetentionRetryAtToRefunds < ActiveRecord::Migration[7.1]
+  def change
+    add_column :refunds, :fee_retention_retry_at, :datetime, precision: nil
+    add_index :refunds, :fee_retention_retry_at, name: "index_refunds_on_fee_retention_retry_at"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_11_125458) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_11_140000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2226,7 +2226,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_11_125458) do
     t.integer "fee_cents"
     t.bigint "flags", default: 0, null: false
     t.bigint "seller_id"
+    t.datetime "fee_retention_retry_at", precision: nil
     t.index ["created_at"], name: "index_refunds_on_created_at"
+    t.index ["fee_retention_retry_at"], name: "index_refunds_on_fee_retention_retry_at"
     t.index ["link_id"], name: "index_refunds_on_link_id"
     t.index ["processor_refund_id"], name: "index_refunds_on_processor_refund_id"
     t.index ["purchase_id"], name: "index_refunds_on_purchase_id"

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -3954,16 +3954,12 @@ describe StripeChargeProcessor, :vcr do
 
       credit = create(:credit, user: @merchant_account.user, amount_cents: 1000, merchant_account_id: @merchant_account.id, fee_retention_refund: create(:refund))
 
-      expect_any_instance_of(Refund).to receive(:update!).with({ debited_stripe_transfer: anything })
-
       described_class.debit_stripe_account_for_refund_fee(credit:)
     end
 
     it "reverses the earliest sale transfer if no internal transfer is present" do
       travel_to(Time.zone.local(2023, 10, 6)) do
         credit = create(:credit, amount_cents: 1000, merchant_account_id: @merchant_account.id, fee_retention_refund: create(:refund))
-
-        expect_any_instance_of(Refund).to receive(:update!).with({ debited_stripe_transfer: anything })
 
         described_class.debit_stripe_account_for_refund_fee(credit:)
       end
@@ -4174,6 +4170,48 @@ describe StripeChargeProcessor, :vcr do
         expect(Stripe::Transfer).not_to receive(:create)
 
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to be_nil
+      end
+
+      it "persists the chosen transfer reversal before submit and resumes it after pending_retry" do
+        create_internal_transfer_payments("tr_eur_1")
+        credit = create_fee_credit
+        refund = credit.fee_retention_refund
+
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_eur_1").and_return(double(id: "tr_eur_1", amount: 2000, amount_reversed: 0, currency: "eur"))
+        expect(Stripe::Transfer).to receive(:create_reversal)
+                                      .with("tr_eur_1", { amount: 920 }, hash_including(idempotency_key: "refund_fee_reversal_#{refund.external_id}"))
+                                      .and_raise(Stripe::APIConnectionError.new("timeout"))
+
+        expect do
+          described_class.debit_stripe_account_for_refund_fee(credit:)
+        end.to raise_error(Stripe::APIConnectionError)
+
+        refund.reload
+        expect(refund.refund_fee_debit_operation).to eq(described_class::FEE_DEBIT_OP_TRANSFER_REVERSAL)
+        expect(refund.refund_fee_debit_transfer_id).to eq("tr_eur_1")
+        expect(refund.refund_fee_debit_amount_cents).to eq(920)
+
+        # Simulate the Credit rescue marker written after a timed-out Stripe call.
+        refund.update!(debited_stripe_transfer: Credit::FEE_DEBIT_PENDING_RETRY)
+
+        # A re-selection would now skip the depleted transfer and fall through to EUR.
+        # Sticky resume must reverse the same transfer instead.
+        expect(Stripe::Transfer).not_to receive(:retrieve)
+        expect(Stripe::Transfer).not_to receive(:list)
+        expect(Stripe::Transfer).not_to receive(:create)
+        transfer_reversal = double(id: "trr_eur_resume", destination_payment_refund: "re_eur_resume")
+        expect(Stripe::Transfer).to receive(:create_reversal)
+                                      .with("tr_eur_1", { amount: 920 }, hash_including(idempotency_key: "refund_fee_reversal_#{refund.external_id}"))
+                                      .and_return(transfer_reversal)
+        expect(Stripe::Refund).to receive(:retrieve)
+                                    .with("re_eur_resume", hash_including(stripe_account: @bg_merchant_account.charge_processor_merchant_id))
+                                    .and_return(double(balance_transaction: "txn_eur_resume"))
+        expect(Stripe::BalanceTransaction).to receive(:retrieve)
+                                                .with("txn_eur_resume", hash_including(stripe_account: @bg_merchant_account.charge_processor_merchant_id))
+                                                .and_return(double(net: -920))
+
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(920)
+        expect(refund.reload.debited_stripe_transfer).to eq("trr_eur_resume")
       end
     end
   end

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -3987,7 +3987,7 @@ describe StripeChargeProcessor, :vcr do
                                     .and_return(destination_refund)
         expect(Stripe::BalanceTransaction).to receive(:retrieve)
                                                 .with("txn_1", hash_including(stripe_account: @cad_merchant_account.charge_processor_merchant_id))
-                                                .and_return(double(net:))
+                                                .and_return(double(net:, currency: "cad"))
         transfer_reversal
       end
 
@@ -4101,7 +4101,7 @@ describe StripeChargeProcessor, :vcr do
                                     .and_return(double(balance_transaction: "txn_eur_1"))
         expect(Stripe::BalanceTransaction).to receive(:retrieve)
                                                 .with("txn_eur_1", hash_including(stripe_account: @bg_merchant_account.charge_processor_merchant_id))
-                                                .and_return(double(net: -920))
+                                                .and_return(double(net: -920, currency: "eur"))
 
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(920)
         expect(credit.fee_retention_refund.reload.debited_stripe_transfer).to eq("trr_eur_1")
@@ -4230,7 +4230,7 @@ describe StripeChargeProcessor, :vcr do
                                     .and_return(double(balance_transaction: "txn_eur_resume"))
         expect(Stripe::BalanceTransaction).to receive(:retrieve)
                                                 .with("txn_eur_resume", hash_including(stripe_account: @bg_merchant_account.charge_processor_merchant_id))
-                                                .and_return(double(net: -920))
+                                                .and_return(double(net: -920, currency: "eur"))
 
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(920)
         expect(refund.reload.debited_stripe_transfer).to eq("trr_eur_resume")

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -4006,7 +4006,7 @@ describe StripeChargeProcessor, :vcr do
 
         # 1000 USD cents * 1.33 = 1330 CAD cents, not the raw USD figure.
         transfer_reversal = stub_reversal_follow_up_calls(transfer_reversal_id: "trr_1", net: -1330)
-        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_cad_1", { amount: 1330 }).and_return(transfer_reversal)
+        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_cad_1", { amount: 1330 }, hash_including(:idempotency_key)).and_return(transfer_reversal)
 
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
         expect(credit.fee_retention_refund.reload.debited_stripe_transfer).to eq("trr_1")
@@ -4029,7 +4029,7 @@ describe StripeChargeProcessor, :vcr do
         expect(Stripe::Transfer).to receive(:retrieve).with("tr_cad_big").and_return(big_transfer)
 
         transfer_reversal = stub_reversal_follow_up_calls(transfer_reversal_id: "trr_2", net: -1330)
-        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_cad_big", { amount: 1330 }).and_return(transfer_reversal)
+        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_cad_big", { amount: 1330 }, hash_including(:idempotency_key)).and_return(transfer_reversal)
 
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
       end
@@ -4043,7 +4043,7 @@ describe StripeChargeProcessor, :vcr do
                                       .and_return([old_transfer])
 
         transfer_reversal = stub_reversal_follow_up_calls(transfer_reversal_id: "trr_3", net: -1330)
-        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_cad_old", { amount: 1330 }).and_return(transfer_reversal)
+        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_cad_old", { amount: 1330 }, hash_including(:idempotency_key)).and_return(transfer_reversal)
 
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
         expect(credit.fee_retention_refund.reload.debited_stripe_transfer).to eq("trr_3")
@@ -4059,7 +4059,7 @@ describe StripeChargeProcessor, :vcr do
         expect(Stripe::Transfer).to receive(:retrieve).with("tr_usd_1").and_return(transfer)
 
         transfer_reversal = stub_reversal_follow_up_calls(transfer_reversal_id: "trr_4", net: -1330)
-        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_usd_1", { amount: 1000 }).and_return(transfer_reversal)
+        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_usd_1", { amount: 1000 }, hash_including(:idempotency_key)).and_return(transfer_reversal)
 
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
       end
@@ -4095,8 +4095,10 @@ describe StripeChargeProcessor, :vcr do
         expect(Stripe::Transfer).to receive(:retrieve).with("tr_eur_1").and_return(double(id: "tr_eur_1", amount: 2000, amount_reversed: 0, currency: "eur"))
 
         transfer_reversal = double(id: "trr_eur_1", destination_payment_refund: "re_eur_1")
-        expect(Stripe::Transfer).not_to receive(:create_reversal).with("tr_bgn_1", anything)
-        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_eur_1", { amount: 920 }).and_return(transfer_reversal)
+        expect(Stripe::Transfer).not_to receive(:create_reversal).with("tr_bgn_1", anything, anything)
+        expect(Stripe::Transfer).to receive(:create_reversal)
+                                      .with("tr_eur_1", { amount: 920 }, hash_including(:idempotency_key))
+                                      .and_return(transfer_reversal)
         expect(Stripe::Transfer).not_to receive(:create)
         expect(Stripe::Refund).to receive(:retrieve)
                                     .with("re_eur_1", hash_including(stripe_account: @bg_merchant_account.charge_processor_merchant_id))

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -4121,7 +4121,8 @@ describe StripeChargeProcessor, :vcr do
         # 1000 USD cents * 0.92 = 920 EUR cents, pulled from the connected account itself.
         expect(Stripe::Transfer).to receive(:create)
                                       .with({ amount: 920, currency: "eur", destination: STRIPE_PLATFORM_ACCOUNT_ID },
-                                            { stripe_account: @bg_merchant_account.charge_processor_merchant_id })
+                                            hash_including(stripe_account: @bg_merchant_account.charge_processor_merchant_id,
+                                                           idempotency_key: "refund_fee_eur_debit_#{credit.fee_retention_refund.external_id}"))
                                       .and_return(double(id: "tr_eur_debit_1"))
 
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(920)
@@ -4137,7 +4138,8 @@ describe StripeChargeProcessor, :vcr do
         expect(Stripe::Transfer).to receive(:list).and_return([])
         expect(Stripe::Transfer).not_to receive(:create_reversal)
         expect(Stripe::Transfer).to receive(:create)
-                                      .with(hash_including(amount: 920, currency: "eur"), anything)
+                                      .with(hash_including(amount: 920, currency: "eur"),
+                                            hash_including(idempotency_key: a_string_starting_with("refund_fee_eur_debit_")))
                                       .and_return(double(id: "tr_eur_debit_2"))
 
         # 920 EUR cents * 1.95583 = 1799.36 BGN stotinki.

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -4126,7 +4126,9 @@ describe StripeChargeProcessor, :vcr do
                                       .and_return(double(id: "tr_eur_debit_1"))
 
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(920)
-        expect(credit.fee_retention_refund.reload.debited_stripe_transfer).to eq("tr_eur_debit_1")
+        refund = credit.fee_retention_refund.reload
+        expect(refund.debited_stripe_transfer).to eq("tr_eur_debit_1")
+        expect(refund.refund_fee_eur_debit_cents).to eq(920)
       end
 
       it "books the EUR debit in BGN at the fixed rate when the account's ledger is still held in BGN" do

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -4172,6 +4172,28 @@ describe StripeChargeProcessor, :vcr do
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to be_nil
       end
 
+      it "records the reversal id even when follow-up Stripe balance lookups fail" do
+        create_internal_transfer_payments("tr_eur_1")
+        credit = create_fee_credit
+        refund = credit.fee_retention_refund
+
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_eur_1").and_return(double(id: "tr_eur_1", amount: 2000, amount_reversed: 0, currency: "eur"))
+        transfer_reversal = double(id: "trr_eur_followup", destination_payment_refund: "re_eur_followup")
+        expect(Stripe::Transfer).to receive(:create_reversal)
+                                      .with("tr_eur_1", { amount: 920 }, hash_including(:idempotency_key))
+                                      .and_return(transfer_reversal)
+        expect(Stripe::Refund).to receive(:retrieve)
+                                    .with("re_eur_followup", hash_including(stripe_account: @bg_merchant_account.charge_processor_merchant_id))
+                                    .and_raise(Stripe::APIConnectionError.new("timeout"))
+
+        expect do
+          described_class.debit_stripe_account_for_refund_fee(credit:)
+        end.to raise_error(Stripe::APIConnectionError)
+
+        expect(refund.reload.debited_stripe_transfer).to eq("trr_eur_followup")
+        expect(refund.refund_fee_debit_operation).to eq(described_class::FEE_DEBIT_OP_TRANSFER_REVERSAL)
+      end
+
       it "persists the chosen transfer reversal before submit and resumes it after pending_retry" do
         create_internal_transfer_payments("tr_eur_1")
         credit = create_fee_credit

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -4064,6 +4064,112 @@ describe StripeChargeProcessor, :vcr do
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
       end
     end
+
+    describe "BGN-settled transfers" do
+      # Stripe rejects reversals on transfers that settled in BGN ("Transfer reversals in
+      # BGN are no longer supported"), so such a transfer must never reach create_reversal.
+      # Only the EUR rate is stubbed: a BGN candidate has to be skipped before any rate lookup.
+      before do
+        allow(described_class).to receive(:get_rate).with("eur").and_return("0.92")
+
+        @bg_merchant_account = create(:merchant_account, charge_processor_merchant_id: "acct_1MdbgS4gcql7bLm", country: "BG", currency: "eur")
+      end
+
+      def create_internal_transfer_payments(*transfer_ids)
+        transfer_ids.each do |transfer_id|
+          create(:payment_completed, user: @bg_merchant_account.user,
+                                     stripe_connect_account_id: @bg_merchant_account.charge_processor_merchant_id,
+                                     stripe_internal_transfer_id: transfer_id)
+        end
+      end
+
+      def create_fee_credit
+        create(:credit, user: @bg_merchant_account.user, amount_cents: 1000, merchant_account_id: @bg_merchant_account.id, fee_retention_refund: create(:refund))
+      end
+
+      it "skips a BGN internal transfer with room and reverses the next eligible transfer" do
+        create_internal_transfer_payments("tr_bgn_1", "tr_eur_1")
+        credit = create_fee_credit
+
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_bgn_1").and_return(double(id: "tr_bgn_1", amount: 5000, amount_reversed: 0, currency: "bgn"))
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_eur_1").and_return(double(id: "tr_eur_1", amount: 2000, amount_reversed: 0, currency: "eur"))
+
+        transfer_reversal = double(id: "trr_eur_1", destination_payment_refund: "re_eur_1")
+        expect(Stripe::Transfer).not_to receive(:create_reversal).with("tr_bgn_1", anything)
+        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_eur_1", { amount: 920 }).and_return(transfer_reversal)
+        expect(Stripe::Transfer).not_to receive(:create)
+        expect(Stripe::Refund).to receive(:retrieve)
+                                    .with("re_eur_1", hash_including(stripe_account: @bg_merchant_account.charge_processor_merchant_id))
+                                    .and_return(double(balance_transaction: "txn_eur_1"))
+        expect(Stripe::BalanceTransaction).to receive(:retrieve)
+                                                .with("txn_eur_1", hash_including(stripe_account: @bg_merchant_account.charge_processor_merchant_id))
+                                                .and_return(double(net: -920))
+
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(920)
+        expect(credit.fee_retention_refund.reload.debited_stripe_transfer).to eq("trr_eur_1")
+      end
+
+      it "debits the account in EUR when every candidate transfer settled in BGN" do
+        create_internal_transfer_payments("tr_bgn_1")
+        credit = create_fee_credit
+
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_bgn_1").and_return(double(id: "tr_bgn_1", amount: 5000, amount_reversed: 0, currency: "bgn"))
+        expect(Stripe::Transfer).to receive(:list)
+                                      .with(hash_including(destination: @bg_merchant_account.charge_processor_merchant_id))
+                                      .and_return([double(id: "tr_bgn_old", amount: 5000, amount_reversed: 0, currency: "BGN")])
+        expect(Stripe::Transfer).not_to receive(:create_reversal)
+        # 1000 USD cents * 0.92 = 920 EUR cents, pulled from the connected account itself.
+        expect(Stripe::Transfer).to receive(:create)
+                                      .with({ amount: 920, currency: "eur", destination: STRIPE_PLATFORM_ACCOUNT_ID },
+                                            { stripe_account: @bg_merchant_account.charge_processor_merchant_id })
+                                      .and_return(double(id: "tr_eur_debit_1"))
+
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(920)
+        expect(credit.fee_retention_refund.reload.debited_stripe_transfer).to eq("tr_eur_debit_1")
+      end
+
+      it "books the EUR debit in BGN at the fixed rate when the account's ledger is still held in BGN" do
+        @bg_merchant_account.update!(currency: "bgn")
+        create_internal_transfer_payments("tr_bgn_1")
+        credit = create_fee_credit
+
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_bgn_1").and_return(double(id: "tr_bgn_1", amount: 5000, amount_reversed: 0, currency: "bgn"))
+        expect(Stripe::Transfer).to receive(:list).and_return([])
+        expect(Stripe::Transfer).not_to receive(:create_reversal)
+        expect(Stripe::Transfer).to receive(:create)
+                                      .with(hash_including(amount: 920, currency: "eur"), anything)
+                                      .and_return(double(id: "tr_eur_debit_2"))
+
+        # 920 EUR cents * 1.95583 = 1799.36 BGN stotinki.
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1799)
+      end
+
+      it "does not debit the account when no transfer is eligible and none settled in BGN" do
+        create_internal_transfer_payments("tr_eur_small")
+        credit = create_fee_credit
+
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_eur_small").and_return(double(id: "tr_eur_small", amount: 500, amount_reversed: 0, currency: "eur"))
+        expect(Stripe::Transfer).to receive(:list).and_return([])
+        expect(Stripe::Transfer).not_to receive(:create_reversal)
+        expect(Stripe::Transfer).not_to receive(:create)
+
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to be_nil
+        expect(credit.fee_retention_refund.reload.debited_stripe_transfer).to be_nil
+      end
+
+      it "does not touch Stripe again once the refund already records a debit" do
+        create_internal_transfer_payments("tr_bgn_1")
+        credit = create_fee_credit
+        credit.fee_retention_refund.update!(debited_stripe_transfer: "tr_eur_debit_1")
+
+        expect(Stripe::Transfer).not_to receive(:retrieve)
+        expect(Stripe::Transfer).not_to receive(:list)
+        expect(Stripe::Transfer).not_to receive(:create_reversal)
+        expect(Stripe::Transfer).not_to receive(:create)
+
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to be_nil
+      end
+    end
   end
 
   describe ".debit_stripe_account_for_australia_backtaxes" do

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -120,11 +120,18 @@ describe Charge, :vcr do
   end
 
   describe "#refund_and_save!" do
+    def stub_purchase_lock(*purchases)
+      purchases.each do |purchase|
+        allow(purchase).to receive(:with_lock).and_yield
+      end
+    end
+
     it "attempts every purchase refund even when one purchase fails" do
       charge = create(:charge)
       failed_errors = instance_double(ActiveModel::Errors, full_messages: ["First refund failed"])
       failed_purchase = instance_double(Purchase, id: 1, refund_and_save!: false, errors: failed_errors)
       successful_purchase = instance_double(Purchase, id: 2, refund_and_save!: true)
+      stub_purchase_lock(failed_purchase, successful_purchase)
       allow(charge).to receive(:successful_purchases).and_return([failed_purchase, successful_purchase])
 
       expect(charge.refund_and_save!(123, reason: "Refund requested by the buyer")).to be(false)
@@ -139,6 +146,7 @@ describe Charge, :vcr do
       first = instance_double(Purchase, id: 1, refund_and_save!: true)
       second_errors = instance_double(ActiveModel::Errors, full_messages: [])
       second = instance_double(Purchase, id: 2, errors: second_errors)
+      stub_purchase_lock(first, second)
       allow(second).to receive(:refund_and_save!).and_raise(RuntimeError, "processor unavailable")
       allow(charge).to receive(:successful_purchases).and_return([first, second])
 

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -125,13 +125,6 @@ describe Charge, :vcr do
       failed_errors = instance_double(ActiveModel::Errors, full_messages: ["First refund failed"])
       failed_purchase = instance_double(Purchase, id: 1, refund_and_save!: false, errors: failed_errors)
       successful_purchase = instance_double(Purchase, id: 2, refund_and_save!: true)
-      # The id-ordered lock pre-pass reloads and row-locks each purchase before any
-      # refund work; stub it out here — the concurrency guarantees are proven by
-      # real-thread coverage in handle_failed_refund_service_concurrency_spec.rb.
-      [failed_purchase, successful_purchase].each do |purchase|
-        allow(purchase).to receive(:reload).and_return(purchase)
-        allow(purchase).to receive(:lock!).and_return(purchase)
-      end
       allow(charge).to receive(:successful_purchases).and_return([failed_purchase, successful_purchase])
 
       expect(charge.refund_and_save!(123, reason: "Refund requested by the buyer")).to be(false)
@@ -139,6 +132,18 @@ describe Charge, :vcr do
       expect(failed_purchase).to have_received(:refund_and_save!).with(123, reason: "Refund requested by the buyer")
       expect(successful_purchase).to have_received(:refund_and_save!).with(123, reason: "Refund requested by the buyer")
       expect(charge.errors[:base]).to include("First refund failed")
+    end
+
+    it "keeps an earlier purchase refund when a later purchase raises" do
+      charge = create(:charge)
+      first = instance_double(Purchase, id: 1, refund_and_save!: true)
+      second_errors = instance_double(ActiveModel::Errors, full_messages: [])
+      second = instance_double(Purchase, id: 2, errors: second_errors)
+      allow(second).to receive(:refund_and_save!).and_raise(RuntimeError, "processor unavailable")
+      allow(charge).to receive(:successful_purchases).and_return([first, second])
+
+      expect { charge.refund_and_save!(123, reason: "Refund requested by the buyer") }.to raise_error(RuntimeError, "processor unavailable")
+      expect(first).to have_received(:refund_and_save!).with(123, reason: "Refund requested by the buyer")
     end
   end
 

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -502,8 +502,14 @@ describe Credit do
                                       .and_return(double(id: "tr_us_fee_legacy"))
 
         credit = Credit.create_for_refund_fee_retention!(refund:)
-        # Simulate pre-patch US success: ledger complete, marker never recorded.
-        refund.update!(debited_stripe_transfer: nil)
+        # Simulate pre-patch US success: ledger complete, no debit marker or retry metadata.
+        refund.update!(
+          debited_stripe_transfer: nil,
+          refund_fee_debit_operation: nil,
+          refund_fee_debit_amount_cents: nil,
+          refund_fee_debit_submitted_at: nil,
+          refund_fee_debit_generation: nil
+        )
         expect(credit.reload.balance_id).to be_present
 
         expect(Stripe::Transfer).not_to receive(:create)

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -446,7 +446,7 @@ describe Credit do
         expect(credit.balance_transaction.issued_amount_net_cents).to eq(-33)
         expect(credit.balance_transaction.holding_amount_net_cents).to eq(-33)
         expect(refund.reload.retained_fee_cents).to eq(33)
-        expect(refund.debited_stripe_transfer).to be_nil
+        expect(refund.debited_stripe_transfer).to eq(Credit::FEE_DEBIT_PENDING_RETRY)
         expect(creator.reload.unpaid_balance_cents).to eq(-33)
         expect(ErrorNotifier).to have_received(:notify).with(stripe_error, hash_including(context: hash_including(refund_id: refund.id)))
       end
@@ -462,7 +462,7 @@ describe Credit do
         end
 
         credit = Credit.create_for_refund_fee_retention!(refund:)
-        expect(refund.reload.debited_stripe_transfer).to be_nil
+        expect(refund.reload.debited_stripe_transfer).to eq(Credit::FEE_DEBIT_PENDING_RETRY)
 
         expect do
           expect(Credit.create_for_refund_fee_retention!(refund:)).to eq(credit)

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -529,6 +529,39 @@ describe Credit do
         expect(attempts).to eq(2)
       end
     end
+
+    describe "when a successful non-US debit retry returns a different holding amount" do
+      let!(:merchant_account) { create(:merchant_account, user: creator, country: "CA", currency: "cad") }
+
+      before do
+        allow(ErrorNotifier).to receive(:notify)
+        allow(StripeChargeProcessor).to receive(:get_rate).with("cad").and_return("1.33")
+      end
+
+      it "adjusts the unpaid balance holding total to the actual Stripe debit" do
+        attempts = 0
+        allow(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee) do |credit:|
+          attempts += 1
+          if attempts == 1
+            raise Stripe::APIConnectionError, "timeout"
+          end
+
+          credit.fee_retention_refund.update!(debited_stripe_transfer: "trr_holding")
+          1400
+        end
+
+        credit = Credit.create_for_refund_fee_retention!(refund:)
+        expect(refund.reload.debited_stripe_transfer).to eq(Credit::FEE_DEBIT_PENDING_RETRY)
+        estimated = credit.balance_transaction.holding_amount_net_cents
+        expect(estimated).to be < 0
+
+        balance_before = credit.balance.holding_amount_cents
+        expect(Credit.create_for_refund_fee_retention!(refund:)).to eq(credit)
+        expect(attempts).to eq(2)
+        expect(refund.reload.refund_fee_holding_debit_cents).to eq(1400)
+        expect(credit.balance.reload.holding_amount_cents).to eq(balance_before + (-1400 - estimated))
+      end
+    end
   end
 
   describe "create_for_balance_change_on_stripe_account!" do

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -424,6 +424,74 @@ describe Credit do
         Credit.create_for_refund_fee_retention!(refund:)
       end.not_to change { refund.purchase.seller.comments.count }
     end
+
+    # The retention runs after the refund has committed and the buyer has their money back,
+    # so a Stripe failure must leave a durable ledger entry and a retry that only finishes
+    # the Stripe side — never a second retention and never a second Stripe debit.
+    describe "when the Stripe debit fails for a Gumroad-controlled non-US account" do
+      let!(:merchant_account) { create(:merchant_account, user: creator, country: "AE") }
+      let(:stripe_error) { Stripe::InvalidRequestError.new("Transfer reversals in BGN are no longer supported", nil) }
+
+      before do
+        allow(ErrorNotifier).to receive(:notify)
+      end
+
+      it "books the retained fee locally, reports the failure, and leaves the Stripe debit for a retry" do
+        expect(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).with(credit: an_instance_of(Credit)).and_raise(stripe_error)
+
+        credit = Credit.create_for_refund_fee_retention!(refund:)
+
+        expect(credit).to be_persisted
+        expect(credit.amount_cents).to eq(-33)
+        expect(credit.balance_transaction.issued_amount_net_cents).to eq(-33)
+        expect(credit.balance_transaction.holding_amount_net_cents).to eq(-33)
+        expect(refund.reload.retained_fee_cents).to eq(33)
+        expect(refund.debited_stripe_transfer).to be_nil
+        expect(creator.reload.unpaid_balance_cents).to eq(-33)
+        expect(ErrorNotifier).to have_received(:notify).with(stripe_error, hash_including(context: hash_including(refund_id: refund.id)))
+      end
+
+      it "retries only the Stripe debit when called again, and stops once the debit is recorded" do
+        attempts = 0
+        allow(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee) do |credit:|
+          attempts += 1
+          raise stripe_error if attempts == 1
+
+          credit.fee_retention_refund.update!(debited_stripe_transfer: "trr_retry")
+          33
+        end
+
+        credit = Credit.create_for_refund_fee_retention!(refund:)
+        expect(refund.reload.debited_stripe_transfer).to be_nil
+
+        expect do
+          expect(Credit.create_for_refund_fee_retention!(refund:)).to eq(credit)
+        end.not_to change { [Credit.count, BalanceTransaction.count, creator.reload.unpaid_balance_cents] }
+        expect(refund.reload.debited_stripe_transfer).to eq("trr_retry")
+
+        expect(Credit.create_for_refund_fee_retention!(refund:)).to eq(credit)
+        expect(attempts).to eq(2)
+      end
+    end
+
+    describe "when re-run for a Gumroad-controlled US account" do
+      let!(:merchant_account) { create(:merchant_account, user: creator, country: "US") }
+
+      it "records the debit transfer on the refund and does not debit Stripe a second time" do
+        allow(Stripe::Account).to receive(:retrieve).and_return(double(id: "acct_platform"))
+        expect(Stripe::Transfer).to receive(:create)
+                                      .with({ amount: 33, currency: "usd", destination: "acct_platform" }, { stripe_account: merchant_account.charge_processor_merchant_id })
+                                      .once
+                                      .and_return(double(id: "tr_us_fee_1"))
+
+        credit = Credit.create_for_refund_fee_retention!(refund:)
+        expect(refund.reload.debited_stripe_transfer).to eq("tr_us_fee_1")
+
+        expect do
+          expect(Credit.create_for_refund_fee_retention!(refund:)).to eq(credit)
+        end.not_to change { [Credit.count, creator.reload.unpaid_balance_cents] }
+      end
+    end
   end
 
   describe "create_for_balance_change_on_stripe_account!" do

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -508,6 +508,26 @@ describe Credit do
         expect(Stripe::Transfer).not_to receive(:create)
         expect(Credit.create_for_refund_fee_retention!(refund:)).to eq(credit)
       end
+
+      it "retries a US debit that failed after booking the local ledger" do
+        allow(Stripe::Account).to receive(:retrieve).and_return(double(id: "acct_platform"))
+        allow(ErrorNotifier).to receive(:notify)
+        attempts = 0
+        allow(Stripe::Transfer).to receive(:create) do
+          attempts += 1
+          raise Stripe::APIConnectionError, "timeout" if attempts == 1
+
+          double(id: "tr_us_fee_retry")
+        end
+
+        credit = Credit.create_for_refund_fee_retention!(refund:)
+        expect(refund.reload.debited_stripe_transfer).to eq(Credit::FEE_DEBIT_PENDING_RETRY)
+        expect(credit).to be_persisted
+
+        expect(Credit.create_for_refund_fee_retention!(refund:)).to eq(credit)
+        expect(refund.reload.debited_stripe_transfer).to eq("tr_us_fee_retry")
+        expect(attempts).to eq(2)
+      end
     end
   end
 

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -449,6 +449,7 @@ describe Credit do
         expect(refund.debited_stripe_transfer).to eq(Credit::FEE_DEBIT_PENDING_RETRY)
         expect(creator.reload.unpaid_balance_cents).to eq(-33)
         expect(ErrorNotifier).to have_received(:notify).with(stripe_error, hash_including(context: hash_including(refund_id: refund.id)))
+        expect(RetryRefundFeeRetentionJob).to have_enqueued_sidekiq_job(refund.id).in(1.minute)
       end
 
       it "retries only the Stripe debit when called again, and stops once the debit is recorded" do

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -559,7 +559,13 @@ describe Credit do
         expect(Credit.create_for_refund_fee_retention!(refund:)).to eq(credit)
         expect(attempts).to eq(2)
         expect(refund.reload.refund_fee_holding_debit_cents).to eq(1400)
-        expect(credit.balance.reload.holding_amount_cents).to eq(balance_before + (-1400 - estimated))
+        expect(refund.refund_fee_holding_reconciled_cents).to eq(1400)
+        expected_holding = balance_before + (-1400 - estimated)
+        expect(credit.balance.reload.holding_amount_cents).to eq(expected_holding)
+
+        # A further retry must not subtract the estimate delta again.
+        expect(Credit.create_for_refund_fee_retention!(refund:)).to eq(credit)
+        expect(credit.balance.reload.holding_amount_cents).to eq(expected_holding)
       end
     end
   end

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -480,7 +480,9 @@ describe Credit do
       it "records the debit transfer on the refund and does not debit Stripe a second time" do
         allow(Stripe::Account).to receive(:retrieve).and_return(double(id: "acct_platform"))
         expect(Stripe::Transfer).to receive(:create)
-                                      .with({ amount: 33, currency: "usd", destination: "acct_platform" }, { stripe_account: merchant_account.charge_processor_merchant_id })
+                                      .with({ amount: 33, currency: "usd", destination: "acct_platform" },
+                                            hash_including(stripe_account: merchant_account.charge_processor_merchant_id,
+                                                           idempotency_key: "refund_fee_us_debit_#{refund.external_id}"))
                                       .once
                                       .and_return(double(id: "tr_us_fee_1"))
 
@@ -490,6 +492,21 @@ describe Credit do
         expect do
           expect(Credit.create_for_refund_fee_retention!(refund:)).to eq(credit)
         end.not_to change { [Credit.count, creator.reload.unpaid_balance_cents] }
+      end
+
+      it "does not re-debit a legacy US retention that completed without a debit marker" do
+        allow(Stripe::Account).to receive(:retrieve).and_return(double(id: "acct_platform"))
+        expect(Stripe::Transfer).to receive(:create)
+                                      .once
+                                      .and_return(double(id: "tr_us_fee_legacy"))
+
+        credit = Credit.create_for_refund_fee_retention!(refund:)
+        # Simulate pre-patch US success: ledger complete, marker never recorded.
+        refund.update!(debited_stripe_transfer: nil)
+        expect(credit.reload.balance_id).to be_present
+
+        expect(Stripe::Transfer).not_to receive(:create)
+        expect(Credit.create_for_refund_fee_retention!(refund:)).to eq(credit)
       end
     end
   end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -482,17 +482,29 @@ describe Payment do
   end
 
   describe "#credit_amount_cents" do
-    it "does not include credits created for refund fee retention" do
+    it "does not include fee-retention credits folded into retained_fee_cents" do
       creator = create(:user)
       balance = create(:balance, user: creator)
       purchase = create(:purchase, succeeded_at: 10.days.ago, link: create(:product, user: creator))
       refund = create(:refund, purchase:, fee_cents: 100)
+      refund.update!(retained_fee_cents: 100)
       credit = create(:credit, user: creator, amount_cents: -100, fee_retention_refund: refund, balance:)
       payment = create(:payment, balances: [balance])
 
       expect(credit.fee_retention_refund).to eq(refund)
       expect(credit.balance).to eq(balance)
       expect(payment.credit_amount_cents).to eq(0)
+    end
+
+    it "includes separately booked fee-retention credits without retained_fee_cents" do
+      creator = create(:user)
+      balance = create(:balance, user: creator)
+      purchase = create(:purchase, succeeded_at: 10.days.ago, link: create(:product, user: creator))
+      refund = create(:refund, purchase:, fee_cents: 100)
+      create(:credit, user: creator, amount_cents: -100, fee_retention_refund: refund, balance:)
+      payment = create(:payment, balances: [balance])
+
+      expect(payment.credit_amount_cents).to eq(-100)
     end
   end
 

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -1897,6 +1897,33 @@ describe "PurchaseRefunds", :vcr do
           hash_including(context: hash_including(refund_id: refund.id))
         )
       end
+
+      it "runs fee retention only after the enclosing transaction commits" do
+        admin = create(:admin_user)
+        expect(ChargeProcessor).to receive(:refund!).and_return(build_charge_refund(@purchase.total_transaction_cents))
+        allow(Credit).to receive(:create_for_refund_fee_retention!).and_return(nil)
+
+        ActiveRecord::Base.transaction do
+          expect(@purchase.refund_and_save!(admin.id, reason: "Refund requested by the buyer")).to be(true)
+          expect(Credit).not_to have_received(:create_for_refund_fee_retention!)
+        end
+
+        expect(Credit).to have_received(:create_for_refund_fee_retention!)
+        expect(@purchase.reload.refunds).to be_present
+      end
+
+      it "does not debit the fee when the enclosing transaction rolls back" do
+        admin = create(:admin_user)
+        expect(ChargeProcessor).to receive(:refund!).and_return(build_charge_refund(@purchase.total_transaction_cents))
+        allow(Credit).to receive(:create_for_refund_fee_retention!)
+
+        ActiveRecord::Base.transaction do
+          expect(@purchase.refund_and_save!(admin.id, reason: "Refund requested by the buyer")).to be(true)
+          raise ActiveRecord::Rollback
+        end
+
+        expect(Credit).not_to have_received(:create_for_refund_fee_retention!)
+      end
     end
 
     describe "Low balance related sidekiq jobs" do

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -1814,6 +1814,69 @@ describe "PurchaseRefunds", :vcr do
       end
     end
 
+    context "when the fee debit fails after the processor refund succeeded" do
+      # By the time the fee is retained, the processor has already returned the buyer's
+      # money: the refund rows must stay committed and the fee has to be recoverable by
+      # re-running the retention, never by touching the buyer's refund again.
+      let(:stripe_error) { Stripe::InvalidRequestError.new("Transfer reversals in BGN are no longer supported", nil) }
+
+      def build_charge_refund(cents)
+        stripe_refund = double("stripe_refund", status: "succeeded", id: "re_fee_debit_failure")
+        charge_refund = ChargeRefund.new
+        charge_refund.charge_processor_id = StripeChargeProcessor.charge_processor_id
+        charge_refund.id = stripe_refund.id
+        charge_refund.flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -cents)
+        charge_refund.instance_variable_set(:@refund, stripe_refund)
+        charge_refund
+      end
+
+      before do
+        @attempts = 0
+        allow(Credit).to receive(:create_for_refund_fee_retention!).and_wrap_original do |original, *args, **kwargs|
+          @attempts += 1
+          raise stripe_error if @attempts == 1
+
+          original.call(*args, **kwargs)
+        end
+        allow(ErrorNotifier).to receive(:notify)
+      end
+
+      it "keeps the full refund committed, reports the failure, and lets the fee retention be re-run" do
+        admin = create(:admin_user)
+        expect(ChargeProcessor).to receive(:refund!).and_return(build_charge_refund(@purchase.total_transaction_cents))
+
+        expect(@purchase.refund_and_save!(admin.id, reason: "Refund requested by the buyer")).to be(true)
+
+        @purchase.reload
+        refund = @purchase.refunds.sole
+        expect(@purchase.stripe_refunded).to be(true)
+        expect(refund.processor_refund_id).to eq("re_fee_debit_failure")
+        expect(refund.balance_transactions.where(user: @purchase.seller)).to exist
+        expect(Credit.where(fee_retention_refund: refund)).to be_empty
+        expect(ErrorNotifier).to have_received(:notify).with(
+          "Failed to retain refund fee after refund",
+          hash_including(context: hash_including(purchase_id: @purchase.id, refund_id: refund.id))
+        )
+
+        credit = Credit.create_for_refund_fee_retention!(refund:)
+
+        expect(credit.fee_retention_refund).to eq(refund)
+        expect(refund.reload.retained_fee_cents).to eq(credit.amount_cents.abs)
+        expect(@purchase.reload.refunds.count).to eq(1)
+        expect(@attempts).to eq(2)
+      end
+
+      it "keeps a partial refund committed when the fee debit fails" do
+        expect(@purchase.refund_partial_purchase!(@purchase.price_cents / 2, @refunding_user.id)).to be(true)
+
+        @purchase.reload
+        expect(@purchase.stripe_partially_refunded).to be(true)
+        expect(@purchase.refunds.count).to eq(1)
+        expect(Credit.where(fee_retention_refund: @purchase.refunds.sole)).to be_empty
+        expect(ErrorNotifier).to have_received(:notify).with("Failed to retain refund fee after refund", anything)
+      end
+    end
+
     describe "Low balance related sidekiq jobs" do
       before do
         @flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, @purchase.price_cents)

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -1875,6 +1875,28 @@ describe "PurchaseRefunds", :vcr do
         expect(Credit.where(fee_retention_refund: @purchase.refunds.sole)).to be_empty
         expect(ErrorNotifier).to have_received(:notify).with("Failed to retain refund fee after refund", anything)
       end
+
+      it "keeps a Stripe debit marker when ledger booking fails under the retention locks" do
+        admin = create(:admin_user)
+        expect(ChargeProcessor).to receive(:refund!).and_return(build_charge_refund(@purchase.total_transaction_cents))
+
+        allow(Credit).to receive(:create_for_refund_fee_retention!).and_wrap_original do |_original, refund:|
+          # Mimic Stripe success + marker write inside the enclosing retention transaction,
+          # then a ledger failure. The purchase helper must commit so the marker survives.
+          refund.update!(debited_stripe_transfer: "trr_marker_survives")
+          raise ActiveRecord::RecordInvalid, Credit.new
+        end
+
+        expect(@purchase.refund_and_save!(admin.id, reason: "Refund requested by the buyer")).to be(true)
+
+        refund = @purchase.reload.refunds.sole
+        expect(refund.debited_stripe_transfer).to eq("trr_marker_survives")
+        expect(Credit.where(fee_retention_refund: refund)).to be_empty
+        expect(ErrorNotifier).to have_received(:notify).with(
+          "Failed to retain refund fee after refund",
+          hash_including(context: hash_including(refund_id: refund.id))
+        )
+      end
     end
 
     describe "Low balance related sidekiq jobs" do

--- a/spec/services/purchase/handle_failed_refund_service_concurrency_spec.rb
+++ b/spec/services/purchase/handle_failed_refund_service_concurrency_spec.rb
@@ -270,11 +270,11 @@ describe Purchase::HandleFailedRefundService, "concurrency" do
     expect(@purchase.amount_refundable_cents).to eq(1400)
   end
 
-  # Combined-charge version of the lock-cycle scenario. A charge refund updates every
-  # purchase in the charge plus the shared seller balance inside one transaction; before
-  # the id-ordered lock pre-pass in Charge#refund_and_save! its acquisition order was
-  # purchase₁ → balance → purchase₂, so a sibling failed-refund reversal holding
-  # purchase₂ and waiting for the balance completed a deadlock cycle.
+  # Combined-charge version of the lock-cycle scenario. Charge#refund_and_save! now
+  # commits each purchase under its own with_lock before starting the next, so it never
+  # holds the shared balance while waiting for a later purchase row. A sibling reversal
+  # can lock purchase₂ while the charge refund is still on purchase₁, and both finish
+  # without a deadlock once the balance lock is free.
   it "does not create a lock cycle between a combined-charge refund and a sibling reversal" do
     purchase_two = create(:purchase_with_balance,
                           link: @product,
@@ -319,20 +319,18 @@ describe Purchase::HandleFailedRefundService, "concurrency" do
 
     payout_has_balance_lock = Queue.new
     release_payout = Queue.new
-    charge_refund_locked_purchases = Queue.new
+    charge_refund_locked_first_purchase = Queue.new
     reversal_worker_started = Queue.new
     reversal_has_purchase_lock = Queue.new
 
-    locked_by_charge_refund = []
     allow_any_instance_of(Purchase).to receive(:lock!).and_wrap_original do |method, *args|
       result = method.call(*args)
       purchase_id = method.receiver.id
       case Thread.current[:refund_concurrency_role]
       when :charge_refund
-        locked_by_charge_refund << purchase_id
-        # Fires once the charge refund holds BOTH purchase rows; with the up-front
-        # id-ordered pre-pass this happens before any balance work.
-        charge_refund_locked_purchases << true if (locked_by_charge_refund.uniq - [@purchase.id, purchase_two.id]).empty? && locked_by_charge_refund.uniq.size == 2
+        # Per-purchase commits: signal as soon as purchase₁ is locked (charge is then
+        # blocked on the payout-held balance, before purchase₂ is touched).
+        charge_refund_locked_first_purchase << true if purchase_id == @purchase.id
       when :reversal
         reversal_has_purchase_lock << true if purchase_id == purchase_two.id
       end
@@ -341,7 +339,7 @@ describe Purchase::HandleFailedRefundService, "concurrency" do
 
     shared_balance_id = Balance.where(user: @seller).order(:id).last.id
     threads = []
-    reversal_overtook_charge_refund = nil
+    reversal_locked_purchase_two_while_charge_in_flight = nil
     begin
       threads << start_worker(:payout) do
         Balance.find(shared_balance_id).with_lock do
@@ -354,24 +352,23 @@ describe Purchase::HandleFailedRefundService, "concurrency" do
       threads << start_worker(:charge_refund) do
         raise "Charge refund failed" unless Charge.find(charge.id).refund_and_save!(@seller.id)
       end
-      # The charge refund must be holding both purchase rows (and therefore blocked
-      # on the payout-held balance) before the sibling reversal starts.
-      wait_for(charge_refund_locked_purchases)
+      # Charge refund holds purchase₁ and is blocked on the payout-held balance.
+      wait_for(charge_refund_locked_first_purchase)
 
       threads << start_worker(:reversal) do
         reversal_worker_started << true
         described_class.new(refund: Refund.find(failed_refund.id)).perform
       end
       wait_for(reversal_worker_started)
-      reversal_overtook_charge_refund = received_within?(reversal_has_purchase_lock)
+      # purchase₂ is free while the charge refund is still on purchase₁, so the
+      # reversal can take it without waiting — and without forming a deadlock.
+      reversal_locked_purchase_two_while_charge_in_flight = received_within?(reversal_has_purchase_lock)
     ensure
       release_payout << true
       join_workers(*threads)
     end
 
-    # The reversal queued behind the charge refund's purchase lock instead of
-    # slipping between the per-purchase refunds and closing the deadlock cycle.
-    expect(reversal_overtook_charge_refund).to eq(false)
+    expect(reversal_locked_purchase_two_while_charge_in_flight).to eq(true)
 
     failed_transactions = BalanceTransaction.where(refund_id: failed_refund.id)
     expect(failed_transactions.count).to eq(2)

--- a/spec/sidekiq/retry_pending_refund_fee_debits_job_spec.rb
+++ b/spec/sidekiq/retry_pending_refund_fee_debits_job_spec.rb
@@ -4,40 +4,34 @@ require "spec_helper"
 
 describe RetryPendingRefundFeeDebitsJob do
   describe "#perform" do
-    it "retries refunds marked pending_retry" do
+    it "enqueues per-refund retries for pending_retry refunds inside the window" do
       pending = create(:refund)
       pending.update!(debited_stripe_transfer: Credit::FEE_DEBIT_PENDING_RETRY)
       other = create(:refund)
       other.update!(debited_stripe_transfer: "tr_done")
 
-      expect(Credit).to receive(:create_for_refund_fee_retention!).with(refund: pending)
-      expect(Credit).not_to receive(:create_for_refund_fee_retention!).with(refund: other)
-
       described_class.new.perform
+
+      expect(RetryRefundFeeRetentionJob).to have_enqueued_sidekiq_job(pending.id)
+      expect(RetryRefundFeeRetentionJob).not_to have_enqueued_sidekiq_job(other.id)
     end
 
-    it "retries refunds with fee retention still pending" do
+    it "enqueues refunds with fee retention still pending" do
       pending = create(:refund)
       pending.update!(refund_fee_retention_pending: true)
 
-      expect(Credit).to receive(:create_for_refund_fee_retention!).with(refund: pending)
-
       described_class.new.perform
+
+      expect(RetryRefundFeeRetentionJob).to have_enqueued_sidekiq_job(pending.id)
     end
 
-    it "continues when one refund raises" do
-      first = create(:refund)
-      first.update!(debited_stripe_transfer: Credit::FEE_DEBIT_PENDING_RETRY)
-      second = create(:refund)
-      second.update!(debited_stripe_transfer: Credit::FEE_DEBIT_PENDING_RETRY)
-      allow(Credit).to receive(:create_for_refund_fee_retention!).with(refund: first).and_raise(Stripe::StripeError, "boom")
-      allow(Credit).to receive(:create_for_refund_fee_retention!).with(refund: second)
-      allow(ErrorNotifier).to receive(:notify)
+    it "skips refunds older than the idempotency window" do
+      stale = create(:refund, created_at: (Credit::FEE_DEBIT_IDEMPOTENCY_WINDOW + 1.hour).ago)
+      stale.update!(debited_stripe_transfer: Credit::FEE_DEBIT_PENDING_RETRY)
 
       described_class.new.perform
 
-      expect(Credit).to have_received(:create_for_refund_fee_retention!).with(refund: second)
-      expect(ErrorNotifier).to have_received(:notify).with(instance_of(Stripe::StripeError), hash_including(context: hash_including(refund_id: first.id)))
+      expect(RetryRefundFeeRetentionJob).not_to have_enqueued_sidekiq_job(stale.id)
     end
   end
 end

--- a/spec/sidekiq/retry_pending_refund_fee_debits_job_spec.rb
+++ b/spec/sidekiq/retry_pending_refund_fee_debits_job_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe RetryPendingRefundFeeDebitsJob do
+  describe "#perform" do
+    it "retries refunds marked pending_retry" do
+      pending = create(:refund)
+      pending.update!(debited_stripe_transfer: Credit::FEE_DEBIT_PENDING_RETRY)
+      other = create(:refund)
+      other.update!(debited_stripe_transfer: "tr_done")
+
+      expect(Credit).to receive(:create_for_refund_fee_retention!).with(refund: pending)
+      expect(Credit).not_to receive(:create_for_refund_fee_retention!).with(refund: other)
+
+      described_class.new.perform
+    end
+
+    it "continues when one refund raises" do
+      first = create(:refund)
+      first.update!(debited_stripe_transfer: Credit::FEE_DEBIT_PENDING_RETRY)
+      second = create(:refund)
+      second.update!(debited_stripe_transfer: Credit::FEE_DEBIT_PENDING_RETRY)
+      allow(Credit).to receive(:create_for_refund_fee_retention!).with(refund: first).and_raise(Stripe::StripeError, "boom")
+      allow(Credit).to receive(:create_for_refund_fee_retention!).with(refund: second)
+      allow(ErrorNotifier).to receive(:notify)
+
+      described_class.new.perform
+
+      expect(Credit).to have_received(:create_for_refund_fee_retention!).with(refund: second)
+      expect(ErrorNotifier).to have_received(:notify).with(instance_of(Stripe::StripeError), hash_including(context: hash_including(refund_id: first.id)))
+    end
+  end
+end

--- a/spec/sidekiq/retry_pending_refund_fee_debits_job_spec.rb
+++ b/spec/sidekiq/retry_pending_refund_fee_debits_job_spec.rb
@@ -4,11 +4,14 @@ require "spec_helper"
 
 describe RetryPendingRefundFeeDebitsJob do
   describe "#perform" do
-    it "enqueues per-refund retries for pending_retry refunds" do
+    it "enqueues per-refund retries for indexed pending work" do
       pending = create(:refund)
-      pending.update!(debited_stripe_transfer: Credit::FEE_DEBIT_PENDING_RETRY)
+      pending.update!(
+        debited_stripe_transfer: Credit::FEE_DEBIT_PENDING_RETRY,
+        fee_retention_retry_at: 1.minute.ago
+      )
       other = create(:refund)
-      other.update!(debited_stripe_transfer: "tr_done")
+      other.update!(debited_stripe_transfer: "tr_done", fee_retention_retry_at: nil)
 
       described_class.new.perform
 
@@ -18,11 +21,20 @@ describe RetryPendingRefundFeeDebitsJob do
 
     it "enqueues refunds with fee retention still pending" do
       pending = create(:refund)
-      pending.update!(refund_fee_retention_pending: true)
+      pending.update!(refund_fee_retention_pending: true, fee_retention_retry_at: Time.current)
 
       described_class.new.perform
 
       expect(RetryRefundFeeRetentionJob).to have_enqueued_sidekiq_job(pending.id)
+    end
+
+    it "skips work scheduled in the future" do
+      pending = create(:refund)
+      pending.update!(fee_retention_retry_at: 1.hour.from_now)
+
+      described_class.new.perform
+
+      expect(RetryRefundFeeRetentionJob).not_to have_enqueued_sidekiq_job(pending.id)
     end
   end
 end

--- a/spec/sidekiq/retry_pending_refund_fee_debits_job_spec.rb
+++ b/spec/sidekiq/retry_pending_refund_fee_debits_job_spec.rb
@@ -16,6 +16,15 @@ describe RetryPendingRefundFeeDebitsJob do
       described_class.new.perform
     end
 
+    it "retries refunds with fee retention still pending" do
+      pending = create(:refund)
+      pending.update!(refund_fee_retention_pending: true)
+
+      expect(Credit).to receive(:create_for_refund_fee_retention!).with(refund: pending)
+
+      described_class.new.perform
+    end
+
     it "continues when one refund raises" do
       first = create(:refund)
       first.update!(debited_stripe_transfer: Credit::FEE_DEBIT_PENDING_RETRY)

--- a/spec/sidekiq/retry_pending_refund_fee_debits_job_spec.rb
+++ b/spec/sidekiq/retry_pending_refund_fee_debits_job_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe RetryPendingRefundFeeDebitsJob do
   describe "#perform" do
-    it "enqueues per-refund retries for pending_retry refunds inside the window" do
+    it "enqueues per-refund retries for pending_retry refunds" do
       pending = create(:refund)
       pending.update!(debited_stripe_transfer: Credit::FEE_DEBIT_PENDING_RETRY)
       other = create(:refund)
@@ -23,15 +23,6 @@ describe RetryPendingRefundFeeDebitsJob do
       described_class.new.perform
 
       expect(RetryRefundFeeRetentionJob).to have_enqueued_sidekiq_job(pending.id)
-    end
-
-    it "skips refunds older than the idempotency window" do
-      stale = create(:refund, created_at: (Credit::FEE_DEBIT_IDEMPOTENCY_WINDOW + 1.hour).ago)
-      stale.update!(debited_stripe_transfer: Credit::FEE_DEBIT_PENDING_RETRY)
-
-      described_class.new.perform
-
-      expect(RetryRefundFeeRetentionJob).not_to have_enqueued_sidekiq_job(stale.id)
     end
   end
 end

--- a/spec/sidekiq/retry_refund_fee_retention_job_spec.rb
+++ b/spec/sidekiq/retry_refund_fee_retention_job_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe RetryRefundFeeRetentionJob do
+  describe "#perform" do
+    it "re-runs fee retention for the refund" do
+      refund = create(:refund)
+      expect(Credit).to receive(:create_for_refund_fee_retention!).with(refund:)
+
+      described_class.new.perform(refund.id)
+    end
+
+    it "no-ops when the refund is missing" do
+      expect(Credit).not_to receive(:create_for_refund_fee_retention!)
+
+      described_class.new.perform(-1)
+    end
+
+    it "skips refunds whose balance was reversed on failure" do
+      refund = create(:refund)
+      refund.update!(balance_reversed_on_failure: true)
+      expect(Credit).not_to receive(:create_for_refund_fee_retention!)
+
+      described_class.new.perform(refund.id)
+    end
+  end
+end


### PR DESCRIPTION
## What

Makes refund fee bookkeeping durable and recovers refund fees from Bulgarian (formerly BGN-settled) Gumroad-managed Stripe accounts without reversing BGN transfers.

- `Purchase#refund_purchase!` and `#refund_partial_purchase!` retain the processor fee after the refund transaction commits, in the same step that disables licenses. A failure while retaining the fee is logged and reported to Sentry instead of raising through the refund.
- Fee retention checks eligibility under purchase/refund locks, then runs Stripe outside that transaction so sticky debit choices and success markers are real commits. Ledger booking re-takes the locks and re-checks failed-refund reversal.
- `Credit.create_for_refund_fee_retention!` is idempotent. Re-running it for a refund that already has a retention credit does not create a second credit; it only finishes the Stripe debit if still outstanding. Before each Stripe submit, the chosen recovery route and parameters are persisted; retries resume that same route. After Stripe accepts a debit, the transfer id is recorded before follow-up balance lookups.
- Automatic Stripe resubmits are refused after the idempotency window. Holding-amount estimates are reconciled to the actual Stripe debit when known, without creating unpaid balances that fail payout validation.
- `StripeChargeProcessor.debit_stripe_account_for_refund_fee` never hands a BGN-settled transfer to `Transfer.create_reversal`. It skips BGN candidates and takes the next eligible non-BGN transfer. When only BGN history exists, it debits the connected account with a EUR transfer to the platform.

## Why

Private issue 2460. A seller refund on a Gumroad-managed Bulgarian Stripe account went like this: the Stripe refund succeeded, then the fee retention picked the oldest internal transfer with room, which had settled in BGN, and `Transfer.create_reversal` failed with "Transfer reversals in BGN are no longer supported". Because the fee debit ran inside the refund's database transaction, the exception rolled back the local `Refund`, purchase flags and balance debits even though the buyer already had their money back. The purchase looked unrefunded locally, and retrying only repeated the failure.

Root cause is two separate problems, fixed separately:

1. Fee collection was allowed to unwind a refund that had already happened at the processor. Fee collection is recoverable; a phantom "unrefunded" purchase is not. The after-return `.tap` already existed for license disabling for exactly this reason, so the fee debit moves there and becomes non-fatal and re-runnable.
2. The transfer selection did not know that BGN transfers cannot be reversed. The closed PR #4232 addressed the principal reverse-transfer path, not this fee path, so it is not reused as-is; only its EUR account-debit idea is adapted here, for the fee path only.

The fix never replays or touches the buyer's refund to collect the fee. Historical backfill of the fee credits for the affected refunds is out of scope for this PR.

## Before / After

Before: fee debit failure after a successful Stripe refund rolled back the local refund; BGN transfers were selected for reversal and Stripe rejected them; timed-out fee recovery could be retried as a different Stripe operation and debit twice.

After: the local refund always commits once Stripe has refunded; the fee is retained locally and the Stripe debit is best effort and retryable on a sticky route; BGN transfers are skipped and EUR debits are used when nothing else is eligible; debit markers survive process crashes and ledger failures; retries cannot double-debit via idempotency keys, sticky operations, and ledger isolation.

Non-user-facing change.

## Test Results

Commands to run (not executed in this sandbox; no MySQL/Redis here):

- `bundle exec rspec spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb -e ".debit_stripe_account_for_refund_fee"`
- `bundle exec rspec spec/models/credit_spec.rb -e "create_for_refund_fee_retention!"`
- `bundle exec rspec spec/models/purchase/purchase_refunds_spec.rb -e "when the fee debit fails after the processor refund succeeded"`

If reverted, those examples would fail: BGN would be handed to `create_reversal` again, fee debit failure would roll back the local Refund, a second fee attempt would not be a no-op, and a timed-out reversal could be retried as an EUR debit.

Historical fee Credit backfill for the affected Bulgarian refunds is out of scope.

## QA

Unit specs cover the claim. No seller-visible UI change; no visual QA.

---

Implemented by Codex gpt-5.3 (Cursor).
