### PR TITLE
Pace and coalesce offer-code search indexing

### DIFF
--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -54,6 +54,7 @@ class OfferCode < ApplicationRecord
   after_save :note_column_applicability_changes
   after_commit :repair_detached_default_discounts, if: -> { @applicability_changed }
   after_rollback :forget_applicability_changes
+  before_destroy :capture_reindex_product_ids
   after_destroy :reindex_associated_products
 
   validates_uniqueness_of :code, scope: %i[user_id deleted_at], if: :universal?, unless: :deleted?, message: "must be unique."
@@ -611,17 +612,26 @@ class OfferCode < ApplicationRecord
     end
 
     def reindex_associated_products
-      # A seller-wide pass includes former currencies, exclusions and detached products
-      # without materializing the catalogue in the save/destroy transaction.
-      seller_ids = [user_id, user_id_before_last_save].compact.uniq
+      catalogue = universal? || universal_before_last_save
+      seller_id = user_id
+      seller_ids = [seller_id, user_id_before_last_save].compact.uniq
+      product_ids = @reindex_product_ids || products.ids unless catalogue
       AfterCommitEverywhere.after_commit do
-        seller_ids.each { ReindexSellerOfferCodesJob.enqueue(_1) }
+        if catalogue
+          seller_ids.each { ReindexSellerOfferCodesJob.enqueue(_1) }
+        else
+          ReindexSellerOfferCodesJob.enqueue_products(seller_id, product_ids)
+        end
       end
     end
 
     def reindex_removed_product(product)
-      seller_id = product.user_id
-      AfterCommitEverywhere.after_commit { ReindexSellerOfferCodesJob.enqueue(seller_id) }
+      seller_id, product_id = product.user_id, product.id
+      AfterCommitEverywhere.after_commit { ReindexSellerOfferCodesJob.enqueue_products(seller_id, [product_id]) }
+    end
+
+    def capture_reindex_product_ids
+      @reindex_product_ids = products.ids unless universal?
     end
 
     def validate_not_used_as_default_discount

--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -22,7 +22,7 @@ class OfferCode < ApplicationRecord
 
   has_and_belongs_to_many :products, class_name: "Link", join_table: "offer_codes_products", association_foreign_key: "product_id", after_add: :note_applicability_change, after_remove: [:note_applicability_change, :note_removed_product, :reindex_removed_product]
   has_and_belongs_to_many :ownership_products, class_name: "Link", join_table: "offer_codes_ownership_products", association_foreign_key: "product_id"
-  has_and_belongs_to_many :excluded_products, class_name: "Link", join_table: "offer_codes_excluded_products", association_foreign_key: "product_id", after_add: [:invalidate_excluded_product_cache, :note_applicability_change], after_remove: [:invalidate_excluded_product_cache, :note_applicability_change]
+  has_and_belongs_to_many :excluded_products, class_name: "Link", join_table: "offer_codes_excluded_products", association_foreign_key: "product_id", after_add: [:invalidate_excluded_product_cache, :note_applicability_change, :reindex_removed_product], after_remove: [:invalidate_excluded_product_cache, :note_applicability_change, :reindex_removed_product]
   belongs_to :user
   has_many :purchases
   has_many :purchases_that_count_towards_offer_code_uses, -> { counts_towards_offer_code_uses }, class_name: "Purchase"
@@ -616,9 +616,13 @@ class OfferCode < ApplicationRecord
       seller_id = user_id
       seller_ids = [seller_id, user_id_before_last_save].compact.uniq
       product_ids = destroyed? ? @reindex_product_ids : products.ids unless catalogue
+      # Targeted path indexes Link.where(id:), so unpublished excluded products stay fresh
+      # alongside the alive-only catalogue scan.
+      excluded_ids = catalogue ? (destroyed? ? Array(@reindex_excluded_product_ids) : excluded_products.ids) : []
       AfterCommitEverywhere.after_commit do
         if catalogue
           seller_ids.each { ReindexSellerOfferCodesJob.enqueue(_1) }
+          ReindexSellerOfferCodesJob.enqueue_products(seller_id, excluded_ids) if excluded_ids.any?
         else
           ReindexSellerOfferCodesJob.enqueue_products(seller_id, product_ids)
         end
@@ -631,7 +635,11 @@ class OfferCode < ApplicationRecord
     end
 
     def capture_reindex_product_ids
-      @reindex_product_ids = products.ids unless universal?
+      if universal?
+        @reindex_excluded_product_ids = excluded_products.ids
+      else
+        @reindex_product_ids = products.ids
+      end
     end
 
     def validate_not_used_as_default_discount

--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -20,7 +20,7 @@ class OfferCode < ApplicationRecord
 
   stripped_fields :code
 
-  has_and_belongs_to_many :products, class_name: "Link", join_table: "offer_codes_products", association_foreign_key: "product_id", after_add: :note_applicability_change, after_remove: [:note_applicability_change, :note_removed_product, :reindex_removed_product]
+  has_and_belongs_to_many :products, class_name: "Link", join_table: "offer_codes_products", association_foreign_key: "product_id", after_add: [:note_applicability_change, :reindex_removed_product], after_remove: [:note_applicability_change, :note_removed_product, :reindex_removed_product]
   has_and_belongs_to_many :ownership_products, class_name: "Link", join_table: "offer_codes_ownership_products", association_foreign_key: "product_id"
   has_and_belongs_to_many :excluded_products, class_name: "Link", join_table: "offer_codes_excluded_products", association_foreign_key: "product_id", after_add: [:invalidate_excluded_product_cache, :note_applicability_change, :reindex_removed_product], after_remove: [:invalidate_excluded_product_cache, :note_applicability_change, :reindex_removed_product]
   belongs_to :user
@@ -615,17 +615,16 @@ class OfferCode < ApplicationRecord
       catalogue = universal? || universal_before_last_save
       seller_id = user_id
       seller_ids = [seller_id, user_id_before_last_save].compact.uniq
-      product_ids = destroyed? ? @reindex_product_ids : products.ids unless catalogue
-      # Targeted path indexes Link.where(id:), so unpublished excluded products stay fresh
-      # alongside the alive-only catalogue scan.
-      excluded_ids = catalogue ? (destroyed? ? Array(@reindex_excluded_product_ids) : excluded_products.ids) : []
+      # Targeted path uses Link.where(id:), covering unpublished rows the alive
+      # catalogue scan skips (exclusions and universal→product-specific picks).
+      targeted_ids = if destroyed?
+        Array(@reindex_product_ids) + Array(@reindex_excluded_product_ids)
+      else
+        products.ids + (catalogue ? excluded_products.ids : [])
+      end
       AfterCommitEverywhere.after_commit do
-        if catalogue
-          seller_ids.each { ReindexSellerOfferCodesJob.enqueue(_1) }
-          ReindexSellerOfferCodesJob.enqueue_products(seller_id, excluded_ids) if excluded_ids.any?
-        else
-          ReindexSellerOfferCodesJob.enqueue_products(seller_id, product_ids)
-        end
+        seller_ids.each { ReindexSellerOfferCodesJob.enqueue(_1) } if catalogue
+        ReindexSellerOfferCodesJob.enqueue_products(seller_id, targeted_ids) if targeted_ids.any?
       end
     end
 
@@ -635,11 +634,8 @@ class OfferCode < ApplicationRecord
     end
 
     def capture_reindex_product_ids
-      if universal?
-        @reindex_excluded_product_ids = excluded_products.ids
-      else
-        @reindex_product_ids = products.ids
-      end
+      @reindex_product_ids = products.ids
+      @reindex_excluded_product_ids = excluded_products.ids if universal?
     end
 
     def validate_not_used_as_default_discount

--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -34,7 +34,6 @@ class OfferCode < ApplicationRecord
   MAX_OWNERSHIP_DURATION_TIERS = 10
   # Enough for the seller to recognise the products without an unbounded message.
   NAMED_DEFAULT_DISCOUNT_PRODUCTS = 3
-  PRODUCT_REINDEX_BATCH_SIZE = 1_000
 
   # Regex modified from https://stackoverflow.com/a/26900132
   validates :code, presence: true, format: { with: /\A[A-Za-zÀ-ÖØ-öø-ÿ0-9\-_]*\z/, message: "can only contain numbers, letters, dashes, and underscores." }, unless: -> { is_cancellation_discount? || upsell.present? }
@@ -53,11 +52,9 @@ class OfferCode < ApplicationRecord
   after_save :invalidate_product_cache
   after_save :reindex_associated_products
   after_save :note_column_applicability_changes
-  before_update :reindex_previous_universal_products
   after_commit :repair_detached_default_discounts, if: -> { @applicability_changed }
   after_rollback :forget_applicability_changes
-  before_destroy :capture_associated_product_ids
-  after_destroy :reindex_captured_products
+  after_destroy :reindex_associated_products
 
   validates_uniqueness_of :code, scope: %i[user_id deleted_at], if: :universal?, unless: :deleted?, message: "must be unique."
   validate :code_validation, unless: lambda { |offer_code| offer_code.deleted? || offer_code.universal? || offer_code.upsell.present? }
@@ -613,51 +610,18 @@ class OfferCode < ApplicationRecord
       end
     end
 
-    def reindex_associated_products(products_to_reindex: applicable_products + excluded_products)
-      # A universal code's applicable set is every alive product, so running the
-      # per-product index updates inline after_commit blows the request timeout
-      # for large catalogs. Enqueue them as background jobs after the row commits.
+    def reindex_associated_products
+      # A seller-wide pass includes former currencies, exclusions and detached products
+      # without materializing the catalogue in the save/destroy transaction.
+      seller_ids = [user_id, user_id_before_last_save].compact.uniq
       AfterCommitEverywhere.after_commit do
-        enqueue_offer_code_document_updates(products_to_reindex)
+        seller_ids.each { ReindexSellerOfferCodesJob.enqueue(_1) }
       end
-    end
-
-    def enqueue_offer_code_document_updates(products_to_reindex)
-      if products_to_reindex.is_a?(ActiveRecord::Relation)
-        products_to_reindex.in_batches(of: PRODUCT_REINDEX_BATCH_SIZE) do |batch|
-          enqueue_offer_code_document_ids(batch.ids)
-        end
-      else
-        enqueue_offer_code_document_ids(Array(products_to_reindex).map(&:id))
-      end
-    end
-
-    def enqueue_offer_code_document_ids(product_ids)
-      return if product_ids.empty?
-
-      SendToElasticsearchWorker.perform_bulk(
-        product_ids.map { |product_id| [product_id, "update", ["offer_codes"]] }
-      )
     end
 
     def reindex_removed_product(product)
-      reindex_associated_products(products_to_reindex: [product])
-    end
-
-    def reindex_previous_universal_products
-      return unless universal_in_database && (will_save_change_to_universal? || will_save_change_to_currency_type?)
-
-      products = Link.alive.where(user_id: user_id_in_database)
-      products = products.where(price_currency_type: currency_type_in_database) if currency_type_in_database.present?
-      reindex_associated_products(products_to_reindex: products)
-    end
-
-    def capture_associated_product_ids
-      @product_ids_to_reindex = applicable_products.ids
-    end
-
-    def reindex_captured_products
-      reindex_associated_products(products_to_reindex: Link.where(id: @product_ids_to_reindex)) if @product_ids_to_reindex.present?
+      seller_id = product.user_id
+      AfterCommitEverywhere.after_commit { ReindexSellerOfferCodesJob.enqueue(seller_id) }
     end
 
     def validate_not_used_as_default_discount

--- a/app/models/offer_code.rb
+++ b/app/models/offer_code.rb
@@ -615,7 +615,7 @@ class OfferCode < ApplicationRecord
       catalogue = universal? || universal_before_last_save
       seller_id = user_id
       seller_ids = [seller_id, user_id_before_last_save].compact.uniq
-      product_ids = @reindex_product_ids || products.ids unless catalogue
+      product_ids = destroyed? ? @reindex_product_ids : products.ids unless catalogue
       AfterCommitEverywhere.after_commit do
         if catalogue
           seller_ids.each { ReindexSellerOfferCodesJob.enqueue(_1) }

--- a/app/services/product_offer_code_indexing_service.rb
+++ b/app/services/product_offer_code_indexing_service.rb
@@ -1,18 +1,10 @@
 # frozen_string_literal: true
 
 class ProductOfferCodeIndexingService
-  # Failures that should keep the seller scan pinned so Sidekiq can retry the
-  # same batch. Permanent per-product errors are reported and skipped instead.
-  RETRYABLE_ERRORS = [
-    Faraday::TimeoutError,
-    Faraday::ConnectionFailed,
-    Elasticsearch::Transport::Transport::Errors::RequestTimeout,
-    Elasticsearch::Transport::Transport::Errors::Conflict,
-    Elasticsearch::Transport::Transport::Errors::InternalServerError,
-    Elasticsearch::Transport::Transport::Errors::BadGateway,
-    Elasticsearch::Transport::Transport::Errors::ServiceUnavailable,
-    Elasticsearch::Transport::Transport::Errors::GatewayTimeout
-  ].freeze
+  # Transient transport statuses should keep the seller scan pinned for Sidekiq
+  # retry. Permanent per-product errors (e.g. 400) are reported and skipped.
+  # 429 arrives as a generic ServerError in elasticsearch-transport 7.x.
+  RETRYABLE_STATUS_CODES = [408, 409, 429, 500, 502, 503, 504].freeze
 
   def initialize(products)
     @products = products
