### PR TITLE
Keep refund bookkeeping durable when fee-retention transfer reversal fails

### DIFF
--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -627,8 +627,9 @@ class StripeChargeProcessor
     refund = credit.fee_retention_refund
     return if refund.blank?
     return recorded_refund_fee_collection(credit:) if refund.debited_stripe_transfer.present?
-    # US Gumroad-managed accounts keep fee retention on the ledger; Stripe has no matching reversal.
-    return if credit.merchant_account.country == Compliance::Countries::USA.alpha2
+    # US Gumroad-managed accounts cannot reverse payout transfers; collect with the same
+    # grouped account debit used when a non-US reversal is no longer supported.
+    return debit_refund_fee_from_account(credit:) if credit.merchant_account.country == Compliance::Countries::USA.alpha2
 
     stripe_account_id = credit.merchant_account.charge_processor_merchant_id
     usd_amount_cents = credit.amount_cents.abs

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -648,12 +648,15 @@ class StripeChargeProcessor
     transfer_reversal = nil
     transfer = nil
     if already_pinned_id.present?
-      transfer = Stripe::Transfer.retrieve(already_pinned_id) rescue nil
-      if transfer
-        transfer_reversal = existing_refund_fee_reversal(transfer.id, refund.id)
-        unless transfer_reversal || transfer.amount - transfer.amount_reversed > amount_to_reverse_for.call(transfer)
-          transfer = nil
-        end
+      # Fail closed on retrieve errors: a lost successful reversal must be looked
+      # up on this pin, not skipped for a second collection on another transfer.
+      transfer = Stripe::Transfer.retrieve(already_pinned_id)
+      transfer_reversal = existing_refund_fee_reversal(transfer.id, refund.id)
+      unless transfer_reversal || transfer.amount - transfer.amount_reversed > amount_to_reverse_for.call(transfer)
+        grouped_debit = existing_refund_fee_grouped_debit(refund, stripe_account_id)
+        return adopt_refund_fee_grouped_debit!(refund, grouped_debit) if grouped_debit
+
+        transfer = nil
       end
     end
     unless transfer
@@ -675,7 +678,6 @@ class StripeChargeProcessor
     end
     return unless transfer
 
-    reuse_legacy_reversal_key = refund.fee_retention_source_transfer == transfer.id
     if refund.fee_retention_source_transfer != transfer.id
       refund.fee_retention_source_transfer = transfer.id
       refund.save!
@@ -685,7 +687,7 @@ class StripeChargeProcessor
       transfer_reversal ||= Stripe::Transfer.create_reversal(
         transfer.id,
         { amount: amount_to_reverse_for.call(transfer), metadata: { refund_id: refund.id.to_s } },
-        { idempotency_key: refund_fee_retention_reversal_key(refund, transfer_id: transfer.id, legacy: reuse_legacy_reversal_key) }
+        { idempotency_key: refund_fee_retention_reversal_key(refund, transfer.id) }
       )
     rescue Stripe::InvalidRequestError => error
       raise unless error.message.match?(/no longer supported/i)
@@ -721,11 +723,22 @@ class StripeChargeProcessor
     "refund_fee_retention_#{refund.id}"
   end
 
-  def self.refund_fee_retention_reversal_key(refund, transfer_id: nil, legacy: false)
-    base = "refund_fee_retention_reversal_#{refund.id}"
-    return base if legacy || transfer_id.blank?
+  def self.refund_fee_retention_reversal_key(refund, transfer_id)
+    "refund_fee_retention_reversal_#{refund.id}_#{transfer_id}"
+  end
 
-    "#{base}_#{transfer_id}"
+  def self.existing_refund_fee_grouped_debit(refund, stripe_account_id)
+    Stripe::Transfer.list(
+      { transfer_group: refund_fee_retention_transfer_group(refund), limit: 1 },
+      { stripe_account: stripe_account_id }
+    ).first
+  end
+
+  def self.adopt_refund_fee_grouped_debit!(refund, transfer)
+    refund.debited_stripe_transfer = transfer.id
+    refund.fee_retention_collected_cents = transfer.amount
+    refund.save!
+    transfer.amount
   end
 
   def self.existing_refund_fee_reversal(transfer_id, refund_id)

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -644,18 +644,19 @@ class StripeChargeProcessor
     # raw USD figure in a foreign currency, debiting the creator the wrong amount.
     amount_to_reverse_for = ->(transfer) { usd_cents_to_currency(transfer.currency, usd_amount_cents) }
 
-    already_pinned = refund.fee_retention_source_transfer.present?
+    already_pinned_id = refund.fee_retention_source_transfer
     transfer_reversal = nil
     transfer = nil
-    if already_pinned
-      transfer = Stripe::Transfer.retrieve(refund.fee_retention_source_transfer) rescue nil
-      return unless transfer
-
-      transfer_reversal = existing_refund_fee_reversal(transfer.id, refund.id)
-      unless transfer_reversal || transfer.amount - transfer.amount_reversed > amount_to_reverse_for.call(transfer)
-        return
+    if already_pinned_id.present?
+      transfer = Stripe::Transfer.retrieve(already_pinned_id) rescue nil
+      if transfer
+        transfer_reversal = existing_refund_fee_reversal(transfer.id, refund.id)
+        unless transfer_reversal || transfer.amount - transfer.amount_reversed > amount_to_reverse_for.call(transfer)
+          transfer = nil
+        end
       end
-    else
+    end
+    unless transfer
       # First, try and reverse an internal transfer made from gumroad platform account
       # to the connect account, if possible.
       transfer_ids = credit.user.payments.completed
@@ -674,6 +675,7 @@ class StripeChargeProcessor
     end
     return unless transfer
 
+    reuse_legacy_reversal_key = refund.fee_retention_source_transfer == transfer.id
     if refund.fee_retention_source_transfer != transfer.id
       refund.fee_retention_source_transfer = transfer.id
       refund.save!
@@ -683,7 +685,7 @@ class StripeChargeProcessor
       transfer_reversal ||= Stripe::Transfer.create_reversal(
         transfer.id,
         { amount: amount_to_reverse_for.call(transfer), metadata: { refund_id: refund.id.to_s } },
-        { idempotency_key: refund_fee_retention_reversal_key(refund) }
+        { idempotency_key: refund_fee_retention_reversal_key(refund, transfer_id: transfer.id, legacy: reuse_legacy_reversal_key) }
       )
     rescue Stripe::InvalidRequestError => error
       raise unless error.message.match?(/no longer supported/i)
@@ -719,8 +721,11 @@ class StripeChargeProcessor
     "refund_fee_retention_#{refund.id}"
   end
 
-  def self.refund_fee_retention_reversal_key(refund)
-    "refund_fee_retention_reversal_#{refund.id}"
+  def self.refund_fee_retention_reversal_key(refund, transfer_id: nil, legacy: false)
+    base = "refund_fee_retention_reversal_#{refund.id}"
+    return base if legacy || transfer_id.blank?
+
+    "#{base}_#{transfer_id}"
   end
 
   def self.existing_refund_fee_reversal(transfer_id, refund_id)

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -619,7 +619,7 @@ class StripeChargeProcessor
     raise ChargeProcessorUnavailableError.new("Stripe error while refunding a charge: #{e.message}", original_error: e)
   end
 
-  def self.debit_stripe_account_for_refund_fee(credit:)
+  def self.debit_stripe_account_for_refund_fee(credit:, collect: true)
     return unless credit.present?
     return if credit.amount_cents == 0
     return unless credit.merchant_account&.charge_processor_merchant_id.present?
@@ -627,6 +627,7 @@ class StripeChargeProcessor
     refund = credit.fee_retention_refund
     return if refund.blank?
     return recorded_refund_fee_collection(credit:) if refund.debited_stripe_transfer.present?
+    return adopt_existing_refund_fee_collection(credit:) unless collect
     # US Gumroad-managed accounts cannot reverse payout transfers; collect with the same
     # grouped account debit used when a non-US reversal is no longer supported.
     return debit_refund_fee_from_account(credit:) if credit.merchant_account.country == Compliance::Countries::USA.alpha2
@@ -734,6 +735,28 @@ class StripeChargeProcessor
 
   def self.refund_fee_retention_reversal_key(refund, transfer_id)
     "refund_fee_retention_reversal_#{refund.id}_#{transfer_id}"
+  end
+
+  def self.adopt_existing_refund_fee_collection(credit:)
+    refund = credit.fee_retention_refund
+    return recorded_refund_fee_collection(credit:) if refund.debited_stripe_transfer.present?
+
+    stripe_account_id = credit.merchant_account.charge_processor_merchant_id
+    grouped_debit = existing_refund_fee_grouped_debit(refund, stripe_account_id)
+    return adopt_refund_fee_grouped_debit!(refund, grouped_debit) if grouped_debit
+
+    pin = refund.fee_retention_source_transfer
+    return if pin.blank?
+
+    # Fail closed on retrieve errors: a lost successful reversal on this pin
+    # must be looked up, not treated as "no collection".
+    transfer = Stripe::Transfer.retrieve(pin)
+    transfer_reversal = existing_refund_fee_reversal(transfer.id, refund.id)
+    return if transfer_reversal.blank?
+
+    refund.debited_stripe_transfer = transfer_reversal.id
+    refund.save!
+    record_reversal_collected_cents!(refund, transfer_reversal, stripe_account_id)
   end
 
   def self.existing_refund_fee_grouped_debit(refund, stripe_account_id)

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -625,7 +625,8 @@ class StripeChargeProcessor
     return unless credit.merchant_account&.charge_processor_merchant_id.present?
     return unless credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE
     refund = credit.fee_retention_refund
-    return if refund.blank? || refund.debited_stripe_transfer.present?
+    return if refund.blank?
+    return recorded_refund_fee_collection(credit:) if refund.debited_stripe_transfer.present?
     if credit.merchant_account.country == Compliance::Countries::USA.alpha2
       return debit_refund_fee_from_account(credit:) if refund.fee_retention_pending
       return
@@ -644,25 +645,47 @@ class StripeChargeProcessor
     # raw USD figure in a foreign currency, debiting the creator the wrong amount.
     amount_to_reverse_for = ->(transfer) { usd_cents_to_currency(transfer.currency, usd_amount_cents) }
 
-    # First, try and reverse an internal transfer made from gumroad platform account
-    # to the connect account, if possible.
-    transfer_ids = credit.user.payments.completed
-                         .where(stripe_connect_account_id: stripe_account_id)
-                         .order(:created_at)
-                         .pluck(:stripe_internal_transfer_id)
-    transfer = transfer_ids.compact_blank.lazy
-                           .filter_map { |tr_id| Stripe::Transfer.retrieve(tr_id) rescue nil }
-                           .find { |tr| tr.amount - tr.amount_reversed > amount_to_reverse_for.call(tr) }
-    unless transfer
-      transfers = Stripe::Transfer.list(destination: stripe_account_id, created: { 'lt': 120.days.ago.to_i }, limit: 100)
-      transfer = transfers.find do |tr|
-        tr.present? && tr.amount - tr.amount_reversed > amount_to_reverse_for.call(tr)
+    already_pinned = refund.fee_retention_source_transfer.present?
+    transfer_reversal = nil
+    transfer = nil
+    if already_pinned
+      transfer = Stripe::Transfer.retrieve(refund.fee_retention_source_transfer) rescue nil
+      return unless transfer
+
+      transfer_reversal = existing_refund_fee_reversal(transfer.id, refund.id)
+      unless transfer_reversal || transfer.amount - transfer.amount_reversed > amount_to_reverse_for.call(transfer)
+        return
+      end
+    else
+      # First, try and reverse an internal transfer made from gumroad platform account
+      # to the connect account, if possible.
+      transfer_ids = credit.user.payments.completed
+                           .where(stripe_connect_account_id: stripe_account_id)
+                           .order(:created_at)
+                           .pluck(:stripe_internal_transfer_id)
+      transfer = transfer_ids.compact_blank.lazy
+                             .filter_map { |tr_id| Stripe::Transfer.retrieve(tr_id) rescue nil }
+                             .find { |tr| tr.amount - tr.amount_reversed > amount_to_reverse_for.call(tr) }
+      unless transfer
+        transfers = Stripe::Transfer.list(destination: stripe_account_id, created: { 'lt': 120.days.ago.to_i }, limit: 100)
+        transfer = transfers.find do |tr|
+          tr.present? && tr.amount - tr.amount_reversed > amount_to_reverse_for.call(tr)
+        end
       end
     end
     return unless transfer
 
+    if refund.fee_retention_source_transfer != transfer.id
+      refund.fee_retention_source_transfer = transfer.id
+      refund.save!
+    end
+
     begin
