### PR TITLE
Collect refund fees after the refund commits and cap retries

### DIFF
--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -353,21 +353,12 @@ class Credit < ApplicationRecord
     reversed_amount_cents_in_holding_currency = credit.usd_cents_to_currency(credit.merchant_account.currency, credit.amount_cents)
 
     if credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE
-      stripe_fee_collection_required = credit.amount_cents != 0
-      refund.fee_retention_pending = stripe_fee_collection_required
+      # No Stripe call here: the caller's transaction must commit before money moves
+      # (Purchase#debit_processor_fee_from_merchant_account!). The holding amount below is
+      # the FX estimate; Refund#recover_pending_fee_retention! books the delta to the
+      # amount Stripe actually collected.
+      refund.fee_retention_pending = credit.amount_cents != 0
       refund.save!
-      if stripe_fee_collection_required
-        # Keep the credit and its balance transaction together even if Stripe rejects collection.
-        net_amount_on_stripe_in_holding_currency = refund.retain_fee do
-          StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:)
-        end
-        reversed_amount_cents_in_holding_currency = -net_amount_on_stripe_in_holding_currency if net_amount_on_stripe_in_holding_currency.present?
-        if refund.debited_stripe_transfer.present? && refund.fee_retention_collected_cents.present?
-          refund.fee_retention_pending = false
-          refund.fee_retention_error = nil
-          refund.save!
-        end
-      end
     end
 
     balance_transaction_amount = BalanceTransaction::Amount.new(

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -353,10 +353,9 @@ class Credit < ApplicationRecord
     reversed_amount_cents_in_holding_currency = credit.usd_cents_to_currency(credit.merchant_account.currency, credit.amount_cents)
 
     if credit.merchant_account.holder_of_funds == HolderOfFunds::STRIPE
-      # No Stripe call here: the caller's transaction must commit before money moves
-      # (Purchase#debit_processor_fee_from_merchant_account!). The holding amount below is
-      # the FX estimate; Refund#recover_pending_fee_retention! books the delta to the
-      # amount Stripe actually collected.
+      # No Stripe call here: the caller's transaction commits first. The holding amount below
+      # is the FX estimate; Refund#recover_pending_fee_retention! books the delta to what
+      # Stripe collected.
       refund.fee_retention_pending = credit.amount_cents != 0
       refund.save!
     end

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -137,61 +137,20 @@ class Refund < ApplicationRecord
     ErrorNotifier.notify(error, context: { refund_id: id, purchase_id: purchase_id })
   end
 
+  # Every run that ends without a collection counts as one attempt, including runs
+  # that find no Credit or raise; otherwise a persistent failure keeps the refund in
+  # the job's candidate set and notifies every hour forever.
   def recover_pending_fee_retention!
     pending = purchase.with_lock { reload.fee_retention_pending }
     return unless pending
 
-    credit = Credit.find_by(fee_retention_refund: self, failed_refund_id: nil)
-    unless credit
-      message = "Pending refund fee retention has no Credit"
-      Rails.logger.error("#{message} (refund_id=#{id})")
-      ErrorNotifier.notify(message, context: { refund_id: id, purchase_id: purchase_id })
-      return
-    end
-
-    # Gate on terminally_failed?, not effective?: Stripe-held failures are never
-    # balance-reversed, so effective? stays true and would collect a fee for a refund
-    # the buyer never received. Existing pins and grouped debits are still adopted.
-    credit.fee_retention_refund = self
-    lookup_failed = false
-    retain_fee do
-      StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:, collect: !terminally_failed?)
-    rescue *FEE_RETENTION_ERRORS
-      lookup_failed = true
+    collected = begin
+      collect_pending_fee_retention!
+    rescue StandardError
+      count_fee_retention_attempt!
       raise
     end
-
-    attempts_exhausted = false
-    purchase.with_lock do
-      reload.lock!
-      next unless fee_retention_pending
-      collection_recorded = debited_stripe_transfer.present? && fee_retention_collected_cents.present?
-      no_stripe_collection = credit.amount_cents.zero? || credit.merchant_account.holder_of_funds != HolderOfFunds::STRIPE
-      terminal_without_collection = terminally_failed? && debited_stripe_transfer.blank? && !lookup_failed
-      unless collection_recorded || no_stripe_collection || terminal_without_collection
-        attempts_exhausted = record_fee_retention_attempt!
-        next
-      end
-
-      if fee_retention_collected_cents.present?
-        holding_cents = BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)
-        adjustment_cents = -fee_retention_collected_cents - holding_cents
-        unless adjustment_cents.zero?
-          BalanceTransaction.create!(user: credit.user, merchant_account: credit.merchant_account, credit:,
-                                     issued_amount: BalanceTransaction::Amount.new(currency: Currency::USD, gross_cents: 0, net_cents: 0),
-                                     holding_amount: BalanceTransaction::Amount.new(currency: credit.merchant_account.currency,
-                                                                                    gross_cents: adjustment_cents, net_cents: adjustment_cents))
-        end
-      end
-      self.fee_retention_pending = false
-      self.fee_retention_error = nil
-      save!
-    end
-    return unless attempts_exhausted
-
-    message = "Refund fee retention stopped retrying after #{MAX_FEE_RETENTION_ATTEMPTS} attempts"
-    Rails.logger.error("#{message} (refund_id=#{id})")
-    ErrorNotifier.notify(message, context: { refund_id: id, purchase_id:, fee_retention_error: })
+    count_fee_retention_attempt! unless collected
   end
 
   def fee_retention_attempts_exhausted?
