### PR TITLE
Log direct-listed prepare rejection reasons without changing payment guards

### DIFF
--- a/app/services/checkout/direct_listed_amount_token.rb
+++ b/app/services/checkout/direct_listed_amount_token.rb
@@ -28,11 +28,22 @@ class Checkout::DirectListedAmountToken
       return nil if token.blank?
 
       payload = verifier.verified(token.to_s, purpose: PURPOSE)
-      return nil unless payload.is_a?(Hash)
-      return nil unless payload["sellers"] == seller_ids(sellers)
-      return nil unless payload["currency"] == currency.to_s.downcase
+      unless payload.is_a?(Hash)
+        yield :invalid_or_expired_token if block_given?
+        return nil
+      end
+      unless payload["sellers"] == seller_ids(sellers)
+        yield :seller_mismatch if block_given?
+        return nil
+      end
+      unless payload["currency"] == currency.to_s.downcase
+        yield :currency_mismatch if block_given?
+        return nil
+      end
 
-      normalize_allocations(payload["allocations"])
+      allocations = normalize_allocations(payload["allocations"])
+      yield :invalid_allocations if allocations.nil? && block_given?
+      allocations
     end
 
     private

--- a/app/services/order/prepare_payment_intent_service.rb
+++ b/app/services/order/prepare_payment_intent_service.rb
@@ -602,7 +602,7 @@ class Order::PreparePaymentIntentService
       # total than the Element mounted.
       unless method_forced_listed_allocations_match?(charge, forced_currency)
         @direct_listed_amount_mismatch = true
-        Rails.logger.info("Direct-listed client-confirm amount changed before prepare for order #{order.id}; refusing the stale Payment Element amount")
+        Rails.logger.info("Direct-listed client-confirm amount changed before prepare for order #{order.id}; refusing the stale Payment Element amount; reason=#{@direct_listed_amount_rejection_reason}")
         return nil
       end
 
@@ -713,7 +713,7 @@ class Order::PreparePaymentIntentService
 
       unless direct_listed_allocations_match?(direct_listed_presentment.allocations, decision.currency)
         @direct_listed_amount_mismatch = true
-        Rails.logger.info("Direct-listed client-confirm amount changed before prepare for order #{order.id}; refusing the stale Payment Element amount")
+        Rails.logger.info("Direct-listed client-confirm amount changed before prepare for order #{order.id}; refusing the stale Payment Element amount; reason=#{@direct_listed_amount_rejection_reason}")
         return nil
       end
       presentment = direct_listed_presentment.perform
@@ -758,6 +758,7 @@ class Order::PreparePaymentIntentService
     end
 
     def direct_listed_allocations_match?(actual_allocations, currency)
+      @direct_listed_amount_rejection_reason = nil
       # A checkout tab opened before this snapshot shipped cannot send the token. Preserve the
       # pre-deploy server-computed behavior for those in-flight tabs; any client that sends a
       # token must still pass the exact comparison below.
@@ -767,8 +768,11 @@ class Order::PreparePaymentIntentService
         params[:direct_listed_amount_token],
         sellers: purchases_to_charge.map(&:seller),
         currency:
-      )
-      return false unless reported&.length == actual_allocations.length
+      ) { @direct_listed_amount_rejection_reason = _1 }
+      unless reported&.length == actual_allocations.length
+        @direct_listed_amount_rejection_reason ||= :allocation_count_mismatch
+        return false
+      end
 
       expected = actual_allocations.map do |allocation|
         {
@@ -778,7 +782,10 @@ class Order::PreparePaymentIntentService
           "shipping_cents" => allocation.presentment_shipping_cents,
         }
       end
-      return false unless reported.map { _1.slice(*DIRECT_LISTED_AMOUNT_COMPARED_FIELDS) } == expected
+      unless reported.map { _1.slice(*DIRECT_LISTED_AMOUNT_COMPARED_FIELDS) } == expected
+        @direct_listed_amount_rejection_reason = :component_mismatch
+        return false
+      end
 
       # The token total is the amount the Element mounted with, so it is the most the buyer has
       # reviewed. Never confirm above it; a lower prepare-time total is fine to charge.
@@ -787,7 +794,9 @@ class Order::PreparePaymentIntentService
       if reviewed_total_cents != prepare_total_cents
         Rails.logger.info("Direct-listed prepare total for order #{order.id} is #{prepare_total_cents} #{currency} cents against a reviewed #{reviewed_total_cents}")
       end
-      prepare_total_cents <= reviewed_total_cents
+      matches = prepare_total_cents <= reviewed_total_cents
+      @direct_listed_amount_rejection_reason = :above_reviewed_total unless matches
+      matches
     end
 
     # Legacy fallback for clients that did not report their Element's mount currency. It