-      transfer_reversal = Stripe::Transfer.create_reversal(transfer.id, { amount: amount_to_reverse_for.call(transfer) })
+      transfer_reversal ||= Stripe::Transfer.create_reversal(
+        transfer.id,
+        { amount: amount_to_reverse_for.call(transfer), metadata: { refund_id: refund.id.to_s } },
+        { idempotency_key: refund_fee_retention_reversal_key(refund) }
+      )
     rescue Stripe::InvalidRequestError => error
       raise unless error.message.match?(/no longer supported/i)
 
@@ -670,22 +693,16 @@ class StripeChargeProcessor
     end
     refund.debited_stripe_transfer = transfer_reversal.id
     refund.save!
-    destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
-                                                 stripe_account: stripe_account_id)
-    destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
-                                                                          stripe_account: stripe_account_id)
-    refund.fee_retention_collected_cents = destination_balance_transaction.net.abs
-    refund.save!
-    refund.fee_retention_collected_cents
+    record_reversal_collected_cents!(refund, transfer_reversal, stripe_account_id)
   end
 
   def self.debit_refund_fee_from_account(credit:)
     refund = credit.fee_retention_refund
-    return if refund.debited_stripe_transfer.present?
+    return recorded_refund_fee_collection(credit:) if refund.debited_stripe_transfer.present?
 
     merchant_account = credit.merchant_account
     stripe_account_id = merchant_account.charge_processor_merchant_id
-    transfer_group = "refund_fee_retention_#{refund.id}"
+    transfer_group = refund_fee_retention_transfer_group(refund)
     # The lookup survives Stripe's idempotency-key expiry if the debit was never recorded locally.
     transfer = Stripe::Transfer.list({ transfer_group:, limit: 1 }, { stripe_account: stripe_account_id }).first
     transfer ||= Stripe::Transfer.create({ amount: usd_cents_to_currency(merchant_account.currency, credit.amount_cents.abs),
@@ -697,6 +714,52 @@ class StripeChargeProcessor
     refund.fee_retention_collected_cents = transfer.amount
     refund.save!
     transfer.amount
+  end
+
+  def self.refund_fee_retention_transfer_group(refund)
+    "refund_fee_retention_#{refund.id}"
+  end
+
+  def self.refund_fee_retention_reversal_key(refund)
+    "refund_fee_retention_reversal_#{refund.id}"
+  end
+
+  def self.existing_refund_fee_reversal(transfer_id, refund_id)
+    return unless transfer_id.present? && refund_id.present?
+
+    expected = refund_id.to_s
+    Stripe::Transfer.list_reversals(transfer_id, { limit: 100 }).find do |reversal|
+      metadata = reversal.try(:metadata)
+      next if metadata.blank?
+
+      metadata[:refund_id].to_s == expected || metadata["refund_id"].to_s == expected
+    end
+  end
+
+  def self.recorded_refund_fee_collection(credit:)
+    refund = credit.fee_retention_refund
+    return refund.fee_retention_collected_cents if refund.fee_retention_collected_cents.present?
+
+    stripe_account_id = credit.merchant_account.charge_processor_merchant_id
+    if refund.fee_retention_source_transfer.present?
+      transfer_reversal = Stripe::Transfer.retrieve_reversal(refund.fee_retention_source_transfer, refund.debited_stripe_transfer)
+      record_reversal_collected_cents!(refund, transfer_reversal, stripe_account_id)
+    else
+      transfer = Stripe::Transfer.retrieve(refund.debited_stripe_transfer, { stripe_account: stripe_account_id })
+      refund.fee_retention_collected_cents = transfer.amount
+      refund.save!
+      transfer.amount
+    end
+  end
+
+  def self.record_reversal_collected_cents!(refund, transfer_reversal, stripe_account_id)
+    destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
+                                                 stripe_account: stripe_account_id)
+    destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
+                                                                          stripe_account: stripe_account_id)
+    refund.fee_retention_collected_cents = destination_balance_transaction.net.abs
+    refund.save!
+    refund.fee_retention_collected_cents
   end
 
   def self.debit_stripe_account_for_australia_backtaxes(credit:)

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -624,8 +624,12 @@ class StripeChargeProcessor
     return if credit.amount_cents == 0
     return unless credit.merchant_account&.charge_processor_merchant_id.present?
     return unless credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE
-    return if credit.merchant_account.country == Compliance::Countries::USA.alpha2
-    return if credit.fee_retention_refund&.debited_stripe_transfer.present?
+    refund = credit.fee_retention_refund
+    return if refund.blank? || refund.debited_stripe_transfer.present?
+    if credit.merchant_account.country == Compliance::Countries::USA.alpha2
+      return debit_refund_fee_from_account(credit:) if refund.fee_retention_pending
+      return
+    end
 
     stripe_account_id = credit.merchant_account.charge_processor_merchant_id
     usd_amount_cents = credit.amount_cents.abs
@@ -649,36 +653,50 @@ class StripeChargeProcessor
     transfer = transfer_ids.compact_blank.lazy
                            .filter_map { |tr_id| Stripe::Transfer.retrieve(tr_id) rescue nil }
                            .find { |tr| tr.amount - tr.amount_reversed > amount_to_reverse_for.call(tr) }
-    if transfer.present?
+    unless transfer
+      transfers = Stripe::Transfer.list(destination: stripe_account_id, created: { 'lt': 120.days.ago.to_i }, limit: 100)
+      transfer = transfers.find do |tr|
+        tr.present? && tr.amount - tr.amount_reversed > amount_to_reverse_for.call(tr)
+      end
+    end
+    return unless transfer
+
+    begin
       transfer_reversal = Stripe::Transfer.create_reversal(transfer.id, { amount: amount_to_reverse_for.call(transfer) })
-      refund = credit.fee_retention_refund
-      refund.update!(debited_stripe_transfer: transfer_reversal.id) if refund.present?
-      destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
-                                                   stripe_account: stripe_account_id)
+    rescue Stripe::InvalidRequestError => error
+      raise unless error.message.match?(/no longer supported/i)
 
-      destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
-                                                                            stripe_account: stripe_account_id)
-      return destination_balance_transaction.net.abs
+      return debit_refund_fee_from_account(credit:)
     end
+    refund.debited_stripe_transfer = transfer_reversal.id
+    refund.save!
+    destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
+                                                 stripe_account: stripe_account_id)
+    destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
+                                                                          stripe_account: stripe_account_id)
+    refund.fee_retention_collected_cents = destination_balance_transaction.net.abs
+    refund.save!
+    refund.fee_retention_collected_cents
+  end
 
-    # If no eligible internal transfer was available, reverse a transfer associated with an old purchase.
-    # Try and find a transfer older than 120 days. As disputes and refunds are not allowed after 120 days, it's safe to
-    # reverse these transfers.
-    transfers = Stripe::Transfer.list(destination: stripe_account_id, created: { 'lt': 120.days.ago.to_i }, limit: 100)
-    transfer = transfers.find do |tr|
-      tr.present? && (tr.amount - tr.amount_reversed > amount_to_reverse_for.call(tr))
-    end
-    if transfer.present?
-      transfer_reversal = Stripe::Transfer.create_reversal(transfer.id, { amount: amount_to_reverse_for.call(transfer) })
-      refund = credit.fee_retention_refund
-      refund.update!(debited_stripe_transfer: transfer_reversal.id) if refund.present?
-      destination_refund = Stripe::Refund.retrieve(transfer_reversal.destination_payment_refund,
-                                                   stripe_account: stripe_account_id)
+  def self.debit_refund_fee_from_account(credit:)
+    refund = credit.fee_retention_refund
+    return if refund.debited_stripe_transfer.present?
 
-      destination_balance_transaction = Stripe::BalanceTransaction.retrieve(destination_refund.balance_transaction,
-                                                                            stripe_account: stripe_account_id)
-      destination_balance_transaction.net.abs
-    end
+    merchant_account = credit.merchant_account
+    stripe_account_id = merchant_account.charge_processor_merchant_id
+    transfer_group = "refund_fee_retention_#{refund.id}"
+    # The lookup survives Stripe's idempotency-key expiry if the debit was never recorded locally.
+    transfer = Stripe::Transfer.list({ transfer_group:, limit: 1 }, { stripe_account: stripe_account_id }).first
+    transfer ||= Stripe::Transfer.create({ amount: usd_cents_to_currency(merchant_account.currency, credit.amount_cents.abs),
+                                           currency: merchant_account.currency,
+                                           destination: STRIPE_PLATFORM_ACCOUNT_ID,
+                                           transfer_group:, metadata: { refund_id: refund.id } },
+                                         { stripe_account: stripe_account_id, idempotency_key: transfer_group })
+    refund.debited_stripe_transfer = transfer.id
+    refund.fee_retention_collected_cents = transfer.amount
+    refund.save!
+    transfer.amount
   end
 
   def self.debit_stripe_account_for_australia_backtaxes(credit:)

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -645,6 +645,7 @@ class StripeChargeProcessor
     amount_to_reverse_for = ->(transfer) { usd_cents_to_currency(transfer.currency, usd_amount_cents) }
 
     already_pinned_id = refund.fee_retention_source_transfer
+    observed_pin = already_pinned_id
     transfer_reversal = nil
     transfer = nil
     if already_pinned_id.present?
@@ -678,9 +679,17 @@ class StripeChargeProcessor
     end
     return unless transfer
 
-    if refund.fee_retention_source_transfer != transfer.id
-      refund.fee_retention_source_transfer = transfer.id
-      refund.save!
+    refund.with_lock do
+      refund.reload
+      return recorded_refund_fee_collection(credit:) if refund.debited_stripe_transfer.present?
+      current_pin = refund.fee_retention_source_transfer
+      if current_pin.present? && current_pin != observed_pin
+        return
+      end
+      if current_pin != transfer.id
+        refund.fee_retention_source_transfer = transfer.id
+        refund.save!
+      end
     end
 
     begin

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -627,10 +627,8 @@ class StripeChargeProcessor
     refund = credit.fee_retention_refund
     return if refund.blank?
     return recorded_refund_fee_collection(credit:) if refund.debited_stripe_transfer.present?
-    if credit.merchant_account.country == Compliance::Countries::USA.alpha2
-      return debit_refund_fee_from_account(credit:) if refund.fee_retention_pending
-      return
-    end
+    # US Gumroad-managed accounts keep fee retention on the ledger; Stripe has no matching reversal.
+    return if credit.merchant_account.country == Compliance::Countries::USA.alpha2
 
     stripe_account_id = credit.merchant_account.charge_processor_merchant_id
     usd_amount_cents = credit.amount_cents.abs

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -728,11 +728,22 @@ class StripeChargeProcessor
     return unless transfer_id.present? && refund_id.present?
 
     expected = refund_id.to_s
-    Stripe::Transfer.list_reversals(transfer_id, { limit: 100 }).find do |reversal|
+    reversals = Stripe::Transfer.list_reversals(transfer_id, { limit: 100 })
+    each_refund_fee_reversal(reversals) do |reversal|
       metadata = reversal.try(:metadata)
       next if metadata.blank?
+      next unless metadata[:refund_id].to_s == expected || metadata["refund_id"].to_s == expected
 
-      metadata[:refund_id].to_s == expected || metadata["refund_id"].to_s == expected
+      return reversal
+    end
+    nil
+  end
+
+  def self.each_refund_fee_reversal(reversals, &block)
+    if reversals.respond_to?(:auto_paging_each)
+      reversals.auto_paging_each(&block)
+    else
+      Array(reversals).each(&block)
     end
   end
 

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -353,8 +353,7 @@ class Credit < ApplicationRecord
     reversed_amount_cents_in_holding_currency = credit.usd_cents_to_currency(credit.merchant_account.currency, credit.amount_cents)
 
     if credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE
-      stripe_fee_collection_required = credit.amount_cents != 0 &&
-        credit.merchant_account.country != Compliance::Countries::USA.alpha2
+      stripe_fee_collection_required = credit.amount_cents != 0
       refund.fee_retention_pending = stripe_fee_collection_required
       refund.save!
       if stripe_fee_collection_required

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -356,19 +356,13 @@ class Credit < ApplicationRecord
       refund.fee_retention_pending = credit.amount_cents != 0
       refund.save!
       # Keep the credit and its balance transaction together even if Stripe rejects collection.
+      # US and non-US both go through debit_stripe_account_for_refund_fee so a lost
+      # Stripe response is discoverable by the same transfer_group / reversal identity.
       net_amount_on_stripe_in_holding_currency = refund.retain_fee do