@@ -229,11 +188,68 @@ class Refund < ApplicationRecord
       self.fee_retention_recoverable = fee_retention_pending == true && !fee_retention_attempts_exhausted?
     end
 
-    # True only on the attempt that reaches the cap, so the caller reports it once.
-    def record_fee_retention_attempt!
-      self.fee_retention_attempts = fee_retention_attempts.to_i + 1
-      save!
-      fee_retention_attempts == MAX_FEE_RETENTION_ATTEMPTS
+    # True when the fee is collected or nothing is left to collect; false when this
+    # run counts as a failed attempt.
+    def collect_pending_fee_retention!
+      credit = Credit.find_by(fee_retention_refund: self, failed_refund_id: nil)
+      unless credit
+        message = "Pending refund fee retention has no Credit"
+        Rails.logger.error("#{message} (refund_id=#{id})")
+        ErrorNotifier.notify(message, context: { refund_id: id, purchase_id: })
+        return false
+      end
+
+      # Gate on terminally_failed?, not effective?: Stripe-held failures are never
+      # balance-reversed, so effective? stays true and would collect a fee for a refund
+      # the buyer never received. Existing pins and grouped debits are still adopted.
+      credit.fee_retention_refund = self
+      lookup_failed = false
+      retain_fee do
+        StripeChargeProcessor.debit_stripe_account_for_refund_fee(credit:, collect: !terminally_failed?)
+      rescue *FEE_RETENTION_ERRORS
+        lookup_failed = true
+        raise
+      end
+
+      purchase.with_lock do
+        reload.lock!
+        next true unless fee_retention_pending
+        collection_recorded = debited_stripe_transfer.present? && fee_retention_collected_cents.present?
+        no_stripe_collection = credit.amount_cents.zero? || credit.merchant_account.holder_of_funds != HolderOfFunds::STRIPE
+        terminal_without_collection = terminally_failed? && debited_stripe_transfer.blank? && !lookup_failed
+        next false unless collection_recorded || no_stripe_collection || terminal_without_collection
+
+        if fee_retention_collected_cents.present?
+          holding_cents = BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)
+          adjustment_cents = -fee_retention_collected_cents - holding_cents
+          unless adjustment_cents.zero?
+            BalanceTransaction.create!(user: credit.user, merchant_account: credit.merchant_account, credit:,
+                                       issued_amount: BalanceTransaction::Amount.new(currency: Currency::USD, gross_cents: 0, net_cents: 0),
+                                       holding_amount: BalanceTransaction::Amount.new(currency: credit.merchant_account.currency,
+                                                                                      gross_cents: adjustment_cents, net_cents: adjustment_cents))
+          end
+        end
+        self.fee_retention_pending = false
+        self.fee_retention_error = nil
+        save!
+        true
+      end
+    end
+
+    # Reports once, on the attempt that reaches the cap.
+    def count_fee_retention_attempt!
+      exhausted = purchase.with_lock do
+        reload.lock!
+        next false unless fee_retention_pending
+        self.fee_retention_attempts = fee_retention_attempts.to_i + 1
+        save!
+        fee_retention_attempts == MAX_FEE_RETENTION_ATTEMPTS
+      end
+      return unless exhausted
+
+      message = "Refund fee retention stopped retrying after #{MAX_FEE_RETENTION_ATTEMPTS} attempts"
+      Rails.logger.error("#{message} (refund_id=#{id})")
+      ErrorNotifier.notify(message, context: { refund_id: id, purchase_id:, fee_retention_error: })
     end
 
     def assign_product

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -115,10 +115,9 @@ class Refund < ApplicationRecord
                           Stripe::AuthenticationError, Stripe::PermissionError, Stripe::RateLimitError,
                           Stripe::IdempotencyError].freeze
 
-  # One week of hourly RecoverPendingRefundFeeRetentionJob runs: a Stripe-held account
-  # with no reversible transfer yet receives its next payout transfer inside this window.
-  # At the cap the row stays fee_retention_pending for visibility but leaves the job's
-  # candidate set (fee_retention_recoverable).
+  # One week of hourly runs: a Stripe-held account with no reversible transfer yet gets its
+  # next payout transfer inside this window. At the cap the row keeps fee_retention_pending
+  # for visibility but leaves fee_retention_recoverable.
   MAX_FEE_RETENTION_ATTEMPTS = 168
 
   scope :pending_fee_retention, -> { where(fee_retention_recoverable: true) }