@@ -65,8 +57,18 @@ class ProductOfferCodeIndexingService
 
     def report_indexing_failure(product, error)
       raise if error.is_a?(Elasticsearch::Transport::Transport::Errors::NotFound) && error.message.include?("index_not_found")
-      raise if RETRYABLE_ERRORS.any? { error.is_a?(_1) }
+      raise if retryable_indexing_error?(error)
 
       ErrorNotifier.notify(error, product_id: product.id, user_id: product.user_id)
+    end
+
+    def retryable_indexing_error?(error)
+      return true if error.is_a?(Faraday::TimeoutError) || error.is_a?(Faraday::ConnectionFailed)
+
+      status = Elasticsearch::Transport::Transport::ERRORS.key(error.class)
+      if status.nil? && error.is_a?(Elasticsearch::Transport::Transport::ServerError)
+        status = Integer(Regexp.last_match(1), 10) if error.message =~ /\A\[(\d{3})\]/
+      end
+      RETRYABLE_STATUS_CODES.include?(status)
     end
 end

--- a/app/services/product_offer_code_indexing_service.rb
+++ b/app/services/product_offer_code_indexing_service.rb
@@ -8,6 +8,8 @@ class ProductOfferCodeIndexingService
   def perform
     return if @products.empty?
 
+    raise Elasticsearch::Transport::Transport::Errors::NotFound, "index_not_found_exception" unless Link.__elasticsearch__.client.indices.exists?(index: Link.index_name)
+
     product_ids = @products.map(&:id)
     universal_codes = OfferCode.alive.universal.where(user_id: @products.map(&:user_id).uniq).to_a.group_by(&:user_id)
     product_codes = OfferCode.alive.joins(:products).where(links: { id: product_ids })
@@ -28,8 +30,9 @@ class ProductOfferCodeIndexingService
       begin
         product.__elasticsearch__.update_document_attributes("offer_codes" => values)
       rescue Elasticsearch::Transport::Transport::Errors::NotFound => error
-        # A deleted search document must not strand the rest of the catalogue.
         raise unless error.message.include?("document_missing_exception")
+
+        product.__elasticsearch__.index_document unless product.deleted?
       end
     end
   end

--- a/app/services/product_offer_code_indexing_service.rb
+++ b/app/services/product_offer_code_indexing_service.rb
@@ -39,20 +39,18 @@ class ProductOfferCodeIndexingService
 
   private
     def index_offer_codes(product, values)
-      begin
-        product.__elasticsearch__.update_document_attributes("offer_codes" => values)
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound => error
-        raise unless error.message.include?("document_missing_exception")
+      product.__elasticsearch__.update_document_attributes("offer_codes" => values)
+    rescue Elasticsearch::Transport::Transport::Errors::NotFound => error
+      raise unless error.message.include?("document_missing_exception")
 
-        yield if block_given?
-        begin
-          product.__elasticsearch__.index_document unless product.deleted?
-        rescue => error
-          report_indexing_failure(product, error)
-        end
+      yield if block_given?
+      begin
+        product.__elasticsearch__.index_document unless product.deleted?
       rescue => error
         report_indexing_failure(product, error)
       end
+    rescue => error
+      report_indexing_failure(product, error)
     end
 
     def report_indexing_failure(product, error)

--- a/app/services/product_offer_code_indexing_service.rb
+++ b/app/services/product_offer_code_indexing_service.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class ProductOfferCodeIndexingService
-  # Transient transport statuses should keep the seller scan pinned for Sidekiq
-  # retry. Permanent per-product errors (e.g. 400) are reported and skipped.
+  # Transient transport statuses and unclassified/seller-wide failures keep the
+  # seller scan pinned for Sidekiq retry. Only permanent per-product errors
+  # (HTTP 400) are reported and skipped so the cursor can advance.
   # 429 arrives as a generic ServerError in elasticsearch-transport 7.x.
   RETRYABLE_STATUS_CODES = [408, 409, 429, 500, 502, 503, 504].freeze
 
@@ -58,15 +59,26 @@ class ProductOfferCodeIndexingService
       raise if retryable_indexing_error?(error)
 
       ErrorNotifier.notify(error, product_id: product.id, user_id: product.user_id)
+      # Only permanent document-level failures (e.g. 400 bad mapping) may be skipped.
+      # Seller-wide / unclassified errors must preserve pending work.
+      raise unless permanent_document_indexing_error?(error)
+    end
+
+    def permanent_document_indexing_error?(error)
+      elasticsearch_status_code(error) == 400
     end
 
     def retryable_indexing_error?(error)
       return true if error.is_a?(Faraday::TimeoutError) || error.is_a?(Faraday::ConnectionFailed)
 
+      RETRYABLE_STATUS_CODES.include?(elasticsearch_status_code(error))
+    end
+
+    def elasticsearch_status_code(error)
       status = Elasticsearch::Transport::Transport::ERRORS.key(error.class)
       if status.nil? && error.is_a?(Elasticsearch::Transport::Transport::ServerError)
         status = Integer(Regexp.last_match(1), 10) if error.message =~ /\A\[(\d{3})\]/
       end
-      RETRYABLE_STATUS_CODES.include?(status)
+      status
     end
 end

--- a/app/services/product_offer_code_indexing_service.rb
+++ b/app/services/product_offer_code_indexing_service.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 class ProductOfferCodeIndexingService
+  # Failures that should keep the seller scan pinned so Sidekiq can retry the
+  # same batch. Permanent per-product errors are reported and skipped instead.
+  RETRYABLE_ERRORS = [
+    Faraday::TimeoutError,
+    Faraday::ConnectionFailed,
+    Elasticsearch::Transport::Transport::Errors::RequestTimeout,
+    Elasticsearch::Transport::Transport::Errors::Conflict,
+    Elasticsearch::Transport::Transport::Errors::InternalServerError,
+    Elasticsearch::Transport::Transport::Errors::BadGateway,
+    Elasticsearch::Transport::Transport::Errors::ServiceUnavailable,
+    Elasticsearch::Transport::Transport::Errors::GatewayTimeout
+  ].freeze
+
   def initialize(products)
     @products = products
   end
@@ -52,6 +65,7 @@ class ProductOfferCodeIndexingService
 
     def report_indexing_failure(product, error)
       raise if error.is_a?(Elasticsearch::Transport::Transport::Errors::NotFound) && error.message.include?("index_not_found")
+      raise if RETRYABLE_ERRORS.any? { error.is_a?(_1) }
 
       ErrorNotifier.notify(error, product_id: product.id, user_id: product.user_id)
     end

--- a/app/services/product_offer_code_indexing_service.rb
+++ b/app/services/product_offer_code_indexing_service.rb
@@ -6,10 +6,11 @@ class ProductOfferCodeIndexingService
   # rejections are reported and skipped so the cursor can advance.
   # 429 arrives as a generic ServerError in elasticsearch-transport 7.x.
   RETRYABLE_STATUS_CODES = [408, 409, 429, 500, 502, 503, 504].freeze
+  # Bare parsing_exception is also used for malformed requests / batch-wide
+  # failures; only document-specific subtypes may be skipped.
   DOCUMENT_LEVEL_400_MARKERS = %w[
     mapper_parsing_exception
     document_parsing_exception
-    parsing_exception
   ].freeze
 
   def initialize(products)

--- a/app/services/product_offer_code_indexing_service.rb
+++ b/app/services/product_offer_code_indexing_service.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 class ProductOfferCodeIndexingService
-  # Transient transport statuses and unclassified/seller-wide failures keep the
-  # seller scan pinned for Sidekiq retry. Only known permanent document-level
-  # rejections are reported and skipped so the cursor can advance.
-  # 429 arrives as a generic ServerError in elasticsearch-transport 7.x.
+  # Transient and unclassified failures keep the seller scan pinned for retry;
+  # only permanent document-level rejections are skipped. In transport 7.x,
+  # HTTP 429 arrives as a generic ServerError.
   RETRYABLE_STATUS_CODES = [408, 409, 429, 500, 502, 503, 504].freeze
   # Bare parsing_exception is also used for malformed requests / batch-wide
   # failures; only document-specific subtypes may be skipped.

--- a/app/services/product_offer_code_indexing_service.rb
+++ b/app/services/product_offer_code_indexing_service.rb
@@ -27,15 +27,32 @@ class ProductOfferCodeIndexingService
         codes << [code.id, code.code, code.created_at]
       end
       values = codes.sort_by(&:last).last(Link::MAX_OFFER_CODES_IN_INDEX).map { _1[1] }
+      yield if block_given?
+      index_offer_codes(product, values) { yield if block_given? }
+    end
+  end
+
+  private
+    def index_offer_codes(product, values)
       begin
-        yield if block_given?
         product.__elasticsearch__.update_document_attributes("offer_codes" => values)
       rescue Elasticsearch::Transport::Transport::Errors::NotFound => error
         raise unless error.message.include?("document_missing_exception")
 
         yield if block_given?
-        product.__elasticsearch__.index_document unless product.deleted?
+        begin
+          product.__elasticsearch__.index_document unless product.deleted?
+        rescue => error
+          report_indexing_failure(product, error)
+        end
+      rescue => error
+        report_indexing_failure(product, error)
       end
     end
-  end
+
+    def report_indexing_failure(product, error)
+      raise if error.is_a?(Elasticsearch::Transport::Transport::Errors::NotFound) && error.message.include?("index_not_found")
+
+      ErrorNotifier.notify(error, product_id: product.id, user_id: product.user_id)
+    end
 end

--- a/app/services/product_offer_code_indexing_service.rb
+++ b/app/services/product_offer_code_indexing_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class ProductOfferCodeIndexingService
+  def initialize(products)
+    @products = products
+  end
+
+  def perform
+    return if @products.empty?
+
+    product_ids = @products.map(&:id)
+    universal_codes = OfferCode.alive.universal.where(user_id: @products.map(&:user_id).uniq).to_a.group_by(&:user_id)
+    product_codes = OfferCode.alive.joins(:products).where(links: { id: product_ids })
+                            .pluck("links.id", "offer_codes.id", "offer_codes.code", "offer_codes.created_at").group_by(&:first)
+    exclusions = OfferCode.joins(:excluded_products).where(links: { id: product_ids })
+                          .pluck("links.id", "offer_codes.id").group_by(&:first)
+
+    @products.each do |product|
+      excluded_ids = exclusions.fetch(product.id, []).map(&:last)
+      codes = product_codes.fetch(product.id, []).map { |_, id, code, created_at| [id, code, created_at] }
+      universal_codes.fetch(product.user_id, []).each do |code|
+        next if code.currency_type.present? && code.currency_type != product.price_currency_type
+        next if excluded_ids.include?(code.id)
+
+        codes << [code.id, code.code, code.created_at]
+      end
+      values = codes.sort_by(&:last).last(Link::MAX_OFFER_CODES_IN_INDEX).map { _1[1] }
+      begin
+        product.__elasticsearch__.update_document_attributes("offer_codes" => values)
+      rescue Elasticsearch::Transport::Transport::Errors::NotFound => error
+        # A deleted search document must not strand the rest of the catalogue.
+        raise unless error.message.include?("document_missing_exception")
+      end
+    end
+  end
+end

--- a/app/services/product_offer_code_indexing_service.rb
+++ b/app/services/product_offer_code_indexing_service.rb
@@ -2,10 +2,15 @@
 
 class ProductOfferCodeIndexingService
   # Transient transport statuses and unclassified/seller-wide failures keep the
-  # seller scan pinned for Sidekiq retry. Only permanent per-product errors
-  # (HTTP 400) are reported and skipped so the cursor can advance.
+  # seller scan pinned for Sidekiq retry. Only known permanent document-level
+  # rejections are reported and skipped so the cursor can advance.
   # 429 arrives as a generic ServerError in elasticsearch-transport 7.x.
   RETRYABLE_STATUS_CODES = [408, 409, 429, 500, 502, 503, 504].freeze
+  DOCUMENT_LEVEL_400_MARKERS = %w[
+    mapper_parsing_exception
+    document_parsing_exception
+    parsing_exception
+  ].freeze
 
   def initialize(products)
     @products = products
@@ -59,13 +64,16 @@ class ProductOfferCodeIndexingService
       raise if retryable_indexing_error?(error)
 
       ErrorNotifier.notify(error, product_id: product.id, user_id: product.user_id)
-      # Only permanent document-level failures (e.g. 400 bad mapping) may be skipped.
-      # Seller-wide / unclassified errors must preserve pending work.
+      # Skip only known document-level 400s. Index-wide 400s (e.g. index_closed)
+      # must preserve pending work.
       raise unless permanent_document_indexing_error?(error)
     end
 
     def permanent_document_indexing_error?(error)