-        if credit.merchant_account.country == Compliance::Countries::USA.alpha2
-          transfer = Stripe::Transfer.create({ amount: credit.amount_cents.abs, currency: "usd", destination: Stripe::Account.retrieve.id },
-                                             { stripe_account: credit.merchant_account.charge_processor_merchant_id })
-          refund.debited_stripe_transfer = transfer.id
-          refund.save!
-          credit.amount_cents.abs
-        else
-          StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:)
-        end
+        StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:)
       end
       reversed_amount_cents_in_holding_currency = -net_amount_on_stripe_in_holding_currency if net_amount_on_stripe_in_holding_currency.present?
-      if refund.debited_stripe_transfer.present?
+      if refund.debited_stripe_transfer.present? && refund.fee_retention_collected_cents.present?
         refund.fee_retention_pending = false
         refund.fee_retention_error = nil
         refund.save!

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -352,17 +352,27 @@ class Credit < ApplicationRecord
     reversed_amount_cents_in_usd = credit.amount_cents
     reversed_amount_cents_in_holding_currency = credit.usd_cents_to_currency(credit.merchant_account.currency, credit.amount_cents)
 
-    # For Stripe sales that use a gumroad-managed custom connect account, we debit the Stripe account for the fee amount.
-    if credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE && credit.merchant_account.country == Compliance::Countries::USA.alpha2
-      # For gumroad-controlled Stripe accounts from the US, we can make new debit transfers.
-      # So we transfer the retained fee back to Gumroad's Stripe platform account.
-      Stripe::Transfer.create({ amount: credit.amount_cents.abs, currency: "usd", destination: Stripe::Account.retrieve.id, },
-                              { stripe_account: credit.merchant_account.charge_processor_merchant_id })
-    elsif credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE
-      # For non-US gumroad-controlled Stripe accounts, we cannot make debit transfers.
-      # So we try and reverse the retained fee amount from one of the old transfers made to that Stripe account.
-      net_amount_on_stripe_in_holding_currency = StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:)
+    if credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE
+      refund.fee_retention_pending = credit.amount_cents != 0
+      refund.save!
+      # Keep the credit and its balance transaction together even if Stripe rejects collection.
+      net_amount_on_stripe_in_holding_currency = refund.retain_fee do
+        if credit.merchant_account.country == Compliance::Countries::USA.alpha2
+          transfer = Stripe::Transfer.create({ amount: credit.amount_cents.abs, currency: "usd", destination: Stripe::Account.retrieve.id },
+                                             { stripe_account: credit.merchant_account.charge_processor_merchant_id })
+          refund.debited_stripe_transfer = transfer.id
+          refund.save!
+          credit.amount_cents.abs
+        else
+          StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:)
+        end
+      end
       reversed_amount_cents_in_holding_currency = -net_amount_on_stripe_in_holding_currency if net_amount_on_stripe_in_holding_currency.present?
+      if refund.debited_stripe_transfer.present?
+        refund.fee_retention_pending = false
+        refund.fee_retention_error = nil
+        refund.save!
+      end
     end
 
     balance_transaction_amount = BalanceTransaction::Amount.new(

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -353,19 +353,21 @@ class Credit < ApplicationRecord
     reversed_amount_cents_in_holding_currency = credit.usd_cents_to_currency(credit.merchant_account.currency, credit.amount_cents)
 
     if credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE
-      refund.fee_retention_pending = credit.amount_cents != 0
+      stripe_fee_collection_required = credit.amount_cents != 0 &&
+        credit.merchant_account.country != Compliance::Countries::USA.alpha2
+      refund.fee_retention_pending = stripe_fee_collection_required
       refund.save!
-      # Keep the credit and its balance transaction together even if Stripe rejects collection.
-      # US and non-US both go through debit_stripe_account_for_refund_fee so a lost
-      # Stripe response is discoverable by the same transfer_group / reversal identity.
-      net_amount_on_stripe_in_holding_currency = refund.retain_fee do
-        StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:)
-      end
-      reversed_amount_cents_in_holding_currency = -net_amount_on_stripe_in_holding_currency if net_amount_on_stripe_in_holding_currency.present?
-      if refund.debited_stripe_transfer.present? && refund.fee_retention_collected_cents.present?
-        refund.fee_retention_pending = false
-        refund.fee_retention_error = nil
-        refund.save!
+      if stripe_fee_collection_required
+        # Keep the credit and its balance transaction together even if Stripe rejects collection.
+        net_amount_on_stripe_in_holding_currency = refund.retain_fee do
+          StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:)
+        end
+        reversed_amount_cents_in_holding_currency = -net_amount_on_stripe_in_holding_currency if net_amount_on_stripe_in_holding_currency.present?
+        if refund.debited_stripe_transfer.present? && refund.fee_retention_collected_cents.present?
+          refund.fee_retention_pending = false
+          refund.fee_retention_error = nil
+          refund.save!
+        end
       end
     end
 

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -142,12 +142,15 @@ class Refund < ApplicationRecord
       return
     end
 
-    # Ineffective refunds must not start a new collection. They still look up a
-    # pinned reversal or grouped debit so a lost Stripe response is not abandoned.
+    # Failed or canceled refunds must not start a new collection: the buyer never got
+    # the money, and on Stripe-held accounts HandleFailedRefundService leaves them
+    # to the exception queue instead of reversing the balance, so effective? stays
+    # true. They still look up a pinned reversal or grouped debit so a lost Stripe
+    # response is not abandoned.
     credit.fee_retention_refund = self
     lookup_failed = false
     retain_fee do
-      StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:, collect: effective?)
+      StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:, collect: !terminally_failed?)
     rescue *FEE_RETENTION_ERRORS
       lookup_failed = true
       raise
@@ -158,7 +161,7 @@ class Refund < ApplicationRecord
       next unless fee_retention_pending
       collection_recorded = debited_stripe_transfer.present? && fee_retention_collected_cents.present?
       no_stripe_collection = credit.amount_cents.zero? || credit.merchant_account.holder_of_funds != HolderOfFunds::STRIPE
-      terminal_without_collection = !effective? && debited_stripe_transfer.blank? && !lookup_failed
+      terminal_without_collection = terminally_failed? && debited_stripe_transfer.blank? && !lookup_failed
       next unless collection_recorded || no_stripe_collection || terminal_without_collection
 
       if fee_retention_collected_cents.present?

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -142,11 +142,15 @@ class Refund < ApplicationRecord
       return
     end
 
-    # Ineffective refunds must not start a new collection, but a debit already
-    # recorded on Stripe still needs settlement lookup before we clear pending.
-    if effective? || debited_stripe_transfer.present?
-      credit.fee_retention_refund = self
-      retain_fee { StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:) }
+    # Ineffective refunds must not start a new collection. They still look up a
+    # pinned reversal or grouped debit so a lost Stripe response is not abandoned.
+    credit.fee_retention_refund = self
+    lookup_failed = false
+    retain_fee do
+      StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:, collect: effective?)
+    rescue *FEE_RETENTION_ERRORS
+      lookup_failed = true
+      raise
     end
 
     purchase.with_lock do
@@ -154,7 +158,8 @@ class Refund < ApplicationRecord
       next unless fee_retention_pending
       collection_recorded = debited_stripe_transfer.present? && fee_retention_collected_cents.present?
       no_stripe_collection = credit.amount_cents.zero? || credit.merchant_account.holder_of_funds != HolderOfFunds::STRIPE
-      next unless collection_recorded || no_stripe_collection || !effective?
+      terminal_without_collection = !effective? && debited_stripe_transfer.blank? && !lookup_failed
+      next unless collection_recorded || no_stripe_collection || terminal_without_collection
 
       if fee_retention_collected_cents.present?
         holding_cents = BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -131,7 +131,7 @@ class Refund < ApplicationRecord
   end
 
   def recover_pending_fee_retention!
-    pending = purchase.with_lock { reload.fee_retention_pending && effective? }
+    pending = purchase.with_lock { reload.fee_retention_pending }
     return unless pending
 
     credit = Credit.find_by(fee_retention_refund: self, failed_refund_id: nil)
@@ -142,15 +142,19 @@ class Refund < ApplicationRecord
       return
     end
 
-    credit.fee_retention_refund = self
-    retain_fee { StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:) }
+    # Ineffective refunds must not start a new collection, but a debit already
+    # recorded on Stripe still needs settlement lookup before we clear pending.
+    if effective? || debited_stripe_transfer.present?
+      credit.fee_retention_refund = self
+      retain_fee { StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:) }
+    end
 
     purchase.with_lock do
       reload.lock!
-      next unless fee_retention_pending && effective?
+      next unless fee_retention_pending
       collection_recorded = debited_stripe_transfer.present? && fee_retention_collected_cents.present?
       no_stripe_collection = credit.amount_cents.zero? || credit.merchant_account.holder_of_funds != HolderOfFunds::STRIPE
-      next unless collection_recorded || no_stripe_collection
+      next unless collection_recorded || no_stripe_collection || !effective?
 
       if fee_retention_collected_cents.present?
         holding_cents = BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -80,6 +80,10 @@ class Refund < ApplicationRecord
   attr_json_data_accessor :business_vat_id
   attr_json_data_accessor :debited_stripe_transfer
   attr_json_data_accessor :retained_fee_cents
+  attr_json_data_accessor :fee_retention_pending
+  attr_json_data_accessor :fee_retention_error
+  attr_json_data_accessor :fee_retention_collected_cents
+
   attr_json_data_accessor :presentment_currency
   attr_json_data_accessor :presentment_amount_cents
   attr_json_data_accessor :presentment_price_cents
@@ -103,6 +107,62 @@ class Refund < ApplicationRecord
   # the original refund event stays booked to its own day untouched, because ledger
   # days must regenerate bit-identical.
   attr_json_data_accessor :balance_reversed_on_failure_at
+
+  FEE_RETENTION_ERRORS = [Stripe::InvalidRequestError, Stripe::APIError, Stripe::APIConnectionError,
+                          Stripe::AuthenticationError, Stripe::PermissionError, Stripe::RateLimitError,
+                          Stripe::IdempotencyError].freeze
+
+  scope :pending_fee_retention, -> { where("refunds.json_data->>'$.fee_retention_pending' = 'true'") }
+
+  def retain_fee
+    yield
+  rescue *FEE_RETENTION_ERRORS => error
+    record_fee_retention_failure!(error)
+    nil
+  end
+
+  def record_fee_retention_failure!(error)
+    self.fee_retention_pending = true
+    self.fee_retention_error = { class: error.class.name, message: error.message }
+    save!
+    ErrorNotifier.notify(error, context: { refund_id: id, purchase_id: purchase_id })
+  end
+
+  def recover_pending_fee_retention!
+    pending = purchase.with_lock { reload.fee_retention_pending && effective? }
+    return unless pending
+
+    credit = Credit.find_by(fee_retention_refund: self, failed_refund_id: nil)
+    unless credit
+      message = "Pending refund fee retention has no Credit"
+      Rails.logger.error("#{message} (refund_id=#{id})")
+      ErrorNotifier.notify(message, context: { refund_id: id, purchase_id: purchase_id })
+      return
+    end
+
+    credit.fee_retention_refund = self
+    retain_fee { StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:) }
+
+    purchase.with_lock do
+      reload.lock!
+      next unless fee_retention_pending && effective?
+      next unless debited_stripe_transfer.present? || credit.amount_cents.zero? || credit.merchant_account.holder_of_funds != HolderOfFunds::STRIPE
+
+      if fee_retention_collected_cents.present?
+        holding_cents = BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)
+        adjustment_cents = -fee_retention_collected_cents - holding_cents
+        unless adjustment_cents.zero?
+          BalanceTransaction.create!(user: credit.user, merchant_account: credit.merchant_account, credit:,
+                                     issued_amount: BalanceTransaction::Amount.new(currency: Currency::USD, gross_cents: 0, net_cents: 0),
+                                     holding_amount: BalanceTransaction::Amount.new(currency: credit.merchant_account.currency,
+                                                                                    gross_cents: adjustment_cents, net_cents: adjustment_cents))
+        end
+      end
+      self.fee_retention_pending = false
+      self.fee_retention_error = nil
+      save!
+    end
+  end
 
   # In-memory mirror of the .effective scope, for callers working with preloaded
   # refunds. Keep the two in sync.

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -83,6 +83,7 @@ class Refund < ApplicationRecord
   attr_json_data_accessor :fee_retention_pending
   attr_json_data_accessor :fee_retention_error
   attr_json_data_accessor :fee_retention_collected_cents
+  attr_json_data_accessor :fee_retention_source_transfer
 
   attr_json_data_accessor :presentment_currency
   attr_json_data_accessor :presentment_amount_cents
@@ -146,7 +147,9 @@ class Refund < ApplicationRecord
     purchase.with_lock do
       reload.lock!
       next unless fee_retention_pending && effective?