@@ -236,11 +235,14 @@ class Refund < ApplicationRecord
       end
     end
 
-    # Reports once, on the attempt that reaches the cap.
+    # Reports once, on the attempt that reaches the cap. A recorded Stripe collection never
+    # counts: the money already moved, so the settlement lookup must keep retrying until
+    # the ledger is reconciled.
     def count_fee_retention_attempt!
       exhausted = purchase.with_lock do
         reload.lock!
         next false unless fee_retention_pending
+        next false if debited_stripe_transfer.present?
         self.fee_retention_attempts = fee_retention_attempts.to_i + 1
         save!
         fee_retention_attempts == MAX_FEE_RETENTION_ATTEMPTS

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -85,6 +85,7 @@ class Refund < ApplicationRecord
   attr_json_data_accessor :fee_retention_error
   attr_json_data_accessor :fee_retention_collected_cents
   attr_json_data_accessor :fee_retention_source_transfer
+  attr_json_data_accessor :fee_retention_attempts
 
   attr_json_data_accessor :presentment_currency
   attr_json_data_accessor :presentment_amount_cents
@@ -113,6 +114,12 @@ class Refund < ApplicationRecord
   FEE_RETENTION_ERRORS = [Stripe::InvalidRequestError, Stripe::APIError, Stripe::APIConnectionError,
                           Stripe::AuthenticationError, Stripe::PermissionError, Stripe::RateLimitError,
                           Stripe::IdempotencyError].freeze
+
+  # One week of hourly RecoverPendingRefundFeeRetentionJob runs: a Stripe-held account
+  # with no reversible transfer yet receives its next payout transfer inside this window.
+  # At the cap the row stays fee_retention_pending for visibility but leaves the job's
+  # candidate set (fee_retention_recoverable).
+  MAX_FEE_RETENTION_ATTEMPTS = 168
 
   scope :pending_fee_retention, -> { where(fee_retention_recoverable: true) }
 
@@ -154,13 +161,17 @@ class Refund < ApplicationRecord
       raise
     end
 
+    attempts_exhausted = false
     purchase.with_lock do
       reload.lock!
       next unless fee_retention_pending
       collection_recorded = debited_stripe_transfer.present? && fee_retention_collected_cents.present?
       no_stripe_collection = credit.amount_cents.zero? || credit.merchant_account.holder_of_funds != HolderOfFunds::STRIPE
       terminal_without_collection = terminally_failed? && debited_stripe_transfer.blank? && !lookup_failed
-      next unless collection_recorded || no_stripe_collection || terminal_without_collection
+      unless collection_recorded || no_stripe_collection || terminal_without_collection
+        attempts_exhausted = record_fee_retention_attempt!
+        next
+      end
 
       if fee_retention_collected_cents.present?
         holding_cents = BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)
@@ -176,6 +187,15 @@ class Refund < ApplicationRecord
       self.fee_retention_error = nil
       save!
     end
+    return unless attempts_exhausted
+
+    message = "Refund fee retention stopped retrying after #{MAX_FEE_RETENTION_ATTEMPTS} attempts"
+    Rails.logger.error("#{message} (refund_id=#{id})")
+    ErrorNotifier.notify(message, context: { refund_id: id, purchase_id:, fee_retention_error: })
+  end
+
+  def fee_retention_attempts_exhausted?
+    fee_retention_attempts.to_i >= MAX_FEE_RETENTION_ATTEMPTS
   end
 
   # In-memory mirror of the .effective scope, for callers working with preloaded
@@ -206,7 +226,14 @@ class Refund < ApplicationRecord
 
   private
     def sync_fee_retention_recoverable
-      self.fee_retention_recoverable = fee_retention_pending == true
+      self.fee_retention_recoverable = fee_retention_pending == true && !fee_retention_attempts_exhausted?
+    end
+
+    # True only on the attempt that reaches the cap, so the caller reports it once.
+    def record_fee_retention_attempt!
+      self.fee_retention_attempts = fee_retention_attempts.to_i + 1
+      save!
+      fee_retention_attempts == MAX_FEE_RETENTION_ATTEMPTS
     end
 
     def assign_product

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -672,11 +672,9 @@ class Purchase
       Stripe::Transfer.create_reversal(transfer.id, { amount: amount_refundable_cents }) if transfer.present?
     end
 
-    # Books the retention credit inside the caller's transaction and collects from Stripe
-    # only after the OUTERMOST commit: Charge#refund_and_save! wraps several purchase
-    # refunds in one transaction, and a process death mid-collection must not roll back a
-    # refund Stripe already paid. The pending marker commits with the refund, so the hourly
-    # RecoverPendingRefundFeeRetentionJob finishes whatever this block does not.
+    # Stripe collection waits for the OUTERMOST commit: Charge#refund_and_save! wraps several
+    # purchase refunds in one transaction, and a crash mid-collection must not roll back a
+    # refund Stripe already paid. The committed pending marker lets the hourly job finish it.
     def debit_processor_fee_from_merchant_account!(refund)
       Credit.create_for_refund_fee_retention!(refund:)
       return unless refund.fee_retention_pending

