### PR TITLE
Stack sticky price above CTA at narrow widths; wrap titles on word boundaries

### DIFF
--- a/app/javascript/components/Product/Layout.tsx
+++ b/app/javascript/components/Product/Layout.tsx
@@ -290,7 +290,9 @@ const CtaBar = ({
     >
       <div
         ref={ref}
-        className="mx-auto flex max-w-product-page items-center justify-between gap-2 p-4 max-sm:flex-wrap lg:gap-4 lg:px-8"
+        // Below sm the price and CTA are both nowrap and do not fit side by side (Instagram's
+        // WebView is ~280px), so stack them instead of letting them overlap.
+        className="mx-auto flex max-w-product-page items-center justify-between gap-2 p-4 max-sm:flex-col max-sm:items-stretch lg:gap-4 lg:px-8"
         style={{
           transition: "var(--transition-duration)",
           marginTop: visible || !isDesktop ? undefined : -height,
@@ -326,7 +328,7 @@ const CtaBar = ({
         {product.ratings != null && product.ratings.count > 0 ? (
           <RatingsSummary className="hidden lg:flex" ratings={product.ratings} />
         ) : null}
-        <div className="flex shrink-0 items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2 max-sm:flex-col max-sm:items-stretch">
           <CtaButton
             product={product}
             purchase={purchase}

--- a/app/javascript/components/Product/index.bundleLayout.test.tsx
+++ b/app/javascript/components/Product/index.bundleLayout.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -171,9 +171,10 @@ describe("product page bundle mobile layout", () => {
       expect.arrayContaining(["max-w-1/2", "shrink-0", "flex-row", "items-start"]),
     );
 
-    expect(bundleLink.querySelector("h4")?.className.split(" ")).toEqual(expect.arrayContaining(["break-words"]));
+    // wrap-break-word is overflow-wrap: break-word; break-words is deprecated in Tailwind v4.1.
+    expect(bundleLink.querySelector("h4")?.className.split(" ")).toEqual(expect.arrayContaining(["wrap-break-word"]));
     expect(screen.getByRole("heading", { name: product.name }).className.split(" ")).toEqual(
-      expect.arrayContaining(["break-words"]),
+      expect.arrayContaining(["wrap-break-word"]),
     );
 
     const priceTag = document.querySelector("[itemprop='price']");
@@ -186,7 +187,7 @@ describe("product page bundle mobile layout", () => {
     expect(cta.className.split(" ")).toEqual(expect.arrayContaining(["whitespace-nowrap", "shrink-0"]));
   });
 
-  it("lets the sticky CTA bar wrap instead of squeezing price and CTA", () => {
+  it("stacks the sticky CTA bar price above the CTA on narrow screens", () => {
     class FakeIntersectionObserver {
       observe() {}
       unobserve() {}
@@ -217,14 +218,20 @@ describe("product page bundle mobile layout", () => {
 
     const bar = screen.getByRole("region", { name: "Product information bar" });
     const inner = bar.querySelector(".max-w-product-page");
-    expect(inner?.className.split(" ")).toEqual(expect.arrayContaining(["max-sm:flex-wrap"]));
+    const innerClasses = inner?.className.split(" ");
+    expect(innerClasses).toEqual(expect.arrayContaining(["flex", "max-sm:flex-col", "max-sm:items-stretch"]));
+    expect(innerClasses).not.toContain("max-sm:flex-wrap");
     expect(bar.querySelector("[itemprop='price']")?.className.split(" ")).toEqual(
       expect.arrayContaining(["whitespace-nowrap"]),
     );
-    const ctaWrap = bar.querySelector(".shrink-0.items-center");
-    expect(ctaWrap?.className.split(" ")).toEqual(expect.arrayContaining(["shrink-0"]));
-    expect(screen.getAllByRole("link", { name: "I want this!" })[0]?.className.split(" ")).toEqual(
-      expect.arrayContaining(["whitespace-nowrap", "shrink-0"]),
+    const cta = within(bar).getByRole("link", { name: "I want this!" });
+    expect(cta.className.split(" ")).toEqual(expect.arrayContaining(["whitespace-nowrap", "shrink-0"]));
+    const ctaWrap = cta.parentElement;
+    expect(ctaWrap?.className.split(" ")).toEqual(
+      expect.arrayContaining(["shrink-0", "max-sm:flex-col", "max-sm:items-stretch"]),
     );
+    // Price wrapper precedes the CTA wrapper, so a column puts the price on top.
+    expect(inner?.firstElementChild?.getAttribute("itemprop")).toBe("offers");
+    expect(inner?.lastElementChild).toBe(ctaWrap);
   });
 });

--- a/app/javascript/components/Product/index.tsx
+++ b/app/javascript/components/Product/index.tsx
@@ -427,8 +427,10 @@ export const Product = ({
           {/* dir="auto" lets an RTL product name (Hebrew, Arabic) render right-to-left
               instead of inheriting the document's LTR base direction, which misplaces
               neutral characters like quotes and digits (gumroad-private#1259; same
-              rationale as the description fix in #6138). */}
-          <h1 itemProp="name" dir="auto" className="break-words">
+              rationale as the description fix in #6138).
+              wrap-break-word overrides the inherited global overflow-wrap: anywhere, which
+              splits titles mid-word in narrow in-app browsers. */}
+          <h1 itemProp="name" dir="auto" className="wrap-break-word">
             {product.name}
           </h1>
         </header>
@@ -525,7 +527,7 @@ export const Product = ({
                     <CartItemMain className="min-h-16 min-w-2/5 sm:h-28">
                       <CartItemTitle asChild>
                         <a href={bundleProduct.url}>
-                          <h4 className="font-bold break-words">{bundleProduct.name}</h4>
+                          <h4 className="font-bold wrap-break-word">{bundleProduct.name}</h4>
                         </a>
                       </CartItemTitle>
                       {bundleProduct.ratings ? (


### PR DESCRIPTION
Follow-up to #7554 / antiwork/gumroad-private#2480: stack the sticky price above the CTA when nowrap tokens cannot sit side-by-side at Instagram ~280px, and wrap product titles on word boundaries.

## What

- Sticky product bar: below `sm`, use `flex-col` + `items-stretch` so the nowrap price sits on its own full-width row above the CTA. Wider viewports keep the side-by-side nowrap row.
- Product and bundle titles: `wrap-break-word` (`overflow-wrap: break-word`) so they override the global `overflow-wrap: anywhere` inheritance and wrap at word boundaries when the word fits the line.

## Why

#7554 kept `$14.99` and `Add to cart` on one line with `whitespace-nowrap`. At ~280px those tokens no longer fit side-by-side, so they overlapped (worse than wrapping). Titles still inherited `overflow-wrap: anywhere` and could split mid-token in narrow in-app browsers.

## Before / after

Measured on the live bundle product page at 280px with an Instagram Android UA, then the declarations this PR ships injected on the live DOM.

- Before: sticky bar keeps price and CTA on one row; nowrap tokens overlap at ~280px. Titles can split mid-word under the global `anywhere` wrap.
- After: sticky bar stacks price above CTA with no overlap. Titles use `overflow-wrap: break-word` and wrap on word boundaries when the word fits (e.g. `Window &` stays whole).

![sticky-price-cta-stack-280](https://github.com/user-attachments/assets/371871dd-6383-4769-ae1a-9ed7c3344f3b)

![title-word-wrap-280](https://github.com/user-attachments/assets/4f172601-ae61-4447-847a-7c59957236e6)

## Test Results

`./node_modules/.bin/vitest run --reporter=dot app/javascript/components/Product/index.bundleLayout.test.tsx` — 2 passed at `13149fcc644`. Mutants dropping sticky `max-sm:flex-col` / `max-sm:items-stretch` or title `wrap-break-word` each redden the updated examples.

Astra (`codex` / `gpt-6-astra`, `--mode local`, thinking high): clean before push.

## QA

1. Open a bundle product page at ~280px (or Instagram in-app).
2. Scroll until the sticky product bar shows. Confirm price is above the CTA, with no overlap.
3. Confirm the product title wraps at spaces; words that fit the line do not split mid-token.

---

Generated with Claude Code (claude-fable-5-1).