-      elasticsearch_status_code(error) == 400
+      return false unless elasticsearch_status_code(error) == 400
+
+      message = error.message.to_s
+      DOCUMENT_LEVEL_400_MARKERS.any? { message.include?(_1) }
     end
 
     def retryable_indexing_error?(error)

--- a/app/services/product_offer_code_indexing_service.rb
+++ b/app/services/product_offer_code_indexing_service.rb
@@ -28,10 +28,12 @@ class ProductOfferCodeIndexingService
       end
       values = codes.sort_by(&:last).last(Link::MAX_OFFER_CODES_IN_INDEX).map { _1[1] }
       begin
+        yield if block_given?
         product.__elasticsearch__.update_document_attributes("offer_codes" => values)
       rescue Elasticsearch::Transport::Transport::Errors::NotFound => error
         raise unless error.message.include?("document_missing_exception")
 
+        yield if block_given?
         product.__elasticsearch__.index_document unless product.deleted?
       end
     end

--- a/app/sidekiq/reindex_seller_offer_codes_job.rb
+++ b/app/sidekiq/reindex_seller_offer_codes_job.rb
@@ -80,7 +80,9 @@ class ReindexSellerOfferCodesJob
       ActiveRecord::Base.connection.stick_to_primary!
       cursor, scan_version = $redis.mget("#{key}:cursor", "#{key}:scan_version")
       scan_version ||= version
-      products = Link.alive.where(user_id: seller_id).where("id > ?", cursor.to_i).order(:id).limit(BATCH_SIZE).to_a
+      # Include unpublished/banned rows: offer_codes can go stale while a product is
+      # inactive, and republication does not otherwise refresh them.
+      products = Link.visible.where(user_id: seller_id).where("id > ?", cursor.to_i).order(:id).limit(BATCH_SIZE).to_a
       attempted = true
       $redis.set("#{key}:last_batch", "catalogue")
       ProductOfferCodeIndexingService.new(products).perform(&renew_lock)

--- a/app/sidekiq/reindex_seller_offer_codes_job.rb
+++ b/app/sidekiq/reindex_seller_offer_codes_job.rb
@@ -8,7 +8,7 @@ class ReindexSellerOfferCodesJob
   INTERVAL = 5.seconds
 
   sidekiq_retries_exhausted do |message, _error|
-    perform_in(1.hour, message.fetch("args").first)
+    ReindexSellerOfferCodesRecoveryJob.perform_in(1.hour, message.fetch("args").first)
   end
 
   def self.enqueue(seller_id)
@@ -19,14 +19,17 @@ class ReindexSellerOfferCodesJob
   def self.enqueue_products(seller_id, product_ids)
     return if product_ids.empty?
 
-    $redis.hset("offer_code_index:#{seller_id}:products", product_ids.index_with { SecureRandom.hex(16) })
+    $redis.eval(<<~LUA, keys: ["offer_code_index:#{seller_id}:products", "offer_code_index:#{seller_id}:sequence"], argv: product_ids)
+      local version = redis.call('INCR', KEYS[2])
+      for _, id in ipairs(ARGV) do redis.call('ZADD', KEYS[1], version, id) end
+    LUA
     perform_async(seller_id)
   end
 
   def perform(seller_id)
     key = "offer_code_index:#{seller_id}"
     token = SecureRandom.hex(16)
-    unless $redis.set("#{key}:lock", token, nx: true, ex: 1.hour.to_i)
+    unless $redis.set("#{key}:lock", token, nx: true, ex: 10.minutes.to_i)
       self.class.perform_in(INTERVAL, seller_id)
       return
     end
@@ -36,18 +39,18 @@ class ReindexSellerOfferCodesJob
         return
       end
 
-      pending_ids = $redis.hscan_each("#{key}:products", count: BATCH_SIZE).take(BATCH_SIZE).map(&:first)
+      pending = $redis.zrange("#{key}:products", 0, BATCH_SIZE - 1, with_scores: true)
+      pending_ids = pending.map(&:first)
       catalogue_pending = $redis.exists?("#{key}:version")
       if pending_ids.any? && (!catalogue_pending || $redis.get("#{key}:last_batch") != "targeted")
-        versions = $redis.hmget("#{key}:products", *pending_ids)
         $redis.set("#{key}:cooldown", (Time.current + INTERVAL).to_f, ex: INTERVAL.to_i)
         ActiveRecord::Base.connection.stick_to_primary!
         attempted = true
         $redis.set("#{key}:last_batch", "targeted")
         ProductOfferCodeIndexingService.new(Link.where(id: pending_ids).to_a).perform
         self.class.perform_in(INTERVAL, seller_id)
-        pending_ids.zip(versions).each do |product_id, version|
-          $redis.eval("if redis.call('HGET', KEYS[1], ARGV[1]) == ARGV[2] then return redis.call('HDEL', KEYS[1], ARGV[1]) end", keys: ["#{key}:products"], argv: [product_id, version])
+        pending.each do |product_id, version|
+          $redis.eval("if tonumber(redis.call('ZSCORE', KEYS[1], ARGV[1])) == tonumber(ARGV[2]) then return redis.call('ZREM', KEYS[1], ARGV[1]) end", keys: ["#{key}:products"], argv: [product_id, version])
         end
         $redis.set("#{key}:cooldown", (Time.current + INTERVAL).to_f, ex: INTERVAL.to_i)
         return
@@ -60,7 +63,7 @@ class ReindexSellerOfferCodesJob
       ActiveRecord::Base.connection.stick_to_primary!
       cursor, scan_version = $redis.mget("#{key}:cursor", "#{key}:scan_version")
       scan_version ||= version
-      products = Link.where(user_id: seller_id).where("id > ?", cursor.to_i).order(:id).limit(BATCH_SIZE).to_a
+      products = Link.alive.where(user_id: seller_id).where("id > ?", cursor.to_i).order(:id).limit(BATCH_SIZE).to_a
       attempted = true
       $redis.set("#{key}:last_batch", "catalogue")
       ProductOfferCodeIndexingService.new(products).perform

--- a/app/sidekiq/reindex_seller_offer_codes_job.rb
+++ b/app/sidekiq/reindex_seller_offer_codes_job.rb
@@ -6,6 +6,8 @@ class ReindexSellerOfferCodesJob
 
   BATCH_SIZE = 25
   INTERVAL = 5.seconds
+  LOCK_TTL = 10.minutes
+  LockLost = Class.new(StandardError)
 
   sidekiq_retries_exhausted do |message, _error|
     ReindexSellerOfferCodesRecoveryJob.perform_in(1.hour, message.fetch("args").first)
@@ -19,9 +21,12 @@ class ReindexSellerOfferCodesJob
   def self.enqueue_products(seller_id, product_ids)
     return if product_ids.empty?
 
-    $redis.eval(<<~LUA, keys: ["offer_code_index:#{seller_id}:products", "offer_code_index:#{seller_id}:sequence"], argv: product_ids)
+    $redis.eval(<<~LUA, keys: ["offer_code_index:#{seller_id}:products", "offer_code_index:#{seller_id}:sequence", "offer_code_index:#{seller_id}:product_versions"], argv: product_ids)
       local version = redis.call('INCR', KEYS[2])
-      for _, id in ipairs(ARGV) do redis.call('ZADD', KEYS[1], version, id) end
+      for _, id in ipairs(ARGV) do
+        redis.call('ZADD', KEYS[1], 'NX', version, id)
+        redis.call('HSET', KEYS[3], id, version)
+      end
     LUA
     perform_async(seller_id)
   end
@@ -29,9 +34,13 @@ class ReindexSellerOfferCodesJob
   def perform(seller_id)
     key = "offer_code_index:#{seller_id}"
     token = SecureRandom.hex(16)
-    unless $redis.set("#{key}:lock", token, nx: true, ex: 10.minutes.to_i)
+    unless $redis.set("#{key}:lock", token, nx: true, ex: LOCK_TTL.to_i)
       self.class.perform_in(INTERVAL, seller_id)
       return
+    end
+    renew_lock = lambda do
+      renewed = $redis.eval("if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('EXPIRE', KEYS[1], ARGV[2]) end", keys: ["#{key}:lock"], argv: [token, LOCK_TTL.to_i])
+      raise LockLost unless renewed == 1
     end
     begin
       if $redis.get("#{key}:cooldown").to_f > Time.current.to_f
@@ -39,18 +48,26 @@ class ReindexSellerOfferCodesJob
         return
       end
 
-      pending = $redis.zrange("#{key}:products", 0, BATCH_SIZE - 1, with_scores: true)
-      pending_ids = pending.map(&:first)
+      pending_ids = $redis.zrange("#{key}:products", 0, BATCH_SIZE - 1)
+      pending = pending_ids.zip(pending_ids.any? ? $redis.hmget("#{key}:product_versions", *pending_ids) : [])
       catalogue_pending = $redis.exists?("#{key}:version")
       if pending_ids.any? && (!catalogue_pending || $redis.get("#{key}:last_batch") != "targeted")
         $redis.set("#{key}:cooldown", (Time.current + INTERVAL).to_f, ex: INTERVAL.to_i)
         ActiveRecord::Base.connection.stick_to_primary!
         attempted = true
         $redis.set("#{key}:last_batch", "targeted")
-        ProductOfferCodeIndexingService.new(Link.where(id: pending_ids).to_a).perform
+        ProductOfferCodeIndexingService.new(Link.where(id: pending_ids).to_a).perform(&renew_lock)
+        renew_lock.call
         self.class.perform_in(INTERVAL, seller_id)
         pending.each do |product_id, version|
-          $redis.eval("if tonumber(redis.call('ZSCORE', KEYS[1], ARGV[1])) == tonumber(ARGV[2]) then return redis.call('ZREM', KEYS[1], ARGV[1]) end", keys: ["#{key}:products"], argv: [product_id, version])
+          $redis.eval(<<~LUA, keys: ["#{key}:products", "#{key}:sequence", "#{key}:product_versions"], argv: [product_id, version])
+            if redis.call('HGET', KEYS[3], ARGV[1]) == ARGV[2] then
+              redis.call('ZREM', KEYS[1], ARGV[1])
+              redis.call('HDEL', KEYS[3], ARGV[1])
+            else
+              redis.call('ZADD', KEYS[1], redis.call('INCR', KEYS[2]), ARGV[1])
+            end
+          LUA
         end
         $redis.set("#{key}:cooldown", (Time.current + INTERVAL).to_f, ex: INTERVAL.to_i)
         return
@@ -66,7 +83,8 @@ class ReindexSellerOfferCodesJob
       products = Link.alive.where(user_id: seller_id).where("id > ?", cursor.to_i).order(:id).limit(BATCH_SIZE).to_a
       attempted = true
       $redis.set("#{key}:last_batch", "catalogue")
-      ProductOfferCodeIndexingService.new(products).perform
+      ProductOfferCodeIndexingService.new(products).perform(&renew_lock)
+      renew_lock.call
 
       # Schedule before advancing: a failed push retries this batch, never skips it.
       self.class.perform_in(INTERVAL, seller_id)

--- a/app/sidekiq/reindex_seller_offer_codes_job.rb
+++ b/app/sidekiq/reindex_seller_offer_codes_job.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class ReindexSellerOfferCodesJob
+  include Sidekiq::Job
+  sidekiq_options queue: :low, retry: 10, lock: :until_executing
+
+  BATCH_SIZE = 25
+  INTERVAL = 5.seconds
+
+  def self.enqueue(seller_id)
+    $redis.incr("offer_code_index:#{seller_id}:version")
+    perform_async(seller_id)
+  end
+
+  def perform(seller_id)
+    key = "offer_code_index:#{seller_id}"
+    semaphore = Suo::Client::Redis.new("#{key}:lock", client: $redis)
+    acquired = false
+    semaphore.lock do
+      acquired = true
+      if $redis.get("#{key}:cooldown").to_f > Time.current.to_f
+        self.class.perform_in(INTERVAL, seller_id)
+        next
+      end
+
+      version = $redis.get("#{key}:version")
+      next unless version
+
+      $redis.set("#{key}:cooldown", (Time.current + INTERVAL).to_f, ex: INTERVAL.to_i)
+      ActiveRecord::Base.connection.stick_to_primary!
+      cursor, scan_version = $redis.mget("#{key}:cursor", "#{key}:scan_version")
+      scan_version ||= version
+      products = Link.where(user_id: seller_id).where("id > ?", cursor.to_i).order(:id).limit(BATCH_SIZE).to_a
+      ProductOfferCodeIndexingService.new(products).perform
+
+      # Schedule before advancing: a failed push retries this batch, never skips it.
+      self.class.perform_in(INTERVAL, seller_id)
+      $redis.multi do |redis|
+        redis.set("#{key}:cooldown", (Time.current + INTERVAL).to_f, ex: INTERVAL.to_i)
+        if products.size == BATCH_SIZE
+          redis.set("#{key}:cursor", products.last.id)
+          redis.set("#{key}:scan_version", scan_version)
+        else
+          redis.del("#{key}:cursor", "#{key}:scan_version")
+        end
+      end
+      if products.size < BATCH_SIZE
+        # An edit during the scan needs another pass, including products behind the cursor.
+        $redis.eval("if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) end", keys: ["#{key}:version"], argv: [scan_version])
+      end
+    end
+    self.class.perform_in(INTERVAL, seller_id) unless acquired
+  end
+end