--- a/app/modules/purchase/refundable.rb
+++ b/app/modules/purchase/refundable.rb
@@ -341,11 +341,7 @@ class Purchase
       save!
       reverse_the_transfer_made_for_dispute_win! if chargedback? && chargeback_reversed
       reverse_excess_amount_from_stripe_transfer(refund:) if stripe_partially_refunded && vat_already_refunded
-      # A fee collection failure must not undo a refund already accepted by the processor,
-      # including when Charge#refund_and_save! owns the outer transaction.
-      unless is_refund_chargeback_fee_waived || chargedback_not_reversed?
-        refund.retain_fee { debit_processor_fee_from_merchant_account!(refund) }
-      end
+      debit_processor_fee_from_merchant_account!(refund) unless is_refund_chargeback_fee_waived || chargedback_not_reversed?
       Credit.create_for_vat_exclusive_refund!(refund:) if (paypal_order_id.present? || merchant_account&.is_a_stripe_connect_account?) && !chargedback_not_reversed?
       subscription.original_purchase.update!(should_exclude_product_review: true) if subscription&.should_exclude_product_review_on_charge_reversal?
       send_refunded_notification_webhook
@@ -676,8 +672,23 @@ class Purchase
       Stripe::Transfer.create_reversal(transfer.id, { amount: amount_refundable_cents }) if transfer.present?
     end
 
+    # Books the retention credit inside the caller's transaction and collects from Stripe
+    # only after the OUTERMOST commit: Charge#refund_and_save! wraps several purchase
+    # refunds in one transaction, and a process death mid-collection must not roll back a
+    # refund Stripe already paid. The pending marker commits with the refund, so the hourly
+    # RecoverPendingRefundFeeRetentionJob finishes whatever this block does not.
     def debit_processor_fee_from_merchant_account!(refund)
       Credit.create_for_refund_fee_retention!(refund:)
+      return unless refund.fee_retention_pending
+
+      refund_id = refund.id
+      purchase_id = id
+      AfterCommitEverywhere.after_commit do
+        Refund.find(refund_id).recover_pending_fee_retention!
+      rescue StandardError => e
+        Rails.logger.error("Refund fee collection after commit failed (refund_id=#{refund_id}): #{e.class}: #{e.message}")
+        ErrorNotifier.notify(e, context: { refund_id:, purchase_id: })
+      end
     end
 
     def insufficient_funds_refund_error_message

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -120,31 +120,39 @@ describe Charge, :vcr do
   end
 
   describe "#refund_and_save!" do
-    it "commits every purchase refund when fee retention fails inside the outer transaction" do
+    it "collects each purchase's retained fee only after the outer transaction commits" do
       seller = create(:user)
-      purchases = Array.new(2) { create(:purchase, seller:, link: create(:product, user: seller), stripe_transaction_id: "ch_combined_refund") }
+      merchant_account = create(:merchant_account, user: seller, country: "BG", currency: "usd")
+      purchases = Array.new(2) do
+        create(:purchase, seller:, merchant_account:, link: create(:product, user: seller), stripe_transaction_id: "ch_combined_refund")
+      end
       charge = create(:charge, seller:, purchases:)
       create(:balance, user: seller, amount_cents: 10_000)
-      error = Stripe::InvalidRequestError.new("Transfer reversals are no longer supported", nil)
-      allow_any_instance_of(Purchase).to receive(:debit_processor_fee_from_merchant_account!).and_raise(error)
-      expect(ErrorNotifier).to receive(:notify).with(error, context: hash_including(:refund_id, :purchase_id)).twice
       purchases.each do |purchase|
         flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -purchase.total_transaction_cents)
         expect(ChargeProcessor).to receive(:refund!).with(anything, "ch_combined_refund", hash_including(purchase:))
           .and_return(double(id: "re_fee_#{purchase.id}", refund: nil, flow_of_funds:))
       end
+      transaction_depth = ApplicationRecord.connection.open_transactions
+      collected_for = []
+      expect(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).twice do |credit:, **|
+        expect(ApplicationRecord.connection.open_transactions).to eq(transaction_depth)
+        refund = credit.fee_retention_refund
+        collected_for << refund.purchase_id
+        refund.update!(debited_stripe_transfer: "tr_fee_#{refund.id}", fee_retention_collected_cents: credit.amount_cents.abs)
+        credit.amount_cents.abs
+      end
 
       expect { expect(charge.refund_and_save!(seller.id)).to be(true) }.to change(Refund, :count).by(2)
 
+      expect(collected_for).to match_array(purchases.map(&:id))
       purchases.each do |purchase|
         refund = purchase.reload.refunds.sole
         expect(purchase.stripe_refunded).to be(true)