-      next unless debited_stripe_transfer.present? || credit.amount_cents.zero? || credit.merchant_account.holder_of_funds != HolderOfFunds::STRIPE
+      collection_recorded = debited_stripe_transfer.present? && fee_retention_collected_cents.present?
+      no_stripe_collection = credit.amount_cents.zero? || credit.merchant_account.holder_of_funds != HolderOfFunds::STRIPE
+      next unless collection_recorded || no_stripe_collection
 
       if fee_retention_collected_cents.present?
         holding_cents = BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -24,6 +24,7 @@ class Refund < ApplicationRecord
 
   before_validation :assign_product, on: :create
   before_validation :assign_seller, on: :create
+  before_save :sync_fee_retention_recoverable
   validates_uniqueness_of :processor_refund_id, scope: :link_id, allow_blank: true
 
   # Refund selection for the tax report jobs' refund leg: refunds that get reported as their
@@ -113,7 +114,7 @@ class Refund < ApplicationRecord
                           Stripe::AuthenticationError, Stripe::PermissionError, Stripe::RateLimitError,
                           Stripe::IdempotencyError].freeze
 
-  scope :pending_fee_retention, -> { where("refunds.json_data->>'$.fee_retention_pending' = 'true'") }
+  scope :pending_fee_retention, -> { where(fee_retention_recoverable: true) }
 
   def retain_fee
     yield
@@ -194,6 +195,10 @@ class Refund < ApplicationRecord
   end
 
   private
+    def sync_fee_retention_recoverable
+      self.fee_retention_recoverable = fee_retention_pending == true
+    end
+
     def assign_product
       self.link_id = purchase.link_id
     end

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -142,11 +142,9 @@ class Refund < ApplicationRecord
       return
     end
 
-    # Failed or canceled refunds must not start a new collection: the buyer never got
-    # the money, and on Stripe-held accounts HandleFailedRefundService leaves them
-    # to the exception queue instead of reversing the balance, so effective? stays
-    # true. They still look up a pinned reversal or grouped debit so a lost Stripe
-    # response is not abandoned.
+    # Gate on terminally_failed?, not effective?: Stripe-held failures are never
+    # balance-reversed, so effective? stays true and would collect a fee for a refund
+    # the buyer never received. Existing pins and grouped debits are still adopted.
     credit.fee_retention_refund = self
     lookup_failed = false
     retain_fee do

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -341,7 +341,11 @@ class Purchase
       save!
       reverse_the_transfer_made_for_dispute_win! if chargedback? && chargeback_reversed
       reverse_excess_amount_from_stripe_transfer(refund:) if stripe_partially_refunded && vat_already_refunded
-      debit_processor_fee_from_merchant_account!(refund) unless is_refund_chargeback_fee_waived || chargedback_not_reversed?
+      # A fee collection failure must not undo a refund already accepted by the processor,
+      # including when Charge#refund_and_save! owns the outer transaction.
+      unless is_refund_chargeback_fee_waived || chargedback_not_reversed?
+        refund.retain_fee { debit_processor_fee_from_merchant_account!(refund) }
+      end
       Credit.create_for_vat_exclusive_refund!(refund:) if (paypal_order_id.present? || merchant_account&.is_a_stripe_connect_account?) && !chargedback_not_reversed?
       subscription.original_purchase.update!(should_exclude_product_review: true) if subscription&.should_exclude_product_review_on_charge_reversal?
       send_refunded_notification_webhook

--- a/app/sidekiq/recover_pending_refund_fee_retention_job.rb
+++ b/app/sidekiq/recover_pending_refund_fee_retention_job.rb
@@ -7,8 +7,8 @@ class RecoverPendingRefundFeeRetentionJob
 
   # Hourly cron. Worst case is one Stripe collection per pending row; keep the
   # declared attempt under interval − RecurringLockTtl::SAFETY_MARGIN so a
-  # stranded digest cannot mute the next fire. Unindexed pending_fee_retention
-  # remains a separate queue-schema issue.
+  # stranded digest cannot mute the next fire. Candidates come from the indexed
+  # refunds.fee_retention_recoverable column.
   include RecurringLockTtl
   recurring_lock_ttl max_attempt: 45.minutes
 

--- a/app/sidekiq/recover_pending_refund_fee_retention_job.rb
+++ b/app/sidekiq/recover_pending_refund_fee_retention_job.rb
@@ -5,7 +5,19 @@ class RecoverPendingRefundFeeRetentionJob
 
   sidekiq_options retry: 5, queue: :low, lock: :until_executed
 
+  # Hourly cron. Worst case is one Stripe collection per pending row; keep the
+  # declared attempt under interval − RecurringLockTtl::SAFETY_MARGIN so a
+  # stranded digest cannot mute the next fire. Unindexed pending_fee_retention
+  # remains a separate queue-schema issue.
+  include RecurringLockTtl
+  recurring_lock_ttl max_attempt: 45.minutes
+
   def perform
-    Refund.pending_fee_retention.find_each(&:recover_pending_fee_retention!)
+    Refund.pending_fee_retention.find_each do |refund|
+      refund.recover_pending_fee_retention!
+    rescue StandardError => e
+      Rails.logger.error("Pending refund fee retention failed (refund_id=#{refund.id}): #{e.class}: #{e.message}")
+      ErrorNotifier.notify(e, context: { refund_id: refund.id, purchase_id: refund.purchase_id })
+    end
   end
 end

--- a/app/sidekiq/recover_pending_refund_fee_retention_job.rb
+++ b/app/sidekiq/recover_pending_refund_fee_retention_job.rb
@@ -5,10 +5,8 @@ class RecoverPendingRefundFeeRetentionJob
 
   sidekiq_options retry: 5, queue: :low, lock: :until_executed
 
-  # Hourly cron. Worst case is one Stripe collection per pending row; keep the
-  # declared attempt under interval − RecurringLockTtl::SAFETY_MARGIN so a
-  # stranded digest cannot mute the next fire. Candidates come from the indexed
-  # refunds.fee_retention_recoverable column.
+  # Hourly cron: keep max_attempt under the interval minus RecurringLockTtl::SAFETY_MARGIN
+  # so a stranded lock digest cannot mute the next fire.
   include RecurringLockTtl
   recurring_lock_ttl max_attempt: 45.minutes
 

--- a/app/sidekiq/recover_pending_refund_fee_retention_job.rb
+++ b/app/sidekiq/recover_pending_refund_fee_retention_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RecoverPendingRefundFeeRetentionJob
+  include Sidekiq::Job
+
+  sidekiq_options retry: 5, queue: :low, lock: :until_executed
+
+  def perform
+    Refund.pending_fee_retention.find_each(&:recover_pending_fee_retention!)
+  end
+end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -1,3 +1,8 @@
+recover_pending_refund_fee_retention:
+  cron: "0 * * * *"
+  class: RecoverPendingRefundFeeRetentionJob
+  description: Retries fee collection without issuing another customer refund
+
 # Every minute
 dispatch_pending_workflow_installment_schedule_intents:
   cron: "* * * * *" # Every minute

--- a/db/migrate/20261212090000_add_fee_retention_recoverable_to_refunds.rb
+++ b/db/migrate/20261212090000_add_fee_retention_recoverable_to_refunds.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddFeeRetentionRecoverableToRefunds < ActiveRecord::Migration[7.1]
+  def change
+    add_column :refunds, :fee_retention_recoverable, :boolean, default: false, null: false
+    add_index :refunds, :fee_retention_recoverable, name: "index_refunds_on_fee_retention_recoverable"
+  end
+end

--- a/db/migrate/20261212090000_add_fee_retention_recoverable_to_refunds.rb
+++ b/db/migrate/20261212090000_add_fee_retention_recoverable_to_refunds.rb
@@ -2,7 +2,9 @@
 
 class AddFeeRetentionRecoverableToRefunds < ActiveRecord::Migration[7.1]
   def change
-    add_column :refunds, :fee_retention_recoverable, :boolean, default: false, null: false
-    add_index :refunds, :fee_retention_recoverable, name: "index_refunds_on_fee_retention_recoverable"
+    change_table :refunds, bulk: true do |t|
+      t.boolean :fee_retention_recoverable, default: false, null: false
+      t.index :fee_retention_recoverable, name: "index_refunds_on_fee_retention_recoverable"
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_11_125458) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_12_090000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -2225,8 +2225,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_11_125458) do
     t.string "processor_refund_id", limit: 191
     t.integer "fee_cents"
     t.bigint "flags", default: 0, null: false
+    t.boolean "fee_retention_recoverable", default: false, null: false
     t.bigint "seller_id"
     t.index ["created_at"], name: "index_refunds_on_created_at"
+    t.index ["fee_retention_recoverable"], name: "index_refunds_on_fee_retention_recoverable"
     t.index ["link_id"], name: "index_refunds_on_link_id"
     t.index ["processor_refund_id"], name: "index_refunds_on_processor_refund_id"
     t.index ["purchase_id"], name: "index_refunds_on_purchase_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2225,8 +2225,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_12_090000) do
     t.string "processor_refund_id", limit: 191
     t.integer "fee_cents"
     t.bigint "flags", default: 0, null: false
-    t.boolean "fee_retention_recoverable", default: false, null: false
     t.bigint "seller_id"
+    t.boolean "fee_retention_recoverable", default: false, null: false
     t.index ["created_at"], name: "index_refunds_on_created_at"
     t.index ["fee_retention_recoverable"], name: "index_refunds_on_fee_retention_recoverable"
     t.index ["link_id"], name: "index_refunds_on_link_id"

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -4156,6 +4156,32 @@ describe StripeChargeProcessor, :vcr do
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
       end
 
+      it "searches another transfer when the pinned source has no reversal and no remaining capacity" do
+        refund = create(:refund)
+        refund.fee_retention_source_transfer = "tr_cad_exhausted"
+        refund.save!
+        credit = create(:credit, user: @cad_merchant_account.user, amount_cents: 1000, merchant_account_id: @cad_merchant_account.id, fee_retention_refund: refund)
+        create(:payment_completed, user: @cad_merchant_account.user,
+                                   stripe_connect_account_id: @cad_merchant_account.charge_processor_merchant_id,
+                                   stripe_internal_transfer_id: "tr_cad_next")
+        exhausted = double(id: "tr_cad_exhausted", amount: 1330, amount_reversed: 1330, currency: "cad")
+        next_transfer = double(id: "tr_cad_next", amount: 2000, amount_reversed: 0, currency: "cad")
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_cad_exhausted").and_return(exhausted)
+        empty_reversals = double("reversal_list")
+        expect(empty_reversals).to receive(:auto_paging_each)
+        expect(Stripe::Transfer).to receive(:list_reversals).with("tr_cad_exhausted", { limit: 100 }).and_return(empty_reversals)
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_cad_next").and_return(next_transfer)
+        transfer_reversal = stub_reversal_follow_up_calls(transfer_reversal_id: "trr_next", net: -1330)
+        expect(Stripe::Transfer).to receive(:create_reversal)
+          .with("tr_cad_next", hash_including(amount: 1330),
+                hash_including(idempotency_key: "refund_fee_retention_reversal_#{refund.id}_tr_cad_next"))
+          .and_return(transfer_reversal)
+
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
+        expect(refund.reload.fee_retention_source_transfer).to eq("tr_cad_next")
+        expect(refund.debited_stripe_transfer).to eq("trr_next")
+      end
+
       it "adopts an existing reversal for the pinned source transfer instead of reversing again" do
         refund = create(:refund)
         refund.fee_retention_source_transfer = "tr_cad_1"

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -3954,7 +3954,7 @@ describe StripeChargeProcessor, :vcr do
 
       credit = create(:credit, user: @merchant_account.user, amount_cents: 1000, merchant_account_id: @merchant_account.id, fee_retention_refund: create(:refund))
 
-      expect_any_instance_of(Refund).to receive(:update!).with({ debited_stripe_transfer: anything })
+      expect_any_instance_of(Refund).to receive(:debited_stripe_transfer=).with(anything).and_call_original
 
       described_class.debit_stripe_account_for_refund_fee(credit:)
     end
@@ -3963,9 +3963,79 @@ describe StripeChargeProcessor, :vcr do
       travel_to(Time.zone.local(2023, 10, 6)) do
         credit = create(:credit, amount_cents: 1000, merchant_account_id: @merchant_account.id, fee_retention_refund: create(:refund))
 
-        expect_any_instance_of(Refund).to receive(:update!).with({ debited_stripe_transfer: anything })
+        expect_any_instance_of(Refund).to receive(:debited_stripe_transfer=).with(anything).and_call_original
 
         described_class.debit_stripe_account_for_refund_fee(credit:)
