### PR TITLE
Hide included-product ratings on a bundle page

### DIFF
--- a/app/controllers/bundles/share_controller.rb
+++ b/app/controllers/bundles/share_controller.rb
@@ -20,6 +20,7 @@ class Bundles::ShareController < Bundles::BaseController
         tags: share_permitted_params[:tags],
         section_ids: share_permitted_params[:section_ids],
         display_product_reviews: share_permitted_params[:display_product_reviews],
+        hide_bundle_product_reviews: share_permitted_params[:hide_bundle_product_reviews],
         is_adult: share_permitted_params[:is_adult]
       ).perform
 
@@ -40,7 +41,7 @@ class Bundles::ShareController < Bundles::BaseController
 
   private
     def share_permitted_params
-      params.permit(:taxonomy_id, :display_product_reviews, :is_adult, section_ids: [], tags: [])
+      params.permit(:taxonomy_id, :display_product_reviews, :hide_bundle_product_reviews, :is_adult, section_ids: [], tags: [])
     end
 
     def ensure_published

--- a/app/javascript/components/BundleEdit/ProductPreview.tsx
+++ b/app/javascript/components/BundleEdit/ProductPreview.tsx
@@ -24,6 +24,7 @@ type ProductPreviewBundle = {
   allow_installment_plan: boolean;
   installment_plan: { number_of_installments: number } | null;
   display_product_reviews: boolean;
+  hide_bundle_product_reviews?: boolean;
   quantity_enabled: boolean;
   should_show_sales_count: boolean;
   custom_button_text_option: CustomButtonTextOption | null;
@@ -144,6 +145,7 @@ export const ProductPreview = ({
             price: computeStandalonePrice(bundleProduct),
             variant:
               bundleProduct.variants?.list.find(({ id }) => id === bundleProduct.variants?.selected_id)?.name ?? null,
+            ratings: bundle.hide_bundle_product_reviews ? null : bundleProduct.ratings,
           })),
           public_files: bundle.public_files,
         }}