-        expect(purchase.amount_refundable_cents).to eq(0)
-        expect(refund.fee_retention_pending).to be(true)
-        expect(refund.balance_transactions.where(user_id: seller.id).count).to eq(1)
+        expect(refund.fee_retention_pending).to be_falsey
+        expect(refund.fee_retention_recoverable).to be(false)
+        expect(refund.debited_stripe_transfer).to eq("tr_fee_#{refund.id}")
       end
-      expect(charge.refund_and_save!(seller.id)).to be(false)
-      expect(charge.purchases.sum { |purchase| purchase.refunds.count }).to eq(2)
     end
 
     it "attempts every purchase refund even when one purchase fails" do

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -298,16 +298,15 @@ describe Credit do
     let!(:refund) { create(:refund, purchase:, fee_cents: 100) }
 
     before do
-      allow(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).and_return(33)
+      # Collection runs after the refund transaction commits (Purchase#debit_processor_fee_from_merchant_account!).
+      expect(StripeChargeProcessor).not_to receive(:debit_stripe_account_for_refund_fee)
     end
 
-    context "when Stripe fee collection fails" do
+    context "for Stripe-held funds" do
       let!(:merchant_account) { create(:merchant_account, user: creator, country: "BG", currency: "usd") }
 
-      it "keeps the credit and balance debit when Stripe fee collection fails" do
-        error = Stripe::InvalidRequestError.new("Account debit is not permitted", nil)
-        expect(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).and_raise(error)
-        expect(ErrorNotifier).to receive(:notify).with(error, context: { refund_id: refund.id, purchase_id: purchase.id })
+      it "books the credit and balance debit and leaves the Stripe collection pending" do
+        expect(ErrorNotifier).not_to receive(:notify)
 
         credit = Credit.create_for_refund_fee_retention!(refund:)
 
@@ -329,24 +328,15 @@ describe Credit do
     context "US Gumroad-managed account" do
       let!(:merchant_account) { create(:merchant_account, user: creator, country: "US", currency: "usd") }
 
-      it "collects the retained fee via a grouped Stripe account debit" do
-        allow(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).and_call_original
-        transfer_group = "refund_fee_retention_#{refund.id}"
-        expect(Stripe::Transfer).to receive(:list)
-          .with({ transfer_group:, limit: 1 }, { stripe_account: merchant_account.charge_processor_merchant_id })
-          .and_return([])
-        expect(Stripe::Transfer).to receive(:create)
-          .with({ amount: 33, currency: "usd", destination: STRIPE_PLATFORM_ACCOUNT_ID,
-                  transfer_group:, metadata: { refund_id: refund.id } },
-                { stripe_account: merchant_account.charge_processor_merchant_id, idempotency_key: transfer_group })
-          .and_return(double(id: "tr_us_fee", amount: 33))
+      it "marks the fee pending without debiting the Stripe account" do
+        expect(Stripe::Transfer).not_to receive(:create)
 
         credit = Credit.create_for_refund_fee_retention!(refund:)
 
         expect(credit.amount_cents).to eq(-33)
-        expect(refund.reload.debited_stripe_transfer).to eq("tr_us_fee")
-        expect(refund.fee_retention_collected_cents).to eq(33)
-        expect(refund.fee_retention_pending).not_to eq(true)
+        expect(refund.reload.debited_stripe_transfer).to be_nil
+        expect(refund.fee_retention_pending).to be(true)
+        expect(refund.fee_retention_recoverable).to be(true)
       end
     end
 
@@ -388,8 +378,7 @@ describe Credit do
           oldest_balance = create(:balance, user: creator, merchant_account: non_us_stripe_account, amount_cents: 1000, holding_currency: "aud", date: purchase.succeeded_at.to_date - 2.days)
           create(:balance, user: creator, merchant_account: non_us_stripe_account, amount_cents: 2000,
                            holding_currency: "aud", date: purchase.succeeded_at.to_date)
-          allow(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).and_call_original
-          expect(Stripe::Transfer).to receive(:create_reversal).and_call_original
+          expect(Stripe::Transfer).not_to receive(:create_reversal)
           expect(creator.unpaid_balance_cents).to eq(3000)
 
           credit = Credit.create_for_refund_fee_retention!(refund:)
@@ -398,7 +387,8 @@ describe Credit do
           expect(credit.balance).to eq(oldest_balance)
           expect(credit.balance.merchant_account).to eq(non_us_stripe_account)
           expect(credit.balance_transaction.issued_amount_net_cents).to eq(-33)
-          expect(credit.balance_transaction.holding_amount_net_cents).to eq(-52)
+          # FX estimate from lib/currency/backup_rates.json; recovery books the delta to the collected amount.
+          expect(credit.balance_transaction.holding_amount_net_cents).to eq(-32)
           expect(creator.reload.unpaid_balance_cents).to eq(2967) # 3000 - 33
         end
       end

--- a/spec/models/purchase/purchase_refunds_spec.rb
+++ b/spec/models/purchase/purchase_refunds_spec.rb
@@ -1772,28 +1772,72 @@ describe "PurchaseRefunds", :vcr do
       @refunding_user = create(:user)
     end
 
