### PR TITLE
Keep bundle prices and CTAs from wrapping in in-app browsers

### DIFF
--- a/app/javascript/components/Product/CtaButton.tsx
+++ b/app/javascript/components/Product/CtaButton.tsx
@@ -97,8 +97,7 @@ const PARAMETERS_NOT_INHERITED_FROM_URL = new Set([
 
 export const CtaButton = React.forwardRef<HTMLAnchorElement, Props>(
   ({ product, purchase, discountCode, selection, label, onClick, showInstallmentPlanNotes = false }, ref) => {
-    const hasInstallments = product.installment_plan != null && product.installment_plan.number_of_installments > 1;
-    const compactOnMobile = hasInstallments ? "max-lg:text-sm max-lg:px-2 max-lg:py-3" : undefined;
+    const compactOnMobile = "max-lg:text-sm max-lg:px-2 max-lg:py-3 whitespace-nowrap shrink-0";
     const { searchParams } = new URL(useOriginalLocation());
 
     const [referrer, setReferrer] = React.useState("");

--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -290,7 +290,7 @@ const CtaBar = ({
     >
       <div
         ref={ref}
-        className="mx-auto flex max-w-product-page items-center justify-between gap-2 p-4 lg:gap-4 lg:px-8"
+        className="mx-auto flex max-w-product-page items-center justify-between gap-2 p-4 max-sm:flex-wrap lg:gap-4 lg:px-8"
         style={{
           transition: "var(--transition-duration)",
           marginTop: visible || !isDesktop ? undefined : -height,
@@ -326,7 +326,7 @@ const CtaBar = ({
         {product.ratings != null && product.ratings.count > 0 ? (
           <RatingsSummary className="hidden lg:flex" ratings={product.ratings} />
         ) : null}
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           <CtaButton
             product={product}
             purchase={purchase}

--- a/app/javascript/components/Product/PriceTag.tsx
+++ b/app/javascript/components/Product/PriceTag.tsx
@@ -67,10 +67,10 @@ export const PriceTag = ({
   const borderClasses = "border-r-transparent border-[calc(0.5lh+--spacing(1))] border-l-1";
 
   return (
-    <div itemScope itemProp="offers" itemType="https://schema.org/Offer" className="flex items-center">
+    <div itemScope itemProp="offers" itemType="https://schema.org/Offer" className="flex shrink-0 items-center">
       <div className="relative grid grid-flow-col border border-r-0 border-border">
         <div
-          className="bg-accent-with-text px-2 py-1 text-accent-foreground"
+          className="bg-accent-with-text px-2 py-1 whitespace-nowrap text-accent-foreground"
           itemProp="price"
           content={formatPriceCentsWithoutCurrencySymbolAndComma(currencyCode, price)}
         >

--- a/app/javascript/components/Product/index.bundleLayout.test.tsx
+++ b/app/javascript/components/Product/index.bundleLayout.test.tsx
@@ -156,8 +156,14 @@ describe("product page bundle mobile layout", () => {
     expect(bundleLink.closest("section")?.className.split(" ")).toEqual(expect.arrayContaining(["min-w-2/5"]));
 
     const bundlePrice = bundleItem.querySelector(".current-price");
+    expect(bundlePrice?.className.split(" ")).toEqual(expect.arrayContaining(["current-price", "whitespace-nowrap"]));
     expect(bundlePrice?.closest("section")?.className.split(" ")).toEqual(
-      expect.arrayContaining(["max-w-1/2", "flex-row", "items-start"]),
+      expect.arrayContaining(["max-w-1/2", "shrink-0", "flex-row", "items-start"]),
+    );
+
+    expect(bundleLink.querySelector("h4")?.className.split(" ")).toEqual(expect.arrayContaining(["break-words"]));
+    expect(screen.getByRole("heading", { name: product.name }).className.split(" ")).toEqual(
+      expect.arrayContaining(["break-words"]),
     );
   });
 });

--- a/app/javascript/components/Product/index.bundleLayout.test.tsx
+++ b/app/javascript/components/Product/index.bundleLayout.test.tsx
@@ -5,7 +5,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { Product, type Product as ProductData } from "$app/components/Product";
 import type { PriceSelection } from "$app/components/Product/ConfigurationSelector";
+import { Layout } from "$app/components/Product/Layout";
 
+vi.stubGlobal("SSR", false);
+vi.stubGlobal("Routes", {
+  checkout_url: () => "https://example.com/checkout",
+  edit_link_url: () => "https://example.com/edit",
+});
+
+vi.mock("$app/utils/classNames", () => ({
+  classNames: (...xs: unknown[]) => xs.filter((x): x is string => typeof x === "string" && x.length > 0).join(" "),
+}));
 vi.mock("$app/data/user_action_event", () => ({ trackUserProductAction: vi.fn() }));
 vi.mock("$app/data/view_event", () => ({ incrementProductViews: vi.fn() }));
 vi.mock("$app/utils/user_analytics", () => ({
@@ -20,11 +30,8 @@ vi.mock("$app/components/useOriginalLocation", () => ({
   useOriginalLocation: () => "https://example.com/products/bundle",
 }));
 vi.mock("$app/components/useRunOnce", () => ({ useRunOnce: vi.fn() }));
-vi.mock("$app/components/Product/CtaButton", () => {
-  const CtaButton = React.forwardRef<HTMLAnchorElement>(() => null);
-  CtaButton.displayName = "CtaButton";
-  return { CtaButton };
-});
+vi.mock("$app/components/DomainSettings", () => ({ useAppDomain: () => "example.com" }));
+vi.mock("$app/components/useIsAboveBreakpoint", () => ({ useIsAboveBreakpoint: () => false }));
 vi.mock("$app/components/Product/ConfigurationSelector", () => {
   const ConfigurationSelector = React.forwardRef(() => null);
   ConfigurationSelector.displayName = "ConfigurationSelector";
@@ -38,6 +45,9 @@ vi.mock("$app/components/Product/ConfigurationSelector", () => {
       isPWYW: false,
       maxQuantity: null,
       selectedOption: null,
+      hasRentOption: false,
+      hasMultipleRecurrences: false,
+      hasConfigurableQuantity: false,
     }),
     buyerLocalPriceCentsForSelection: (priceCents?: number) => priceCents,
     buyerLocalContextFor: (product: ProductData) => ({
@@ -164,6 +174,57 @@ describe("product page bundle mobile layout", () => {
     expect(bundleLink.querySelector("h4")?.className.split(" ")).toEqual(expect.arrayContaining(["break-words"]));
     expect(screen.getByRole("heading", { name: product.name }).className.split(" ")).toEqual(
       expect.arrayContaining(["break-words"]),
+    );
+
+    const priceTag = document.querySelector("[itemprop='price']");
+    expect(priceTag?.className.split(" ")).toEqual(expect.arrayContaining(["whitespace-nowrap"]));
+    expect(priceTag?.closest("[itemprop='offers']")?.className.split(" ")).toEqual(
+      expect.arrayContaining(["flex", "shrink-0"]),
+    );
+
+    const cta = screen.getByRole("link", { name: "I want this!" });
+    expect(cta.className.split(" ")).toEqual(expect.arrayContaining(["whitespace-nowrap", "shrink-0"]));
+  });
+
+  it("lets the sticky CTA bar wrap instead of squeezing price and CTA", () => {
+    class FakeIntersectionObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
+
+    render(
+      <Layout
+        product={product}
+        purchase={null}
+        discount_code={null}
+        wishlists={[]}
+        main_section_index={0}
+        sections={[]}
+        creator_profile={{
+          external_id: "seller",
+          name: "Measure Twice Digital",
+          avatar_url: "https://example.com/avatar.png",
+          twitter_handle: null,
+          subdomain: null,
+          is_verified: false,
+          can_edit: false,
+        }}
+        currency_code="usd"
+      />,
+    );
+
+    const bar = screen.getByRole("region", { name: "Product information bar" });
+    const inner = bar.querySelector(".max-w-product-page");
+    expect(inner?.className.split(" ")).toEqual(expect.arrayContaining(["max-sm:flex-wrap"]));
+    expect(bar.querySelector("[itemprop='price']")?.className.split(" ")).toEqual(
+      expect.arrayContaining(["whitespace-nowrap"]),
+    );
+    const ctaWrap = bar.querySelector(".shrink-0.items-center");
+    expect(ctaWrap?.className.split(" ")).toEqual(expect.arrayContaining(["shrink-0"]));
+    expect(screen.getAllByRole("link", { name: "I want this!" })[0]?.className.split(" ")).toEqual(
+      expect.arrayContaining(["whitespace-nowrap", "shrink-0"]),
     );
   });
 });

--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -428,7 +428,7 @@ export const Product = ({
               instead of inheriting the document's LTR base direction, which misplaces
               neutral characters like quotes and digits (gumroad-private#1259; same
               rationale as the description fix in #6138). */}
-          <h1 itemProp="name" dir="auto">
+          <h1 itemProp="name" dir="auto" className="break-words">
             {product.name}
           </h1>
         </header>
@@ -525,7 +525,7 @@ export const Product = ({
                     <CartItemMain className="min-h-16 min-w-2/5 sm:h-28">
                       <CartItemTitle asChild>
                         <a href={bundleProduct.url}>
-                          <h4 className="font-bold">{bundleProduct.name}</h4>
+                          <h4 className="font-bold break-words">{bundleProduct.name}</h4>
                         </a>
                       </CartItemTitle>
                       {bundleProduct.ratings ? (
@@ -543,8 +543,8 @@ export const Product = ({
                         </CartItemFooter>
                       ) : null}
                     </CartItemMain>
-                    <CartItemEnd className="max-w-1/2 flex-row items-start gap-4 p-4 text-right">
-                      <span className="current-price" aria-label="Price">
+                    <CartItemEnd className="max-w-1/2 shrink-0 flex-row items-start gap-4 p-4 text-right">
+                      <span className="current-price whitespace-nowrap" aria-label="Price">
                         {comparisonPriceCents !== null && discountedPriceCents < comparisonPriceCents ? (
                           <s>{price}</s>
                         ) : (


### PR DESCRIPTION
Premerge review: clean @ 3f689966712080551362111f3de16fb6dee47a07

Keep bundle product-page prices and CTAs on one line in in-app browsers

Addresses antiwork/gumroad-private#2480

## What

Stop Instagram-style in-app browsers from wrapping `$2.99`, product titles mid-word, and the buy button. Prices and the CTA are `whitespace-nowrap`; titles use `break-words` instead of inheriting global `overflow-wrap: anywhere`. The sticky product bar can wrap as a row instead of squeezing those tokens.

## Why

gp#2354 / #7465 floored the bundle columns for Chrome 100% zoom. That left `html, body { overflow-wrap: anywhere }` and `* { min-width: 0 }` free to stack a short price into a 22×66 box (measured `$2.99` at 280px) and wrap "Add to cart". Instagram's in-app WebView is the remaining seller path.

Member order follows `bundle_products.in_order` (`position` ascending). The description list on that product is the reverse of current positions — editor order, not this layout bug.

## Before / after

Measured at 280px with Instagram Android UA on the live bundle page, then the same declarations this PR ships injected on the live DOM.

- Before: `.current-price` `$2.99` is 22×66, `overflow-wrap: anywhere`. CTA wraps.
- After: `$2.99` is 44×22, `white-space: nowrap`. CTA `nowrap`.

![CTA wrapping before](https://github.com/user-attachments/assets/03e4d44e-561b-4fc9-b322-e76a3cbdf7df)
![CTA after nowrap](https://github.com/user-attachments/assets/1af1673c-b4c4-441c-9f7f-3b7cd51946a5)

Hosted preview QA after deploy.

## Checklist

- [x] Scope — product page header, bundle CartItem price/title, PriceTag, CtaButton, sticky bar. Checkout floors unchanged.
- [x] Design — nowrap prices/CTA; break-word titles; do not set `text-size-adjust: 100%`.
- [x] Build — `fix/gp2480-instagram-bundle-wrap`
- [x] QA — structural 280px stills attached; preview app up (no seller bundle on staging)
- [ ] Shipped
- [ ] Market — n/a, bugfix
- [ ] Sell — n/a

## Test Results

`./node_modules/.bin/vitest run --reporter=dot app/javascript/components/Product/index.bundleLayout.test.tsx` — 2 passed at `3f689966712`. Mutants dropping PriceTag `whitespace-nowrap`, CtaButton `nowrap`/`shrink-0`, and sticky-bar `max-sm:flex-wrap` each redden the new examples. Greptile P2 coverage gap closed.

## QA

1. Open a bundle product page at ~280px (or Instagram in-app).
2. Confirm each member `$2.99` stays on one line and the buy button does not wrap.
3. Confirm titles wrap at word boundaries, not inside a word.

---

## AI disclosure

Generated with grok-4.6 (xAI), running as Gumclaw. Prompts/instructions: autonomous-product-dev on gp#2480 (Instagram in-app bundle wrap after the Chrome 100% zoom fix).
