### PR TITLE
Refresh expired direct-listed amount tokens before submitting payment

### DIFF
--- a/app/controllers/customer_surcharge_controller.rb
+++ b/app/controllers/customer_surcharge_controller.rb
@@ -147,6 +147,10 @@ class CustomerSurchargeController < ApplicationController
       sellers: sellers_for_direct_listed_amount_token(charge_allocations, quote_line_items),
       currency: direct_listed_allocation_currency
     )
+    # Client-side expiry uses this timestamp with the response Date, the same clock-skew
+    # calibration as buyer_currency_quote.expires_at. The signed token still expires on TTL.
+    direct_listed_amount_token_expires_at =
+      direct_listed_amount_token.present? ? Checkout::DirectListedAmountToken::TTL.from_now.utc.iso8601 : nil
 
     render json: {
       vat_id_valid:,
@@ -160,6 +164,7 @@ class CustomerSurchargeController < ApplicationController
       charge_canonical_total_cents: all_lines_quotable ? quote_line_items.sum(&:charge_canonical_total_cents) : nil,
       direct_listed_line_allocations:,
       direct_listed_amount_token:,
+      direct_listed_amount_token_expires_at:,
       buyer_currency_quote: quote_props,
       detected_buyer_currency:,
       available_buyer_currencies: available

--- a/app/javascript/components/Checkout/createReducer.test.tsx
+++ b/app/javascript/components/Checkout/createReducer.test.tsx
@@ -251,6 +251,41 @@ describe("createReducer surcharge refetches", () => {
     expect(dismissAlert).not.toHaveBeenCalled();
   });
 
+  const listedToken = (expiresAt: string, amount = 1500) => ({
+    direct_listed_amount_token: `listed-${amount}`,
+    direct_listed_amount_token_expires_at: expiresAt,
+    direct_listed_line_allocations: [
+      { permalink: "abc", price_cents: amount, tip_cents: 0, tax_cents: 0, shipping_cents: 0, total_cents: amount },
+    ],
+  });
+
+  it.each(["focus", "visibilitychange"])(
+    "refreshes an expired listed amount token once on %s without resuming payment",
+    async (event) => {
+      const requests = stubSurchargeRequests();
+      const { result } = renderCheckout({ checkoutPayment: directListedCheckoutPayment });
+      await act(() => vi.advanceTimersByTimeAsync(300));
+      await act(async () =>
+        requests[0]?.resolve(
+          surchargesResponse(listedToken(new Date(Date.now() + 1000).toISOString())),
+        ),
+      );
+      vi.setSystemTime(Date.now() + 2000);
+      act(() => (event === "focus" ? window : document).dispatchEvent(new Event(event)));
+      expect(result.current[0].surcharges.type).toBe("pending");
+      expect(result.current[0].status.type).toBe("input");
+      expect(result.current[0].warning).toContain("review the updated total");
+      act(() => window.dispatchEvent(new Event("focus")));
+      await act(() => vi.advanceTimersByTimeAsync(300));
+      expect(requests).toHaveLength(2);
+      await act(async () => requests[1]?.resolve(surchargesResponse(listedToken("2999-01-01T00:00:00Z", 1600))));
+      expect(result.current[0].status.type).toBe("input");
+      expect(result.current[0].resumeSubmitAfterCheckoutPayment).toBe(false);
+      await act(() => vi.advanceTimersByTimeAsync(60000));
+      expect(requests).toHaveLength(2);
+    },
+  );
+
   it("does not dismiss unrelated alerts when refreshed cart data replaces a surcharge error", async () => {
     const requests = stubSurchargeRequests();
     const { result } = renderCheckout();

--- a/app/javascript/components/Checkout/createReducer.test.tsx
+++ b/app/javascript/components/Checkout/createReducer.test.tsx
@@ -266,9 +266,7 @@ describe("createReducer surcharge refetches", () => {
       const { result } = renderCheckout({ checkoutPayment: directListedCheckoutPayment });
       await act(() => vi.advanceTimersByTimeAsync(300));
       await act(async () =>
-        requests[0]?.resolve(
-          surchargesResponse(listedToken(new Date(Date.now() + 1000).toISOString())),
-        ),
+        requests[0]?.resolve(surchargesResponse(listedToken(new Date(Date.now() + 1000).toISOString()))),
       );
       vi.setSystemTime(Date.now() + 2000);
       act(() => (event === "focus" ? window : document).dispatchEvent(new Event(event)));

--- a/app/javascript/components/Checkout/createReducer.test.tsx
+++ b/app/javascript/components/Checkout/createReducer.test.tsx
@@ -284,6 +284,54 @@ describe("createReducer surcharge refetches", () => {
     },
   );
 
+  it("keeps a method-forced listed currency when a matching preference is persisted", async () => {
+    document.cookie = "gumroad_buyer_currency=eur; path=/";
+    const requests = stubSurchargeRequests();
+    const { result } = renderCheckout({
+      checkoutPayment: methodForcedCheckoutPayment,
+      address: { street: null, city: null, zip: "10001" },
+      products: initialArgs.products.map((product) => ({ ...product, listedChargePriceCents: 1_000 })),
+    });
+    const offered = [
+      { code: "usd", label: "$ (US Dollars)" },
+      { code: "eur", label: "€ (Euros)" },
+    ];
+    await act(() => vi.advanceTimersByTimeAsync(300));
+    await act(async () =>
+      requests[0]?.resolve(
+        surchargesResponse({
+          ...listedToken(new Date(Date.now() + 1000).toISOString()),
+          available_buyer_currencies: offered,
+        }),
+      ),
+    );
+    expect(result.current[0].buyerCurrency).toBe("eur");
+    vi.setSystemTime(Date.now() + 2000);
+    act(() => result.current[1]({ type: "validate" }));
+    expect(result.current[0].surcharges.type).toBe("pending");
+    await act(() => vi.advanceTimersByTimeAsync(300));
+    expect(requests).toHaveLength(2);
+    await act(async () =>
+      requests[1]?.resolve(
+        surchargesResponse({
+          ...listedToken("2999-01-01T00:00:00Z", 1600),
+          available_buyer_currencies: offered,
+        }),
+      ),
+    );
+    expect(result.current[0].buyerCurrency).toBe("eur");
+    expect(result.current[0].unavailableBuyerCurrency).toBeNull();
+    expect(result.current[0].surcharges.type).toBe("loaded");
+    expect(
+      result.current[0].surcharges.type === "loaded" && result.current[0].surcharges.result.direct_listed_amount_token,
+    ).toBe("listed-1600");
+    expect(result.current[0].status.type).toBe("input");
+    expect(result.current[0].resumeSubmitAfterCheckoutPayment).toBe(false);
+    expect(requests).toHaveLength(2);
+    act(() => result.current[1]({ type: "validate" }));
+    expect(result.current[0].status.type).toBe("validating");
+  });
+
   it("does not dismiss unrelated alerts when refreshed cart data replaces a surcharge error", async () => {
     const requests = stubSurchargeRequests();
     const { result } = renderCheckout();

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -568,6 +568,38 @@ describe("expired direct-listed amount token submission", () => {
     expect(reduceCheckoutState(serverConfirm, { type: "validate" }).status.type).toBe("validating");
   });
 
+  it("keeps a method-forced listed currency when a matching preference is persisted", () => {
+    const expired = listedState(methodForcedEurConfig);
+    expired.buyerCurrency = "eur";
+    const refused = reduceCheckoutState(expired, { type: "validate" });
+    const loading = reduceCheckoutState(refused, {
+      type: "set-value",
+      surcharges: { type: "loading", requestId: 1, abort: vi.fn() },
+    });
+    const fresh = listedState(methodForcedEurConfig, "2999-01-01T00:00:00Z");
+    if (fresh.surcharges.type !== "loaded") throw new Error("Expected loaded");
+    const refreshed = reduceCheckoutState(loading, {
+      type: "surcharges-fetch-succeeded",
+      requestId: 1,
+      result: {
+        ...fresh.surcharges.result,
+        buyer_currency_quote: null,
+        direct_listed_amount_token: "fresh-listed-token",
+        available_buyer_currencies: [
+          { code: "usd", label: "$ (US Dollars)" },
+          { code: "eur", label: "€ (Euros)" },
+        ],
+      },
+    });
+    expect(refreshed.buyerCurrency).toBe("eur");
+    expect(refreshed.unavailableBuyerCurrency).toBeNull();
+    expect(refreshed.surcharges.type).toBe("loaded");
+    expect(getLoadedDirectListedAmountToken(refreshed)).toBe("fresh-listed-token");
+    expect(refreshed.status.type).toBe("input");
+    expect(refreshed.resumeSubmitAfterCheckoutPayment).toBe(false);
+    expect(reduceCheckoutState(refreshed, { type: "validate" }).status.type).toBe("validating");
+  });
+
   it("refreshes at the listed-token expiry boundary and refuses malformed expiry", () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-09-08T12:00:00Z"));
     try {

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -486,6 +486,102 @@ describe("expired buyer-currency quote submission", () => {
   });
 });
 
+describe("expired direct-listed amount token submission", () => {
+  const listedState = (checkoutPayment: CheckoutPaymentConfig, expiresAt = "2000-01-01T00:00:00Z") => {
+    const s = state({ checkoutPayment });
+    if (s.surcharges.type !== "loaded") throw new Error("Expected loaded surcharges");
+    s.surcharges.result.direct_listed_amount_token = "expired-listed-token";
+    s.surcharges.result.direct_listed_amount_token_expires_at = expiresAt;
+    s.surcharges.result.direct_listed_line_allocations = [
+      { permalink: "product-a", price_cents: 1500, tip_cents: 0, tax_cents: 0, shipping_cents: 0, total_cents: 1500 },
+    ];
+    return s;
+  };
+
+  it.each([directListedCardConfig, methodForcedEurConfig])(
+    "requires a new submit after refreshing an expired listed token on $elements_options.currency",
+    (config) => {
+      for (const type of ["offer", "validate", "start-payment"] as const) {
+        const expired = listedState(config);
+        const refused = reduceCheckoutState(expired, { type });
+        expect(refused.status.type).toBe("input");
+        expect(refused.surcharges.type).toBe("pending");
+        expect(refused.resumeSubmitAfterCheckoutPayment).toBe(false);
+        expect(refused.warning).toContain("review the updated total");
+        const loading = reduceCheckoutState(refused, {
+          type: "set-value",
+          surcharges: { type: "loading", requestId: 1, abort: vi.fn() },
+        });
+        const fresh = listedState(config, "2999-01-01T00:00:00Z");
+        if (fresh.surcharges.type !== "loaded") throw new Error("Expected loaded");
+        const result = {
+          ...fresh.surcharges.result,
+          direct_listed_amount_token: "fresh-listed-token",
+          direct_listed_line_allocations: [
+            {
+              permalink: "product-a",
+              price_cents: 1600,
+              tip_cents: 0,
+              tax_cents: 0,
+              shipping_cents: 0,
+              total_cents: 1600,
+            },
+          ],
+        };
+        const refreshed = reduceCheckoutState(loading, { type: "surcharges-fetch-succeeded", requestId: 1, result });
+        expect(refreshed.status.type).toBe("input");
+        expect(getLoadedDirectListedAmountToken(refreshed)).toBe("fresh-listed-token");
+        expect(reduceCheckoutState(refreshed, { type: "validate" }).status.type).toBe("validating");
+      }
+    },
+  );
+
+  it("does not silently confirm an unchanged total after refresh", () => {
+    const expired = listedState(directListedCardConfig);
+    const refused = reduceCheckoutState(expired, { type: "validate" });
+    const loading = reduceCheckoutState(refused, {
+      type: "set-value",
+      surcharges: { type: "loading", requestId: 1, abort: vi.fn() },
+    });
+    const sameTotal = listedState(directListedCardConfig, "2999-01-01T00:00:00Z");
+    if (sameTotal.surcharges.type !== "loaded") throw new Error("Expected loaded");
+    const refreshed = reduceCheckoutState(loading, {
+      type: "surcharges-fetch-succeeded",
+      requestId: 1,
+      result: { ...sameTotal.surcharges.result, direct_listed_amount_token: "fresh-same-total" },
+    });
+    expect(refreshed.status.type).toBe("input");
+    expect(refreshed.resumeSubmitAfterCheckoutPayment).toBe(false);
+    expect(refreshed.warning).toContain("review the updated total");
+    expect(reduceCheckoutState(refreshed, { type: "validate" }).status.type).toBe("validating");
+  });
+
+  it("does not intercept a still-fresh listed token", () => {
+    const fresh = listedState(directListedCardConfig, "2999-01-01T00:00:00Z");
+    expect(reduceCheckoutState(fresh, { type: "offer" }).status.type).toBe("offering");
+    expect(reduceCheckoutState(fresh, { type: "offer" }).surcharges.type).toBe("loaded");
+  });
+
+  it("does not intercept a listed token on server-confirm Payment Element", () => {
+    const serverConfirm = listedState(paymentElementConfig);
+    expect(getLoadedDirectListedAmountToken(serverConfirm)).toBeNull();
+    expect(reduceCheckoutState(serverConfirm, { type: "validate" }).status.type).toBe("validating");
+  });
+
+  it("refreshes at the listed-token expiry boundary and refuses malformed expiry", () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-09-08T12:00:00Z"));
+    try {
+      for (const expiry of ["2026-09-08T12:00:00Z", "invalid"]) {
+        expect(reduceCheckoutState(listedState(directListedCardConfig, expiry), { type: "validate" }).surcharges.type).toBe(
+          "pending",
+        );
+      }
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+});
+
 describe("canUseStripePaymentElement", () => {
   it("allows a flagged positive one-off card checkout without a saved card", () => {
     expect(canUseStripePaymentElement(state())).toBe(true);

--- a/app/javascript/components/Checkout/payment.test.ts
+++ b/app/javascript/components/Checkout/payment.test.ts
@@ -572,9 +572,9 @@ describe("expired direct-listed amount token submission", () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-09-08T12:00:00Z"));
     try {
       for (const expiry of ["2026-09-08T12:00:00Z", "invalid"]) {
-        expect(reduceCheckoutState(listedState(directListedCardConfig, expiry), { type: "validate" }).surcharges.type).toBe(
-          "pending",
-        );
+        expect(
+          reduceCheckoutState(listedState(directListedCardConfig, expiry), { type: "validate" }).surcharges.type,
+        ).toBe("pending");
       }
     } finally {
       vi.restoreAllMocks();

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -340,6 +340,9 @@ export type State = {
     // total change the snapshot exists to prevent. Display only; pay and disable gates keep
     // reading live `usingSavedCard`.
     previousUsingSavedCard?: boolean;
+    // Listed-amount token refresh, not an FX pick. Those responses have no
+    // buyer_currency_quote even when the required currency is kept.
+    listedTokenRefresh?: boolean;
   } | null;
   // A currency the buyer chose that the server then came back without. The summary names it, so a
   // total that reverts to another currency says why instead of changing under the buyer.
@@ -1327,6 +1330,7 @@ function refreshExpiredLocalCurrencyToken(state: State) {
   state.buyerCurrencyRemint = {
     surcharges: state.surcharges.result,
     previousCurrency: loadedBuyerCurrency(state),
+    listedTokenRefresh: hasExpiredDirectListedAmountToken(state),
   };
   state.surcharges = { type: "pending" };
   state.resumeSubmitAfterCheckoutPayment = false;
@@ -1755,6 +1759,7 @@ export const reduceCheckoutState = produce((state: State, action: Action) => {
         if (
           remint &&
           !remint.surfaceSwitch &&
+          !remint.listedTokenRefresh &&
           state.buyerCurrency != null &&
           !honorsBuyerCurrency(state, action.result, state.buyerCurrency)
         ) {

--- a/app/javascript/components/Checkout/payment.ts
+++ b/app/javascript/components/Checkout/payment.ts
@@ -1264,7 +1264,7 @@ function resumeRefusedSubmitIfReady(state: State) {
   // pipeline already moved on under its own steam and does not need restarting.
   if (state.status.type !== "input") return;
 
-  if (refreshExpiredBuyerCurrencyQuote(state)) return;
+  if (refreshExpiredLocalCurrencyToken(state)) return;
   state.resumeSubmitAfterCheckoutPayment = false;
   // A resumed submit is not a free pass: it re-runs the same field validation a fresh submit does,
   // so an incomplete form lands back on "input" with the offending fields flagged.
@@ -1300,8 +1300,28 @@ export function hasExpiredBuyerCurrencyQuote(state: State) {
   return display !== null && !(expiresAt > Date.now());
 }
 
+export function hasExpiredDirectListedAmountToken(state: State) {
+  // Only the checkout that would submit this token. Server-confirm FX never sends it.
+  if (!getLoadedDirectListedAmountToken(state) || state.surcharges.type !== "loaded") return false;
+  const result = state.surcharges.result;
+  const expiresAt =
+    result.direct_listed_amount_token_client_expires_at ??
+    (result.direct_listed_amount_token_expires_at == null
+      ? Number.MAX_SAFE_INTEGER
+      : Date.parse(result.direct_listed_amount_token_expires_at));
+  return !(expiresAt > Date.now());
+}
+
 function refreshExpiredBuyerCurrencyQuote(state: State) {
-  if (!hasExpiredBuyerCurrencyQuote(state) || state.surcharges.type !== "loaded") return false;
+  return refreshExpiredLocalCurrencyToken(state);
+}
+
+function refreshExpiredLocalCurrencyToken(state: State) {
+  if (
+    state.surcharges.type !== "loaded" ||
+    (!hasExpiredBuyerCurrencyQuote(state) && !hasExpiredDirectListedAmountToken(state))
+  )
+    return false;
   // Keep the reviewed currency visible while the existing fenced surcharge request replaces it.
   // Never resume this attempt: even an unchanged total needs a fresh buyer submit.
   state.buyerCurrencyRemint = {

--- a/app/javascript/data/customer_surcharge.test.ts
+++ b/app/javascript/data/customer_surcharge.test.ts
@@ -44,6 +44,52 @@ describe("quote expiry clock", () => {
     expect(result.buyer_currency_quote?.token).toBe("quote");
   });
 
+  it.each([-3600000, 3600000])(
+    "uses the server Date for a direct-listed amount token when the buyer clock is offset by %s ms",
+    async (skew) => {
+      vi.useFakeTimers();
+      const serverNow = Date.parse("2026-09-08T12:00:00Z");
+      vi.setSystemTime(serverNow + skew);
+      const payload: SurchargesResponse = {
+        vat_id_valid: false,
+        has_vat_id_input: false,
+        shipping_rate_cents: 0,
+        tax_cents: 0,
+        tax_included_cents: 0,
+        subtotal: 1000,
+        buyer_currency_quote: null,
+        direct_listed_amount_token: "listed-token",
+        direct_listed_amount_token_expires_at: "2026-09-08T12:05:00Z",
+      };
+      request.mockImplementation(async () => {
+        vi.setSystemTime(Date.now() + 2000);
+        return new Response(JSON.stringify(payload), { headers: { Date: "Tue, 08 Sep 2026 12:00:00 GMT" } });
+      });
+      const result = await getSurcharges({ products: [], country: "US" });
+      expect(result.direct_listed_amount_token_client_expires_at).toBe(serverNow + skew + 299000);
+      expect((result.direct_listed_amount_token_client_expires_at ?? 0) - Date.now()).toBe(297000);
+      expect(result.direct_listed_amount_token).toBe("listed-token");
+    },
+  );
+
+  it("does not expire a listed token against the device clock when expires_at or Date is missing", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.parse("2026-09-08T14:00:00Z"));
+    const payload: SurchargesResponse = {
+      vat_id_valid: false,
+      has_vat_id_input: false,
+      shipping_rate_cents: 0,
+      tax_cents: 0,
+      tax_included_cents: 0,
+      subtotal: 1000,
+      buyer_currency_quote: null,
+      direct_listed_amount_token: "listed-token",
+    };
+    request.mockResolvedValue(new Response(JSON.stringify(payload), { headers: {} }));
+    const result = await getSurcharges({ products: [], country: "US" });
+    expect(result.direct_listed_amount_token_client_expires_at).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
   it("does not expire quotes against the device clock when the Date header is missing", async () => {
     vi.useFakeTimers();
     const serverNow = Date.parse("2026-09-08T12:00:00Z");

--- a/app/javascript/data/customer_surcharge.ts
+++ b/app/javascript/data/customer_surcharge.ts
@@ -60,6 +60,10 @@ export type SurchargesResponse = {
   direct_listed_line_allocations?: DirectListedLineAllocation[] | null | undefined;
   // Signed proof of the exact direct-listed split that mounted the Payment Element.
   direct_listed_amount_token?: string | null | undefined;
+  // Absolute expiry of that token. Optional for rolling deploy with servers that omit it.
+  direct_listed_amount_token_expires_at?: string | null | undefined;
+  // Client deadline derived from the response's server clock, not the device's wall-clock offset.
+  direct_listed_amount_token_client_expires_at?: number;
   buyer_currency_quote: {
     token: string;
     currency: CurrencyCode;
@@ -115,16 +119,31 @@ export const getSurcharges = async (data: GetSurchargesRequest, abortSignal?: Ab
   if (!response.ok) throw new ResponseError();
   const result = typia.assert<SurchargesResponse>(await response.json());
   const serverTime = Date.parse(response.headers.get("Date") ?? "");
-  if (result.buyer_currency_quote && Number.isFinite(serverTime)) {
-    // Starting the lifetime at request start also deducts transit time. HTTP Date has
-    // whole-second precision, so reserve that second rather than extending the quote.
-    result.buyer_currency_quote.client_expires_at =
-      startedAt + Date.parse(result.buyer_currency_quote.expires_at) - serverTime - 1000;
-  } else if (result.buyer_currency_quote) {
-    // No trusted server clock. Do not derive expiry from the device clock — a clock that is
-    // ≥1h fast would treat every fresh quote as expired and loop local-currency checkout.
-    // Leave the quote non-expiring client-side; the server still refuses a truly expired token.
-    result.buyer_currency_quote.client_expires_at = Number.MAX_SAFE_INTEGER;
+  if (result.buyer_currency_quote) {
+    result.buyer_currency_quote.client_expires_at = clientExpiresAt(
+      result.buyer_currency_quote.expires_at,
+      startedAt,
+      serverTime,
+    );
+  }
+  if (result.direct_listed_amount_token) {
+    // A rolling-deploy response can still omit expires_at. Do not treat that as already expired.
+    result.direct_listed_amount_token_client_expires_at =
+      result.direct_listed_amount_token_expires_at == null
+        ? Number.MAX_SAFE_INTEGER
+        : clientExpiresAt(result.direct_listed_amount_token_expires_at, startedAt, serverTime);
   }
   return result;
 };
+
+function clientExpiresAt(expiresAt: string, startedAt: number, serverTime: number) {
+  if (!Number.isFinite(serverTime)) {
+    // No trusted server clock. Do not derive expiry from the device clock — a clock that is
+    // ≥1h fast would treat every fresh token as expired and loop local-currency checkout.
+    // Leave it non-expiring client-side; the server still refuses a truly expired token.
+    return Number.MAX_SAFE_INTEGER;
+  }
+  // Starting the lifetime at request start also deducts transit time. HTTP Date has
+  // whole-second precision, so reserve that second rather than extending the token.
+  return startedAt + Date.parse(expiresAt) - serverTime - 1000;
+}

--- a/app/javascript/pages/Checkout/Show.test.tsx
+++ b/app/javascript/pages/Checkout/Show.test.tsx
@@ -85,6 +85,7 @@ vi.mock("$app/components/Checkout", () => ({
             : "Updating"}
         </output>
         <p>{state.warning}</p>
+        <p aria-label="buyer currency">{state.buyerCurrency}</p>
       </>
     );
   },
@@ -203,6 +204,7 @@ afterEach(() => {
   cleanup();
   vi.useRealTimers();
   vi.resetAllMocks();
+  document.cookie = "gumroad_buyer_currency=; path=/; max-age=0";
 });
 
 describe.each([false, true])("checkout expired quote (client-confirm=%s)", (client) => {
@@ -364,4 +366,35 @@ describe.each([false, true])("checkout expired listed amount token (method-force
     expect(mocks.clientOrder).not.toHaveBeenCalled();
     expect(screen.getByText("1600")).toBeTruthy();
   });
+});
+
+it("keeps a method-forced listed currency when a matching preference is persisted", async () => {
+  document.cookie = "gumroad_buyer_currency=eur; path=/";
+  mocks.props.checkout_payment = listedConfig(true);
+  const offered = [
+    { code: "usd", label: "$ (US Dollars)" },
+    { code: "eur", label: "€ (Euros)" },
+  ];
+  mocks.surcharges
+    .mockResolvedValueOnce({ ...listed("2026-09-08T12:00:01Z"), available_buyer_currencies: offered })
+    .mockResolvedValue({
+      ...listed("2999-01-01T00:00:00Z", 1600),
+      available_buyer_currencies: offered,
+    });
+  render(<CheckoutPage />);
+  await act(() => vi.advanceTimersByTimeAsync(400));
+  expect(screen.getByLabelText("buyer currency").textContent).toBe("eur");
+  vi.setSystemTime(new Date("2026-09-08T12:00:02Z"));
+  fireEvent.click(screen.getByRole("button", { name: "Pay" }));
+  await act(() => vi.advanceTimersByTimeAsync(400));
+  expect(mocks.surcharges).toHaveBeenCalledTimes(2);
+  expect(screen.getByLabelText("buyer currency").textContent).toBe("eur");
+  expect(screen.getByText("1600")).toBeTruthy();
+  expect(screen.getByText(/Please review the updated total/u)).toBeTruthy();
+  expect(mocks.clientOrder).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByRole("button", { name: "Pay" }));
+  await act(() => vi.advanceTimersByTimeAsync(0));
+  expect(mocks.clientOrder).toHaveBeenCalledOnce();
+  expect(mocks.clientOrder.mock.calls[0]?.[0].directListedAmountToken).toBe("listed-1600");
+  expect(screen.getByLabelText("buyer currency").textContent).toBe("eur");
 });

--- a/app/javascript/pages/Checkout/Show.test.tsx
+++ b/app/javascript/pages/Checkout/Show.test.tsx
@@ -63,7 +63,7 @@ vi.mock("$app/components/Checkout", () => ({
                   selectedMethodType: "card",
                   cardCountry: "US",
                   walletType: null,
-                  mountCurrency: "cad",
+                  mountCurrency: state.checkoutPayment.elements_options.currency,
                   methodListToken: null,
                 }
               : { type: "saved" },
@@ -80,7 +80,8 @@ vi.mock("$app/components/Checkout", () => ({
         </button>
         <output>
           {state.surcharges.type === "loaded"
-            ? state.surcharges.result.buyer_currency_quote?.presentment_total_cents
+            ? (state.surcharges.result.direct_listed_line_allocations?.[0]?.total_cents ??
+              state.surcharges.result.buyer_currency_quote?.presentment_total_cents)
             : "Updating"}
         </output>
         <p>{state.warning}</p>
@@ -251,5 +252,116 @@ describe.each([false, true])("checkout expired quote (client-confirm=%s)", (clie
     expect(mocks.clientOrder).not.toHaveBeenCalled();
     expect(screen.getByText("1500")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Pay" }).hasAttribute("disabled")).toBe(false);
+  });
+});
+
+const listed = (expiresAt: string, amount = 1500): SurchargesResponse => ({
+  vat_id_valid: false,
+  has_vat_id_input: false,
+  shipping_rate_cents: 0,
+  tax_cents: 0,
+  tax_included_cents: 0,
+  subtotal: 1000,
+  buyer_currency_quote: null,
+  direct_listed_amount_token: `listed-${amount}`,
+  direct_listed_amount_token_expires_at: expiresAt,
+  direct_listed_line_allocations: [
+    {
+      permalink: "test-product",
+      price_cents: amount,
+      tip_cents: 0,
+      tax_cents: 0,
+      shipping_cents: 0,
+      total_cents: amount,
+    },
+  ],
+});
+
+const listedConfig = (forced: boolean): CheckoutPaymentConfig => ({
+  fallback_reason: null,
+  disable_wallets: true,
+  request_apple_pay_merchant_tokens: false,
+  payment_element_wallets: false,
+  flat_payment_methods: true,
+  integration: "payment_element_client_confirm",
+  recurring_upi_registration: false,
+  elements_options: {
+    stripe_elements_mode: "payment",
+    currency: "eur",
+    buyer_currency_presentment: false,
+    presentment_amount_cents: 1500,
+    listed_currency_display: { currency: "eur", subunit_to_unit: 100 },
+    payment_method_types: forced ? ["card", "ideal"] : ["card"],
+    payment_method_list_token: null,
+    stripe_link_enabled: false,
+    stripe_connect_account_id: null,
+    direct_listed_card: !forced,
+  },
+});
+
+describe.each([false, true])("checkout expired listed amount token (method-forced=%s)", (forced) => {
+  it("refreshes before order creation and only submits after another Pay click", async () => {
+    mocks.props.checkout_payment = listedConfig(forced);
+    mocks.surcharges
+      .mockResolvedValueOnce(listed("2026-09-08T12:00:01Z"))
+      .mockResolvedValue(listed("2999-01-01T00:00:00Z", 1600));
+    render(<CheckoutPage />);
+    await act(() => vi.advanceTimersByTimeAsync(400));
+    expect(screen.getByText("1500")).toBeTruthy();
+    vi.setSystemTime(new Date("2026-09-08T12:00:02Z"));
+    fireEvent.click(screen.getByRole("button", { name: "Pay" }));
+    await act(() => vi.advanceTimersByTimeAsync(400));
+    expect(mocks.order).not.toHaveBeenCalled();
+    expect(mocks.clientOrder).not.toHaveBeenCalled();
+    expect(screen.getByText("1600")).toBeTruthy();
+    expect(screen.getByText(/Please review the updated total/u)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Pay" }));
+    await act(() => vi.advanceTimersByTimeAsync(0));
+    expect(mocks.clientOrder).toHaveBeenCalledOnce();
+    expect(mocks.clientOrder.mock.calls[0]?.[0].directListedAmountToken).toBe("listed-1600");
+    expect(mocks.order).not.toHaveBeenCalled();
+  });
+
+  it("still requires another Pay click when the refreshed listed total is unchanged", async () => {
+    mocks.props.checkout_payment = listedConfig(forced);
+    mocks.surcharges
+      .mockResolvedValueOnce(listed("2026-09-08T12:00:01Z"))
+      .mockResolvedValue({ ...listed("2999-01-01T00:00:00Z"), direct_listed_amount_token: "listed-fresh" });
+    render(<CheckoutPage />);
+    await act(() => vi.advanceTimersByTimeAsync(400));
+    vi.setSystemTime(new Date("2026-09-08T12:00:02Z"));
+    fireEvent.click(screen.getByRole("button", { name: "Pay" }));
+    await act(() => vi.advanceTimersByTimeAsync(400));
+    expect(mocks.clientOrder).not.toHaveBeenCalled();
+    expect(screen.getByText(/Please review the updated total/u)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Pay" }));
+    await act(() => vi.advanceTimersByTimeAsync(0));
+    expect(mocks.clientOrder).toHaveBeenCalledOnce();
+    expect(mocks.clientOrder.mock.calls[0]?.[0].directListedAmountToken).toBe("listed-fresh");
+  });
+
+  it("rechecks listed-token expiry after awaited analytics before either order consumer", async () => {
+    mocks.props.checkout_payment = listedConfig(forced);
+    mocks.surcharges
+      .mockResolvedValueOnce(listed("2026-09-08T12:00:01Z"))
+      .mockResolvedValue(listed("2999-01-01T00:00:00Z", 1600));
+    let finishAnalytics: (() => void) | undefined;
+    mocks.analytics.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishAnalytics = resolve;
+        }),
+    );
+    render(<CheckoutPage />);
+    await act(() => vi.advanceTimersByTimeAsync(400));
+    fireEvent.click(screen.getByRole("button", { name: "Pay" }));
+    await act(() => vi.advanceTimersByTimeAsync(0));
+    expect(finishAnalytics).toBeTypeOf("function");
+    vi.setSystemTime(new Date("2026-09-08T12:00:02Z"));
+    await act(async () => finishAnalytics?.());
+    await act(() => vi.advanceTimersByTimeAsync(400));
+    expect(mocks.order).not.toHaveBeenCalled();
+    expect(mocks.clientOrder).not.toHaveBeenCalled();
+    expect(screen.getByText("1600")).toBeTruthy();
   });
 });

--- a/app/javascript/pages/Checkout/Show.tsx
+++ b/app/javascript/pages/Checkout/Show.tsx
@@ -59,6 +59,7 @@ import { computeInitialCheckout, type InitialCheckout } from "$app/components/Ch
 import {
   BUYER_CURRENCY_QUOTE_REFRESH_MESSAGE,
   hasExpiredBuyerCurrencyQuote,
+  hasExpiredDirectListedAmountToken,
   canDisplayBuyerCurrencyQuote,
   canUseStripePaymentElement,
   canUseStripePaymentElementClientConfirm,
@@ -536,7 +537,7 @@ const CheckoutIndexPage = () => {
       }
       // Analytics and CAPTCHA may outlive the quote even when Pay started with a fresh one.
       // Stop before either order endpoint; refreshing must not reuse this payment authorization.
-      if (hasExpiredBuyerCurrencyQuote(state)) {
+      if (hasExpiredBuyerCurrencyQuote(state) || hasExpiredDirectListedAmountToken(state)) {
         dispatch({ type: "refresh-expired-buyer-currency-quote", beforeSubmit: true });
         return;
       }

--- a/spec/controllers/customer_surcharge_controller_spec.rb
+++ b/spec/controllers/customer_surcharge_controller_spec.rb
@@ -322,6 +322,7 @@ describe CustomerSurchargeController, :vcr do
           currency: Currency::CAD
         )
       ).to eq(allocations)
+      expect(Time.iso8601(response.parsed_body.fetch("direct_listed_amount_token_expires_at"))).to be_within(2.seconds).of(Checkout::DirectListedAmountToken::TTL.from_now)
     end
 
     it "returns method-forced allocations without the listed-card ramp" do
@@ -511,6 +512,7 @@ describe CustomerSurchargeController, :vcr do
 
       expect(response.parsed_body.fetch("direct_listed_line_allocations")).to be_nil
       expect(response.parsed_body.fetch("direct_listed_amount_token")).to be_nil
+      expect(response.parsed_body.fetch("direct_listed_amount_token_expires_at")).to be_nil
     end
 
     it "does not advertise the listed currency for a saved-card checkout" do


### PR DESCRIPTION
Refresh expired direct-listed amount tokens before submitting payment

Addresses antiwork/gumroad-private#2446. Follows the pre-submit refresh in #7551 for a different token than the FX quote. #7553 added the `invalid_or_expired_token` reason on prepare; this PR does not change those guards.

Finding
Checkout failures with `buyer_currency_quote_invalid` continue at ~1.5/hour after #7551. The remaining dominant class is `invalid_or_expired_token` on `Checkout::DirectListedAmountToken` (30-minute TTL) for EUR-listed (direct-listed) products. #7551 refreshes only the FX quote and explicitly skips direct-listed checkouts.

Cause
The listed-amount token is issued with the surcharge response and submitted on Pay. A backgrounded tab or a Pay click after 30 minutes sends the expired token. Prepare still correctly refuses it. The client never re-fetched a fresh token before creating a payment request.

What changed
When Pay is clicked (or the tab returns) and the listed-amount token is expired or at its expiry boundary, checkout re-fetches surcharges before either order consumer. The signed token, TTL, and comparator / above-reviewed-total guards are unchanged. A changed total is shown and requires another Pay click; an unchanged replacement total also requires that extra click, matching #7551. Clock skew uses the surcharge response Date the same way as FX quotes. Server-confirm Payment Element still does not submit this token.

Tests
`npm test --` payment.test.ts Show.test.tsx createReducer.test.tsx customer_surcharge.test.ts: 4 files, 268 passed at 9144c88ed29.
`bundle exec rspec spec/controllers/customer_surcharge_controller_spec.rb` for the expires_at pin and the omitted-token example: 1+1 examples, 0 failures.
Prettier clean on the touched JS. Panel (Astra+Fable) running.

Premerge review: clean @ 25a32a12a886aafc62d91e2f9bd42714f61eafbd (Astra + Fable panel, 0 findings each). Greptile P1 (method-forced direct-listed refresh entering FX-refusal fallback) addressed in the same head with a regression test.

AI disclosure: grok-4.6 (xai). Prompt: apply #7551's pre-submit refresh to Checkout::DirectListedAmountToken without lengthening TTL or weakening prepare guards.