-    it "commits the refund and reports a pending fee when fee retention fails" do
-      error = Stripe::InvalidRequestError.new("Transfer reversals are no longer supported", nil)
-      flow_of_funds = FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -@purchase.total_transaction_cents)
-      expect(@purchase).to receive(:debit_processor_fee_from_merchant_account!).and_raise(error)
-      expect(ErrorNotifier).to receive(:notify).with(error, context: hash_including(purchase_id: @purchase.id))
-      expect(@purchase).to receive(:decrement_balance_for_refund_or_chargeback!).once.and_call_original
-      expect(CustomerMailer).to receive(:refund).with(@purchase.email, @purchase.link_id, @purchase.id).and_call_original
+    describe "fee retention for Stripe-held funds" do
+      let(:seller) { create(:user) }
+      let(:merchant_account) { create(:merchant_account, user: seller, country: "BG", currency: "usd") }
+      let(:purchase) { create(:purchase, seller:, merchant_account:, link: create(:product, user: seller)) }
+      let(:flow_of_funds) { FlowOfFunds.build_simple_flow_of_funds(Currency::USD, -purchase.total_transaction_cents) }
 
-      expect do
-        expect(@purchase.refund_purchase!(flow_of_funds, @refunding_user.id)).to be(true)
-      end.to change(Refund, :count).by(1)
+      it "collects the retained fee from Stripe only after the refund transaction commits" do
+        transaction_depth = ApplicationRecord.connection.open_transactions
+        expect(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).once do |credit:, **|
+          expect(ApplicationRecord.connection.open_transactions).to eq(transaction_depth)
+          refund = credit.fee_retention_refund
+          expect(refund.reload.fee_retention_pending).to be(true)
+          refund.update!(debited_stripe_transfer: "tr_after_commit", fee_retention_collected_cents: 30)
+          30
+        end
 
-      refund = @purchase.reload.refunds.sole
-      expect(@purchase.stripe_refunded).to be(true)
-      expect(@purchase.stripe_partially_refunded).to be(false)
-      expect(@purchase.amount_refundable_cents).to eq(0)
-      expect(refund.balance_transactions.where(user_id: @purchase.seller_id).count).to eq(1)
-      expect(refund.fee_retention_pending).to be(true)
-      expect(refund.fee_retention_error).to eq("class" => error.class.name, "message" => error.message)
-      expect(ChargeProcessor).not_to receive(:refund!)
-      expect(@purchase.refund_and_save!(@refunding_user.id)).to be_nil
-      expect(@purchase.refunds.count).to eq(1)
+        expect(purchase.refund_purchase!(flow_of_funds, @refunding_user.id)).to be(true)
+
+        refund = purchase.reload.refunds.sole
+        expect(refund.fee_retention_pending).to be_falsey
+        expect(refund.fee_retention_recoverable).to be(false)
+        expect(refund.debited_stripe_transfer).to eq("tr_after_commit")
+        credit = Credit.find_by(fee_retention_refund: refund)
+        expect(credit.amount_cents).to eq(-33)
+        expect(BalanceTransaction.where(credit:).sum(:issued_amount_net_cents)).to eq(-33)
+        expect(BalanceTransaction.where(credit:).sum(:holding_amount_net_cents)).to eq(-30)
+      end
+
+      it "commits the refund and reports a pending fee when Stripe rejects the collection" do
+        error = Stripe::InvalidRequestError.new("Account debit is not permitted", nil)
+        expect(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).and_raise(error)
+        expect(ErrorNotifier).to receive(:notify).with(error, context: hash_including(purchase_id: purchase.id))
+        expect(CustomerMailer).to receive(:refund).with(purchase.email, purchase.link_id, purchase.id).and_call_original
+
+        expect do
+          expect(purchase.refund_purchase!(flow_of_funds, @refunding_user.id)).to be(true)
+        end.to change(Refund, :count).by(1)
+
+        refund = purchase.reload.refunds.sole
+        expect(purchase.stripe_refunded).to be(true)
+        expect(purchase.amount_refundable_cents).to eq(0)
+        expect(refund.balance_transactions.where(user_id: seller.id).count).to eq(1)
+        expect(Credit.where(fee_retention_refund: refund).count).to eq(1)
+        expect(refund.fee_retention_pending).to be(true)
+        expect(refund.fee_retention_attempts).to eq(1)
+        expect(refund.fee_retention_error).to eq("class" => error.class.name, "message" => error.message)
+        expect(ChargeProcessor).not_to receive(:refund!)
+        expect(purchase.refund_and_save!(@refunding_user.id)).to be_nil
+        expect(purchase.refunds.count).to eq(1)
+      end
+
+      it "keeps the refund and its pending marker when collection fails unexpectedly" do
+        error = RuntimeError.new("connection reset")
+        expect(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).and_raise(error)
+        expect(ErrorNotifier).to receive(:notify).with(error, context: { refund_id: kind_of(Integer), purchase_id: purchase.id })
+
+        expect do
+          expect(purchase.refund_purchase!(flow_of_funds, @refunding_user.id)).to be(true)
+        end.to change(Refund, :count).by(1)
+
+        refund = purchase.reload.refunds.sole
+        expect(purchase.stripe_refunded).to be(true)
+        expect(refund.fee_retention_pending).to be(true)
+        expect(refund.fee_retention_recoverable).to be(true)
+        expect(Credit.where(fee_retention_refund: refund).count).to eq(1)
+      end
     end
 
     it "does not swallow refund bookkeeping failures" do