--- a/app/sidekiq/reindex_seller_offer_codes_job.rb
+++ b/app/sidekiq/reindex_seller_offer_codes_job.rb
@@ -84,8 +84,11 @@ class ReindexSellerOfferCodesJob
         $redis.eval("if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) end", keys: ["#{key}:version"], argv: [scan_version])
       end
     ensure
-      $redis.set("#{key}:cooldown", (Time.current + INTERVAL).to_f, ex: INTERVAL.to_i) if attempted
-      $redis.eval("if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) end", keys: ["#{key}:lock"], argv: [token])
+      begin
+        $redis.set("#{key}:cooldown", (Time.current + INTERVAL).to_f, ex: INTERVAL.to_i) if attempted
+      ensure
+        $redis.eval("if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) end", keys: ["#{key}:lock"], argv: [token])
+      end
     end
   end
 end

--- a/app/sidekiq/reindex_seller_offer_codes_job.rb
+++ b/app/sidekiq/reindex_seller_offer_codes_job.rb
@@ -7,24 +7,51 @@ class ReindexSellerOfferCodesJob
   BATCH_SIZE = 25
   INTERVAL = 5.seconds
 
+  sidekiq_retries_exhausted do |message, _error|
+    perform_in(1.hour, message.fetch("args").first)
+  end
+
   def self.enqueue(seller_id)
     $redis.incr("offer_code_index:#{seller_id}:version")
     perform_async(seller_id)
   end
 
+  def self.enqueue_products(seller_id, product_ids)
+    return if product_ids.empty?
+
+    $redis.hset("offer_code_index:#{seller_id}:products", product_ids.index_with { SecureRandom.hex(16) })
+    perform_async(seller_id)
+  end
+
   def perform(seller_id)
     key = "offer_code_index:#{seller_id}"
-    semaphore = Suo::Client::Redis.new("#{key}:lock", client: $redis)
-    acquired = false
-    semaphore.lock do
-      acquired = true
+    token = SecureRandom.hex(16)
+    unless $redis.set("#{key}:lock", token, nx: true, ex: 1.hour.to_i)
+      self.class.perform_in(INTERVAL, seller_id)
+      return
+    end
+    begin
       if $redis.get("#{key}:cooldown").to_f > Time.current.to_f
         self.class.perform_in(INTERVAL, seller_id)
-        next
+        return
+      end
+
+      pending_ids = $redis.hscan_each("#{key}:products", count: BATCH_SIZE).take(BATCH_SIZE).map(&:first)
+      if pending_ids.any?
+        versions = $redis.hmget("#{key}:products", *pending_ids)
+        $redis.set("#{key}:cooldown", (Time.current + INTERVAL).to_f, ex: INTERVAL.to_i)
+        ActiveRecord::Base.connection.stick_to_primary!
+        ProductOfferCodeIndexingService.new(Link.where(id: pending_ids).to_a).perform
+        self.class.perform_in(INTERVAL, seller_id)
+        pending_ids.zip(versions).each do |product_id, version|
+          $redis.eval("if redis.call('HGET', KEYS[1], ARGV[1]) == ARGV[2] then return redis.call('HDEL', KEYS[1], ARGV[1]) end", keys: ["#{key}:products"], argv: [product_id, version])
+        end
+        $redis.set("#{key}:cooldown", (Time.current + INTERVAL).to_f, ex: INTERVAL.to_i)
+        return
       end
 
       version = $redis.get("#{key}:version")
-      next unless version
+      return unless version
 
       $redis.set("#{key}:cooldown", (Time.current + INTERVAL).to_f, ex: INTERVAL.to_i)
       ActiveRecord::Base.connection.stick_to_primary!
@@ -48,7 +75,8 @@ class ReindexSellerOfferCodesJob
         # An edit during the scan needs another pass, including products behind the cursor.
         $redis.eval("if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) end", keys: ["#{key}:version"], argv: [scan_version])
       end
+    ensure
+      $redis.eval("if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) end", keys: ["#{key}:lock"], argv: [token])
     end
-    self.class.perform_in(INTERVAL, seller_id) unless acquired
   end
 end

--- a/app/sidekiq/reindex_seller_offer_codes_job.rb
+++ b/app/sidekiq/reindex_seller_offer_codes_job.rb
@@ -37,10 +37,13 @@ class ReindexSellerOfferCodesJob
       end
 
       pending_ids = $redis.hscan_each("#{key}:products", count: BATCH_SIZE).take(BATCH_SIZE).map(&:first)
-      if pending_ids.any?
+      catalogue_pending = $redis.exists?("#{key}:version")
+      if pending_ids.any? && (!catalogue_pending || $redis.get("#{key}:last_batch") != "targeted")
         versions = $redis.hmget("#{key}:products", *pending_ids)
         $redis.set("#{key}:cooldown", (Time.current + INTERVAL).to_f, ex: INTERVAL.to_i)
         ActiveRecord::Base.connection.stick_to_primary!
+        attempted = true
+        $redis.set("#{key}:last_batch", "targeted")
         ProductOfferCodeIndexingService.new(Link.where(id: pending_ids).to_a).perform
         self.class.perform_in(INTERVAL, seller_id)
         pending_ids.zip(versions).each do |product_id, version|
@@ -58,6 +61,8 @@ class ReindexSellerOfferCodesJob
       cursor, scan_version = $redis.mget("#{key}:cursor", "#{key}:scan_version")
       scan_version ||= version
       products = Link.where(user_id: seller_id).where("id > ?", cursor.to_i).order(:id).limit(BATCH_SIZE).to_a
+      attempted = true
+      $redis.set("#{key}:last_batch", "catalogue")
       ProductOfferCodeIndexingService.new(products).perform
 
       # Schedule before advancing: a failed push retries this batch, never skips it.
@@ -76,6 +81,7 @@ class ReindexSellerOfferCodesJob
         $redis.eval("if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) end", keys: ["#{key}:version"], argv: [scan_version])
       end
     ensure
+      $redis.set("#{key}:cooldown", (Time.current + INTERVAL).to_f, ex: INTERVAL.to_i) if attempted
       $redis.eval("if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) end", keys: ["#{key}:lock"], argv: [token])
     end
   end

--- a/app/sidekiq/reindex_seller_offer_codes_recovery_job.rb
+++ b/app/sidekiq/reindex_seller_offer_codes_recovery_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ReindexSellerOfferCodesRecoveryJob
+  include Sidekiq::Job
+  sidekiq_options queue: :low, retry: 10
+
+  sidekiq_retries_exhausted do |message, _error|
+    perform_in(1.hour, message.fetch("args").first)
+  end
+
+  def perform(seller_id)
+    ReindexSellerOfferCodesJob.new.perform(seller_id)
+  end
+end

--- a/spec/models/offer_code_spec.rb
+++ b/spec/models/offer_code_spec.rb
@@ -1404,32 +1404,32 @@ describe OfferCode do
 
     describe "after_save callback" do
       it "waits for the enclosing transaction before indexing a removed product" do
-        SendToElasticsearchWorker.clear
+        ReindexSellerOfferCodesJob.clear
 
         OfferCode.transaction(requires_new: true) do
           OfferCode.transaction(requires_new: true) do
             offer_code.update!(products: [product2])
           end
-          expect(SendToElasticsearchWorker.jobs.size).to eq(0)
+          expect(ReindexSellerOfferCodesJob.jobs.size).to eq(0)
         end
 
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+        expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
       end
 
       it "does not index a removal rolled back with its transaction" do
-        SendToElasticsearchWorker.clear
+        ReindexSellerOfferCodesJob.clear
 
         OfferCode.transaction(requires_new: true) do
           offer_code.update!(products: [product2])
           raise ActiveRecord::Rollback
         end
 
-        expect(SendToElasticsearchWorker.jobs.size).to eq(0)
+        expect(ReindexSellerOfferCodesJob.jobs.size).to eq(0)
         expect(offer_code.reload.products).to contain_exactly(product1, product2)
       end
 
       it "does not index a removal rolled back to a savepoint" do
-        SendToElasticsearchWorker.clear
+        ReindexSellerOfferCodesJob.clear
 
         OfferCode.transaction(requires_new: true) do
           OfferCode.transaction(requires_new: true) do
@@ -1438,117 +1438,98 @@ describe OfferCode do
           end
         end
 
-        expect(SendToElasticsearchWorker.jobs.size).to eq(0)
+        expect(ReindexSellerOfferCodesJob.jobs.size).to eq(0)
         expect(offer_code.reload.products).to contain_exactly(product1, product2)
       end
 
       it "indexes a successful retry after a failed removal update" do
-        SendToElasticsearchWorker.clear
+        ReindexSellerOfferCodesJob.clear
 
         expect(offer_code.update(products: [product2], amount_cents: -1)).to be(false)
-        expect(SendToElasticsearchWorker.jobs.size).to eq(0)
+        expect(ReindexSellerOfferCodesJob.jobs.size).to eq(0)
         expect(offer_code.reload.products).to contain_exactly(product1, product2)
 
         offer_code.update!(products: [product2])
 
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+        expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
       end
 
       it "does not index an old universal scope when its change rolls back" do
         universal_offer_code = create(:universal_offer_code, user: creator)
-        SendToElasticsearchWorker.clear
+        ReindexSellerOfferCodesJob.clear
 
         OfferCode.transaction(requires_new: true) do
           universal_offer_code.update!(universal: false, products: [product2])
           raise ActiveRecord::Rollback
         end
 
-        expect(SendToElasticsearchWorker.jobs.size).to eq(0)
+        expect(ReindexSellerOfferCodesJob.jobs.size).to eq(0)
         expect(universal_offer_code.reload).to be_universal
       end
 
       it "reindexes formerly eligible products when a universal code becomes product-specific" do
         universal_offer_code = create(:universal_offer_code, user: creator)
-        SendToElasticsearchWorker.clear
+        ReindexSellerOfferCodesJob.clear
 
         universal_offer_code.update!(universal: false, products: [product2])
 
         expect(product1.reload.product_and_universal_offer_codes).not_to include(universal_offer_code)
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+        expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
       end
 
       it "reindexes the old currency's products when a universal discount changes currency" do
         universal_offer_code = create(:universal_offer_code, user: creator, currency_type: "usd")
         create(:product, user: creator, price_currency_type: "eur")
-        SendToElasticsearchWorker.clear
+        ReindexSellerOfferCodesJob.clear
 
         universal_offer_code.update!(currency_type: "eur")
 
         expect(product1.reload.product_and_universal_offer_codes).not_to include(universal_offer_code)
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
+        expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
       end
 
-      it "enqueues the previous universal catalog in bounded batches" do
+      it "does not enumerate the catalogue in the indexing callback" do
         universal_offer_code = create(:universal_offer_code, user: creator)
-        SendToElasticsearchWorker.clear
-        stub_const("OfferCode::PRODUCT_REINDEX_BATCH_SIZE", 1)
-
-        batch_sizes = []
-        allow(SendToElasticsearchWorker).to receive(:perform_bulk) do |args, **|
-          batch_sizes << args.size
-        end
-
-        universal_offer_code.update!(universal: false, products: [product2])
-
-        expect(batch_sizes.max).to eq(1)
-        expect(batch_sizes.sum).to be >= 2
+        ReindexSellerOfferCodesJob.clear
+        expect(universal_offer_code).not_to receive(:applicable_products)
+        universal_offer_code.send(:reindex_associated_products)
+        expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
       end
 
       it "reindexes products removed from a product-specific offer code" do
-        SendToElasticsearchWorker.clear
+        ReindexSellerOfferCodesJob.clear
 
         offer_code.update!(products: [product2])
 
         expect(product1.reload.product_and_universal_offer_codes).not_to include(offer_code)
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product2.id, "update", ["offer_codes"])
+        expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
       end
 
       it "reindexes products when they are excluded from a universal offer code" do
         universal_offer_code = create(:universal_offer_code, user: creator)
-
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product2.id, "update", ["offer_codes"])
+        ReindexSellerOfferCodesJob.clear
         universal_offer_code.update!(excluded_products: [product1])
+        expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
       end
 
       it "reindexes associated products when offer code is updated" do
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product2.id, "update", ["offer_codes"])
-
-        offer_code.update(amount_cents: 500)
+        ReindexSellerOfferCodesJob.clear
+        offer_code.update!(amount_cents: 500)
+        expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
       end
 
       it "reindexes associated products when offer code code is changed" do
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product2.id, "update", ["offer_codes"])
-
-        offer_code.update(code: "NEWYEAR2025")
+        ReindexSellerOfferCodesJob.clear
+        offer_code.update!(code: "NEWYEAR2025")
+        expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
       end
     end
 
     describe "after_destroy callback" do