+      end
+    end
+
+    describe "account debit recovery" do
+      let(:merchant_account) { create(:merchant_account, country: "BG", currency: "eur", charge_processor_merchant_id: "acct_fee_recovery") }
+      let(:refund) { create(:refund) }
+      let(:credit) { create(:credit, user: merchant_account.user, merchant_account:, amount_cents: -1000, fee_retention_refund: refund) }
+      let(:transfer) { double(id: "tr_fee_candidate", amount: 5000, amount_reversed: 0, currency: "usd") }
+      let(:transfer_group) { "refund_fee_retention_#{refund.id}" }
+
+      before do
+        allow(described_class).to receive(:get_rate).with("eur").and_return("0.90")
+        create(:payment_completed, user: merchant_account.user,
+                                   stripe_connect_account_id: merchant_account.charge_processor_merchant_id,
+                                   stripe_internal_transfer_id: transfer.id)
+        allow(Stripe::Transfer).to receive(:retrieve).with(transfer.id).and_return(transfer)
+        allow(Stripe::Transfer).to receive(:create_reversal)
+          .with(transfer.id, { amount: 1000 })
+          .and_raise(Stripe::InvalidRequestError.new("Transfer reversals in BGN are no longer supported. Please create account debits in eur", nil))
+      end
+
+      it "falls back in the current currency without probing settlement and does not collect twice" do
+        expect(Stripe::Charge).not_to receive(:retrieve)
+        expect(Stripe::Account).not_to receive(:retrieve)
+        expect(Stripe::Transfer).to receive(:list)
+          .with({ transfer_group:, limit: 1 }, { stripe_account: "acct_fee_recovery" }).and_return([])
+        expect(Stripe::Transfer).to receive(:create)
+          .with({ amount: 900, currency: "eur", destination: STRIPE_PLATFORM_ACCOUNT_ID,
+                  transfer_group:, metadata: { refund_id: refund.id } },
+                { stripe_account: "acct_fee_recovery", idempotency_key: transfer_group })
+          .and_return(double(id: "tr_fee_debit", amount: 900))
+
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(900)
+        expect(refund.reload.debited_stripe_transfer).to eq("tr_fee_debit")
+        expect(refund.fee_retention_collected_cents).to eq(900)
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to be_nil
+      end
+
+      it "adopts an unrecorded debit after the idempotency window has expired" do
+        refund.update!(created_at: 3.days.ago)
+        expect(Stripe::Transfer).to receive(:list)
+          .with({ transfer_group:, limit: 1 }, { stripe_account: "acct_fee_recovery" })
+          .and_return([double(id: "tr_existing_fee_debit", amount: 850)])
+        expect(Stripe::Transfer).not_to receive(:create)
+
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(850)
+        expect(refund.reload.debited_stripe_transfer).to eq("tr_existing_fee_debit")
+        expect(refund.fee_retention_collected_cents).to eq(850)
+      end
+
+      it "does not fall back for unrelated invalid requests" do
+        expect(Stripe::Transfer).to receive(:create_reversal)
+          .and_raise(Stripe::InvalidRequestError.new("Insufficient balance", nil))
+        expect(Stripe::Transfer).not_to receive(:list)
+        expect(Stripe::Transfer).not_to receive(:create)
+
+        expect { described_class.debit_stripe_account_for_refund_fee(credit:) }.to raise_error(Stripe::InvalidRequestError, "Insufficient balance")
+      end
+
+      it "skips missing historical transfers before attempting a reversal" do
+        create(:payment_completed, user: merchant_account.user, created_at: 1.day.ago,
+                                   stripe_connect_account_id: merchant_account.charge_processor_merchant_id,
+                                   stripe_internal_transfer_id: "tr_missing_fee_candidate")
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_missing_fee_candidate")
+          .and_raise(Stripe::InvalidRequestError.new("No such transfer", nil))
+        expect(Stripe::Transfer).to receive(:list)
+          .with({ transfer_group:, limit: 1 }, { stripe_account: "acct_fee_recovery" })
+          .and_return([double(id: "tr_existing_fee_debit", amount: 900)])
+
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(900)
       end
     end
 

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -4262,6 +4262,29 @@ describe StripeChargeProcessor, :vcr do
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
         expect(refund.reload.fee_retention_collected_cents).to eq(1330)
       end
+
+      it "looks up existing collections without creating when collect is false" do
+        refund = create(:refund)
+        refund.fee_retention_source_transfer = "tr_cad_1"
+        refund.save!
+        credit = create(:credit, user: @cad_merchant_account.user, amount_cents: 1000, merchant_account_id: @cad_merchant_account.id, fee_retention_refund: refund)
+        transfer = double(id: "tr_cad_1", amount: 2000, amount_reversed: 1330, currency: "cad")
+        existing = double(id: "trr_existing", destination_payment_refund: "re_1", metadata: { "refund_id" => refund.id.to_s })
+        expect(Stripe::Transfer).to receive(:list)
+          .with({ transfer_group: "refund_fee_retention_#{refund.id}", limit: 1 },
+                { stripe_account: @cad_merchant_account.charge_processor_merchant_id })
+          .and_return([])
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_cad_1").and_return(transfer)
+        reversals = double("reversal_list")
+        expect(reversals).to receive(:auto_paging_each).and_yield(existing)
+        expect(Stripe::Transfer).to receive(:list_reversals).with("tr_cad_1", { limit: 100 }).and_return(reversals)
+        expect(Stripe::Transfer).not_to receive(:create)
+        expect(Stripe::Transfer).not_to receive(:create_reversal)
+        stub_reversal_follow_up_calls(transfer_reversal_id: "trr_existing", net: -1330)
+
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:, collect: false)).to eq(1330)
+        expect(refund.reload.debited_stripe_transfer).to eq("trr_existing")
+      end
     end
   end
 

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -3943,17 +3943,26 @@ describe StripeChargeProcessor, :vcr do
       @merchant_account = create(:merchant_account, charge_processor_merchant_id: "acct_1MdawPS4gcql7bLm", country: "AE")
     end
 
-    it "does not collect via account debit for US accounts" do
+    it "collects via account debit for US accounts without searching for a reversal" do
       merchant_account = create(:merchant_account, country: "US", currency: "usd", charge_processor_merchant_id: "acct_us_fee")
       refund = create(:refund)
       refund.fee_retention_pending = true
       refund.save!
       credit = create(:credit, user: merchant_account.user, amount_cents: -1000, merchant_account:, fee_retention_refund: refund)
+      transfer_group = "refund_fee_retention_#{refund.id}"
 
-      expect(Stripe::Transfer).not_to receive(:list)
-      expect(Stripe::Transfer).not_to receive(:create)
+      expect(Stripe::Transfer).not_to receive(:create_reversal)
+      expect(Stripe::Transfer).to receive(:list)
+        .with({ transfer_group:, limit: 1 }, { stripe_account: "acct_us_fee" }).and_return([])
+      expect(Stripe::Transfer).to receive(:create)
+        .with({ amount: 1000, currency: "usd", destination: STRIPE_PLATFORM_ACCOUNT_ID,
+                transfer_group:, metadata: { refund_id: refund.id } },
+              { stripe_account: "acct_us_fee", idempotency_key: transfer_group })
+        .and_return(double(id: "tr_us_fee_debit", amount: 1000))
 
-      expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to be_nil
+      expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1000)
+      expect(refund.reload.debited_stripe_transfer).to eq("tr_us_fee_debit")
+      expect(refund.fee_retention_collected_cents).to eq(1000)
     end
 
     it "reverses an internal transfer made to the stripe connect account if present" do

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -4170,6 +4170,10 @@ describe StripeChargeProcessor, :vcr do
         empty_reversals = double("reversal_list")
         expect(empty_reversals).to receive(:auto_paging_each)
         expect(Stripe::Transfer).to receive(:list_reversals).with("tr_cad_exhausted", { limit: 100 }).and_return(empty_reversals)
+        expect(Stripe::Transfer).to receive(:list)
+          .with({ transfer_group: "refund_fee_retention_#{refund.id}", limit: 1 },
+                { stripe_account: @cad_merchant_account.charge_processor_merchant_id })
+          .and_return([])
         expect(Stripe::Transfer).to receive(:retrieve).with("tr_cad_next").and_return(next_transfer)
         transfer_reversal = stub_reversal_follow_up_calls(transfer_reversal_id: "trr_next", net: -1330)
         expect(Stripe::Transfer).to receive(:create_reversal)
@@ -4180,6 +4184,47 @@ describe StripeChargeProcessor, :vcr do
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
         expect(refund.reload.fee_retention_source_transfer).to eq("tr_cad_next")
         expect(refund.debited_stripe_transfer).to eq("trr_next")
+      end
+
+      it "does not search another transfer when the pinned source cannot be retrieved" do
+        refund = create(:refund)
+        refund.fee_retention_source_transfer = "tr_cad_1"
+        refund.save!
+        credit = create(:credit, user: @cad_merchant_account.user, amount_cents: 1000, merchant_account_id: @cad_merchant_account.id, fee_retention_refund: refund)
+        create(:payment_completed, user: @cad_merchant_account.user,
+                                   stripe_connect_account_id: @cad_merchant_account.charge_processor_merchant_id,
+                                   stripe_internal_transfer_id: "tr_cad_next")
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_cad_1")
+          .and_raise(Stripe::APIConnectionError.new("timeout"))
+        expect(Stripe::Transfer).not_to receive(:create_reversal)
+        expect(Stripe::Transfer).not_to receive(:list)
+
+        expect do
+          described_class.debit_stripe_account_for_refund_fee(credit:)
+        end.to raise_error(Stripe::APIConnectionError)
+        expect(refund.reload.fee_retention_source_transfer).to eq("tr_cad_1")
+        expect(refund.debited_stripe_transfer).to be_nil
+      end
+
+      it "adopts an existing grouped debit when the pinned source has no remaining capacity" do
+        refund = create(:refund)
+        refund.fee_retention_source_transfer = "tr_cad_exhausted"
+        refund.save!
+        credit = create(:credit, user: @cad_merchant_account.user, amount_cents: 1000, merchant_account_id: @cad_merchant_account.id, fee_retention_refund: refund)
+        exhausted = double(id: "tr_cad_exhausted", amount: 1330, amount_reversed: 1330, currency: "cad")
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_cad_exhausted").and_return(exhausted)
+        empty_reversals = double("reversal_list")
+        expect(empty_reversals).to receive(:auto_paging_each)
+        expect(Stripe::Transfer).to receive(:list_reversals).with("tr_cad_exhausted", { limit: 100 }).and_return(empty_reversals)
+        expect(Stripe::Transfer).to receive(:list)
+          .with({ transfer_group: "refund_fee_retention_#{refund.id}", limit: 1 },
+                { stripe_account: @cad_merchant_account.charge_processor_merchant_id })
+          .and_return([double(id: "tr_grouped_debit", amount: 900)])
+        expect(Stripe::Transfer).not_to receive(:create_reversal)
+
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(900)
+        expect(refund.reload.debited_stripe_transfer).to eq("tr_grouped_debit")
+        expect(refund.fee_retention_collected_cents).to eq(900)
       end
 
       it "adopts an existing reversal for the pinned source transfer instead of reversing again" do

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -3943,6 +3943,19 @@ describe StripeChargeProcessor, :vcr do
       @merchant_account = create(:merchant_account, charge_processor_merchant_id: "acct_1MdawPS4gcql7bLm", country: "AE")
     end
 
+    it "does not collect via account debit for US accounts" do
+      merchant_account = create(:merchant_account, country: "US", currency: "usd", charge_processor_merchant_id: "acct_us_fee")
+      refund = create(:refund)
+      refund.fee_retention_pending = true
+      refund.save!
+      credit = create(:credit, user: merchant_account.user, amount_cents: -1000, merchant_account:, fee_retention_refund: refund)
+
+      expect(Stripe::Transfer).not_to receive(:list)
+      expect(Stripe::Transfer).not_to receive(:create)
+
+      expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to be_nil
+    end
+
     it "reverses an internal transfer made to the stripe connect account if present" do
       create(:payment_completed, user: @merchant_account.user,
                                  stripe_connect_account_id: @merchant_account.charge_processor_merchant_id,

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -4145,7 +4145,9 @@ describe StripeChargeProcessor, :vcr do
         transfer = double(id: "tr_cad_1", amount: 2000, amount_reversed: 1330, currency: "cad")
         existing = double(id: "trr_existing", destination_payment_refund: "re_1", metadata: { "refund_id" => refund.id.to_s })
         expect(Stripe::Transfer).to receive(:retrieve).with("tr_cad_1").and_return(transfer)
-        expect(Stripe::Transfer).to receive(:list_reversals).with("tr_cad_1", { limit: 100 }).and_return([existing])
+        reversals = double("reversal_list")
+        expect(reversals).to receive(:auto_paging_each).and_yield(existing)
+        expect(Stripe::Transfer).to receive(:list_reversals).with("tr_cad_1", { limit: 100 }).and_return(reversals)
         expect(Stripe::Transfer).not_to receive(:create_reversal)
         stub_reversal_follow_up_calls(transfer_reversal_id: "trr_existing", net: -1330)
 

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -3983,7 +3983,7 @@ describe StripeChargeProcessor, :vcr do
                                    stripe_internal_transfer_id: transfer.id)
         allow(Stripe::Transfer).to receive(:retrieve).with(transfer.id).and_return(transfer)
         allow(Stripe::Transfer).to receive(:create_reversal)