--- a/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
+++ b/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
@@ -81,6 +81,22 @@ RSpec.describe RecoverPendingRefundFeeRetentionJob, :vcr do
     expect(refund.fee_retention_attempts).to eq(1)
   end
 
+  it "does not count attempts once Stripe recorded the collection" do
+    refund.debited_stripe_transfer = "trr_1"
+    refund.fee_retention_source_transfer = "tr_recovery_candidate"
+    refund.fee_retention_attempts = Refund::MAX_FEE_RETENTION_ATTEMPTS - 1
+    refund.save!
+    error = Stripe::APIConnectionError.new("timeout")
+    expect(Stripe::Transfer).to receive(:retrieve_reversal).with("tr_recovery_candidate", "trr_1").and_raise(error)
+    expect(ErrorNotifier).to receive(:notify).with(error, context: { refund_id: refund.id, purchase_id: purchase.id })
+
+    described_class.new.perform
+
+    expect(refund.reload.fee_retention_pending).to be(true)
+    expect(refund.fee_retention_recoverable).to be(true)
+    expect(refund.fee_retention_attempts).to eq(Refund::MAX_FEE_RETENTION_ATTEMPTS - 1)
+  end
+
   it "counts an attempt when recovery raises unexpectedly" do
     error = RuntimeError.new("bookkeeping")
     expect(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).and_raise(error)

--- a/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
+++ b/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
@@ -88,7 +88,43 @@ RSpec.describe RecoverPendingRefundFeeRetentionJob, :vcr do
     expect { described_class.new.perform }.not_to change(BalanceTransaction, :count)
 
     expect(refund.reload.fee_retention_pending).to be(true)
+    expect(refund.fee_retention_recoverable).to be(true)
+    expect(refund.fee_retention_attempts).to eq(1)
     expect(refund.fee_retention_error["message"]).to eq(error.message)
+  end
+
+  it "counts an attempt when Stripe has no transfer to collect from" do
+    allow(Stripe::Transfer).to receive(:retrieve).with("tr_recovery_candidate")
+      .and_return(double(id: "tr_recovery_candidate", amount: 5000, amount_reversed: 5000, currency: "usd"))
+    allow(Stripe::Transfer).to receive(:list)
+      .with(hash_including(destination: merchant_account.charge_processor_merchant_id)).and_return([])
+    expect(Stripe::Transfer).not_to receive(:create)
+    expect(ErrorNotifier).not_to receive(:notify)
+
+    expect { described_class.new.perform }.not_to change(BalanceTransaction, :count)
+
+    expect(refund.reload.fee_retention_pending).to be(true)
+    expect(refund.fee_retention_recoverable).to be(true)
+    expect(refund.fee_retention_attempts).to eq(1)
+  end
+
+  it "stops retrying at the attempt cap, reports once, and keeps the pending marker" do
+    refund.update!(fee_retention_attempts: Refund::MAX_FEE_RETENTION_ATTEMPTS - 1)
+    error = Stripe::InvalidRequestError.new("Account debit is not permitted", nil)
+    expect(Stripe::Transfer).to receive(:create).once.and_raise(error)
+    expect(ErrorNotifier).to receive(:notify).with(error, context: { refund_id: refund.id, purchase_id: purchase.id }).once
+    expect(ErrorNotifier).to receive(:notify)
+      .with("Refund fee retention stopped retrying after #{Refund::MAX_FEE_RETENTION_ATTEMPTS} attempts",
+            context: hash_including(refund_id: refund.id, purchase_id: purchase.id)).once
+
+    described_class.new.perform
+    described_class.new.perform
+
+    refund.reload
+    expect(refund.fee_retention_attempts).to eq(Refund::MAX_FEE_RETENTION_ATTEMPTS)
+    expect(refund.fee_retention_pending).to be(true)
+    expect(refund.fee_retention_recoverable).to be(false)
+    expect(Refund.pending_fee_retention).not_to include(refund)
   end
 
   it "clears a pending marker when the debit was already recorded" do

--- a/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
+++ b/spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb
@@ -78,6 +78,18 @@ RSpec.describe RecoverPendingRefundFeeRetentionJob, :vcr do
     expect { described_class.new.perform }.not_to change(Credit, :count)
 
     expect(refund.reload.fee_retention_pending).to be(true)