-      let(:products_to_reindex) { [product1, product2] }
-
-      before do
-        allow(Link).to receive(:where).with(id: products_to_reindex.map(&:id)).and_return(products_to_reindex)
-      end
-
       it "reindexes associated products when offer code is destroyed" do
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product2.id, "update", ["offer_codes"])
-
-        offer_code.destroy
+        ReindexSellerOfferCodesJob.clear
+        offer_code.destroy!
+        expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
       end
     end
 
@@ -1560,8 +1541,7 @@ describe OfferCode do
       end
 
       it "only reindexes products that exist" do
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product1.id, "update", ["offer_codes"])
-        expect(SendToElasticsearchWorker).to have_enqueued_sidekiq_job(product2.id, "update", ["offer_codes"])
+        expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
 
         offer_code.send(:reindex_associated_products)
       end

--- a/spec/models/offer_code_spec.rb
+++ b/spec/models/offer_code_spec.rb
@@ -1510,6 +1510,16 @@ describe OfferCode do
         ReindexSellerOfferCodesJob.clear
         universal_offer_code.update!(excluded_products: [product1])
         expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
+        expect($redis.zrange("offer_code_index:#{creator.id}:products", 0, -1)).to include(product1.id.to_s)
+      end
+
+      it "targets unpublished excluded products so republication does not keep a stale discount" do
+        unpublished = create(:product, user: creator, purchase_disabled_at: Time.current)
+        universal_offer_code = create(:universal_offer_code, user: creator, code: "KEEP")
+        ReindexSellerOfferCodesJob.clear
+        universal_offer_code.update!(excluded_products: [unpublished])
+        expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
+        expect($redis.zrange("offer_code_index:#{creator.id}:products", 0, -1)).to include(unpublished.id.to_s)
       end
 
       it "reindexes associated products when offer code is updated" do

--- a/spec/models/offer_code_spec.rb
+++ b/spec/models/offer_code_spec.rb
@@ -1522,6 +1522,15 @@ describe OfferCode do
         expect($redis.zrange("offer_code_index:#{creator.id}:products", 0, -1)).to include(unpublished.id.to_s)
       end
 
+      it "targets unpublished products when a universal discount becomes product-specific" do
+        unpublished = create(:product, user: creator, purchase_disabled_at: Time.current)
+        universal_offer_code = create(:universal_offer_code, user: creator, code: "KEEP")
+        ReindexSellerOfferCodesJob.clear
+        universal_offer_code.update!(universal: false, products: [unpublished])
+        expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(creator.id)
+        expect($redis.zrange("offer_code_index:#{creator.id}:products", 0, -1)).to include(unpublished.id.to_s)
+      end
+
       it "reindexes associated products when offer code is updated" do
         ReindexSellerOfferCodesJob.clear
         offer_code.update!(amount_cents: 500)

--- a/spec/modules/product/searchable/offer_codes_spec.rb
+++ b/spec/modules/product/searchable/offer_codes_spec.rb
@@ -50,10 +50,11 @@ describe "Product::Searchable - Offer codes filtering" do
     it "stops matching a product removed from the discount" do
       args = Link.search_options(offer_code: @offer_code.code)
       expect(Link.__elasticsearch__.search(args).records.to_a).to include(@product_with_offer)
-      SendToElasticsearchWorker.clear
+      ReindexSellerOfferCodesJob.clear
 
       @offer_code.reload.update!(products: [])
-      SendToElasticsearchWorker.drain
+      expect(ReindexSellerOfferCodesJob).to have_enqueued_sidekiq_job(@creator.id)
+      ReindexSellerOfferCodesJob.new.perform(@creator.id)
 
       expect(@product_with_offer.reload.product_and_universal_offer_codes).not_to include(@offer_code)
       expect(Link.__elasticsearch__.search(args).records.to_a).not_to include(@product_with_offer)

--- a/spec/requests/discover/blackfriday_spec.rb
+++ b/spec/requests/discover/blackfriday_spec.rb
@@ -16,7 +16,7 @@ describe("Black Friday 2025", js: true, type: :system) do
       Feature.activate(:offer_codes_search)
 
       product = create(:product, :recommendable, user: @creator, price_cents: 1000)
-      offer_code = create(:offer_code, user: @creator, code: "BLACKFRIDAY2025", amount_percentage: 25, products: [product])
+      offer_code = Sidekiq::Testing.fake! { create(:offer_code, user: @creator, code: "BLACKFRIDAY2025", amount_percentage: 25, products: [product]) }
       create_list(:purchase, 5, link: product, offer_code:, price_cents: 750)
 
       # Stub the stats service to return the expected values
@@ -102,7 +102,7 @@ describe("Black Friday 2025", js: true, type: :system) do
       expect(page).not_to have_product_card(text: "Black Friday Special Product")
 
       # Create the BLACKFRIDAY2025 offer code and associate it with the product
-      blackfriday_offer_code = create(:offer_code, user: @creator, code: "BLACKFRIDAY2025", amount_percentage: 25)
+      blackfriday_offer_code = Sidekiq::Testing.fake! { create(:offer_code, user: @creator, code: "BLACKFRIDAY2025", amount_percentage: 25) }
       product.offer_codes << blackfriday_offer_code
 
       # Create some purchases to make the product potentially appear as featured

--- a/spec/services/product_offer_code_indexing_service_spec.rb
+++ b/spec/services/product_offer_code_indexing_service_spec.rb
@@ -30,8 +30,18 @@ describe ProductOfferCodeIndexingService do
     usd.__elasticsearch__.delete_document
     expect { described_class.new(products).perform }.not_to raise_error
     expect(indexed_codes(eur)).to eq([])
+    expect(indexed_codes(usd)).to eq([])
     allow(eur.__elasticsearch__).to receive(:update_document_attributes).and_raise(Elasticsearch::Transport::Transport::Errors::NotFound, "index_not_found_exception")
     expect { described_class.new([eur]).perform }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound, /index_not_found/)
+  end
+
+  it "raises without creating or acknowledging an absent index" do
+    product = usd
+    original_name = Link.index_name
+    allow(Link).to receive(:index_name).and_return("missing-offer-code-index-#{SecureRandom.hex(8)}")
+    expect { described_class.new([product]).perform }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound, /index_not_found/)
+    expect(Link.__elasticsearch__.client.indices.exists?(index: Link.index_name)).to be(false)
+    expect(Link.__elasticsearch__.client.indices.exists?(index: original_name)).to be(true)
   end
 
   it "preserves the cap and creation ordering" do

--- a/spec/services/product_offer_code_indexing_service_spec.rb
+++ b/spec/services/product_offer_code_indexing_service_spec.rb
@@ -25,6 +25,15 @@ describe ProductOfferCodeIndexingService do
     end
   end
 
+  it "continues past a missing document but raises on a missing index" do
+    products = [usd, eur]
+    usd.__elasticsearch__.delete_document
+    expect { described_class.new(products).perform }.not_to raise_error
+    expect(indexed_codes(eur)).to eq([])
+    allow(eur.__elasticsearch__).to receive(:update_document_attributes).and_raise(Elasticsearch::Transport::Transport::Errors::NotFound, "index_not_found_exception")
+    expect { described_class.new([eur]).perform }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound, /index_not_found/)
+  end
+
   it "preserves the cap and creation ordering" do
     stub_const("Product::Searchable::MAX_OFFER_CODES_IN_INDEX", 2)
     3.times { |i| create(:universal_offer_code, user: seller, code: "CODE#{i}", created_at: i.days.ago) }
@@ -38,10 +47,17 @@ describe ProductOfferCodeIndexingService do
     statements = []
     subscriber = ->(*args) { statements << args.last[:sql] if args.last[:sql].match?(/SELECT.*offer_codes/i) }
     ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+      products.each { _1.reload.build_search_update(["offer_codes"]) }
+    end
+    before_queries = statements.size
+    before_universal = statements.grep(/NOT EXISTS/).size
+    statements.clear
+    ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
       described_class.new(products).perform
     end
+    expect(before_universal).to eq(products.size)
     expect(statements.size).to eq(3)
     expect(statements.grep(/NOT EXISTS/)).to be_empty
-    puts "offer-code batch: products=#{products.size}, offer-code SELECTs=#{statements.size}, per-product universal lookups=0"
+    puts "offer-code batch: products=#{products.size}, SELECTs_before=#{before_queries}, SELECTs_after=#{statements.size}, universal_lookups_before=#{before_universal}, universal_lookups_after=0"
   end
 end

--- a/spec/services/product_offer_code_indexing_service_spec.rb
+++ b/spec/services/product_offer_code_indexing_service_spec.rb
@@ -72,7 +72,6 @@ describe ProductOfferCodeIndexingService do
     ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
       products.each { _1.reload.build_search_update(["offer_codes"]) }
     end
-    before_queries = statements.size
     before_universal = statements.grep(/NOT EXISTS/).size
     statements.clear
     ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
@@ -81,6 +80,32 @@ describe ProductOfferCodeIndexingService do
     expect(before_universal).to eq(products.size)
     expect(statements.size).to eq(3)
     expect(statements.grep(/NOT EXISTS/)).to be_empty
-    puts "offer-code batch: products=#{products.size}, SELECTs_before=#{before_queries}, SELECTs_after=#{statements.size}, universal_lookups_before=#{before_universal}, universal_lookups_after=0"
+  end
+
+  it "reports a single product failure and keeps indexing the rest of the batch" do
+    products = [usd, eur]
+    create(:universal_offer_code, user: seller, code: "KEEP", currency_type: nil, amount_cents: nil, amount_percentage: 10)
+    allow(usd.__elasticsearch__).to receive(:update_document_attributes).and_raise(Elasticsearch::Transport::Transport::Errors::BadRequest, "mapper_parsing_exception")
+    expect(ErrorNotifier).to receive(:notify).with(
+      an_instance_of(Elasticsearch::Transport::Transport::Errors::BadRequest),
+      product_id: usd.id,
+      user_id: seller.id
+    )
+    expect { described_class.new(products).perform }.not_to raise_error
+    expect(indexed_codes(eur)).to eq(["KEEP"])
+  end
+
+  it "reports a missing-document fallback failure without stopping later products" do
+    products = [usd, eur]
+    create(:universal_offer_code, user: seller, code: "KEEP", currency_type: nil, amount_cents: nil, amount_percentage: 10)
+    usd.__elasticsearch__.delete_document
+    allow(usd.__elasticsearch__).to receive(:index_document).and_raise(Faraday::TimeoutError)
+    expect(ErrorNotifier).to receive(:notify).with(
+      an_instance_of(Faraday::TimeoutError),
+      product_id: usd.id,
+      user_id: seller.id
+    )
+    expect { described_class.new(products).perform }.not_to raise_error
+    expect(indexed_codes(eur)).to eq(["KEEP"])
   end
 end

--- a/spec/services/product_offer_code_indexing_service_spec.rb
+++ b/spec/services/product_offer_code_indexing_service_spec.rb
@@ -114,4 +114,11 @@ describe ProductOfferCodeIndexingService do
     expect(ErrorNotifier).not_to receive(:notify)
     expect { described_class.new([usd, eur]).perform }.to raise_error(Faraday::TimeoutError)
   end
+
+  it "re-raises Elasticsearch 429 throttling delivered as a generic ServerError" do
+    allow(usd.__elasticsearch__).to receive(:update_document_attributes)
+      .and_raise(Elasticsearch::Transport::Transport::ServerError, "[429] es_rejected_execution_exception")
+    expect(ErrorNotifier).not_to receive(:notify)
+    expect { described_class.new([usd, eur]).perform }.to raise_error(Elasticsearch::Transport::Transport::ServerError, /429/)
+  end
 end

--- a/spec/services/product_offer_code_indexing_service_spec.rb
+++ b/spec/services/product_offer_code_indexing_service_spec.rb
@@ -109,6 +109,18 @@ describe ProductOfferCodeIndexingService do
     expect(indexed_codes(eur)).to eq(["KEEP"])
   end
 
+
+  it "re-raises unclassified Elasticsearch failures after notifying so pending work stays pinned" do
+    allow(usd.__elasticsearch__).to receive(:update_document_attributes)
+      .and_raise(Elasticsearch::Transport::Transport::Errors::Unauthorized, "[401] security_exception")
+    expect(ErrorNotifier).to receive(:notify).with(
+      an_instance_of(Elasticsearch::Transport::Transport::Errors::Unauthorized),
+      product_id: usd.id,
+      user_id: seller.id
+    )
+    expect { described_class.new([usd, eur]).perform }.to raise_error(Elasticsearch::Transport::Transport::Errors::Unauthorized, /401/)
+  end
+
   it "re-raises retryable transport failures so the seller scan stays pinned" do
     allow(usd.__elasticsearch__).to receive(:update_document_attributes).and_raise(Faraday::TimeoutError)
     expect(ErrorNotifier).not_to receive(:notify)