--- a/app/javascript/pages/Bundles/Product/Edit.tsx
+++ b/app/javascript/pages/Bundles/Product/Edit.tsx
@@ -64,6 +64,7 @@ type ProductPageProps = {
     custom_attributes: Attribute[];
     refund_policy: RefundPolicy;
     display_product_reviews: boolean;
+    hide_bundle_product_reviews: boolean;
     public_files: PublicFileWithStatus[];
     is_published: boolean;
     products: BundleProduct[];

--- a/app/javascript/pages/Bundles/Share/Edit.tsx
+++ b/app/javascript/pages/Bundles/Share/Edit.tsx
@@ -40,6 +40,7 @@ type SharePageProps = {
     allow_installment_plan: boolean;
     installment_plan: { number_of_installments: number } | null;
     display_product_reviews: boolean;
+    hide_bundle_product_reviews: boolean;
     quantity_enabled: boolean;
     should_show_sales_count: boolean;
     custom_button_text_option: CustomButtonTextOption | null;
@@ -70,6 +71,7 @@ type ShareFormData = {
   taxonomy_id: string | null;
   tags: string[];
   display_product_reviews: boolean;
+  hide_bundle_product_reviews: boolean;
   is_adult: boolean;
   unpublish?: boolean;
 };
@@ -100,6 +102,7 @@ export default function BundlesShareEdit() {
     taxonomy_id: bundle.taxonomy_id,
     tags: bundle.tags,
     display_product_reviews: bundle.display_product_reviews,
+    hide_bundle_product_reviews: bundle.hide_bundle_product_reviews,
     is_adult: bundle.is_adult,
   });
 
@@ -124,7 +127,7 @@ export default function BundlesShareEdit() {
       isPublished={bundle.is_published}
       preview={
         <ProductPreview
-          bundle={bundle}
+          bundle={{ ...bundle, hide_bundle_product_reviews: form.data.hide_bundle_product_reviews }}
           id={id}
           uniquePermalink={unique_permalink}
           currencyType={currency_type}
@@ -196,6 +199,11 @@ export default function BundlesShareEdit() {
               checked={form.data.display_product_reviews}
               onChange={(e) => form.setData("display_product_reviews", e.target.checked)}
               label="Display your product's 1-5 star rating to prospective customers"
+            />
+            <Switch
+              checked={form.data.hide_bundle_product_reviews}
+              onChange={(e) => form.setData("hide_bundle_product_reviews", e.target.checked)}
+              label="Hide ratings of included products on this bundle page"
             />
             <Switch
               checked={form.data.is_adult}

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -43,6 +43,7 @@ class Link < ApplicationRecord
             31 => :created_via_cli,
             32 => :DEPRECATED_moderated_by_iffy,
             33 => :hide_sold_out_variants,
+            34 => :hide_bundle_product_reviews,
             :column => "flags",
             :flag_query_mode => :bit_operator,
             check_for_column: false

--- a/app/presenters/bundle_presenter.rb
+++ b/app/presenters/bundle_presenter.rb
@@ -129,6 +129,7 @@ class BundlePresenter
           taxonomy_id: bundle.taxonomy_id&.to_s,
           tags: bundle.tags.pluck(:name),
           display_product_reviews: bundle.display_product_reviews,
+          hide_bundle_product_reviews: bundle.hide_bundle_product_reviews?,
           is_adult: bundle.is_adult,
           discover_fee_per_thousand: bundle.discover_fee_per_thousand,
           section_ids: bundle.user.seller_profile_products_sections.on_profile.filter_map { |section| section.external_id if section.shown_products.include?(bundle.id) },

--- a/app/presenters/product_presenter/product_props.rb
+++ b/app/presenters/product_presenter/product_props.rb
@@ -140,7 +140,7 @@ class ProductPresenter::ProductProps
       {
         id: product.external_id,
         name: product.name,
-        ratings: product.display_product_reviews? ? {
+        ratings: (!@product.hide_bundle_product_reviews? && product.display_product_reviews?) ? {
           count: product.reviews_count,
           average: product.average_rating,
         } : nil,

--- a/app/services/bundle/update_share_service.rb
+++ b/app/services/bundle/update_share_service.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class Bundle::UpdateShareService
-  def initialize(bundle:, taxonomy_id: nil, tags: nil, section_ids: nil, display_product_reviews: nil, is_adult: nil)
+  def initialize(bundle:, taxonomy_id: nil, tags: nil, section_ids: nil, display_product_reviews: nil, hide_bundle_product_reviews: nil, is_adult: nil)
     @bundle = bundle
     @taxonomy_id = taxonomy_id
     @tags = tags
     @section_ids = section_ids
     @display_product_reviews = display_product_reviews
+    @hide_bundle_product_reviews = hide_bundle_product_reviews
     @is_adult = is_adult
   end
 
@@ -14,6 +15,7 @@ class Bundle::UpdateShareService
     @bundle.assign_attributes(
       taxonomy_id: @taxonomy_id,
       display_product_reviews: @display_product_reviews,
+      hide_bundle_product_reviews: @hide_bundle_product_reviews,
       is_adult: @is_adult
     )
 

--- a/spec/controllers/bundles/share_controller_spec.rb
+++ b/spec/controllers/bundles/share_controller_spec.rb
@@ -72,12 +72,14 @@ describe Bundles::ShareController, inertia: true do
           taxonomy_id: taxonomy.id,
           tags: ["tag1", "tag2"],
           display_product_reviews: false,
+          hide_bundle_product_reviews: true,
           is_adult: true
         }
         bundle.reload
       end.to change { bundle.taxonomy_id }.from(nil).to(taxonomy.id)
       .and change { bundle.tags.pluck(:name) }.from([]).to(["tag1", "tag2"])
       .and change { bundle.display_product_reviews }.from(true).to(false)
+      .and change { bundle.hide_bundle_product_reviews }.from(false).to(true)
       .and change { bundle.is_adult }.from(false).to(true)
 
       expect(response).to redirect_to(edit_bundle_share_path(bundle.external_id))

--- a/spec/controllers/bundles/share_controller_spec.rb
+++ b/spec/controllers/bundles/share_controller_spec.rb
@@ -24,6 +24,7 @@ describe Bundles::ShareController, inertia: true do
         expect(inertia.props[:currency_type]).to eq(bundle.price_currency_type)
         expect(inertia.props[:bundle][:name]).to eq(bundle.name)
         expect(inertia.props[:bundle][:products]).to be_an(Array)
+        expect(inertia.props[:bundle][:hide_bundle_product_reviews]).to eq(false)
         expect(inertia.props[:taxonomies]).to be_an(Array)
         expect(inertia.props[:profile_sections]).to be_an(Array)
       end

--- a/spec/presenters/product_presenter/product_props_spec.rb
+++ b/spec/presenters/product_presenter/product_props_spec.rb
@@ -569,6 +569,21 @@ describe ProductPresenter::ProductProps do
         expect(card[:ratings]).to eq(count: 1, average: 5.0)
       end
 
+      it "hides per-product ratings on the bundle page without changing the child's own page" do
+        first_bundled_product = bundle.bundle_products.in_order.first.product
+        create(:product_review, purchase: create(:purchase, link: first_bundled_product), rating: 5)
+        bundle.update!(hide_bundle_product_reviews: true)
+        bundle.reload
+        first_bundled_product.reload
+
+        bundle_card = described_class.new(product: bundle).props(seller_custom_domain_url: nil, request:, pundit_user: nil)[:product][:bundle_products].find { _1[:id] == first_bundled_product.external_id }
+        expect(bundle_card[:ratings]).to be_nil
+
+        child_ratings = described_class.new(product: first_bundled_product).props(seller_custom_domain_url: nil, request:, pundit_user: nil)[:product][:ratings]
+        expect(child_ratings[:count]).to eq(1)
+        expect(child_ratings[:average]).to eq(5.0)
+      end
+
       it "does not issue per-row queries for bundle product card associations" do
         3.times do |i|
           extra = create(:product, user: seller)

--- a/spec/requests/bundles/edit_spec.rb
+++ b/spec/requests/bundles/edit_spec.rb
@@ -422,6 +422,7 @@ describe("Bundle edit page", type: :system, js: true) do
       end
 
       uncheck("Display your product's 1-5 star rating to prospective customers", checked: true)
+      check("Hide ratings of included products on this bundle page", checked: false)
       check("This product contains content meant only for adults, including the preview", checked: false)
 
       expect(page).to have_text "You currently have no sections in your profile to display this"
@@ -435,6 +436,7 @@ describe("Bundle edit page", type: :system, js: true) do
       expect(bundle.tags.first.name).to eq("test0")
       expect(bundle.tags.second.name).to eq("test1")
       expect(bundle.display_product_reviews?).to eq(false)
+      expect(bundle.hide_bundle_product_reviews?).to eq(true)
       expect(bundle.is_adult?).to eq(true)
       expect(bundle.discover_fee_per_thousand).to eq(100)
 
@@ -452,6 +454,7 @@ describe("Bundle edit page", type: :system, js: true) do
       end
 
       check("Display your product's 1-5 star rating to prospective customers", checked: false)
+      uncheck("Hide ratings of included products on this bundle page", checked: true)
       uncheck("This product contains content meant only for adults, including the preview", checked: true)
       check("Unnamed section", checked: false)
 
@@ -462,6 +465,7 @@ describe("Bundle edit page", type: :system, js: true) do
       expect(bundle.tags.size).to eq(1)
       expect(bundle.tags.first.name).to eq("test1")
       expect(bundle.display_product_reviews?).to eq(true)
+      expect(bundle.hide_bundle_product_reviews?).to eq(false)
       expect(bundle.is_adult?).to eq(false)
       expect(bundle.discover_fee_per_thousand).to eq(100)
       expect(section.reload.shown_products).to include bundle.id


### PR DESCRIPTION
# Hide included-product ratings on a bundle page

> Draft status: code + specs pushed; local presenter/controller specs and Share-tab stills still owed before ready.

## What

Sellers can hide the star ratings of products listed inside a bundle page, without hiding reviews on those products' own pages.

A new Share-tab switch, "Hide ratings of included products on this bundle page", sets a per-bundle `hide_bundle_product_reviews` flag (default off). When on, `ProductPresenter` sends `ratings: null` for each `bundle_products` card, and the editor preview does the same. The bundle's own rating toggle is unchanged.

## Why

antiwork/gumroad-private#2483. Bundle pages currently surface each contained product's rating next to its name. The existing `display_product_reviews` flag is per-product and hides ratings everywhere, including the product's own page.

## Before / after

- Before: every included product on a bundle page shows its star rating whenever that product's own reviews are public.
- After: with the switch on, those ratings are omitted on the bundle page and in the bundle editor preview; the included products' own pages still show them.

## Checklist

- [x] Scope — bundle public page + bundle editor preview + Share persist. Not Discover cards, checkout, or a child's own product page.
- [x] Design — new Link flag (default false) rather than a migration. Rejected reusing `display_product_reviews` because that hides ratings on the child's own page too.
- [x] Build — `feat/gp2483-hide-bundle-product-reviews`
- [ ] QA — Share-tab stills on hosted preview still owed
- [ ] Shipped — draft until CI, panel, and stills
- [ ] Market — n/a (seller setting)
- [ ] Sell — n/a

## Tests

```text
spec/presenters/product_presenter/product_props_spec.rb
spec/controllers/bundles/share_controller_spec.rb
spec/requests/bundles/edit_spec.rb (existing Share save path)
```

## QA

Not preview-exercisable yet. After CI, capture Share tab with the switch off (included ratings visible in preview) and on (included ratings gone), plus the included product's own page still showing ratings.

---

## AI disclosure

Generated with grok-4.6 (xAI), running as Gumclaw on antiwork/gumroad-private#2483.
Prompts/instructions given: autonomous-product-dev build-first for a seller-requested per-bundle display control; hide contained-product ratings on the bundle page only.