+    expect(refund.fee_retention_attempts).to eq(1)
+  end
+
+  it "counts an attempt when recovery raises unexpectedly" do
+    error = RuntimeError.new("bookkeeping")
+    expect(StripeChargeProcessor).to receive(:debit_stripe_account_for_refund_fee).and_raise(error)
+    expect(ErrorNotifier).to receive(:notify).with(error, context: { refund_id: refund.id, purchase_id: purchase.id })
+
+    described_class.new.perform
+
+    expect(refund.reload.fee_retention_pending).to be(true)
+    expect(refund.fee_retention_attempts).to eq(1)
   end
 
   it "keeps rejected recoveries pending and reports the error" do


### PR DESCRIPTION
Follow-up to #7552. Tracker: antiwork/gumroad-private#2460.

## What

- `Credit.create_for_refund_fee_retention!` books the credit, the FX-estimated holding debit, and `fee_retention_pending` without calling Stripe.
- `Purchase#debit_processor_fee_from_merchant_account!` runs `Refund#recover_pending_fee_retention!` after the outermost transaction commits, through `AfterCommitEverywhere`. `Charge#refund_and_save!` commits every purchase refund before the first Stripe call.
- The recovery path's zero-USD holding adjustment reconciles the estimate to the amount Stripe collected. `refund_purchase!` drops its `retain_fee` wrapper because nothing inside the transaction reaches Stripe anymore.
- `Refund#fee_retention_attempts` counts each recovery run that ends without a collection, including runs that find no Credit or raise. At `Refund::MAX_FEE_RETENTION_ATTEMPTS` (168, one week of hourly runs) the row leaves the `fee_retention_recoverable` candidate set, keeps `fee_retention_pending` for visibility, and reports once through `ErrorNotifier`. Once Stripe has recorded a collection, attempts stop counting, so ledger reconciliation retries until it finishes.

## Why

#7552 keeps a refund committed when Stripe rejects the fee collection, but the Stripe call still ran inside the refund transaction. A process death during that call rolled back the Refund, the Credit, and the pinned source transfer while the buyer already had the money, and the idempotency pin did not survive the rollback. Committing first closes that window and makes the pin durable.

The hourly `RecoverPendingRefundFeeRetentionJob` retried forever when Stripe had no eligible transfer or rejected the account debit, and notified on every run. The attempt cap bounds that. The cap spans a week because a Stripe-held account with no reversible transfer yet receives its next payout transfer inside that window.

Only the after-commit idea from the closed #7549 is used here. Its sticky-route markers, `Charge#refund_and_save!` rewrite, and payout export changes are out of scope.

## Before / After

Backend-only change. Walkthrough video: TODO before submit.

Before: a refund on a Stripe-held account called Stripe inside the refund transaction. A crash there lost the refund row and the transfer pin.

After: the refund, credit, balance transaction, and pending marker commit first. Stripe collection runs after the outermost commit, and any collection this run misses stays visible to the hourly job for up to 168 attempts.

## Test Results

```
IN_DOCKER=true RAILS_ENV=test bin/rails db:seed  # before each rspec run
bundle exec rspec spec/sidekiq/recover_pending_refund_fee_retention_job_spec.rb          # 17 examples, 0 failures
bundle exec rspec spec/models/credit_spec.rb -e "create_for_refund_fee_retention!"       # 12 examples, 0 failures
bundle exec rspec spec/models/charge_spec.rb                                              # 45 examples, 0 failures
bundle exec rspec spec/models/purchase/purchase_refunds_spec.rb                           # 170 examples, 2 failures (pre-existing Vite manifest errors at :239 and :1373, same on main)
bundle exec rspec spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb -e ".debit_stripe_account_for_refund_fee"  # 17 examples, 0 failures
bundle exec rspec spec/services/purchase/handle_failed_refund_service_spec.rb            # 47 examples, 0 failures
bundle exec rubocop -a <touched files>                                                    # no offenses
```

With the first commit's app change reverted and the specs kept, the new and changed examples fail: 3 in the job spec, 8 in the credit spec, 1 in the charge spec, 3 in the purchase refunds spec. The two follow-up commits add job spec examples that assert `fee_retention_attempts`, which does not exist without the change.

## QA steps

1. On a Stripe-held merchant account (non-US, or US with account debits), refund a sale from the admin purchase page.
2. Confirm the `Refund` row exists with a `Credit` and a balance transaction, and that `refunds.json_data` shows `debited_stripe_transfer` and `fee_retention_pending` cleared after the request returns.
3. Set `fee_retention_pending = true` on a refund whose account has no reversible transfer and run `RecoverPendingRefundFeeRetentionJob.new.perform`. Confirm `fee_retention_attempts` increments and the row stays pending.
4. Set `fee_retention_attempts` to 167 and run the job once more. Confirm one "stopped retrying" report, `fee_retention_recoverable = false`, and `fee_retention_pending` still true.

---

AI disclosure: Claude Fable 5.1.