--- a/spec/services/product_offer_code_indexing_service_spec.rb
+++ b/spec/services/product_offer_code_indexing_service_spec.rb
@@ -95,17 +95,23 @@ describe ProductOfferCodeIndexingService do
     expect(indexed_codes(eur)).to eq(["KEEP"])
   end
 
-  it "reports a missing-document fallback failure without stopping later products" do
+  it "reports a missing-document fallback permanent failure without stopping later products" do
     products = [usd, eur]
     create(:universal_offer_code, user: seller, code: "KEEP", currency_type: nil, amount_cents: nil, amount_percentage: 10)
     usd.__elasticsearch__.delete_document
-    allow(usd.__elasticsearch__).to receive(:index_document).and_raise(Faraday::TimeoutError)
+    allow(usd.__elasticsearch__).to receive(:index_document).and_raise(Elasticsearch::Transport::Transport::Errors::BadRequest, "mapper_parsing_exception")
     expect(ErrorNotifier).to receive(:notify).with(
-      an_instance_of(Faraday::TimeoutError),
+      an_instance_of(Elasticsearch::Transport::Transport::Errors::BadRequest),
       product_id: usd.id,
       user_id: seller.id
     )
     expect { described_class.new(products).perform }.not_to raise_error
     expect(indexed_codes(eur)).to eq(["KEEP"])
+  end
+
+  it "re-raises retryable transport failures so the seller scan stays pinned" do
+    allow(usd.__elasticsearch__).to receive(:update_document_attributes).and_raise(Faraday::TimeoutError)
+    expect(ErrorNotifier).not_to receive(:notify)
+    expect { described_class.new([usd, eur]).perform }.to raise_error(Faraday::TimeoutError)
   end
 end

--- a/spec/services/product_offer_code_indexing_service_spec.rb
+++ b/spec/services/product_offer_code_indexing_service_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ProductOfferCodeIndexingService do
+  let(:seller) { create(:user) }
+  let(:usd) { create(:product, user: seller, price_currency_type: "usd", price_cents: 1000) }
+  let(:eur) { create(:product, user: seller, price_currency_type: "eur", price_cents: 1000) }
+
+  def indexed_codes(product)
+    product.__elasticsearch__.client.get(index: Link.index_name, id: product.id).dig("_source", "offer_codes")
+  end
+
+  it "matches the existing search value for currencies, exclusions, deleted codes and mixed associations" do
+    products = [usd, eur, create(:product)]
+    create(:offer_code, user: seller, products: [usd], code: "SPECIFIC")
+    create(:universal_offer_code, user: seller, code: "USD", currency_type: "usd")
+    create(:universal_offer_code, user: seller, code: "EUR", currency_type: "eur")
+    create(:universal_offer_code, user: seller, code: "PERCENT", currency_type: nil, amount_cents: nil, amount_percentage: 10)
+    create(:universal_offer_code, user: seller, code: "EXCLUDED", excluded_products: [usd])
+    create(:universal_offer_code, user: seller, code: "DELETED", deleted_at: Time.current)
+    described_class.new(products).perform
+    products.each do |product|
+      expect(indexed_codes(product)).to eq(product.reload.build_search_update(["offer_codes"])["offer_codes"])
+    end
+  end
+
+  it "preserves the cap and creation ordering" do
+    stub_const("Product::Searchable::MAX_OFFER_CODES_IN_INDEX", 2)
+    3.times { |i| create(:universal_offer_code, user: seller, code: "CODE#{i}", created_at: i.days.ago) }
+    described_class.new([usd]).perform
+    expect(indexed_codes(usd)).to eq(["CODE1", "CODE0"])
+  end
+
+  it "loads seller-wide codes once per batch instead of once per product" do
+    products = create_list(:product, 25, user: seller)
+    create(:universal_offer_code, user: seller)
+    statements = []
+    subscriber = ->(*args) { statements << args.last[:sql] if args.last[:sql].match?(/SELECT.*offer_codes/i) }
+    ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+      described_class.new(products).perform
+    end
+    expect(statements.size).to eq(3)
+    expect(statements.grep(/NOT EXISTS/)).to be_empty
+    puts "offer-code batch: products=#{products.size}, offer-code SELECTs=#{statements.size}, per-product universal lookups=0"
+  end
+end

--- a/spec/services/product_offer_code_indexing_service_spec.rb
+++ b/spec/services/product_offer_code_indexing_service_spec.rb
@@ -110,6 +110,17 @@ describe ProductOfferCodeIndexingService do
   end
 
 
+  it "re-raises index-wide HTTP 400 failures after notifying so pending work stays pinned" do
+    allow(usd.__elasticsearch__).to receive(:update_document_attributes)
+      .and_raise(Elasticsearch::Transport::Transport::Errors::BadRequest, "[400] index_closed_exception")
+    expect(ErrorNotifier).to receive(:notify).with(
+      an_instance_of(Elasticsearch::Transport::Transport::Errors::BadRequest),
+      product_id: usd.id,
+      user_id: seller.id
+    )
+    expect { described_class.new([usd, eur]).perform }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest, /index_closed/)
+  end
+
   it "re-raises unclassified Elasticsearch failures after notifying so pending work stays pinned" do
     allow(usd.__elasticsearch__).to receive(:update_document_attributes)
       .and_raise(Elasticsearch::Transport::Transport::Errors::Unauthorized, "[401] security_exception")

--- a/spec/services/product_offer_code_indexing_service_spec.rb
+++ b/spec/services/product_offer_code_indexing_service_spec.rb
@@ -121,6 +121,17 @@ describe ProductOfferCodeIndexingService do
     expect { described_class.new([usd, eur]).perform }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest, /index_closed/)
   end
 
+  it "re-raises request-wide parsing_exception after notifying so pending work stays pinned" do
+    allow(usd.__elasticsearch__).to receive(:update_document_attributes)
+      .and_raise(Elasticsearch::Transport::Transport::Errors::BadRequest, "[400] parsing_exception")
+    expect(ErrorNotifier).to receive(:notify).with(
+      an_instance_of(Elasticsearch::Transport::Transport::Errors::BadRequest),
+      product_id: usd.id,
+      user_id: seller.id
+    )
+    expect { described_class.new([usd, eur]).perform }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest, /parsing_exception/)
+  end
+
   it "re-raises unclassified Elasticsearch failures after notifying so pending work stays pinned" do
     allow(usd.__elasticsearch__).to receive(:update_document_attributes)
       .and_raise(Elasticsearch::Transport::Transport::Errors::Unauthorized, "[401] security_exception")

--- a/spec/services/product_offer_code_indexing_service_spec.rb
+++ b/spec/services/product_offer_code_indexing_service_spec.rb
@@ -44,6 +44,19 @@ describe ProductOfferCodeIndexingService do
     expect(Link.__elasticsearch__.client.indices.exists?(index: original_name)).to be(true)
   end
 
+  it "matches the existing capped value when timestamps tie across both sources" do
+    freeze_time
+    product = usd
+    create(:offer_code, user: seller, products: [product], code: "SPECIFIC1")
+    create(:universal_offer_code, user: seller, code: "UNIVERSAL1")
+    create(:offer_code, user: seller, products: [product], code: "SPECIFIC2")
+    create(:universal_offer_code, user: seller, code: "UNIVERSAL2")
+    stub_const("Product::Searchable::MAX_OFFER_CODES_IN_INDEX", 2)
+    expected = product.reload.build_search_update(["offer_codes"])["offer_codes"]
+    described_class.new([product]).perform
+    expect(indexed_codes(product)).to eq(expected)
+  end
+
   it "preserves the cap and creation ordering" do
     stub_const("Product::Searchable::MAX_OFFER_CODES_IN_INDEX", 2)
     3.times { |i| create(:universal_offer_code, user: seller, code: "CODE#{i}", created_at: i.days.ago) }

--- a/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
+++ b/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
@@ -71,13 +71,140 @@ describe ReindexSellerOfferCodesJob do
   it "does no work while another process holds the seller semaphore" do
     create(:product, user: seller)
     described_class.enqueue(seller.id)
-    semaphore = Suo::Client::Redis.new("#{key}:lock", client: $redis)
-    semaphore.lock do
-      expect(ProductOfferCodeIndexingService).not_to receive(:new)
-      job.perform(seller.id)
-    end
+    $redis.set("#{key}:lock", "another-worker", ex: 3600)
+    expect(ProductOfferCodeIndexingService).not_to receive(:new)
+    job.perform(seller.id)
+    expect($redis.get("#{key}:lock")).to eq("another-worker")
     expect(described_class.jobs.any? { _1["at"].present? }).to be(true)
     expect($redis.get("#{key}:version")).to eq("1")
+  end
+
+  it "updates old and new applicability after currency changes, exclusions, detachment and destruction" do
+    products = [create(:product, user: seller, price_cents: 1000), create(:product, user: seller, price_currency_type: "eur", price_cents: 1000)]
+    code = create(:universal_offer_code, user: seller, code: "DISCOUNT")
+    verify = lambda do
+      4.times { run_batch }
+      products.each do |product|
+        actual = product.__elasticsearch__.client.get(index: Link.index_name, id: product.id).dig("_source", "offer_codes")
+        expect(actual).to eq(product.reload.build_search_update(["offer_codes"])["offer_codes"])
+      end
+    end
+    verify.call
+    code.update!(currency_type: "eur")
+    verify.call
+    code.update!(excluded_products: [products.last])
+    verify.call
+    code.update!(excluded_products: [])
+    verify.call
+    code.update!(universal: false, products: [products.last])
+    verify.call
+    code.update!(products: [products.first], currency_type: "usd")
+    verify.call
+    code.destroy!
+    verify.call
+  end
+
+  it "coalesces repeated saves of a large catalogue without a catch-up burst" do
+    stub_const("ReindexSellerOfferCodesJob::BATCH_SIZE", 25)
+    products = create_list(:product, 1001, user: seller, price_cents: 1000)
+    code = create(:universal_offer_code, user: seller, code: "INITIAL")
+    SidekiqUniqueJobs.use_config(enabled: true) do
+      10.times { |i| code.update!(code: "SAVE#{i}") }
+      expect(described_class.jobs.count { _1["args"] == [seller.id] }).to be <= 2
+    end
+    batches = []
+    allow(ProductOfferCodeIndexingService).to receive(:new).and_wrap_original do |original, batch|
+      batches << batch.size
+      original.call(batch)
+    end
+    job.perform(seller.id)
+    20.times { job.perform(seller.id) }
+    expect(batches).to eq([25])
+    travel described_class::INTERVAL
+    41.times { run_batch }
+    expect(batches.sum).to eq(products.size)
+    expect(batches.max).to eq(25)
+    expect($redis.get("#{key}:version")).to be_nil
+    [products.first, products.last].each do |product|
+      expect(product.__elasticsearch__.client.get(index: Link.index_name, id: product.id).dig("_source", "offer_codes")).to eq(["SAVE9"])
+    end
+    puts "large catalogue: products=#{products.size}, saves=10, indexed=#{batches.sum}, batches=#{batches.size}, max_batch=#{batches.max}, catchup_batch=25"
+  end
+
+  it "serializes competing worker executions using the shared Redis semaphore" do
+    create(:product, user: seller)
+    described_class.enqueue(seller.id)
+    entered = Queue.new
+    finish = Queue.new
+    calls = Queue.new
+    allow_any_instance_of(ProductOfferCodeIndexingService).to receive(:perform) do
+      calls << true
+      entered << true
+      finish.pop
+    end
+    first = Thread.new { ActiveRecord::Base.connection_pool.with_connection { described_class.new.perform(seller.id) } }
+    entered.pop
+    second = Thread.new { described_class.new.perform(seller.id) }
+    second.value
+    expect(calls.size).to eq(1)
+  ensure
+    finish << true if finish
+    first&.value
+  end
+
+  it "admits only one simultaneous first acquisition of a missing lock" do
+    seller_id = seller.id
+    described_class.enqueue(seller_id)
+    ready = Queue.new
+    start = Queue.new
+    entered = Queue.new
+    finish = Queue.new
+    calls = Queue.new
+    allow_any_instance_of(ProductOfferCodeIndexingService).to receive(:perform) do
+      calls << true
+      entered << true
+      finish.pop
+    end
+    workers = 2.times.map do
+      Thread.new do
+        ready << true
+        start.pop
+        ActiveRecord::Base.connection_pool.with_connection { described_class.new.perform(seller_id) }
+      end
+    end
+    2.times { ready.pop }
+    2.times { start << true }
+    Timeout.timeout(5) { entered.pop }
+    Timeout.timeout(5) { Thread.pass until workers.any? { !_1.alive? } }
+    expect(calls.size).to eq(1)
+  ensure
+    2.times { finish << true } if finish
+    workers&.each(&:value)
+  end
+
+  it "resumes preserved work after retry exhaustion without a tight retry loop" do
+    described_class.enqueue(seller.id)
+    described_class.clear
+    described_class.sidekiq_retries_exhausted_block.call({ "args" => [seller.id] }, RuntimeError.new)
+    expect(described_class).to have_enqueued_sidekiq_job(seller.id).at(1.hour.from_now)
+    expect($redis.get("#{key}:version")).to eq("1")
+  end
+
+  it "updates only targeted products and preserves an in-flight targeted edit" do
+    products = create_list(:product, 3, user: seller)
+    code = create(:offer_code, user: seller, products: [products.last], code: "BEFORE")
+    processed = []
+    allow(ProductOfferCodeIndexingService).to receive(:new).and_wrap_original do |original, batch|
+      processed.concat(batch.map(&:id))
+      original.call(batch)
+    end
+    run_batch
+    expect(processed).to eq([products.last.id])
+    expect($redis.get("#{key}:version")).to be_nil
+    described_class.enqueue_products(seller.id, [products.last.id])
+    allow_any_instance_of(ProductOfferCodeIndexingService).to receive(:perform) { code.update!(code: "AFTER") }
+    run_batch
+    expect($redis.hkeys("#{key}:products")).to eq([products.last.id.to_s])
   end
 
   it "preserves an edit arriving during the final batch" do