--- a/spec/services/order/direct_listed_rejection_diagnostics_spec.rb
+++ b/spec/services/order/direct_listed_rejection_diagnostics_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+describe Order::PreparePaymentIntentService do
+  let(:seller) { build_stubbed(:user) }
+  let(:purchase) { double(seller:, link: double(unique_permalink: "product")) }
+  let(:order) { double(id: 123) }
+  let(:params) { {} }
+  let(:service) { described_class.new(order:, params:, confirmation_token: "unused") }
+  let(:reported) do
+    { "permalink" => "product", "price_cents" => 1200, "tip_cents" => 100,
+      "shipping_cents" => 0, "tax_cents" => 50, "total_cents" => 1350 }
+  end
+  let(:actual) do
+    double(purchase:, presentment_price_cents: 1200, presentment_tip_cents: 100,
+           presentment_shipping_cents: 0, presentment_total_cents: 1350)
+  end
+
+  before do
+    allow(service).to receive(:purchases_to_charge).and_return([purchase])
+    allow(service).to receive(:gumroad_amount_cents).and_return(100)
+    allow(Rails.logger).to receive(:info)
+  end
+
+  def sign(allocations: [reported], sellers: [seller], currency: Currency::CAD)
+    Checkout::DirectListedAmountToken.issue(allocations:, sellers:, currency:)
+  end
+
+  def reject_with(reason, allocations: [actual])
+    listed = double(allocations:)
+    allow(Charge::DirectListedPresentment).to receive(:new).and_return(listed)
+    expect(listed).not_to receive(:perform)
+    decision = double(currency: Currency::CAD)
+
+    expect(service.send(:direct_listed_presentment_for, double, decision)).to be_nil
+    expect(service.instance_variable_get(:@direct_listed_amount_mismatch)).to eq(true)
+    expect(Rails.logger).to have_received(:info).with(
+      "Direct-listed client-confirm amount changed before prepare for order 123; refusing the stale Payment Element amount; reason=#{reason}"
+    )
+  end
+
+  it "logs an invalid signature without logging the supplied token" do
+    params[:direct_listed_amount_token] = "sensitive-invalid-token"
+    reject_with(:invalid_or_expired_token)
+  end
+
+  it "logs an expired token as unverifiable without attempting to decode it again" do
+    params[:direct_listed_amount_token] = sign
+    travel(Checkout::DirectListedAmountToken::TTL + 1.second) { reject_with(:invalid_or_expired_token) }
+  end
+
+  it "logs the seller mismatch before a simultaneous currency mismatch" do
+    params[:direct_listed_amount_token] = sign(sellers: [build_stubbed(:user)], currency: Currency::EUR)
+    reject_with(:seller_mismatch)
+  end
+
+  it "logs a currency mismatch" do
+    params[:direct_listed_amount_token] = sign(currency: Currency::EUR)
+    reject_with(:currency_mismatch)
+  end
+
+  it "logs malformed signed allocations" do
+    params[:direct_listed_amount_token] = Rails.application.message_verifier(Checkout::DirectListedAmountToken::PURPOSE).generate(
+      { "sellers" => [seller.id], "currency" => Currency::CAD, "allocations" => [] },
+      purpose: Checkout::DirectListedAmountToken::PURPOSE
+    )
+    reject_with(:invalid_allocations)
+  end
+
+  it "logs a different allocation count" do
+    params[:direct_listed_amount_token] = sign(allocations: [reported, reported])
+    reject_with(:allocation_count_mismatch)
+  end
+
+  %w[permalink price_cents tip_cents shipping_cents].each do |field|
+    it "logs a #{field} component mismatch before comparing totals" do
+      changed = reported.merge(field => (field == "permalink" ? "other-product" : 99), "total_cents" => 1)
+      params[:direct_listed_amount_token] = sign(allocations: [changed])
+      reject_with(:component_mismatch)
+    end
+  end
+
+  it "logs an above-reviewed total after matching components" do
+    params[:direct_listed_amount_token] = sign(allocations: [reported.merge("total_cents" => 1349)])
+    reject_with(:above_reviewed_total)
+  end
+
+  it "includes the reason at the method-forced rejection log site" do
+    params[:direct_listed_amount_token] = sign(currency: Currency::EUR)
+    service.instance_variable_set(:@previewed_payment_method_type, "ideal")
+    allow(service).to receive(:intent_forced_currency).and_return(Currency::CAD)
+    allow(service).to receive(:free_and_test_lines_share_currency?).and_return(true)
+    allow(service).to receive(:client_confirm_buyer_currency_decision).and_return(double(eligible?: false))
+    allow(purchase.link).to receive(:price_currency_type).and_return(Currency::CAD)
+    allow(Charge::DirectListedPresentment).to receive(:new).and_return(double(allocations: [actual]))
+
+    expect(service.send(:client_confirm_presentment_for, double)).to be_nil
+    expect(Rails.logger).to have_received(:info).with(
+      "Direct-listed client-confirm amount changed before prepare for order 123; refusing the stale Payment Element amount; reason=currency_mismatch"
+    )
+  end
+
+  [nil, 1350, 1400].each do |total|
+    it "accepts #{total || 'absent'} reviewed total without a rejection reason" do
+      params[:direct_listed_amount_token] = sign(allocations: [reported.merge("total_cents" => total)]) if total
+      expect(service.send(:direct_listed_allocations_match?, [actual], Currency::CAD)).to eq(true)
+      expect(service.instance_variable_get(:@direct_listed_amount_rejection_reason)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## What

Add finite rejection reasons to the two existing direct-listed prepare refusal logs. Payment acceptance, guard ordering, public error codes/messages, expiry, amounts, tax and fee calculations remain unchanged. The verifier optionally yields its first rejection reason; existing callers still receive the same allocations or nil.

## Why

The existing generic refusal cannot distinguish an unverifiable token from seller/currency mismatch, malformed signed allocations, allocation count, component mismatch, or an above-reviewed total. Do not infer a historical cause from these new prospective diagnostics. No raw tokens, customer inputs, new identifiers, amounts or persistent columns are added.

## Before/After

Before: one generic refusal log. After: the same log plus `reason=invalid_or_expired_token`, `seller_mismatch`, `currency_mismatch`, `invalid_allocations`, `allocation_count_mismatch`, `component_mismatch`, or `above_reviewed_total`. Invalid signatures and expiry intentionally remain one code because the existing verifier returns nil for both; no second decoding or verification is performed. Component mismatch covers the existing ordered permalink/price/tip/shipping comparison. No user-visible surface changes; no manufactured screenshots/video.

## Test Results

- Isolated lane0: `bundle exec rspec spec/services/order/prepare_payment_intent_service_spec.rb spec/services/checkout/direct_listed_amount_token_spec.rb spec/services/order/direct_listed_rejection_diagnostics_spec.rb` — **159 examples, 0 failures**.
- Ruby lint: all 3 changed files passed; whitespace check passed.
- Actual base (`39d2b36bb5400ca2c39b3da1f6532f678790b89f`) and branch: 14 existing direct-listed integration examples passed on each. An additional throwaway integration matrix ran 11 cases on each, comparing success/error code/error message, processor amount/currency and persisted purchase state exactly. This does not compare randomized identifiers or claim a browser/Stripe end-to-end charge.

| Synthetic scenario | Base and branch | New reason |
| --- | --- | --- |
| Invalid signature / expired signature | Reject; unchanged public quote-invalid error; no intent | `invalid_or_expired_token` |
| Seller / currency mismatch | Same rejection | `seller_mismatch` / `currency_mismatch` |
| Malformed signed allocations / changed count | Same rejection | `invalid_allocations` / `allocation_count_mismatch` |
| Changed ordered permalink/price/tip/shipping | Same rejection | `component_mismatch` |
| Prepare total above reviewed total | Same rejection | `above_reviewed_total` |
| Matching / lower total / legacy absent token | Accept; same processor amount/currency | None |

- All 12 new rejection-log assertions fail on base; 3 acceptance controls remain green. Four label-only mutants (token seller→currency, count→component, component→total, total→component) fail **1 / 1 / 4 / 1** intended log assertions. Restored token/diagnostics run: 17 passed. Source restored byte-for-byte; no mutation or throwaway probe committed.
- Development Astra autoreview clean. Current-head Astra + Fable panel: no findings.
- `bin/test-confidence` was exercised but timed out after 180 seconds; its partial progress is not a completed gate. The complete focused service suite above subsequently passed.
- Adjacent charge/presentment/confirm/finalize suite: 7 files, 134 examples, 0 failures.
- Distinct final code/spec/comment/evidence audit: PASS at the current head; no blocking findings. Limits: log expectations do not forbid an additional hypothetical sensitive log, and acceptance controls use a fresh service rather than proving reuse-state reset. Source audit verifies both properties in this patch.
- Contract/surcharge/quote/resolver/create/response/webhook suite: 6 files, 346 examples, 0 failures. Together the three serial batches ran 639 examples in 16 files with no failures.
- Full [`run-all-specs` CI](https://github.com/antiwork/gumroad/actions/runs/34283715518) passed at this head: 18 Fast, 50 Slow and 2 Minitest shards; 77 jobs successful, 4 skipped. All current-head check/status results are successful or intentionally skipped.

QA: run the three spec files above. Rejection tests require the exact finite log code and forbid presentment execution at the refusal; an additional example checks the method-forced log site. Review the unchanged public quote-invalid response, legacy absent-token allowance, and strict above-reviewed-total refusal. No new rendered surface; screenshots/video would not demonstrate these diagnostics. All automated gates complete. Gianfranco is the human payments reviewer; no merge or auto-merge. This is not deployed, and prospective diagnostics do not establish the causes of historical failures.

Premerge review: clean @ 636e076d7311567b3287dc2d23c84c443ca5121c

---
AI assistance: OpenAI GPT-6 Astra. Instructions: add the smallest diagnostic-only rejection patch; preserve exact payment behavior and public responses; avoid sensitive log inputs; prove baseline equivalence and distinguish rejection arms; full CI and independent review before human handoff.