-          .with(transfer.id, { amount: 1000 })
+          .with(transfer.id, hash_including(amount: 1000), hash_including(:idempotency_key))
           .and_raise(Stripe::InvalidRequestError.new("Transfer reversals in BGN are no longer supported. Please create account debits in eur", nil))
       end
 
@@ -4001,7 +4001,7 @@ describe StripeChargeProcessor, :vcr do
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(900)
         expect(refund.reload.debited_stripe_transfer).to eq("tr_fee_debit")
         expect(refund.fee_retention_collected_cents).to eq(900)
-        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to be_nil
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(900)
       end
 
       it "adopts an unrecorded debit after the idempotency window has expired" do
@@ -4076,7 +4076,7 @@ describe StripeChargeProcessor, :vcr do
 
         # 1000 USD cents * 1.33 = 1330 CAD cents, not the raw USD figure.
         transfer_reversal = stub_reversal_follow_up_calls(transfer_reversal_id: "trr_1", net: -1330)
-        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_cad_1", { amount: 1330 }).and_return(transfer_reversal)
+        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_cad_1", hash_including(amount: 1330), hash_including(:idempotency_key)).and_return(transfer_reversal)
 
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
         expect(credit.fee_retention_refund.reload.debited_stripe_transfer).to eq("trr_1")
@@ -4099,7 +4099,7 @@ describe StripeChargeProcessor, :vcr do
         expect(Stripe::Transfer).to receive(:retrieve).with("tr_cad_big").and_return(big_transfer)
 
         transfer_reversal = stub_reversal_follow_up_calls(transfer_reversal_id: "trr_2", net: -1330)
-        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_cad_big", { amount: 1330 }).and_return(transfer_reversal)
+        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_cad_big", hash_including(amount: 1330), hash_including(:idempotency_key)).and_return(transfer_reversal)
 
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
       end
@@ -4113,7 +4113,7 @@ describe StripeChargeProcessor, :vcr do
                                       .and_return([old_transfer])
 
         transfer_reversal = stub_reversal_follow_up_calls(transfer_reversal_id: "trr_3", net: -1330)
-        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_cad_old", { amount: 1330 }).and_return(transfer_reversal)
+        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_cad_old", hash_including(amount: 1330), hash_including(:idempotency_key)).and_return(transfer_reversal)
 
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
         expect(credit.fee_retention_refund.reload.debited_stripe_transfer).to eq("trr_3")
@@ -4129,9 +4129,43 @@ describe StripeChargeProcessor, :vcr do
         expect(Stripe::Transfer).to receive(:retrieve).with("tr_usd_1").and_return(transfer)
 
         transfer_reversal = stub_reversal_follow_up_calls(transfer_reversal_id: "trr_4", net: -1330)
-        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_usd_1", { amount: 1000 }).and_return(transfer_reversal)
+        expect(Stripe::Transfer).to receive(:create_reversal).with("tr_usd_1", hash_including(amount: 1000), hash_including(:idempotency_key)).and_return(transfer_reversal)
 
         expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
+      end
+
+      it "adopts an existing reversal for the pinned source transfer instead of reversing again" do
+        refund = create(:refund)
+        refund.fee_retention_source_transfer = "tr_cad_1"
+        refund.save!
+        credit = create(:credit, user: @cad_merchant_account.user, amount_cents: 1000, merchant_account_id: @cad_merchant_account.id, fee_retention_refund: refund)
+        create(:payment_completed, user: @cad_merchant_account.user,
+                                   stripe_connect_account_id: @cad_merchant_account.charge_processor_merchant_id,
+                                   stripe_internal_transfer_id: "tr_other")
+        transfer = double(id: "tr_cad_1", amount: 2000, amount_reversed: 1330, currency: "cad")
+        existing = double(id: "trr_existing", destination_payment_refund: "re_1", metadata: { "refund_id" => refund.id.to_s })
+        expect(Stripe::Transfer).to receive(:retrieve).with("tr_cad_1").and_return(transfer)
+        expect(Stripe::Transfer).to receive(:list_reversals).with("tr_cad_1", { limit: 100 }).and_return([existing])
+        expect(Stripe::Transfer).not_to receive(:create_reversal)
+        stub_reversal_follow_up_calls(transfer_reversal_id: "trr_existing", net: -1330)
+
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
+        expect(refund.reload.debited_stripe_transfer).to eq("trr_existing")
+      end
+
+      it "resumes settlement lookup when a reversal id exists without collected cents" do
+        refund = create(:refund)
+        refund.fee_retention_source_transfer = "tr_cad_1"
+        refund.debited_stripe_transfer = "trr_1"
+        refund.save!
+        credit = create(:credit, user: @cad_merchant_account.user, amount_cents: 1000, merchant_account_id: @cad_merchant_account.id, fee_retention_refund: refund)
+        transfer_reversal = double(id: "trr_1", destination_payment_refund: "re_1")
+        expect(Stripe::Transfer).to receive(:retrieve_reversal).with("tr_cad_1", "trr_1").and_return(transfer_reversal)
+        expect(Stripe::Transfer).not_to receive(:create_reversal)
+        stub_reversal_follow_up_calls(transfer_reversal_id: "trr_1", net: -1330)
+
+        expect(described_class.debit_stripe_account_for_refund_fee(credit:)).to eq(1330)
+        expect(refund.reload.fee_retention_collected_cents).to eq(1330)
       end
     end
   end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -120,6 +120,33 @@ describe Charge, :vcr do
   end
 
   describe "#refund_and_save!" do
+    it "commits every purchase refund when fee retention fails inside the outer transaction" do
+      seller = create(:user)
+      purchases = Array.new(2) { create(:purchase, seller:, link: create(:product, user: seller), stripe_transaction_id: "ch_combined_refund") }
+      charge = create(:charge, seller:, purchases:)
+      create(:balance, user: seller, amount_cents: 10_000)
+      error = Stripe::InvalidRequestError.new("Transfer reversals are no longer supported", nil)
+      allow_any_instance_of(Purchase).to receive(:debit_processor_fee_from_merchant_account!).and_raise(error)
+      expect(ErrorNotifier).to receive(:notify).with(error, context: hash_including(:refund_id, :purchase_id)).twice
+      purchases.each do |purchase|
+        flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -purchase.total_transaction_cents)
+        expect(ChargeProcessor).to receive(:refund!).with(anything, "ch_combined_refund", hash_including(purchase:))
+          .and_return(double(id: "re_fee_#{purchase.id}", refund: nil, flow_of_funds:))
+      end
+
+      expect { expect(charge.refund_and_save!(seller.id)).to be(true) }.to change(Refund, :count).by(2)
+
+      purchases.each do |purchase|
+        refund = purchase.reload.refunds.sole
+        expect(purchase.stripe_refunded).to be(true)
+        expect(purchase.amount_refundable_cents).to eq(0)
+        expect(refund.fee_retention_pending).to be(true)
+        expect(refund.balance_transactions.where(user_id: seller.id).count).to eq(1)
+      end
+      expect(charge.refund_and_save!(seller.id)).to be(false)
+      expect(charge.purchases.sum { |purchase| purchase.refunds.count }).to eq(2)
+    end
+
     it "attempts every purchase refund even when one purchase fails" do
       charge = create(:charge)
       failed_errors = instance_double(ActiveModel::Errors, full_messages: ["First refund failed"])

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -326,6 +326,21 @@ describe Credit do
       expect(credit.fee_retention_refund).to eq(refund)
     end
 
+    context "US Gumroad-managed account" do
+      let!(:merchant_account) { create(:merchant_account, user: creator, country: "US", currency: "usd") }
+
+      it "does not queue Stripe collection" do
+        allow(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).and_call_original
+        expect(Stripe::Transfer).not_to receive(:list)
+        expect(Stripe::Transfer).not_to receive(:create)
+
+        credit = Credit.create_for_refund_fee_retention!(refund:)
+
+        expect(credit.amount_cents).to eq(-33)
+        expect(refund.reload.fee_retention_pending).not_to eq(true)
+      end
+    end
+
     it "updates the unpaid_balance_cents for the seller" do
       expect(creator.unpaid_balance_cents).to eq(0)
 

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -297,6 +297,10 @@ describe Credit do
     let!(:purchase) { create(:purchase, succeeded_at: 3.days.ago, link: create(:product, user: creator), merchant_account:) }
     let!(:refund) { create(:refund, purchase:, fee_cents: 100) }
 
+    before do
+      allow(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).and_return(33)
+    end
+
     context "when Stripe fee collection fails" do
       let!(:merchant_account) { create(:merchant_account, user: creator, country: "BG", currency: "usd") }
 
@@ -318,13 +322,11 @@ describe Credit do
     end
 
     it "assigns the refund as fee_retention_refund" do
-      expect(Stripe::Transfer).to receive(:create).and_call_original
       credit = Credit.create_for_refund_fee_retention!(refund:)
       expect(credit.fee_retention_refund).to eq(refund)
     end
 
     it "updates the unpaid_balance_cents for the seller" do
-      expect(Stripe::Transfer).to receive(:create).and_call_original
       expect(creator.unpaid_balance_cents).to eq(0)
 
       credit = Credit.create_for_refund_fee_retention!(refund:)
@@ -334,7 +336,6 @@ describe Credit do
     end
 
     it "creates a balance record after credit" do
-      expect(Stripe::Transfer).to receive(:create).and_call_original
       credit = Credit.create_for_refund_fee_retention!(refund:)
       expect(credit.balance).to eq(Balance.last)
     end
@@ -342,7 +343,6 @@ describe Credit do
     it "applies the credit to the oldest unpaid balance and not the unpaid balance from purchase date" do
       oldest_balance = create(:balance, user: creator, amount_cents: 1000, merchant_account:, date: purchase.succeeded_at.to_date - 2.days)
       create(:balance, user: creator, amount_cents: 2000, merchant_account:, date: purchase.succeeded_at.to_date)
-      expect(Stripe::Transfer).to receive(:create).and_call_original
       expect(creator.unpaid_balance_cents).to eq(3000)
 
       credit = Credit.create_for_refund_fee_retention!(refund:)
@@ -364,6 +364,7 @@ describe Credit do
           oldest_balance = create(:balance, user: creator, merchant_account: non_us_stripe_account, amount_cents: 1000, holding_currency: "aud", date: purchase.succeeded_at.to_date - 2.days)
           create(:balance, user: creator, merchant_account: non_us_stripe_account, amount_cents: 2000,
                            holding_currency: "aud", date: purchase.succeeded_at.to_date)
+          allow(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).and_call_original
           expect(Stripe::Transfer).to receive(:create_reversal).and_call_original
           expect(creator.unpaid_balance_cents).to eq(3000)
 

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -329,15 +329,24 @@ describe Credit do
     context "US Gumroad-managed account" do
       let!(:merchant_account) { create(:merchant_account, user: creator, country: "US", currency: "usd") }
 
-      it "does not queue Stripe collection" do
+      it "collects the retained fee via a grouped Stripe account debit" do
         allow(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).and_call_original
-        expect(Stripe::Transfer).not_to receive(:list)
-        expect(Stripe::Transfer).not_to receive(:create)
+        transfer_group = "refund_fee_retention_#{refund.id}"
+        expect(Stripe::Transfer).to receive(:list)
+          .with({ transfer_group:, limit: 1 }, { stripe_account: merchant_account.charge_processor_merchant_id })
+          .and_return([])
+        expect(Stripe::Transfer).to receive(:create)
+          .with({ amount: 33, currency: "usd", destination: STRIPE_PLATFORM_ACCOUNT_ID,
+                  transfer_group:, metadata: { refund_id: refund.id } },
+                { stripe_account: merchant_account.charge_processor_merchant_id, idempotency_key: transfer_group })
+          .and_return(double(id: "tr_us_fee", amount: 33))
 
         credit = Credit.create_for_refund_fee_retention!(refund:)
 
         expect(credit.amount_cents).to eq(-33)