--- a/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
+++ b/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
@@ -193,8 +193,14 @@ describe ReindexSellerOfferCodesJob do
   it "schedules exhaustion recovery even while the failed job holds its unique lock" do
     SidekiqUniqueJobs.use_config(enabled: true) do
       described_class.enqueue(seller.id)
+      message = described_class.jobs.first
       described_class.clear
-      described_class.sidekiq_retries_exhausted_block.call({ "args" => [seller.id] }, RuntimeError.new)
+      middleware = SidekiqUniqueJobs::Middleware::Server.new
+      expect do
+        middleware.call(described_class.new, message, "low") { raise "index unavailable" }
+      end.to raise_error("index unavailable")
+      expect(described_class.perform_async(seller.id)).to be_nil
+      described_class.sidekiq_retries_exhausted_block.call(message, RuntimeError.new)
       expect(ReindexSellerOfferCodesRecoveryJob.jobs.size).to eq(1)
       expect(ReindexSellerOfferCodesRecoveryJob.jobs.first["lock"]).to be_nil
     end
@@ -277,6 +283,17 @@ describe ReindexSellerOfferCodesJob do
     end
     3.times { run_batch }
     expect(processed.uniq).to match_array(products.map(&:id))
+  end
+
+  it "releases its lock when the final cooldown write fails" do
+    create(:product, user: seller)
+    described_class.enqueue(seller.id)
+    allow($redis).to receive(:set).and_call_original
+    allow_any_instance_of(ProductOfferCodeIndexingService).to receive(:perform) do
+      allow($redis).to receive(:set).with("#{key}:cooldown", anything, ex: anything).and_raise(Redis::BaseError, "unavailable")
+    end
+    expect { job.perform(seller.id) }.to raise_error(Redis::BaseError)
+    expect($redis.get("#{key}:lock")).to be_nil
   end
 
   it "preserves an edit arriving during the final batch" do

--- a/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
+++ b/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
@@ -307,6 +307,17 @@ describe ReindexSellerOfferCodesJob do
   end
 
 
+
+  it "indexes an unpublished excluded product through the targeted queue" do
+    unpublished = create(:product, user: seller, purchase_disabled_at: Time.current, price_cents: 1000)
+    code = create(:universal_offer_code, user: seller, code: "KEEP")
+    ProductOfferCodeIndexingService.new([unpublished]).perform
+    expect(unpublished.__elasticsearch__.client.get(index: Link.index_name, id: unpublished.id).dig("_source", "offer_codes")).to include("KEEP")
+    code.update!(excluded_products: [unpublished])
+    3.times { run_batch }
+    expect(unpublished.__elasticsearch__.client.get(index: Link.index_name, id: unpublished.id).dig("_source", "offer_codes")).not_to include("KEEP")
+  end
+
   it "does not advance the catalogue cursor on an unclassified Elasticsearch failure" do
     products = create_list(:product, 3, user: seller, price_cents: 1000)
     described_class.enqueue(seller.id)

--- a/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
+++ b/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
@@ -186,8 +186,28 @@ describe ReindexSellerOfferCodesJob do
     described_class.enqueue(seller.id)
     described_class.clear
     described_class.sidekiq_retries_exhausted_block.call({ "args" => [seller.id] }, RuntimeError.new)
-    expect(described_class).to have_enqueued_sidekiq_job(seller.id).at(1.hour.from_now)
+    expect(ReindexSellerOfferCodesRecoveryJob).to have_enqueued_sidekiq_job(seller.id).at(1.hour.from_now)
     expect($redis.get("#{key}:version")).to eq("1")
+  end
+
+  it "schedules exhaustion recovery even while the failed job holds its unique lock" do
+    SidekiqUniqueJobs.use_config(enabled: true) do
+      described_class.enqueue(seller.id)
+      described_class.clear
+      described_class.sidekiq_retries_exhausted_block.call({ "args" => [seller.id] }, RuntimeError.new)
+      expect(ReindexSellerOfferCodesRecoveryJob.jobs.size).to eq(1)
+      expect(ReindexSellerOfferCodesRecoveryJob.jobs.first["lock"]).to be_nil
+    end
+  end
+
+  it "skips deleted catalogue rows without consuming batch capacity" do
+    deleted = create_list(:product, 3, user: seller)
+    deleted.each { _1.update_columns(deleted_at: Time.current) }
+    active = create(:product, user: seller)
+    described_class.enqueue(seller.id)
+    expect(ProductOfferCodeIndexingService).to receive(:new).with([active]).and_call_original
+    run_batch
+    expect($redis.get("#{key}:version")).to be_nil
   end
 
   it "updates only targeted products and preserves an in-flight targeted edit" do
@@ -204,7 +224,7 @@ describe ReindexSellerOfferCodesJob do
     described_class.enqueue_products(seller.id, [products.last.id])
     allow_any_instance_of(ProductOfferCodeIndexingService).to receive(:perform) { code.update!(code: "AFTER") }
     run_batch
-    expect($redis.hkeys("#{key}:products")).to eq([products.last.id.to_s])
+    expect($redis.zrange("#{key}:products", 0, -1)).to eq([products.last.id.to_s])
   end
 
   it "advances the catalogue despite a targeted edit before every execution" do
@@ -241,9 +261,22 @@ describe ReindexSellerOfferCodesJob do
       raise ActiveRecord::Rollback
     end
     code.reload.update!(products: [products.last])
-    expect($redis.hkeys("#{key}:products")).to include(products.last.id.to_s)
+    expect($redis.zrange("#{key}:products", 0, -1)).to include(products.last.id.to_s)
     3.times { run_batch }
     expect(products.last.__elasticsearch__.client.get(index: Link.index_name, id: products.last.id).dig("_source", "offer_codes")).to include(code.code)
+  end
+
+  it "moves hot targeted products behind older pending work" do
+    products = create_list(:product, 5, user: seller)
+    described_class.enqueue_products(seller.id, products.map(&:id))
+    processed = []
+    allow(ProductOfferCodeIndexingService).to receive(:new).and_wrap_original do |original, batch|
+      processed.concat(batch.map(&:id))
+      described_class.enqueue_products(seller.id, batch.map(&:id))
+      original.call(batch)
+    end
+    3.times { run_batch }
+    expect(processed.uniq).to match_array(products.map(&:id))
   end
 
   it "preserves an edit arriving during the final batch" do

--- a/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
+++ b/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
@@ -128,7 +128,6 @@ describe ReindexSellerOfferCodesJob do
     [products.first, products.last].each do |product|
       expect(product.__elasticsearch__.client.get(index: Link.index_name, id: product.id).dig("_source", "offer_codes")).to eq(["SAVE9"])
     end
-    puts "large catalogue: products=#{products.size}, saves=10, indexed=#{batches.sum}, batches=#{batches.size}, max_batch=#{batches.max}, catchup_batch=25"
   end
 
   it "serializes competing worker executions using the shared Redis semaphore" do
@@ -305,6 +304,36 @@ describe ReindexSellerOfferCodesJob do
     expect { job.perform(seller.id) }.to raise_error(described_class::LockLost)
     expect($redis.get("#{key}:version")).to eq("1")
     expect($redis.get("#{key}:lock")).to eq("replacement-worker")
+  end
+
+  it "advances the cursor when one product in a batch fails to index" do
+    products = create_list(:product, 3, user: seller, price_cents: 1000)
+    create(:universal_offer_code, user: seller, code: "KEEP")
+    described_class.enqueue(seller.id)
+    allow(ProductOfferCodeIndexingService).to receive(:new).and_wrap_original do |original, batch|
+      service = original.call(batch)
+      allow(service).to receive(:perform).and_wrap_original do |perform_original, &block|
+        batch.each do |product|
+          next unless product.id == products.first.id
+          allow(product.__elasticsearch__).to receive(:update_document_attributes).and_raise(
+            Elasticsearch::Transport::Transport::Errors::BadRequest, "mapper_parsing_exception"
+          )
+        end
+        perform_original.call(&block)
+      end
+      service
+    end
+    expect(ErrorNotifier).to receive(:notify).with(
+      an_instance_of(Elasticsearch::Transport::Transport::Errors::BadRequest),
+      product_id: products.first.id,
+      user_id: seller.id
+    )
+    run_batch
+    expect($redis.get("#{key}:cursor")).to eq(products.second.id.to_s)
+    expect(products.second.__elasticsearch__.client.get(index: Link.index_name, id: products.second.id).dig("_source", "offer_codes")).to include("KEEP")
+    2.times { run_batch }
+    expect(products.third.__elasticsearch__.client.get(index: Link.index_name, id: products.third.id).dig("_source", "offer_codes")).to include("KEEP")
+    expect($redis.get("#{key}:version")).to be_nil
   end
 
   it "preserves an edit arriving during the final batch" do

--- a/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
+++ b/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ReindexSellerOfferCodesJob do
+  let(:seller) { create(:user) }
+  let(:key) { "offer_code_index:#{seller.id}" }
+  let(:job) { described_class.new }
+
+  before do
+    freeze_time
+    stub_const("ReindexSellerOfferCodesJob::BATCH_SIZE", 2)
+  end
+
+  def run_batch
+    job.perform(seller.id)
+    travel ReindexSellerOfferCodesJob::INTERVAL
+  end
+
+  it "bounds actual work across queued duplicates and resumes from the last batch" do
+    products = create_list(:product, 5, user: seller)
+    10.times { described_class.enqueue(seller.id) }
+    batches = []
+    allow(ProductOfferCodeIndexingService).to receive(:new).and_wrap_original do |original, batch|
+      batches << batch.map(&:id)
+      original.call(batch)
+    end
+    job.perform(seller.id)
+    10.times { job.perform(seller.id) }
+    expect(batches).to eq([products.first(2).map(&:id)])
+    travel described_class::INTERVAL
+    3.times { run_batch }
+    expect(batches.flatten).to eq(products.map(&:id))
+    expect($redis.get("#{key}:version")).to be_nil
+    expect(SendToElasticsearchWorker.jobs.select { _1["args"].last == ["offer_codes"] }).to be_empty
+  end
+
+  it "revisits products behind the cursor after a mid-flight edit" do
+    products = create_list(:product, 3, user: seller)
+    code = create(:universal_offer_code, user: seller, code: "BEFORE")
+    run_batch
+    code.update!(code: "AFTER")
+    4.times { run_batch }
+    products.each do |product|
+      expect(product.__elasticsearch__.client.get(index: Link.index_name, id: product.id).dig("_source", "offer_codes")).to include("AFTER")
+    end
+    expect($redis.get("#{key}:version")).to be_nil
+  end
+
+  it "retains the cursor and dirty generation when indexing fails" do
+    create_list(:product, 3, user: seller)
+    described_class.enqueue(seller.id)
+    allow_any_instance_of(ProductOfferCodeIndexingService).to receive(:perform).and_raise("index unavailable")
+    expect { job.perform(seller.id) }.to raise_error("index unavailable")
+    expect($redis.get("#{key}:cursor")).to be_nil
+    expect($redis.get("#{key}:version")).to eq("1")
+    allow_any_instance_of(ProductOfferCodeIndexingService).to receive(:perform).and_call_original
+    3.times { run_batch }
+    expect($redis.get("#{key}:version")).to be_nil
+  end
+
+  it "does not acknowledge a batch if scheduling its continuation fails" do
+    create_list(:product, 3, user: seller)
+    described_class.enqueue(seller.id)
+    allow(described_class).to receive(:perform_in).and_raise("queue unavailable")
+    expect { job.perform(seller.id) }.to raise_error("queue unavailable")
+    expect($redis.get("#{key}:cursor")).to be_nil
+    expect($redis.get("#{key}:version")).to eq("1")
+  end
+
+  it "does no work while another process holds the seller semaphore" do
+    create(:product, user: seller)
+    described_class.enqueue(seller.id)
+    semaphore = Suo::Client::Redis.new("#{key}:lock", client: $redis)
+    semaphore.lock do
+      expect(ProductOfferCodeIndexingService).not_to receive(:new)
+      job.perform(seller.id)
+    end
+    expect(described_class.jobs.any? { _1["at"].present? }).to be(true)
+    expect($redis.get("#{key}:version")).to eq("1")
+  end
+
+  it "preserves an edit arriving during the final batch" do
+    create(:product, user: seller)
+    described_class.enqueue(seller.id)
+    allow_any_instance_of(ProductOfferCodeIndexingService).to receive(:perform) { described_class.enqueue(seller.id) }
+    run_batch
+    expect($redis.get("#{key}:version")).to eq("2")
+    expect($redis.get("#{key}:cursor")).to be_nil
+  end
+end

--- a/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
+++ b/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
@@ -278,7 +278,7 @@ describe ReindexSellerOfferCodesJob do
     processed = []
     allow(ProductOfferCodeIndexingService).to receive(:new).and_wrap_original do |original, batch|
       processed.concat(batch.map(&:id))
-      described_class.enqueue_products(seller.id, batch.map(&:id))
+      described_class.enqueue_products(seller.id, products.map(&:id))
       original.call(batch)
     end
     3.times { run_batch }
@@ -294,6 +294,17 @@ describe ReindexSellerOfferCodesJob do
     end
     expect { job.perform(seller.id) }.to raise_error(Redis::BaseError)
     expect($redis.get("#{key}:lock")).to be_nil
+  end
+
+  it "does not acknowledge work after losing its lease" do
+    create(:product, user: seller)
+    described_class.enqueue(seller.id)
+    allow_any_instance_of(ProductOfferCodeIndexingService).to receive(:perform) do
+      $redis.set("#{key}:lock", "replacement-worker", ex: 600)
+    end
+    expect { job.perform(seller.id) }.to raise_error(described_class::LockLost)
+    expect($redis.get("#{key}:version")).to eq("1")
+    expect($redis.get("#{key}:lock")).to eq("replacement-worker")
   end
 
   it "preserves an edit arriving during the final batch" do

--- a/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
+++ b/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
@@ -207,6 +207,45 @@ describe ReindexSellerOfferCodesJob do
     expect($redis.hkeys("#{key}:products")).to eq([products.last.id.to_s])
   end
 
+  it "advances the catalogue despite a targeted edit before every execution" do
+    products = create_list(:product, 3, user: seller)
+    described_class.enqueue(seller.id)
+    6.times do
+      described_class.enqueue_products(seller.id, [products.last.id])
+      run_batch
+    end
+    expect($redis.get("#{key}:version")).to be_nil
+  end
+
+  it "paces retries after a slow partial indexing failure" do
+    create(:product, user: seller)
+    described_class.enqueue(seller.id)
+    calls = 0
+    allow_any_instance_of(ProductOfferCodeIndexingService).to receive(:perform) do
+      calls += 1
+      travel 10.seconds
+      raise "partial failure"
+    end
+    expect { job.perform(seller.id) }.to raise_error("partial failure")
+    job.perform(seller.id)
+    expect(calls).to eq(1)
+    expect($redis.get("#{key}:version")).to eq("1")
+  end
+
+  it "does not reuse product IDs from a rolled-back destruction" do
+    products = create_list(:product, 2, user: seller)
+    code = create(:offer_code, user: seller, products: [products.first])
+    run_batch
+    OfferCode.transaction(requires_new: true) do
+      code.destroy!
+      raise ActiveRecord::Rollback
+    end
+    code.reload.update!(products: [products.last])
+    expect($redis.hkeys("#{key}:products")).to include(products.last.id.to_s)
+    3.times { run_batch }
+    expect(products.last.__elasticsearch__.client.get(index: Link.index_name, id: products.last.id).dig("_source", "offer_codes")).to include(code.code)
+  end
+
   it "preserves an edit arriving during the final batch" do
     create(:product, user: seller)
     described_class.enqueue(seller.id)

--- a/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
+++ b/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
@@ -205,6 +205,15 @@ describe ReindexSellerOfferCodesJob do
     end
   end
 
+  it "indexes unpublished catalogue rows so offer codes stay fresh across republication" do
+    unpublished = create(:product, user: seller, purchase_disabled_at: Time.current, price_cents: 1000)
+    create(:universal_offer_code, user: seller, code: "KEEP")
+    described_class.enqueue(seller.id)
+    expect(ProductOfferCodeIndexingService).to receive(:new).with([unpublished]).and_call_original
+    run_batch
+    expect(unpublished.__elasticsearch__.client.get(index: Link.index_name, id: unpublished.id).dig("_source", "offer_codes")).to include("KEEP")
+  end
+
   it "skips deleted catalogue rows without consuming batch capacity" do
     deleted = create_list(:product, 3, user: seller)
     deleted.each { _1.update_columns(deleted_at: Time.current) }

--- a/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
+++ b/spec/sidekiq/reindex_seller_offer_codes_job_spec.rb
@@ -306,6 +306,52 @@ describe ReindexSellerOfferCodesJob do
     expect($redis.get("#{key}:lock")).to eq("replacement-worker")
   end
 
+
+  it "does not advance the catalogue cursor on an unclassified Elasticsearch failure" do
+    products = create_list(:product, 3, user: seller, price_cents: 1000)
+    described_class.enqueue(seller.id)
+    allow(ProductOfferCodeIndexingService).to receive(:new).and_wrap_original do |original, batch|
+      service = original.call(batch)
+      allow(service).to receive(:perform).and_wrap_original do |perform_original, &block|
+        batch.each do |product|
+          allow(product.__elasticsearch__).to receive(:update_document_attributes).and_raise(
+            Elasticsearch::Transport::Transport::Errors::Unauthorized, "[401] security_exception"
+          )
+        end
+        perform_original.call(&block)
+      end
+      service
+    end
+    expect(ErrorNotifier).to receive(:notify).with(
+      an_instance_of(Elasticsearch::Transport::Transport::Errors::Unauthorized),
+      product_id: products.first.id,
+      user_id: seller.id
+    )
+    expect { job.perform(seller.id) }.to raise_error(Elasticsearch::Transport::Transport::Errors::Unauthorized, /401/)
+    expect($redis.get("#{key}:cursor")).to be_nil
+    expect($redis.get("#{key}:version")).to eq("1")
+  end
+
+  it "does not clear targeted product IDs on an unclassified Elasticsearch failure" do
+    products = create_list(:product, 2, user: seller)
+    described_class.enqueue_products(seller.id, products.map(&:id))
+    allow(ProductOfferCodeIndexingService).to receive(:new).and_wrap_original do |original, batch|
+      service = original.call(batch)
+      allow(service).to receive(:perform).and_wrap_original do |perform_original, &block|
+        batch.each do |product|
+          allow(product.__elasticsearch__).to receive(:update_document_attributes).and_raise(
+            Elasticsearch::Transport::Transport::Errors::Unauthorized, "[401] security_exception"
+          )
+        end
+        perform_original.call(&block)
+      end
+      service
+    end
+    expect(ErrorNotifier).to receive(:notify)
+    expect { job.perform(seller.id) }.to raise_error(Elasticsearch::Transport::Transport::Errors::Unauthorized, /401/)
+    expect($redis.zrange("#{key}:products", 0, -1)).to match_array(products.map { _1.id.to_s })
+  end
+
   it "advances the cursor when one product in a batch fails to index" do
     products = create_list(:product, 3, user: seller, price_cents: 1000)
     create(:universal_offer_code, user: seller, code: "KEEP")

--- a/spec/sidekiq/reindex_seller_offer_codes_recovery_job_spec.rb
+++ b/spec/sidekiq/reindex_seller_offer_codes_recovery_job_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ReindexSellerOfferCodesRecoveryJob do
+  it "resumes the preserved cursor through the same bounded worker" do
+    seller = create(:user)
+    products = create_list(:product, 3, user: seller)
+    ReindexSellerOfferCodesJob.enqueue(seller.id)
+    $redis.set("offer_code_index:#{seller.id}:cursor", products.first.id)
+    $redis.set("offer_code_index:#{seller.id}:scan_version", "1")
+    expect(ProductOfferCodeIndexingService).to receive(:new).with(products.last(2)).and_call_original
+
+    described_class.new.perform(seller.id)
+
+    expect($redis.get("offer_code_index:#{seller.id}:version")).to be_nil
+    expect(ReindexSellerOfferCodesJob.jobs.any? { _1["at"].present? }).to be(true)
+  end
+
+  it "retains a delayed recovery after a prolonged outage exhausts its own retries" do
+    freeze_time
+    described_class.sidekiq_retries_exhausted_block.call({ "args" => [123] }, RuntimeError.new)
+    expect(described_class).to have_enqueued_sidekiq_job(123).at(1.hour.from_now)
+  end
+
+  it "does not bypass an active seller lock" do
+    seller = create(:user)
+    ReindexSellerOfferCodesJob.enqueue(seller.id)
+    $redis.set("offer_code_index:#{seller.id}:lock", "active-worker", ex: 600)
+    expect(ProductOfferCodeIndexingService).not_to receive(:new)
+
+    described_class.new.perform(seller.id)
+
+    expect($redis.get("offer_code_index:#{seller.id}:version")).to eq("1")
+    expect($redis.get("offer_code_index:#{seller.id}:lock")).to eq("active-worker")
+  end
+
+  it "propagates an indexing failure for Sidekiq retry without acknowledging work" do
+    seller = create(:user)
+    create(:product, user: seller)
+    ReindexSellerOfferCodesJob.enqueue(seller.id)
+    allow_any_instance_of(ProductOfferCodeIndexingService).to receive(:perform).and_raise("unavailable")
+
+    expect { described_class.new.perform(seller.id) }.to raise_error("unavailable")
+    expect($redis.get("offer_code_index:#{seller.id}:version")).to eq("1")
+  end
+end


### PR DESCRIPTION
## Verified inline-execution blocker — September 8

Fresh Astra + Fable panel at `882abea3c6613f4a62a432e184e61f965ca0141f` returned one Fable finding; Astra returned none. The exact job with real Sidekiq 7.3.0 inline testing and a lock-held Redis double reproduced `SystemStackError` after 457 lock attempts: the lock-conflict path calls `perform_in`, which inline mode immediately executes recursively. This is a standalone job probe, not a Rails integration run or a production recursion claim.

Current CI is green, but the inline behavior remains unsafe for test callers; two offer-code creations in the changed Black Friday spec are already wrapped in fake mode. Resolve scheduling/testing semantics without weakening production pacing, then rerun the affected inline path and panel. Gianfranco retains the active implementation; no concurrent code changes or merge were performed. [Pace and coalesce offer-code search indexing](https://github.com/antiwork/gumroad/pull/7550).

## What

Pace offer-code search indexing with a per-seller cursor, a 25-product batch limit and an execution-time cooldown. Coalesce universal edits and keep product-specific edits targeted.

## Why

Immediate per-product fanout repeats seller-wide queries. Bounded batches reduce repeated reads; retries and hourly recovery preserve unfinished scans.

## Before/After

No templates change. Earlier verification at `0a86006a41bb15edbfc1ed03d97671cf6bb0860b` exercised actual MySQL, Redis and Elasticsearch data. That evidence does not cover the subsequent error-handling commits.

## Current status

Draft. The unclassified-error finding is confirmed: a direct Ruby probe at `2685a1c8cdda87d9794db141ef3d8d35270d846c` showed `Unauthorized` being reported and swallowed. Gianfranco pushed `3744a4ef4766222cd278cae94611cf642acfade9` during verification and retains ownership of the active revision; the webhook worker stopped concurrent edits and pushed no fix. The finding remains unresolved.

Premerge review: blocked @ 882abea3c6613f4a62a432e184e61f965ca0141f. See the verified inline-execution blocker above.

## Test Results

Earlier head: 238 focused examples passed, Ruby lint passed, and nine guard mutants failed their intended regressions. Full CI passed at that earlier head: https://github.com/antiwork/gumroad/actions/runs/34260366961

The newer head needs error-propagation regression tests, current-head CI, and renewed panel/QA verification. The webhook worker's attempted regression run produced no completed verdict and is not counted as evidence.

Reproduction: `bundle exec rspec spec/sidekiq/reindex_seller_offer_codes_job_spec.rb spec/sidekiq/reindex_seller_offer_codes_recovery_job_spec.rb spec/services/product_offer_code_indexing_service_spec.rb spec/modules/product/searchable/offer_codes_spec.rb` against isolated test services.

- [x] Scope: bounded, coalesced offer-code indexing.
- [x] Design: seller serialization, cooldown and retry recovery.
- [ ] Build: address unclassified failures and verify the current head.
- [ ] Ship: current-head panel, QA, CI and human review; no automatic merge.
- [ ] Market: not applicable to this internal indexing change.
- [ ] Sell: not applicable to this internal indexing change.

---
AI assistance: GPT-6 Astra; implement bounded offer-code indexing and verify review feedback without merging.