-        expect(refund.reload.fee_retention_pending).not_to eq(true)
+        expect(refund.reload.debited_stripe_transfer).to eq("tr_us_fee")
+        expect(refund.fee_retention_collected_cents).to eq(33)
+        expect(refund.fee_retention_pending).not_to eq(true)
       end
     end
 

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -297,6 +297,26 @@ describe Credit do
     let!(:purchase) { create(:purchase, succeeded_at: 3.days.ago, link: create(:product, user: creator), merchant_account:) }
     let!(:refund) { create(:refund, purchase:, fee_cents: 100) }
 
+    context "when Stripe fee collection fails" do
+      let!(:merchant_account) { create(:merchant_account, user: creator, country: "BG", currency: "usd") }
+
+      it "keeps the credit and balance debit when Stripe fee collection fails" do
+        error = Stripe::InvalidRequestError.new("Account debit is not permitted", nil)
+        expect(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).and_raise(error)
+        expect(ErrorNotifier).to receive(:notify).with(error, context: { refund_id: refund.id, purchase_id: purchase.id })
+
+        credit = Credit.create_for_refund_fee_retention!(refund:)
+
+        expect(credit.reload.amount_cents).to eq(-33)
+        expect(credit.balance_transaction.issued_amount_net_cents).to eq(-33)
+        expect(credit.balance_transaction.holding_amount_net_cents).to eq(-33)
+        expect(credit.balance).to eq(credit.balance_transaction.balance)
+        expect(creator.reload.unpaid_balance_cents).to eq(-33)
+        expect(refund.reload.fee_retention_pending).to be(true)
+        expect(refund.retained_fee_cents).to eq(33)
+      end
+    end
+
     it "assigns the refund as fee_retention_refund" do
       expect(Stripe::Transfer).to receive(:create).and_call_original
       credit = Credit.create_for_refund_fee_retention!(refund:)

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -1772,6 +1772,41 @@ describe "PurchaseRefunds", :vcr do
       @refunding_user = create(:user)
     end
 
+    it "commits the refund and reports a pending fee when fee retention fails" do
+      error = Stripe::InvalidRequestError.new("Transfer reversals are no longer supported", nil)
+      flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -@purchase.total_transaction_cents)
+      expect(@purchase).to receive(:debit_processor_fee_from_merchant_account!).and_raise(error)
+      expect(ErrorNotifier).to receive(:notify).with(error, context: hash_including(purchase_id: @purchase.id))
+      expect(@purchase).to receive(:decrement_balance_for_refund_or_chargeback!).once.and_call_original
+      expect(CustomerMailer).to receive(:refund).with(@purchase.email, @purchase.link_id, @purchase.id).and_call_original
+
+      expect do
+        expect(@purchase.refund_purchase!(flow_of_funds, @refunding_user.id)).to be(true)
+      end.to change(Refund, :count).by(1)
+
+      refund = @purchase.reload.refunds.sole
+      expect(@purchase.stripe_refunded).to be(true)
+      expect(@purchase.stripe_partially_refunded).to be(false)
+      expect(@purchase.amount_refundable_cents).to eq(0)
+      expect(refund.balance_transactions.where(user_id: @purchase.seller_id).count).to eq(1)
+      expect(refund.fee_retention_pending).to be(true)
+      expect(refund.fee_retention_error).to eq("class" => error.class.name, "message" => error.message)
+      expect(ChargeProcessor).not_to receive(:refund!)
+      expect(@purchase.refund_and_save!(@refunding_user.id)).to be_nil
+      expect(@purchase.refunds.count).to eq(1)
+    end
+
+    it "does not swallow refund bookkeeping failures" do
+      flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -@purchase.total_transaction_cents)
+      expect(@purchase).to receive(:decrement_balance_for_refund_or_chargeback!).and_raise(ActiveRecord::RecordInvalid)
+      expect(ErrorNotifier).not_to receive(:notify)
+
+      expect do
+        @purchase.refund_purchase!(flow_of_funds, @refunding_user.id)
+      end.to raise_error(ActiveRecord::RecordInvalid)
+      expect(@purchase.reload.refunds).to be_empty
+    end
+
     it "enqueues a UpdateSellerRefundEligibilityJob" do
       flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, @purchase.price_cents)
       expect do

--- a/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
+++ b/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
@@ -115,4 +115,19 @@ RSpec.describe RecoverPendingRefundFeeRetentionJob, :vcr do
 
     expect(refund.reload.fee_retention_pending).to be(true)
   end
+
+  it "isolates an unhandled recovery error so later refunds still run" do
+    other_purchase = create(:purchase, merchant_account:, seller: merchant_account.user, link: create(:product, user: merchant_account.user))
+    other_refund = create(:refund, purchase: other_purchase, fee_retention_pending: true)
+    seen = []
+    allow_any_instance_of(Refund).to receive(:recover_pending_fee_retention!) do |instance|
+      seen << instance.id
+      raise RuntimeError, "bookkeeping" if instance.id == refund.id
+    end
+    expect(ErrorNotifier).to receive(:notify).with(instance_of(RuntimeError), hash_including(context: hash_including(refund_id: refund.id)))
+
+    expect { described_class.new.perform }.not_to raise_error
+
+    expect(seen).to include(refund.id, other_refund.id)
+  end
 end

--- a/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
+++ b/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
@@ -143,6 +143,43 @@ RSpec.describe RecoverPendingRefundFeeRetentionJob, :vcr do
     expect(refund.debited_stripe_transfer).to be_nil
   end
 
+  it "keeps an ineffective refund pending when settlement lookup fails" do
+    refund.status = "failed"
+    refund.balance_reversed_on_failure = true
+    refund.debited_stripe_transfer = "trr_1"
+    refund.fee_retention_source_transfer = "tr_recovery_candidate"
+    refund.save!
+    error = Stripe::APIConnectionError.new("timeout")
+    expect(Stripe::Transfer).to receive(:retrieve_reversal).with("tr_recovery_candidate", "trr_1").and_raise(error)
+    expect(Stripe::Transfer).not_to receive(:create)
+    expect(Stripe::Transfer).not_to receive(:create_reversal)
+    expect(ErrorNotifier).to receive(:notify).with(error, context: { refund_id: refund.id, purchase_id: purchase.id })
+
+    described_class.new.perform
+
+    expect(refund.reload.fee_retention_pending).to be(true)
+    expect(refund.fee_retention_error["message"]).to eq(error.message)
+    expect(refund.debited_stripe_transfer).to eq("trr_1")
+    expect(refund.fee_retention_collected_cents).to be_nil
+  end
+
+  it "adopts an unrecorded debit for an ineffective refund without collecting again" do
+    refund.status = "failed"
+    refund.balance_reversed_on_failure = true
+    refund.save!
+    expect(Stripe::Transfer).to receive(:list)
+      .with({ transfer_group:, limit: 1 }, { stripe_account: merchant_account.charge_processor_merchant_id })
+      .and_return([double(id: "tr_existing_fee", amount: 850)])
+    expect(Stripe::Transfer).not_to receive(:create)
+    expect(Stripe::Transfer).not_to receive(:create_reversal)
+
+    described_class.new.perform
+
+    expect(refund.reload.fee_retention_pending).to be_falsey
+    expect(refund.debited_stripe_transfer).to eq("tr_existing_fee")
+    expect(BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)).to eq(-850)
+  end
+
   it "isolates an unhandled recovery error so later refunds still run" do
     other_purchase = create(:purchase, merchant_account:, seller: merchant_account.user, link: create(:product, user: merchant_account.user))
     other_refund = create(:refund, purchase: other_purchase, fee_retention_pending: true)

--- a/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
+++ b/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
@@ -125,6 +125,11 @@ RSpec.describe RecoverPendingRefundFeeRetentionJob, :vcr do
     expect(BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)).to eq(-900)
   end
 
+  it "selects pending recoveries through the indexed recoverable column" do
+    expect(Refund.pending_fee_retention.to_sql).to include("fee_retention_recoverable")
+    expect(refund.reload.fee_retention_recoverable).to be(true)
+  end
+
   it "does not recover fees for a reversed failed refund" do
     refund.status = "failed"
     refund.balance_reversed_on_failure = true

--- a/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
+++ b/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
@@ -143,6 +143,30 @@ RSpec.describe RecoverPendingRefundFeeRetentionJob, :vcr do
     expect(refund.debited_stripe_transfer).to be_nil
   end
 
+  it "does not collect for a failed Stripe-held refund whose balance was never reversed" do
+    refund.status = "failed"
+    refund.save!
+    expect(Stripe::Transfer).not_to receive(:create)
+    expect(Stripe::Transfer).not_to receive(:create_reversal)
+
+    expect { described_class.new.perform }.not_to change(BalanceTransaction, :count)
+
+    expect(refund.reload.fee_retention_pending).to be_falsey
+    expect(refund.debited_stripe_transfer).to be_nil
+  end
+
+  it "does not collect for a canceled Stripe-held refund whose balance was never reversed" do
+    refund.status = "canceled"
+    refund.save!
+    expect(Stripe::Transfer).not_to receive(:create)
+    expect(Stripe::Transfer).not_to receive(:create_reversal)
+
+    expect { described_class.new.perform }.not_to change(BalanceTransaction, :count)
+
+    expect(refund.reload.fee_retention_pending).to be_falsey
+    expect(refund.debited_stripe_transfer).to be_nil
+  end
+
   it "keeps an ineffective refund pending when settlement lookup fails" do
     refund.status = "failed"
     refund.balance_reversed_on_failure = true

--- a/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
+++ b/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RecoverPendingRefundFeeRetentionJob, :vcr do
+  let(:merchant_account) { create(:merchant_account, country: "BG", currency: "eur", charge_processor_merchant_id: "acct_fee_recovery_job") }
+  let(:purchase) { create(:purchase, merchant_account:, seller: merchant_account.user, link: create(:product, user: merchant_account.user)) }
+  let(:refund) { create(:refund, purchase:, fee_retention_pending: true) }
+  let!(:credit) { create(:credit, user: merchant_account.user, merchant_account:, fee_retention_refund: refund, amount_cents: -1000) }
+  let(:transfer_group) { "refund_fee_retention_#{refund.id}" }
+
+  before do
+    allow(StripeChargeProcessor).to receive(:get_rate).with("eur").and_return("0.90")
+    create(:payment_completed, user: merchant_account.user,
+                               stripe_connect_account_id: merchant_account.charge_processor_merchant_id,
+                               stripe_internal_transfer_id: "tr_recovery_candidate")
+    allow(Stripe::Transfer).to receive(:retrieve).with("tr_recovery_candidate")
+      .and_return(double(id: "tr_recovery_candidate", amount: 5000, amount_reversed: 0, currency: "usd"))
+    allow(Stripe::Transfer).to receive(:create_reversal)
+      .and_raise(Stripe::InvalidRequestError.new("Transfer reversals are no longer supported", nil))
+    allow(Stripe::Transfer).to receive(:list)
+      .with({ transfer_group:, limit: 1 }, { stripe_account: merchant_account.charge_processor_merchant_id }).and_return([])
+    BalanceTransaction.create!(user: credit.user, merchant_account:, credit:,
+                               issued_amount: BalanceTransaction::Amount.new(currency: "usd", gross_cents: -1000, net_cents: -1000),
+                               holding_amount: BalanceTransaction::Amount.new(currency: "eur", gross_cents: -800, net_cents: -800))
+  end
+
+  it "clears pending recovery without creating another credit or collecting twice" do
+    transaction_depth = ApplicationRecord.connection.open_transactions
+    expect(Stripe::Transfer).to receive(:create).once
+      .with({ amount: 900, currency: "eur", destination: STRIPE_PLATFORM_ACCOUNT_ID,
+              transfer_group:, metadata: { refund_id: refund.id } },
+            { stripe_account: merchant_account.charge_processor_merchant_id, idempotency_key: transfer_group }) do
+      expect(ApplicationRecord.connection.open_transactions).to eq(transaction_depth)
+      double(id: "tr_recovered_fee", amount: 900)
+    end
+    expect(Stripe::Transfer).to receive(:create_reversal) do
+      expect(ApplicationRecord.connection.open_transactions).to eq(transaction_depth)
+      raise Stripe::InvalidRequestError.new("Transfer reversals are no longer supported", nil)
+    end
+    expect(ChargeProcessor).not_to receive(:refund!)
+
+    expect do
+      described_class.new.perform
+      expect(refund.reload.fee_retention_pending).to be_falsey
+      expect(refund.debited_stripe_transfer).to eq("tr_recovered_fee")
+      expect(BalanceTransaction.where(credit:).sum(:issued_amount_net_cents)).to eq(-1000)
+      expect(BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)).to eq(-900)
+      described_class.new.perform
+    end.not_to change(Credit, :count)
+
+    expect(refund.reload.fee_retention_pending).to be_falsey
+    expect(refund.fee_retention_error).to be_nil
+    expect(BalanceTransaction.where(credit:).count).to eq(2)
+  end
+
+  it "adopts an unrecorded debit and reconciles its actual holding amount" do
+    expect(Stripe::Transfer).to receive(:list)
+      .with({ transfer_group:, limit: 1 }, { stripe_account: merchant_account.charge_processor_merchant_id })
+      .and_return([double(id: "tr_existing_fee", amount: 850)])
+    expect(Stripe::Transfer).not_to receive(:create)
+
+    described_class.new.perform
+
+    expect(refund.reload.fee_retention_pending).to be_falsey
+    expect(refund.debited_stripe_transfer).to eq("tr_existing_fee")
+    expect(BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)).to eq(-850)
+    expect(BalanceTransaction.where(credit:).sum(:issued_amount_net_cents)).to eq(-1000)
+  end
+
+  it "logs and reports a missing credit without creating one or moving money" do
+    credit.fee_retention_refund = nil
+    credit.save!
+    expect(Rails.logger).to receive(:error).with("Pending refund fee retention has no Credit (refund_id=#{refund.id})")
+    expect(ErrorNotifier).to receive(:notify).with("Pending refund fee retention has no Credit", context: { refund_id: refund.id, purchase_id: purchase.id })
+    expect(StripeChargeProcessor).not_to receive(:debit_stripe_account_for_refund_fee)
+
+    expect { described_class.new.perform }.not_to change(Credit, :count)
+
+    expect(refund.reload.fee_retention_pending).to be(true)
+  end
+
+  it "keeps rejected recoveries pending and reports the error" do
+    error = Stripe::InvalidRequestError.new("Account debit is not permitted", nil)
+    expect(Stripe::Transfer).to receive(:create).and_raise(error)
+    expect(ErrorNotifier).to receive(:notify).with(error, context: { refund_id: refund.id, purchase_id: purchase.id })
+
+    expect { described_class.new.perform }.not_to change(BalanceTransaction, :count)
+
+    expect(refund.reload.fee_retention_pending).to be(true)
+    expect(refund.fee_retention_error["message"]).to eq(error.message)
+  end
+
+  it "clears a pending marker when the debit was already recorded" do
+    refund.debited_stripe_transfer = "tr_already_collected"
+    refund.fee_retention_collected_cents = 900
+    refund.save!
+    expect(Stripe::Transfer).not_to receive(:create)
+    expect(Stripe::Transfer).not_to receive(:create_reversal)
+
+    described_class.new.perform
+
+    expect(refund.reload.fee_retention_pending).to be_falsey
+    expect(BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)).to eq(-900)
+  end
+
+  it "does not recover fees for a reversed failed refund" do
+    refund.status = "failed"
+    refund.balance_reversed_on_failure = true
+    refund.save!
+    expect(Stripe::Transfer).not_to receive(:create)
+    expect(Stripe::Transfer).not_to receive(:create_reversal)
+
+    described_class.new.perform
+
+    expect(refund.reload.fee_retention_pending).to be(true)
+  end
+end

--- a/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
+++ b/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
@@ -104,6 +104,27 @@ RSpec.describe RecoverPendingRefundFeeRetentionJob, :vcr do
     expect(BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)).to eq(-900)
   end
 
+  it "resumes settlement when a reversal id exists without collected cents" do
+    refund.debited_stripe_transfer = "trr_1"
+    refund.fee_retention_source_transfer = "tr_recovery_candidate"
+    refund.save!
+    transfer_reversal = double(id: "trr_1", destination_payment_refund: "re_1")
+    expect(Stripe::Transfer).to receive(:retrieve_reversal).with("tr_recovery_candidate", "trr_1").and_return(transfer_reversal)
+    expect(Stripe::Refund).to receive(:retrieve)
+      .with("re_1", hash_including(stripe_account: merchant_account.charge_processor_merchant_id))
+      .and_return(double(balance_transaction: "txn_1"))
+    expect(Stripe::BalanceTransaction).to receive(:retrieve)
+      .with("txn_1", hash_including(stripe_account: merchant_account.charge_processor_merchant_id))
+      .and_return(double(net: -900))
+    expect(Stripe::Transfer).not_to receive(:create)
+
+    described_class.new.perform
+
+    expect(refund.reload.fee_retention_pending).to be_falsey
+    expect(refund.fee_retention_collected_cents).to eq(900)
+    expect(BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)).to eq(-900)
+  end
+
   it "does not recover fees for a reversed failed refund" do
     refund.status = "failed"
     refund.balance_reversed_on_failure = true

--- a/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
+++ b/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
@@ -139,7 +139,8 @@ RSpec.describe RecoverPendingRefundFeeRetentionJob, :vcr do
 
     described_class.new.perform
 
-    expect(refund.reload.fee_retention_pending).to be(true)
+    expect(refund.reload.fee_retention_pending).to be_falsey
+    expect(refund.debited_stripe_transfer).to be_nil
   end
 
   it "isolates an unhandled recovery error so later refunds still run" do

--- a/spec/support/refund_fee_retention_transfer_stubs.rb
+++ b/spec/support/refund_fee_retention_transfer_stubs.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# US Gumroad-managed refunds now look up (then create) a grouped Stripe account
+# debit before finishing local bookkeeping. Existing VCR cassettes predate that
+# call and record :none, so every refund example that never cared about fee
+# collection would otherwise raise UnhandledHTTPRequestError. Intercept only
+# the refund-fee-retention transfer_group; every other Transfer.list/create
+# still hits VCR or the example's own stub.
+module RefundFeeRetentionTransferStubs
+  def self.retention_group?(params)
+    params.is_a?(Hash) && params[:transfer_group].to_s.start_with?("refund_fee_retention_")
+  end
+
+  def self.params_from(args, kwargs)
+    args.first.is_a?(Hash) ? args.first : kwargs
+  end
+end
+
+RSpec.configure do |config|
+  config.before do
+    allow(Stripe::Transfer).to receive(:list).and_wrap_original do |method, *args, **kwargs|
+      params = RefundFeeRetentionTransferStubs.params_from(args, kwargs)
+      if RefundFeeRetentionTransferStubs.retention_group?(params)
+        []
+      else
+        method.call(*args, **kwargs)
+      end
+    end
+
+    allow(Stripe::Transfer).to receive(:create).and_wrap_original do |method, *args, **kwargs|
+      params = RefundFeeRetentionTransferStubs.params_from(args, kwargs)
+      if RefundFeeRetentionTransferStubs.retention_group?(params)
+        Stripe::Transfer.construct_from(
+          id: "tr_test_refund_fee_#{params.dig(:metadata, :refund_id) || params.dig(:metadata, "refund_id") || "debit"}",
+          object: "transfer",
+          amount: params[:amount],
+          currency: params[:currency],
+          transfer_group: params[:transfer_group]
+        )
+      else
+        method.call(*args, **kwargs)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Status
- [x] Scope: audit the recovery findings at the current PR head.
- [x] RecurringLockTtl: declared 45-minute worst-case on the hourly job; per-row recovery errors no longer abort later rows.
- [ ] Design: high-risk review of crash-safe collection, resumable reconciliation, and an indexed queue.
- [x] Build: indexed recoverable column plus terminal disposition for ineffective refunds that still look up existing Stripe collections.
- [ ] Ship: current-head QA audit and required checks, then human merge approval.
- [ ] Market: not applicable; backend correctness fix.
- [ ] Sell: not applicable; no pricing or launch work.

Assigned `gianfrancopiana` with `awaiting-human`. Money-path draft: accept or reject the declined Astra P1 below, then merge. Do not run production recovery.

## Merge blocked — recovery correctness
At `5e06a714eb472f6a647bd1efad88b8a52042b7ae`. Astra+Fable panel is not a clean merge verdict (Fable 0, Astra 1). This is still a draft. Do not run production recovery from this branch.

- [x] Prevent duplicate transfer reversals after Stripe succeeds but the local save fails. Pin the selected source transfer before the reversal, reuse `refund_fee_retention_reversal_<id>` as the idempotency key, page through existing reversals with `auto_paging_each` after key expiry, and adopt a matching `refund_id` metadata reversal instead of creating another.
- [x] Resume settlement reconciliation when a reversal ID exists without `fee_retention_collected_cents`. Pending no longer clears on ID alone; recovery looks up the destination refund/balance transaction (or the grouped account debit) and records collected cents first.
- [x] Make the initial US debit discoverable by recovery. The US path now uses the same grouped, idempotent account debit as recovery (`refund_fee_retention_<id>`), so a lost Stripe response cannot create a second debit.
- [x] Replace the unindexed JSON predicate with an indexed durable candidate source (`refunds.fee_retention_recoverable`).
- [x] Isolate each recovery's failure so one database/bookkeeping error cannot prevent later rows from running. Job-level rescue is in.
- [x] Terminally resolve pending work for ineffective, balance-reversed refunds without collecting another fee; look up any pinned reversal or grouped debit first, keep pending when that lookup fails, and clear only after collected cents are recorded or Stripe has no collection.

Panel at this head (Astra+Fable, `--max-priority P1`): not clean. Dispositions:

- Accepted then fixed at this head: Astra P1 from `509b0bc2b201cf421ba174e8227544dccba3a1d3` (`!effective?` cleared pending after a failed settlement lookup or a lost Stripe collection). Ineffective refunds now call `debit_stripe_account_for_refund_fee(collect: false)` and do not clear pending when that lookup errors.
- Declined Astra P1 (serialize Stripe collection with failed-refund auto-reversal): `Credit.create_for_refund_fee_retention!` sets `fee_retention_pending` only when `holder_of_funds == STRIPE`. `HandleFailedRefundService#auto_reversal_eligible?` requires Gumroad-held funds. Those transitions cannot interleave on the same refund. Re-verified at this head in `app/models/credit.rb`, `app/services/purchase/handle_failed_refund_service.rb`, and `StripeChargeProcessor.debit_stripe_account_for_refund_fee`.
- Declined Fable P1 (hourly retry / alert with no attempt cap): leaving `fee_retention_pending` set when Stripe returns no eligible transfer is the recovery contract (retry when a later payout appears). `ErrorNotifier.notify` on a raised Stripe rejection is the existing failure report, not a new money movement. An attempt-cap/backoff is follow-up, not a merge-blocking correctness hole in this diff. This panel run reported 0 Fable findings.

Fable P1 at `d623f1cdc09ca7c9b64deac9a749dc0f29afccec` (US accounts skipped Stripe collection) remains fixed: US Gumroad-managed accounts collect through `debit_refund_fee_from_account`.

Recommended acceptance contract: one processor collection per refund across crashes and delayed retries, settlement lookup resumable independently of collection, and pending cleared only after ledger reconciliation or an explicit terminal disposition. Keep external money calls outside recovery database transactions.

## Problem
A successful processor refund could roll back locally when retaining its processing fee failed, leaving the purchase refundable again.

## Cause
Fee collection runs inside refund bookkeeping, including combined-charge transactions; a retired settlement currency makes Stripe reject the payout-transfer reversal.

## Change
Catch only fee-retention Stripe errors, preserve the Refund, Credit and balance entries, and report pending recovery through ErrorNotifier. Attempt the existing reversal without a settlement probe; only a `no longer supported` invalid-request error falls back to an account debit in the connected account's current currency. Pin the source transfer, reverse with a stable idempotency key and refund metadata, page existing reversals before retrying, and resume settlement lookup when an ID exists without collected cents. US collection uses the same grouped, idempotent debit as recovery.

Retry hourly with `lock: :until_executed` and RecurringLockTtl, using the existing Credit only. Recovery calls Stripe outside database locks and transactions, then appends any zero-USD holding-currency adjustment and clears pending under a lock only after collected cents are recorded. Missing Credits are logged and reported, not recreated. Ineffective refunds look up existing collections and do not start a new one.

Tracker: antiwork/gumroad-private#2460

## Tests
- New recovery examples at this head cover settlement-lookup failure on an ineffective refund (pending stays) and adopting an unrecorded grouped debit without creating another collection.
- Treat CI at this head as the suite proof. No production recovery.

QA: no production recovery. Panel at this head is not clean (declined Astra P1 above). `ci/green` is success; `buildkite/gumroad` Build #22723 failed.

## Risk
Stripe's own error instructs creating account debits in EUR, which is the accepted basis for US-platform → EU-connected eligibility; if Stripe rejects the debit, `fee_retention_pending` remains set and ErrorNotifier surfaces it without undoing the buyer refund.

---
Built with GPT-6 Astra; reviewed with GPT-6 Astra and Claude Fable 5.1.
