### PR TITLE
Add TikTok OAuth connect behind tiktok_connect

### DIFF
--- a/app/controllers/connections_controller.rb
+++ b/app/controllers/connections_controller.rb
@@ -32,6 +32,14 @@ class ConnectionsController < Sellers::BaseController
     render json: { success: false, error_message: e.message }
   end
 
+  def unlink_tiktok
+    current_seller.tiktok_identity&.destroy!
+
+    render json: { success: true }
+  rescue => e
+    render json: { success: false, error_message: e.message }
+  end
+
   private
     def authorize
       super([:settings, :profile], :manage_social_connections?)

--- a/app/controllers/tiktok_callbacks_controller.rb
+++ b/app/controllers/tiktok_callbacks_controller.rb
@@ -5,6 +5,9 @@ class TiktokCallbacksController < ApplicationController
 
   def deauthorize
     payload = webhook.parse(request.raw_post, signature_header)
+    return head :bad_request if payload.blank?
+    return head :ok unless payload["event"] == "authorization.removed"
+
     open_id = webhook.open_id(payload)
     return head :bad_request if open_id.blank?
 

--- a/app/controllers/tiktok_callbacks_controller.rb
+++ b/app/controllers/tiktok_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class TiktokCallbacksController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:deauthorize]
+
+  def deauthorize
+    payload = webhook.parse(request.raw_post, signature_header)
+    open_id = webhook.open_id(payload)
+    return head :bad_request if open_id.blank?
+
+    unlink_tiktok_identity(open_id)
+    head :ok
+  end
+
+  private
+    def webhook
+      @_webhook ||= TiktokWebhook.new
+    end
+
+    def signature_header
+      request.get_header("HTTP_TIKTOK_SIGNATURE") || request.headers["TikTok-Signature"] || request.headers["Tiktok-Signature"]
+    end
+
+    # Deauthorize only ends the live link; the verified identity stays as
+    # shared-identity veto evidence, like an in-app disconnect.
+    def unlink_tiktok_identity(open_id)
+      SocialConnectVerification.current.where(platform: "tiktok", uid: open_id).update_all(superseded_at: Time.current)
+      UserTiktokIdentity.where(tiktok_open_id: open_id).delete_all
+    end
+end

--- a/app/controllers/user/omniauth_callbacks_controller.rb
+++ b/app/controllers/user/omniauth_callbacks_controller.rb
@@ -196,6 +196,38 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     redirect_to profile_path
   end
 
+  def tiktok
+    if logged_in_user.blank?
+      flash[:alert] = "You need to be logged in to link your TikTok account."
+      return redirect_to login_path
+    end
+
+    unless Feature.active?(:tiktok_connect, logged_in_user)
+      flash[:alert] = "TikTok connect is not available."
+      return redirect_to profile_path
+    end
+
+    token = request.env.dig("omniauth.auth", "credentials", "token")
+    profile = TiktokProfileFetcher.new(token).fetch
+    if profile.blank?
+      flash[:alert] = "Couldn't read a TikTok account."
+      return redirect_to profile_path
+    end
+
+    verification = SocialConnectVerification.record_from_tiktok!(logged_in_user, profile)
+    if verification.blank?
+      flash[:alert] = "Couldn't save your TikTok connection. Please try again."
+      return redirect_to profile_path
+    end
+    identity = logged_in_user.tiktok_identity || logged_in_user.build_tiktok_identity
+    identity.update!(tiktok_open_id: verification.uid, handle: verification.handle)
+    redirect_to profile_path
+  rescue StandardError => e
+    Rails.logger.error("TikTok connect failed for user #{logged_in_user.id}: #{e.class}")
+    flash[:alert] = "Couldn't save your TikTok connection. Please try again."
+    redirect_to profile_path
+  end
+
   def apple
     @user = User.find_or_create_for_apple_oauth(request.env["omniauth.auth"])
     sign_in_with_oauth("Apple")
@@ -203,8 +235,8 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def failure
     connect_provider = request.env["omniauth.error.strategy"]&.name.to_s
-    if %w[youtube instagram].include?(connect_provider)
-      provider_name = connect_provider == "youtube" ? "YouTube" : "Instagram"
+    if %w[youtube instagram tiktok].include?(connect_provider)
+      provider_name = { "youtube" => "YouTube", "instagram" => "Instagram", "tiktok" => "TikTok" }.fetch(connect_provider)
       flash[:alert] = "Couldn't connect #{provider_name}. Please try again."
       redirect_to(logged_in_user.present? ? profile_path : login_path)
     elsif params[:error_description].present?

--- a/app/controllers/user/omniauth_callbacks_controller.rb
+++ b/app/controllers/user/omniauth_callbacks_controller.rb
@@ -281,7 +281,7 @@ class User::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     def set_social_connect_destination
       provider = action_name == "failure" ? request.env["omniauth.error.strategy"]&.name.to_s : action_name
-      connecting = %w[youtube instagram].include?(provider) ||
+      connecting = %w[youtube instagram tiktok].include?(provider) ||
         (provider == "twitter" && request.env.dig("omniauth.params", REQ_PARAM_STATE) == "link_twitter_account")
       @return_to_onboarding = connecting && consume_social_connect_return
       session.delete(:social_connect_return) unless connecting || action_name == "failure"

--- a/app/javascript/components/Button.test.tsx
+++ b/app/javascript/components/Button.test.tsx
@@ -41,4 +41,19 @@ describe("Button brand colors", () => {
     expect(instagram.className).toBe(x.className);
     expect(instagram.className).toContain("bg-black");
   });
+
+  it("fills the TikTok button like the X button", () => {
+    render(
+      <>
+        <Button color="twitter">Connect to X</Button>
+        <Button color="tiktok">Connect to TikTok</Button>
+      </>,
+    );
+
+    const x = screen.getByRole("button", { name: "Connect to X" });
+    const tiktok = screen.getByRole("button", { name: "Connect to TikTok" });
+
+    expect(tiktok.className).toBe(x.className);
+    expect(tiktok.className).toContain("bg-black");
+  });
 });

--- a/app/javascript/components/Button.tsx
+++ b/app/javascript/components/Button.tsx
@@ -19,6 +19,7 @@ export const brandNames = [
   "google",
   "youtube",
   "instagram",
+  "tiktok",
 ] as const;
 
 export type BrandName = (typeof brandNames)[number];
@@ -64,6 +65,7 @@ export const buttonVariants = cva(
         google: "bg-[#5383ec] text-white border-[#5383ec]",
         youtube: "bg-black text-white",
         instagram: "bg-black text-white",
+        tiktok: "bg-black text-white",
       },
     },
     compoundVariants: [

--- a/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.test.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.test.tsx
@@ -78,6 +78,7 @@ describe("optional review connections", () => {
             { provider: "twitter", connected: true },
             { provider: "youtube", connected: false },
             { provider: "instagram", connected: false },
+            { provider: "tiktok", connected: false },
           ],
         }}
         payoutsPausedBy={null}
@@ -93,6 +94,10 @@ describe("optional review connections", () => {
     const instagramForm = submit.mock.instances[1];
     if (!(instagramForm instanceof HTMLFormElement)) throw new Error("Missing Instagram form");
     expect(instagramForm.getAttribute("action")).toBe("/users/auth/instagram");
+    fireEvent.click(screen.getByRole("button", { name: "Connect to TikTok" }));
+    const tiktokForm = submit.mock.instances[2];
+    if (!(tiktokForm instanceof HTMLFormElement)) throw new Error("Missing TikTok form");
+    expect(tiktokForm.getAttribute("action")).toBe("/users/auth/tiktok");
   });
 
   it("hides the review notice and social prompt while the system payout pause alert is showing", () => {

--- a/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
+++ b/app/javascript/components/Settings/PaymentsPage/AccountStatusSection.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { SocialAuthButton } from "$app/components/SocialAuthButton";
 import { Alert } from "$app/components/ui/Alert";
 
-const SOCIAL_PROVIDER_NAMES = { twitter: "X", youtube: "YouTube", instagram: "Instagram" };
+const SOCIAL_PROVIDER_NAMES = { twitter: "X", youtube: "YouTube", instagram: "Instagram", tiktok: "TikTok" };
 
 const SupportLink = () => (
   <>
@@ -34,7 +34,9 @@ export type AccountStatus = {
   compliance_actions: ComplianceAction[];
   needs_id_upload: boolean;
   gumroad_status: string | null;
-  social_connections_for_review: { provider: "twitter" | "youtube" | "instagram"; connected: boolean }[] | null;
+  social_connections_for_review:
+    | { provider: "twitter" | "youtube" | "instagram" | "tiktok"; connected: boolean }[]
+    | null;
   stripe_rejected: boolean;
   stripe_rejected_balance_status: "stripe_hold" | "auto_payout" | "too_small" | "held" | null;
   stripe_rejected_formatted_balance: string | null;
@@ -201,7 +203,9 @@ export default function AccountStatusSection({
                           })
                         : provider === "youtube"
                           ? Routes.user_youtube_omniauth_authorize_path()
-                          : Routes.user_instagram_omniauth_authorize_path()
+                          : provider === "tiktok"
+                            ? "/users/auth/tiktok"
+                            : Routes.user_instagram_omniauth_authorize_path()
                     }
                   >
                     Connect to {SOCIAL_PROVIDER_NAMES[provider]}

--- a/app/javascript/data/profile_settings.ts
+++ b/app/javascript/data/profile_settings.ts
@@ -132,3 +132,13 @@ export const unlinkInstagram = async () => {
   const json = typia.assert<{ success: false; error_message: string } | { success: true }>(await response.json());
   if (!json.success) throw new ResponseError(json.error_message);
 };
+
+export const unlinkTiktok = async () => {
+  const response = await request({
+    method: "POST",
+    url: "/settings/connections/unlink_tiktok",
+    accept: "json",
+  });
+  const json = typia.assert<{ success: false; error_message: string } | { success: true }>(await response.json());
+  if (!json.success) throw new ResponseError(json.error_message);
+};

--- a/app/javascript/pages/Settings/Profile/Show.tsx
+++ b/app/javascript/pages/Settings/Profile/Show.tsx
@@ -1,4 +1,4 @@
-import { FontFamily, Instagram, TwitterX, Youtube } from "@boxicons/react";
+import { FontFamily, Instagram, Tiktok, TwitterX, Youtube } from "@boxicons/react";
 import { Link, router, usePage } from "@inertiajs/react";
 import { isEqual } from "lodash-es";
 import * as React from "react";
@@ -7,6 +7,7 @@ import typia from "typia";
 import {
   updateProfileSettings as saveProfileSettings,
   unlinkInstagram,
+  unlinkTiktok,
   unlinkTwitter,
   unlinkYoutube,
 } from "$app/data/profile_settings";
@@ -80,6 +81,9 @@ type ProfilePageProps = {
   instagram_connect_enabled: boolean;
   instagram_connected: boolean;
   instagram_handle: string | null;
+  tiktok_connect_enabled: boolean;
+  tiktok_connected: boolean;
+  tiktok_handle: string | null;
   has_custom_landing_page: boolean;
   seller_fonts_css_source: string;
   username: string;
@@ -100,6 +104,9 @@ export default function SettingsPage() {
     instagram_connect_enabled,
     instagram_connected,
     instagram_handle,
+    tiktok_connect_enabled,
+    tiktok_connected,
+    tiktok_handle,
     has_custom_landing_page,
     seller_fonts_css_source,
     username,
@@ -297,6 +304,16 @@ export default function SettingsPage() {
   const handleUnlinkInstagram = asyncVoid(async () => {
     try {
       await unlinkInstagram();
+      router.reload();
+    } catch (e) {
+      assertResponseError(e);
+      showAlert(e.message, "error");
+    }
+  });
+
+  const handleUnlinkTiktok = asyncVoid(async () => {
+    try {
+      await unlinkTiktok();
       router.reload();
     } catch (e) {
       assertResponseError(e);
@@ -567,6 +584,17 @@ export default function SettingsPage() {
                     <SocialAuthButton provider="instagram" href={Routes.user_instagram_omniauth_authorize_path()}>
                       <Instagram pack="brands" className="size-5" />
                       Connect to Instagram
+                    </SocialAuthButton>
+                  ) : null}
+                  {tiktok_connected ? (
+                    <Button type="button" color="tiktok" onClick={handleUnlinkTiktok}>
+                      <Tiktok pack="brands" className="size-5" />
+                      Disconnect {tiktok_handle ? `${tiktok_handle} from TikTok` : "TikTok"}
+                    </Button>
+                  ) : tiktok_connect_enabled ? (
+                    <SocialAuthButton provider="tiktok" href="/users/auth/tiktok">
+                      <Tiktok pack="brands" className="size-5" />
+                      Connect to TikTok
                     </SocialAuthButton>
                   ) : null}
                 </Fieldset>

--- a/app/models/social_connect_verification.rb
+++ b/app/models/social_connect_verification.rb
@@ -37,6 +37,9 @@ class SocialConnectVerification < ApplicationRecord
     when "instagram"
       instagram_user_id = user.instagram_identity&.instagram_user_id
       instagram_user_id.present? && instagram_user_id.to_s == uid.to_s
+    when "tiktok"
+      tiktok_open_id = user.tiktok_identity&.tiktok_open_id
+      tiktok_open_id.present? && tiktok_open_id.to_s == uid.to_s
     else
       false
     end
@@ -79,6 +82,20 @@ class SocialConnectVerification < ApplicationRecord
     )
   end
 
+  def self.record_from_tiktok!(user, profile)
+    uid = profile["open_id"].to_s
+    return if uid.blank?
+
+    record!(
+      user, "tiktok", uid,
+      handle: tiktok_handle(profile),
+      account_created_at: nil,
+      follower_count: int_or_unknown(profile["follower_count"]),
+      post_count: int_or_unknown(profile["video_count"]),
+      last_posted_at: nil,
+    )
+  end
+
   def self.record_from_instagram!(user, profile)
     # Meta's deauthorize/data-deletion signed_request carries the app-scoped
     # (token) user id, so that must be the canonical uid or those callbacks
@@ -116,6 +133,22 @@ class SocialConnectVerification < ApplicationRecord
     end
   end
   private_class_method :record!
+
+  def self.tiktok_handle(profile)
+    profile["username"].presence ||
+      profile["profile_web_link"].to_s[%r{@([^/?#]+)}, 1].presence ||
+      profile["display_name"].presence
+  end
+  private_class_method :tiktok_handle
+
+  def self.int_or_unknown(value)
+    return if value.nil? || (value.is_a?(String) && value.strip.empty?)
+
+    Integer(value)
+  rescue ArgumentError, TypeError
+    nil
+  end
+  private_class_method :int_or_unknown
 
   def self.parse_twitter_time(value)
     return if value.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ApplicationRecord
   has_many :social_connect_verifications, dependent: :destroy
   has_one :youtube_identity, class_name: "UserYoutubeIdentity", dependent: :destroy
   has_one :instagram_identity, class_name: "UserInstagramIdentity", dependent: :destroy
+  has_one :tiktok_identity, class_name: "UserTiktokIdentity", dependent: :destroy
 
   stripped_fields :name, :facebook_meta_tag, :google_analytics_id, :username, :email, :support_email
 

--- a/app/models/user_tiktok_identity.rb
+++ b/app/models/user_tiktok_identity.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class UserTiktokIdentity < ApplicationRecord
+  belongs_to :user
+
+  validates :tiktok_open_id, presence: true
+  validates :user_id, uniqueness: true
+end

--- a/app/presenters/creator_home_presenter.rb
+++ b/app/presenters/creator_home_presenter.rb
@@ -138,6 +138,9 @@ class CreatorHomePresenter
       if seller.instagram_identity.present? || Feature.active?(:instagram_connect, seller)
         connections << { name: "Instagram", connected: seller.instagram_identity.present? }
       end
+      if seller.tiktok_identity.present? || Feature.active?(:tiktok_connect, seller)
+        connections << { name: "TikTok", connected: seller.tiktok_identity.present? }
+      end
       { social_connections: connections }
     end
 

--- a/app/presenters/profile_presenter.rb
+++ b/app/presenters/profile_presenter.rb
@@ -88,6 +88,9 @@ class ProfilePresenter
         instagram_connect_enabled: Feature.active?(:instagram_connect, seller),
         instagram_connected: seller.instagram_identity.present?,
         instagram_handle: seller.instagram_identity&.handle,
+        tiktok_connect_enabled: Feature.active?(:tiktok_connect, seller),
+        tiktok_connected: seller.tiktok_identity.present?,
+        tiktok_handle: seller.tiktok_identity&.handle,
         has_custom_landing_page: seller.has_custom_landing_page?,
         username: seller.username,
       }

--- a/app/presenters/settings_presenter.rb
+++ b/app/presenters/settings_presenter.rb
@@ -581,6 +581,7 @@ class SettingsPresenter
       connections = [{ provider: "twitter", connected: seller.twitter_user_id.present? }]
       connections << { provider: "youtube", connected: seller.youtube_identity.present? } if Feature.active?(:youtube_connect, seller)
       connections << { provider: "instagram", connected: seller.instagram_identity.present? } if Feature.active?(:instagram_connect, seller)
+      connections << { provider: "tiktok", connected: seller.tiktok_identity.present? } if Feature.active?(:tiktok_connect, seller)
       connections
     end
 

--- a/app/services/gdpr_data_erasure_service.rb
+++ b/app/services/gdpr_data_erasure_service.rb
@@ -256,6 +256,7 @@ class GdprDataErasureService
       @user.social_connect_verifications.destroy_all
       @user.youtube_identity&.destroy
       @user.instagram_identity&.destroy
+      @user.tiktok_identity&.destroy
 
       anonymized_email
     end

--- a/app/services/social_score_shadow_evaluation_service.rb
+++ b/app/services/social_score_shadow_evaluation_service.rb
@@ -77,6 +77,8 @@ class SocialScoreShadowEvaluationService
     def scored_verifications(shared_identity_counts)
       user.social_connect_verifications.filter_map do |verification|
         next unless verification.currently_linked?
+        # Linking TikTok must not start scoring it. Any TikTok threshold is a separate reviewed decision.
+        next if verification.platform == "tiktok"
         next if verification.last_verified_at.nil? || verification.last_verified_at < MAX_VERIFICATION_AGE.ago
 
         shared_identity_user_count = shared_identity_counts.fetch(verification.id)

--- a/app/services/tiktok_profile_fetcher.rb
+++ b/app/services/tiktok_profile_fetcher.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class TiktokProfileFetcher
+  USER_INFO_URL = "https://open.tiktokapis.com/v2/user/info/"
+  FIELDS = "open_id,union_id,avatar_url,display_name,username,profile_web_link,follower_count,video_count"
+
+  def initialize(access_token)
+    @access_token = access_token
+  end
+
+  def fetch
+    return if @access_token.blank?
+
+    response = HTTParty.get(
+      USER_INFO_URL,
+      query: { fields: FIELDS },
+      headers: { "Authorization" => "Bearer #{@access_token}" },
+      timeout: 5,
+    )
+    unless response.success?
+      Rails.logger.error("TiktokProfileFetcher HTTP #{response.code}")
+      return
+    end
+
+    body = response.parsed_response
+    return unless body.is_a?(Hash)
+
+    error_code = body.dig("error", "code")
+    if error_code.present? && error_code != "ok"
+      Rails.logger.error("TiktokProfileFetcher API #{error_code}")
+      return
+    end
+
+    user = body.dig("data", "user")
+    return unless user.is_a?(Hash)
+    return if user["open_id"].blank?
+
+    user
+  rescue HTTParty::Error, SocketError, Timeout::Error, JSON::ParserError, Errno::ECONNRESET, OpenSSL::SSL::SSLError => e
+    Rails.logger.error("TiktokProfileFetcher failed: #{e.class}")
+    nil
+  end
+end

--- a/app/services/tiktok_webhook.rb
+++ b/app/services/tiktok_webhook.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class TiktokWebhook
-  # TikTok signs `t=<unix>,s=<hex>` over "#{timestamp}.#{raw_body}". Replay
-  # window is not documented; 5 minutes matches common webhook practice and
-  # Hookdeck's Login Kit sample. Each retry is expected to carry a fresh `t`.
+  # TikTok signs `t=<unix>,s=<hex>` over "#{timestamp}.#{raw_body}".
+  # The replay window is undocumented; retries should carry a fresh timestamp.
   MAX_TIMESTAMP_AGE = 5.minutes
 
   def initialize(client_secret = TIKTOK_CLIENT_SECRET)

--- a/app/services/tiktok_webhook.rb
+++ b/app/services/tiktok_webhook.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class TiktokWebhook
+  def initialize(client_secret = TIKTOK_CLIENT_SECRET)
+    @client_secret = client_secret
+  end
+
+  def parse(raw_body, signature)
+    return if raw_body.blank? || signature.blank? || @client_secret.blank?
+
+    expected = OpenSSL::HMAC.hexdigest("SHA256", @client_secret, raw_body)
+    provided = signature.to_s.delete_prefix("sha256=")
+    return unless provided.bytesize == expected.bytesize
+    return unless ActiveSupport::SecurityUtils.secure_compare(provided, expected)
+
+    payload = JSON.parse(raw_body)
+    return unless payload.is_a?(Hash)
+
+    payload
+  rescue JSON::ParserError
+    nil
+  end
+
+  def open_id(payload)
+    return if payload.blank?
+
+    payload["user_openid"].presence || payload.dig("content", "open_id").presence || payload.dig("user", "open_id").presence
+  end
+end

--- a/app/services/tiktok_webhook.rb
+++ b/app/services/tiktok_webhook.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class TiktokWebhook
+  # TikTok signs `t=<unix>,s=<hex>` over "#{timestamp}.#{raw_body}". Replay
+  # window is not documented; 5 minutes matches common webhook practice and
+  # Hookdeck's Login Kit sample. Each retry is expected to carry a fresh `t`.
+  MAX_TIMESTAMP_AGE = 5.minutes
+
   def initialize(client_secret = TIKTOK_CLIENT_SECRET)
     @client_secret = client_secret
   end
@@ -8,10 +13,13 @@ class TiktokWebhook
   def parse(raw_body, signature)
     return if raw_body.blank? || signature.blank? || @client_secret.blank?
 
-    expected = OpenSSL::HMAC.hexdigest("SHA256", @client_secret, raw_body)
-    provided = signature.to_s.delete_prefix("sha256=")
+    timestamp, provided = timestamp_and_digest(signature)
+    return if timestamp.blank? || provided.blank? || !timestamp.match?(/\A\d+\z/)
+
+    expected = OpenSSL::HMAC.hexdigest("SHA256", @client_secret, "#{timestamp}.#{raw_body}")
     return unless provided.bytesize == expected.bytesize
     return unless ActiveSupport::SecurityUtils.secure_compare(provided, expected)
+    return unless timestamp_fresh?(timestamp)
 
     payload = JSON.parse(raw_body)
     return unless payload.is_a?(Hash)
@@ -26,4 +34,17 @@ class TiktokWebhook
 
     payload["user_openid"].presence || payload.dig("content", "open_id").presence || payload.dig("user", "open_id").presence
   end
+
+  private
+    def timestamp_and_digest(signature)
+      parts = signature.to_s.split(",").each_with_object({}) do |pair, acc|
+        key, value = pair.split("=", 2)
+        acc[key] = value if key.present? && value.present?
+      end
+      [parts["t"], parts["s"]]
+    end
+
+    def timestamp_fresh?(timestamp)
+      (Time.current.to_i - Integer(timestamp, 10)).abs <= MAX_TIMESTAMP_AGE.to_i
+    end
 end

--- a/app/services/tiktok_webhook.rb
+++ b/app/services/tiktok_webhook.rb
@@ -32,7 +32,9 @@ class TiktokWebhook
   def open_id(payload)
     return if payload.blank?
 
-    payload["user_openid"].presence || payload.dig("content", "open_id").presence || payload.dig("user", "open_id").presence
+    # TikTok documents user_openid. content can be a JSON string on the wire,
+    # so dig("content", ...) would TypeError; do not fall back to undocumented shapes.
+    payload["user_openid"].presence
   end
 
   private

--- a/config/initializers/000_tiktok.rb
+++ b/config/initializers/000_tiktok.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+TIKTOK_CLIENT_KEY = GlobalConfig.get("TIKTOK_CLIENT_KEY")
+TIKTOK_CLIENT_SECRET = GlobalConfig.get("TIKTOK_CLIENT_SECRET")

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -5,6 +5,7 @@ require "omniauth-twitter"
 require "omniauth-google-oauth2"
 require_relative "../../lib/omni_auth/strategies/youtube"
 require_relative "../../lib/omni_auth/strategies/instagram"
+require_relative "../../lib/omni_auth/strategies/tiktok"
 
 Devise.setup do |config|
   # Changing this invalidates existing confirmation, reset-password, and unlock tokens.
@@ -55,6 +56,10 @@ Devise.setup do |config|
   config.omniauth :instagram,
                   INSTAGRAM_APP_ID,
                   INSTAGRAM_APP_SECRET
+
+  config.omniauth :tiktok,
+                  TIKTOK_CLIENT_KEY,
+                  TIKTOK_CLIENT_SECRET
 
   config.omniauth :apple,
                   APPLE_CLIENT_ID,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -626,6 +626,7 @@ Rails.application.routes.draw do
     end
 
     post "/instagram/deauthorize", to: "instagram_callbacks#deauthorize", as: :instagram_deauthorize
+    post "/tiktok/deauthorize", to: "tiktok_callbacks#deauthorize", as: :tiktok_deauthorize
     post "/instagram/data_deletion", to: "instagram_callbacks#data_deletion", as: :instagram_data_deletion
     get "/instagram/data_deletion/:confirmation_code", to: "instagram_callbacks#data_deletion_status", as: :instagram_data_deletion_status
 
@@ -707,6 +708,7 @@ Rails.application.routes.draw do
           post :unlink_twitter
           post :unlink_youtube
           post :unlink_instagram
+          post :unlink_tiktok
         end
       end
     end

--- a/db/migrate/20261213090000_create_user_tiktok_identities.rb
+++ b/db/migrate/20261213090000_create_user_tiktok_identities.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# users is frozen (docs/migrations.md); live TikTok identity lives here so
+# connect/unlink does not ALTER that table. The SocialConnectVerification row
+# stays as dormant risk evidence after disconnect.
+class CreateUserTiktokIdentities < ActiveRecord::Migration[7.1]
+  def change
+    create_table :user_tiktok_identities do |t|
+      t.references :user, null: false, index: { unique: true }
+      t.string :tiktok_open_id, null: false
+      t.string :handle
+      t.timestamps
+
+      t.index :tiktok_open_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_12_12_090000) do
+ActiveRecord::Schema[7.1].define(version: 2026_12_13_090000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -2504,8 +2504,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_12_090000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "superseded_at"
-    t.index ["user_id", "platform", "uid"], name: "index_scv_on_user_id_platform_and_uid", unique: true
     t.index ["platform", "uid"], name: "index_social_connect_verifications_on_platform_and_uid"
+    t.index ["user_id", "platform", "uid"], name: "index_scv_on_user_id_platform_and_uid", unique: true
     t.index ["user_id", "platform"], name: "index_social_connect_verifications_on_user_id_and_platform"
   end
 
@@ -2970,6 +2970,16 @@ ActiveRecord::Schema[7.1].define(version: 2026_12_12_090000) do
     t.datetime "updated_at", null: false
     t.index ["user_id", "tax_year", "tax_form_type"], name: "index_user_tax_forms_on_user_id_and_tax_year_and_tax_form_type", unique: true
     t.index ["user_id"], name: "index_user_tax_forms_on_user_id"
+  end
+
+  create_table "user_tiktok_identities", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "tiktok_open_id", null: false
+    t.string "handle"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tiktok_open_id"], name: "index_user_tiktok_identities_on_tiktok_open_id"
+    t.index ["user_id"], name: "index_user_tiktok_identities_on_user_id", unique: true
   end
 
   create_table "user_youtube_identities", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/lib/omni_auth/strategies/tiktok.rb
+++ b/lib/omni_auth/strategies/tiktok.rb
@@ -37,7 +37,7 @@ module OmniAuth
       end
 
       def request_phase
-        return redirect(flag_off_redirect) unless tiktok_connect_enabled?
+        return unavailable_connection unless tiktok_connect_enabled?
 
         params = authorize_params.merge(redirect_uri: callback_url)
         params[:client_key] = client.id
@@ -48,12 +48,23 @@ module OmniAuth
       end
 
       def callback_phase
-        return redirect(flag_off_redirect) unless tiktok_connect_enabled?
+        return unavailable_connection unless tiktok_connect_enabled?
 
         super
       end
 
       private
+        def unavailable_connection
+          if session&.dig("omniauth.params", "social_connect_return").present? && on_request_path?
+            env["omniauth.params"] = session.delete("omniauth.params")
+          end
+          if env.dig("omniauth.params", "social_connect_return").present?
+            fail!(:social_connect_unavailable)
+          else
+            redirect(flag_off_redirect)
+          end
+        end
+
         def tiktok_connect_enabled?
           Feature.active?(:tiktok_connect, tiktok_connect_actor)
         end
@@ -69,7 +80,7 @@ module OmniAuth
         end
 
         def flag_off_redirect
-          tiktok_connect_actor.present? ? "/profile" : "/login"
+          tiktok_connect_actor.present? ? "/settings/social_connections" : "/login"
         end
     end
   end

--- a/lib/omni_auth/strategies/tiktok.rb
+++ b/lib/omni_auth/strategies/tiktok.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "omniauth-oauth2"
+
+module OmniAuth
+  module Strategies
+    class Tiktok < OAuth2
+      option :name, "tiktok"
+      option :scope, "user.info.basic,user.info.profile,user.info.stats"
+      option :client_options,
+             site: "https://open.tiktokapis.com",
+             authorize_url: "https://www.tiktok.com/v2/auth/authorize/",
+             token_url: "https://open.tiktokapis.com/v2/oauth/token/",
+             auth_scheme: :request_body
+
+      uid { access_token.params["open_id"] || access_token.params[:open_id] }
+      info { {} }
+      extra { { "raw_info" => access_token.params } }
+
+      def callback_url
+        full_host + callback_path
+      end
+
+      def authorize_params
+        super.tap do |params|
+          params[:client_key] = options.client_id
+          params.delete(:client_id)
+        end
+      end
+
+      def token_params
+        super.tap do |params|
+          params[:client_key] = options.client_id
+          params[:client_secret] = options.client_secret
+        end
+      end
+
+      def request_phase
+        return redirect(flag_off_redirect) unless tiktok_connect_enabled?
+
+        params = authorize_params.merge(redirect_uri: callback_url)
+        params[:client_key] = client.id
+        params.delete(:client_id)
+        params.delete("client_id")
+        authorize_url = options.client_options[:authorize_url]
+        redirect "#{authorize_url}#{authorize_url.include?("?") ? "&" : "?"}#{Rack::Utils.build_query(params)}"
+      end
+
+      def callback_phase
+        return redirect(flag_off_redirect) unless tiktok_connect_enabled?
+
+        super
+      end
+
+      private
+        def tiktok_connect_enabled?
+          Feature.active?(:tiktok_connect, tiktok_connect_actor)
+        end
+
+        def tiktok_connect_actor
+          user = env["warden"]&.user
+          return user unless user&.is_team_member?
+
+          impersonated_user_id = $redis.get(RedisKey.impersonated_user(user.id))
+          return user if impersonated_user_id.blank?
+
+          User.alive.find_by(id: impersonated_user_id) || user
+        end
+
+        def flag_off_redirect
+          tiktok_connect_actor.present? ? "/profile" : "/login"
+        end
+    end
+  end
+end

--- a/lib/omni_auth/strategies/tiktok.rb
+++ b/lib/omni_auth/strategies/tiktok.rb
@@ -24,6 +24,7 @@ module OmniAuth
       def authorize_params
         super.tap do |params|
           params[:client_key] = options.client_id
+          params[:response_type] = "code"
           params.delete(:client_id)
         end
       end

--- a/lib/omni_auth/strategies/tiktok.rb
+++ b/lib/omni_auth/strategies/tiktok.rb
@@ -66,7 +66,7 @@ module OmniAuth
         end
 
         def tiktok_connect_enabled?
-          Feature.active?(:tiktok_connect, tiktok_connect_actor)
+          TIKTOK_CLIENT_KEY.present? && Feature.active?(:tiktok_connect, tiktok_connect_actor)
         end
 
         def tiktok_connect_actor

--- a/spec/controllers/api/internal/admin/users_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/users_controller_spec.rb
@@ -2222,6 +2222,22 @@ describe Api::Internal::Admin::UsersController do
       expect(response.parsed_body["social_connections"].sole).to include("uid" => "17841400000000000", "currently_linked" => false)
     end
 
+    it "reports currently_linked from the user's live TikTok identity" do
+      user = create(:user, email: "seller@example.com")
+      create(:user_tiktok_identity, user:, tiktok_open_id: "open-123")
+      create(:social_connect_verification, user:, platform: "tiktok", uid: "open-123", handle: "gumroad")
+
+      get :social_connections, params: { email: user.email }
+
+      expect(response.parsed_body["social_connections"].sole).to include("uid" => "open-123", "currently_linked" => true)
+
+      user.tiktok_identity.destroy!
+
+      get :social_connections, params: { email: user.email }
+
+      expect(response.parsed_body["social_connections"].sole).to include("uid" => "open-123", "currently_linked" => false)
+    end
+
     it "returns only the latest dated shadow evidence without evaluating or changing the seller" do
       user = create(:user, email: "seller@example.com")
       verification = create(:social_connect_verification, user:)

--- a/spec/controllers/connections_controller_spec.rb
+++ b/spec/controllers/connections_controller_spec.rb
@@ -102,4 +102,17 @@ describe ConnectionsController do
       expect(SocialConnectVerification.exists?(id: verification.id)).to be(true)
     end
   end
+
+  describe "POST unlink_tiktok" do
+    it "clears the live TikTok identity and keeps the verification row" do
+      create(:user_tiktok_identity, user: seller, tiktok_open_id: "open-123", handle: "gumroad")
+      verification = create(:social_connect_verification, user: seller, platform: "tiktok", uid: "open-123", handle: "gumroad")
+
+      post :unlink_tiktok
+
+      expect(response.body).to eq({ success: true }.to_json)
+      expect(seller.reload.tiktok_identity).to be_nil
+      expect(SocialConnectVerification.exists?(id: verification.id)).to be(true)
+    end
+  end
 end

--- a/spec/controllers/tiktok_callbacks_controller_spec.rb
+++ b/spec/controllers/tiktok_callbacks_controller_spec.rb
@@ -43,7 +43,6 @@ describe TiktokCallbacksController do
       expect(UserTiktokIdentity.exists?(identity.id)).to be(true)
     end
 
-
     it "returns 400 when a signed payload has string content and no user_openid" do
       secret = "tiktok-client-secret"
       stub_const("TIKTOK_CLIENT_SECRET", secret)
@@ -55,9 +54,9 @@ describe TiktokCallbacksController do
       digest = OpenSSL::HMAC.hexdigest("SHA256", secret, "#{timestamp}.#{body}")
       request.headers["TikTok-Signature"] = "t=#{timestamp},s=#{digest}"
 
-      expect {
+      expect do
         post :deauthorize, body:, as: :json
-      }.not_to raise_error
+      end.not_to raise_error
       expect(response).to have_http_status(:bad_request)
     end
 

--- a/spec/controllers/tiktok_callbacks_controller_spec.rb
+++ b/spec/controllers/tiktok_callbacks_controller_spec.rb
@@ -12,7 +12,10 @@ describe TiktokCallbacksController do
       other = create(:social_connect_verification, platform: "tiktok")
       first_identity = create(:user_tiktok_identity, user: first.user, tiktok_open_id: open_id)
       other_identity = create(:user_tiktok_identity, user: other.user, tiktok_open_id: other.uid)
-      allow_any_instance_of(TiktokWebhook).to receive(:parse).and_return("user_openid" => open_id)
+      allow_any_instance_of(TiktokWebhook).to receive(:parse).and_return(
+        "event" => "authorization.removed",
+        "user_openid" => open_id,
+      )
 
       post :deauthorize
 
@@ -23,6 +26,39 @@ describe TiktokCallbacksController do
       expect(first.shared_identity_user_ids).to eq([second.user_id])
       expect(UserTiktokIdentity.exists?(first_identity.id)).to be(false)
       expect(UserTiktokIdentity.exists?(other_identity.id)).to be(true)
+    end
+
+    it "returns 200 without unlinking for a signed non-deauthorize event" do
+      verification = create(:social_connect_verification, platform: "tiktok", uid: open_id)
+      identity = create(:user_tiktok_identity, user: verification.user, tiktok_open_id: open_id)
+      allow_any_instance_of(TiktokWebhook).to receive(:parse).and_return(
+        "event" => "video.publish.completed",
+        "user_openid" => open_id,
+      )
+
+      post :deauthorize
+
+      expect(response).to have_http_status(:ok)
+      expect(verification.reload.superseded_at).to be_nil
+      expect(UserTiktokIdentity.exists?(identity.id)).to be(true)
+    end
+
+
+    it "returns 400 when a signed payload has string content and no user_openid" do
+      secret = "tiktok-client-secret"
+      stub_const("TIKTOK_CLIENT_SECRET", secret)
+      body = {
+        "event" => "authorization.removed",
+        "content" => { "open_id" => open_id }.to_json,
+      }.to_json
+      timestamp = Time.current.to_i.to_s
+      digest = OpenSSL::HMAC.hexdigest("SHA256", secret, "#{timestamp}.#{body}")
+      request.headers["TikTok-Signature"] = "t=#{timestamp},s=#{digest}"
+
+      expect {
+        post :deauthorize, body:, as: :json
+      }.not_to raise_error
+      expect(response).to have_http_status(:bad_request)
     end
 
     it "rejects an invalid signature" do

--- a/spec/controllers/tiktok_callbacks_controller_spec.rb
+++ b/spec/controllers/tiktok_callbacks_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TiktokCallbacksController do
+  let(:open_id) { "open-123" }
+
+  describe "POST deauthorize" do
+    it "unlinks the live identity but keeps the verification as superseded evidence for every matching Gumroad account" do
+      first = create(:social_connect_verification, platform: "tiktok", uid: open_id)
+      second = create(:social_connect_verification, platform: "tiktok", uid: open_id)
+      other = create(:social_connect_verification, platform: "tiktok")
+      first_identity = create(:user_tiktok_identity, user: first.user, tiktok_open_id: open_id)
+      other_identity = create(:user_tiktok_identity, user: other.user, tiktok_open_id: other.uid)
+      allow_any_instance_of(TiktokWebhook).to receive(:parse).and_return("user_openid" => open_id)
+
+      post :deauthorize
+
+      expect(response).to have_http_status(:ok)
+      expect(first.reload).to have_attributes(uid: open_id, superseded_at: be_present, currently_linked?: false)
+      expect(second.reload.superseded_at).to be_present
+      expect(other.reload.superseded_at).to be_nil
+      expect(first.shared_identity_user_ids).to eq([second.user_id])
+      expect(UserTiktokIdentity.exists?(first_identity.id)).to be(false)
+      expect(UserTiktokIdentity.exists?(other_identity.id)).to be(true)
+    end
+
+    it "rejects an invalid signature" do
+      allow_any_instance_of(TiktokWebhook).to receive(:parse).and_return(nil)
+
+      post :deauthorize
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end

--- a/spec/controllers/user/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/user/omniauth_callbacks_controller_spec.rb
@@ -724,6 +724,66 @@ describe User::OmniauthCallbacksController do
     end
   end
 
+  describe "#tiktok" do
+    let(:user) { create(:user) }
+    let(:profile) do
+      {
+        "open_id" => "open-123",
+        "username" => "gumroad",
+        "follower_count" => 250_000,
+        "video_count" => 1_200,
+      }
+    end
+
+    before do
+      OmniAuth.config.mock_auth[:tiktok] = OmniAuth::AuthHash.new(
+        provider: "tiktok",
+        uid: profile["open_id"],
+        credentials: { token: "tiktok-token" },
+      )
+      request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:tiktok]
+    end
+
+    it "records the TikTok account on a signed-in user" do
+      Feature.activate_user(:tiktok_connect, user)
+      allow(controller).to receive(:logged_in_user).and_return(user)
+      allow(TiktokProfileFetcher).to receive(:new).and_return(instance_double(TiktokProfileFetcher, fetch: profile))
+
+      post :tiktok
+
+      expect(response).to redirect_to profile_path
+      identity = user.reload.tiktok_identity
+      expect(identity.tiktok_open_id).to eq("open-123")
+      expect(identity.handle).to eq("gumroad")
+      expect(user.social_connect_verifications.find_by!(platform: "tiktok")).to have_attributes(
+        uid: "open-123",
+        handle: "gumroad",
+        account_created_at: nil,
+        last_posted_at: nil,
+      )
+    end
+
+    it "redirects to login when no user is signed in" do
+      allow(controller).to receive(:logged_in_user).and_return(nil)
+
+      post :tiktok
+
+      expect(response).to redirect_to login_path
+      expect(flash[:alert]).to eq "You need to be logged in to link your TikTok account."
+    end
+
+    it "does not connect when the tiktok_connect flag is off" do
+      allow(controller).to receive(:logged_in_user).and_return(user)
+
+      post :tiktok
+
+      expect(user.social_connect_verifications.find_by(platform: "tiktok")).to be_nil
+      expect(user.reload.tiktok_identity).to be_nil
+      expect(flash[:alert]).to eq "TikTok connect is not available."
+      expect(response).to redirect_to profile_path
+    end
+  end
+
   describe "#failure" do
     it "redirects YouTube OAuth failures to profile instead of payments settings" do
       user = create(:user)
@@ -745,6 +805,17 @@ describe User::OmniauthCallbacksController do
 
       expect(response).to redirect_to profile_path
       expect(flash[:alert]).to eq "Couldn't connect Instagram. Please try again."
+    end
+
+    it "redirects TikTok OAuth failures to profile" do
+      user = create(:user)
+      allow(controller).to receive(:logged_in_user).and_return(user)
+      request.env["omniauth.error.strategy"] = instance_double(OmniAuth::Strategies::Tiktok, name: "tiktok")
+
+      get :failure, params: { error: "access_denied" }
+
+      expect(response).to redirect_to profile_path
+      expect(flash[:alert]).to eq "Couldn't connect TikTok. Please try again."
     end
   end
 end

--- a/spec/controllers/user/social_connect_return_spec.rb
+++ b/spec/controllers/user/social_connect_return_spec.rb
@@ -13,7 +13,7 @@ describe User::OmniauthCallbacksController do
     request.env["omniauth.params"] = { "social_connect_return" => token, "state" => "link_twitter_account" }
   end
 
-  %w[youtube instagram twitter].each do |provider|
+  %w[youtube instagram twitter tiktok].each do |provider|
     it "returns #{provider} cancellation to onboarding and consumes intent" do
       request.env["omniauth.error.strategy"] = double(name: provider)
       get :failure
@@ -48,6 +48,16 @@ describe User::OmniauthCallbacksController do
     post :instagram
     expect(response).to redirect_to dashboard_path
     expect(seller.reload.instagram_identity.instagram_user_id).to eq("example-id")
+  end
+
+  it "returns a successful TikTok connection to onboarding" do
+    Feature.activate_user(:tiktok_connect, seller)
+    request.env["omniauth.auth"] = OmniAuth::AuthHash.new(uid: "open-123", credentials: { token: "tiktok-token" })
+    profile = { "open_id" => "open-123", "username" => "gumroad" }
+    allow(TiktokProfileFetcher).to receive(:new).and_return(instance_double(TiktokProfileFetcher, fetch: profile))
+    post :tiktok
+    expect(response).to redirect_to dashboard_path
+    expect(seller.reload.tiktok_identity.tiktok_open_id).to eq("open-123")
   end
 
   it "preserves the Social connections default without a session intent" do

--- a/spec/factories/user_tiktok_identities.rb
+++ b/spec/factories/user_tiktok_identities.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user_tiktok_identity do
+    user
+    sequence(:tiktok_open_id) { "tiktok-open-id-#{_1}" }
+    handle { "gumroad" }
+  end
+end

--- a/spec/lib/omni_auth/strategies/social_connect_return_spec.rb
+++ b/spec/lib/omni_auth/strategies/social_connect_return_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-[OmniAuth::Strategies::Youtube, OmniAuth::Strategies::Instagram].each do |strategy_class|
+[OmniAuth::Strategies::Youtube, OmniAuth::Strategies::Instagram, OmniAuth::Strategies::Tiktok].each do |strategy_class|
   describe strategy_class do
     let(:strategy) { described_class.new(->(_env) { [200, {}, ["ok"]] }) }
     let(:user) { create(:user) }

--- a/spec/lib/omni_auth/strategies/tiktok_spec.rb
+++ b/spec/lib/omni_auth/strategies/tiktok_spec.rb
@@ -12,8 +12,21 @@ describe OmniAuth::Strategies::Tiktok do
   end
 
   describe "#tiktok_connect_enabled?" do
+    before do
+      stub_const("TIKTOK_CLIENT_KEY", "client-key")
+    end
+
     it "is false when the flag is off" do
       assign_env(create(:user))
+
+      expect(strategy.send(:tiktok_connect_enabled?)).to eq(false)
+    end
+
+    it "is false when the client key is blank even if the flag is on" do
+      stub_const("TIKTOK_CLIENT_KEY", "")
+      user = create(:user)
+      Feature.activate_user(:tiktok_connect, user)
+      assign_env(user)
 
       expect(strategy.send(:tiktok_connect_enabled?)).to eq(false)
     end

--- a/spec/lib/omni_auth/strategies/tiktok_spec.rb
+++ b/spec/lib/omni_auth/strategies/tiktok_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe OmniAuth::Strategies::Tiktok do
+  let(:app) { ->(_env) { [200, {}, ["ok"]] } }
+  let(:strategy) { described_class.new(app, "client-key", "client-secret") }
+
+  def assign_env(user)
+    warden = instance_double(Warden::Proxy, user:)
+    strategy.instance_variable_set(:@env, { "warden" => warden })
+  end
+
+  describe "#tiktok_connect_enabled?" do
+    it "is false when the flag is off" do
+      assign_env(create(:user))
+
+      expect(strategy.send(:tiktok_connect_enabled?)).to eq(false)
+    end
+
+    it "is true when the signed-in user has the flag" do
+      user = create(:user)
+      Feature.activate_user(:tiktok_connect, user)
+      assign_env(user)
+
+      expect(strategy.send(:tiktok_connect_enabled?)).to eq(true)
+    end
+
+    it "uses the impersonated seller as the flag actor" do
+      admin = create(:admin_user)
+      seller = create(:user)
+      Feature.activate_user(:tiktok_connect, seller)
+      allow($redis).to receive(:get).with(RedisKey.impersonated_user(admin.id)).and_return(seller.id.to_s)
+      assign_env(admin)
+
+      expect(strategy.send(:tiktok_connect_enabled?)).to eq(true)
+    end
+  end
+
+  describe "#request_phase" do
+    it "redirects to profile when the flag is off for a signed-in user" do
+      assign_env(create(:user))
+
+      status, headers, = strategy.request_phase
+
+      expect(status).to eq(302)
+      expect(headers["Location"]).to eq("/profile")
+    end
+
+    it "redirects to login when the flag is off and no user is signed in" do
+      assign_env(nil)
+
+      status, headers, = strategy.request_phase
+
+      expect(status).to eq(302)
+      expect(headers["Location"]).to eq("/login")
+    end
+  end
+
+  describe "#callback_phase" do
+    let(:session) { {} }
+    let(:callback_strategy) { described_class.new(app, "client-key", "client-secret") }
+    let(:redirect_uri) { "https://example.com/users/auth/tiktok/callback" }
+    let(:token_request) do
+      stub_request(:post, "https://open.tiktokapis.com/v2/oauth/token/")
+        .to_return(
+          headers: { "Content-Type" => "application/json" },
+          body: { access_token: "tiktok-token", open_id: "open-123", token_type: "Bearer" }.to_json,
+        )
+    end
+
+    before do
+      [strategy, callback_strategy].each do |instance|
+        allow(instance).to receive(:full_host).and_return("https://example.com")
+        allow(instance).to receive(:tiktok_connect_enabled?).and_return(true)
+        instance.options.callback_path = "/users/auth/tiktok/callback"
+      end
+      strategy.instance_variable_set(:@env, Rack::MockRequest.env_for("https://example.com/users/auth/tiktok").merge("rack.session" => session))
+      token_request
+    end
+
+    it "validates state and uses the authorization redirect URI without callback query parameters" do
+      _, headers, = strategy.request_phase
+      authorize_params = Rack::Utils.parse_query(URI(headers["Location"]).query)
+      expect(authorize_params.fetch("client_key")).to eq("client-key")
+      expect(authorize_params).not_to have_key("client_id")
+      expect(authorize_params.fetch("scope")).to eq("user.info.basic,user.info.profile,user.info.stats")
+      expect(authorize_params.fetch("redirect_uri")).to eq(redirect_uri)
+      state = authorize_params.fetch("state")
+      expect(state).to be_present
+      expect(session["omniauth.state"]).to eq(state)
+
+      callback_env = Rack::MockRequest.env_for("#{redirect_uri}?#{Rack::Utils.build_query(code: "authorization-code", state:)}").merge("rack.session" => session)
+      callback_strategy.instance_variable_set(:@env, callback_env)
+
+      expect(callback_strategy.callback_phase.first).to eq(200)
+      expect(callback_env["omniauth.auth"].uid).to eq("open-123")
+      expect(session).not_to have_key("omniauth.state")
+      expect(token_request.with do |req|
+        body = Rack::Utils.parse_query(req.body)
+        body["code"] == "authorization-code" &&
+          body["redirect_uri"] == redirect_uri &&
+          body["client_key"] == "client-key"
+      end).to have_been_requested.once
+    end
+
+    [nil, "mismatched-state"].each do |state|
+      it "rejects #{state.nil? ? "missing" : "mismatched"} state before token exchange" do
+        strategy.request_phase
+        callback_env = Rack::MockRequest.env_for("#{redirect_uri}?#{Rack::Utils.build_query(code: "authorization-code", state:)}").merge("rack.session" => session)
+        callback_strategy.instance_variable_set(:@env, callback_env)
+        allow(OmniAuth.config).to receive(:on_failure).and_return(->(_env) { [401, {}, []] })
+
+        expect(callback_strategy.callback_phase.first).to eq(401)
+        expect(callback_env["omniauth.error.type"]).to eq(:csrf_detected)
+        expect(callback_env).not_to have_key("omniauth.auth")
+        expect(token_request).not_to have_been_requested
+      end
+    end
+  end
+
+  it "requests read-only Login Kit scopes" do
+    expect(strategy.options.scope).to eq("user.info.basic,user.info.profile,user.info.stats")
+    expect(strategy.options.scope).not_to include("video.list")
+  end
+end

--- a/spec/lib/omni_auth/strategies/tiktok_spec.rb
+++ b/spec/lib/omni_auth/strategies/tiktok_spec.rb
@@ -84,6 +84,7 @@ describe OmniAuth::Strategies::Tiktok do
       authorize_params = Rack::Utils.parse_query(URI(headers["Location"]).query)
       expect(authorize_params.fetch("client_key")).to eq("client-key")
       expect(authorize_params).not_to have_key("client_id")
+      expect(authorize_params.fetch("response_type")).to eq("code")
       expect(authorize_params.fetch("scope")).to eq("user.info.basic,user.info.profile,user.info.stats")
       expect(authorize_params.fetch("redirect_uri")).to eq(redirect_uri)
       state = authorize_params.fetch("state")

--- a/spec/lib/omni_auth/strategies/tiktok_spec.rb
+++ b/spec/lib/omni_auth/strategies/tiktok_spec.rb
@@ -38,13 +38,13 @@ describe OmniAuth::Strategies::Tiktok do
   end
 
   describe "#request_phase" do
-    it "redirects to profile when the flag is off for a signed-in user" do
+    it "redirects to Social connections when the flag is off for a signed-in user" do
       assign_env(create(:user))
 
       status, headers, = strategy.request_phase
 
       expect(status).to eq(302)
-      expect(headers["Location"]).to eq("/profile")
+      expect(headers["Location"]).to eq("/settings/social_connections")
     end
 
     it "redirects to login when the flag is off and no user is signed in" do

--- a/spec/models/social_connect_verification_spec.rb
+++ b/spec/models/social_connect_verification_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe SocialConnectVerification do
   describe "#currently_linked?" do
-    %w[twitter youtube instagram].each do |platform|
+    %w[twitter youtube instagram tiktok].each do |platform|
       it "requires the matching current #{platform} UID" do
         user = create(:user)
         verification = create(:social_connect_verification, user:, platform:, uid: "123")
@@ -17,6 +17,8 @@ describe SocialConnectVerification do
           create(:user_youtube_identity, user:, channel_id: "123")
         when "instagram"
           create(:user_instagram_identity, user:, instagram_user_id: "123")
+        when "tiktok"
+          create(:user_tiktok_identity, user:, tiktok_open_id: "123")
         end
         verification.reload
         expect(verification.currently_linked?).to be(true)
@@ -34,6 +36,8 @@ describe SocialConnectVerification do
           verification.user.youtube_identity.update_columns(channel_id: "")
         when "instagram"
           verification.user.instagram_identity.update_columns(instagram_user_id: "")
+        when "tiktok"
+          verification.user.tiktok_identity.update_columns(tiktok_open_id: "")
         end
         expect(verification.currently_linked?).to be(false)
         verification.uid = ""
@@ -48,9 +52,9 @@ describe SocialConnectVerification do
       expect(verification.currently_linked?).to be(false)
     end
 
-    it "does not consider an unsupported platform linked" do
-      verification = create(:social_connect_verification, platform: "tiktok")
-      verification.user.update!(twitter_user_id: verification.uid)
+    it "does not consider an unknown platform linked" do
+      verification = build(:social_connect_verification, platform: "myspace")
+      allow(verification).to receive(:platform).and_return("myspace")
 
       expect(verification.currently_linked?).to be(false)
     end
@@ -291,6 +295,61 @@ describe SocialConnectVerification do
     it "records nothing when the user id is missing" do
       expect do
         described_class.record_from_instagram!(user, profile.except("user_id"))
+      end.not_to change { described_class.count }
+    end
+  end
+
+  describe ".record_from_tiktok!" do
+    let(:user) { create(:user) }
+    let(:profile) do
+      {
+        "open_id" => "open-123",
+        "username" => "gumroad",
+        "display_name" => "Gumroad",
+        "profile_web_link" => "https://www.tiktok.com/@gumroad",
+        "follower_count" => 250_000,
+        "video_count" => 1_200,
+      }
+    end
+
+    it "stores verified metadata and leaves TikTok-unsupported dates unknown" do
+      verification = described_class.record_from_tiktok!(user, profile)
+
+      expect(verification.reload).to have_attributes(
+        platform: "tiktok",
+        uid: "open-123",
+        handle: "gumroad",
+        account_created_at: nil,
+        follower_count: 250_000,
+        post_count: 1_200,
+        last_posted_at: nil,
+      )
+    end
+
+    it "stores missing counts as unknown rather than zero" do
+      verification = described_class.record_from_tiktok!(user, profile.merge("follower_count" => nil, "video_count" => ""))
+
+      expect(verification.reload).to have_attributes(follower_count: nil, post_count: nil)
+    end
+
+    it "keeps a real zero count" do
+      verification = described_class.record_from_tiktok!(user, profile.merge("follower_count" => 0, "video_count" => 0))
+
+      expect(verification.reload).to have_attributes(follower_count: 0, post_count: 0)
+    end
+
+    it "falls back to the profile link handle then display name" do
+      without_username = described_class.record_from_tiktok!(user, profile.except("username"))
+      expect(without_username.handle).to eq("gumroad")
+
+      without_username.supersede!
+      display_only = described_class.record_from_tiktok!(user, profile.except("username", "profile_web_link"))
+      expect(display_only.handle).to eq("Gumroad")
+    end
+
+    it "records nothing when open_id is missing" do
+      expect do
+        described_class.record_from_tiktok!(user, profile.except("open_id"))
       end.not_to change { described_class.count }
     end
   end

--- a/spec/presenters/creator_home_presenter_spec.rb
+++ b/spec/presenters/creator_home_presenter_spec.rb
@@ -27,6 +27,7 @@ describe CreatorHomePresenter do
       before do
         Feature.deactivate(:youtube_connect)
         Feature.deactivate(:instagram_connect)
+        Feature.deactivate(:tiktok_connect)
       end
 
       it "offers X without offering gated providers" do
@@ -51,20 +52,23 @@ describe CreatorHomePresenter do
 
         Feature.activate_user(:youtube_connect, seller)
         Feature.activate_user(:instagram_connect, seller)
+        Feature.activate_user(:tiktok_connect, seller)
         expect(presenter.creator_home_props[:social_connections]).to eq([
-                                                                          { name: "X", connected: false }, { name: "YouTube", connected: false }, { name: "Instagram", connected: false }
+                                                                          { name: "X", connected: false }, { name: "YouTube", connected: false }, { name: "Instagram", connected: false }, { name: "TikTok", connected: false }
                                                                         ])
       end
 
       it "shows current identities even when new connections are gated and removes disconnected ones" do
         seller.create_youtube_identity!(channel_id: "example-channel")
         seller.create_instagram_identity!(instagram_user_id: "example-instagram")
+        seller.create_tiktok_identity!(tiktok_open_id: "example-tiktok")
         expect(presenter.creator_home_props[:social_connections]).to eq([
-                                                                          { name: "X", connected: false }, { name: "YouTube", connected: true }, { name: "Instagram", connected: true }
+                                                                          { name: "X", connected: false }, { name: "YouTube", connected: true }, { name: "Instagram", connected: true }, { name: "TikTok", connected: true }
                                                                         ])
 
         seller.youtube_identity.destroy!
         seller.instagram_identity.destroy!
+        seller.tiktok_identity.destroy!
         seller.reload
         expect(presenter.creator_home_props[:social_connections]).to eq([{ name: "X", connected: false }])
       end

--- a/spec/presenters/profile_presenter_spec.rb
+++ b/spec/presenters/profile_presenter_spec.rb
@@ -86,6 +86,22 @@ describe ProfilePresenter do
       expect(props[:instagram_handle]).to eq("gumroad")
     end
 
+    it "reports TikTok connected from the live identity, not a dormant verification row" do
+      create(:social_connect_verification, user: seller, platform: "tiktok", uid: "open-123", handle: "oldhandle")
+      seller.reload
+
+      props = described_class.new(pundit_user:, seller:).profile_settings_props(request:)
+      expect(props[:tiktok_connected]).to eq(false)
+      expect(props[:tiktok_handle]).to be_nil
+
+      create(:user_tiktok_identity, user: seller, tiktok_open_id: "open-123", handle: "gumroad")
+      seller.reload
+
+      props = described_class.new(pundit_user:, seller:).profile_settings_props(request:)
+      expect(props[:tiktok_connected]).to eq(true)
+      expect(props[:tiktok_handle]).to eq("gumroad")
+    end
+
     it "includes hide_follow_form when the seller has turned it on" do
       seller.update!(hide_follow_form: true)
 
@@ -337,6 +353,9 @@ describe ProfilePresenter do
           instagram_connect_enabled: false,
           instagram_connected: false,
           instagram_handle: nil,
+          tiktok_connect_enabled: false,
+          tiktok_connected: false,
+          tiktok_handle: nil,
           has_custom_landing_page: false,
           username: seller.username,
           # seller_analytics is only added to the public profile_props — the settings

--- a/spec/presenters/settings_social_review_spec.rb
+++ b/spec/presenters/settings_social_review_spec.rb
@@ -15,6 +15,7 @@ describe SettingsPresenter, "optional social connections for account review" do
     create(:user_compliance_info, user: seller, country: "United States")
     Feature.deactivate(:youtube_connect)
     Feature.deactivate(:instagram_connect)
+    Feature.deactivate(:tiktok_connect)
   end
 
   %w[on_probation flagged_for_fraud flagged_for_tos_violation].each do |state|
@@ -64,21 +65,26 @@ describe SettingsPresenter, "optional social connections for account review" do
     seller.update!(user_risk_state: "on_probation")
     Feature.activate_user(:youtube_connect, seller)
     Feature.activate_user(:instagram_connect, seller)
+    Feature.activate_user(:tiktok_connect, seller)
     expect(connections).to eq([
                                 { provider: "twitter", connected: false },
                                 { provider: "youtube", connected: false },
                                 { provider: "instagram", connected: false },
+                                { provider: "tiktok", connected: false },
                               ])
     seller.create_youtube_identity!(channel_id: "example_channel", handle: "example_creator")
     seller.create_instagram_identity!(instagram_user_id: "123", handle: "example_creator")
-    expect(connections.last(2)).to eq([
+    seller.create_tiktok_identity!(tiktok_open_id: "open-123", handle: "example_creator")
+    expect(connections.last(3)).to eq([
                                         { provider: "youtube", connected: true },
                                         { provider: "instagram", connected: true },
+                                        { provider: "tiktok", connected: true },
                                       ])
     seller.youtube_identity.destroy!
     seller.instagram_identity.destroy!
+    seller.tiktok_identity.destroy!
     seller.reload
-    expect(connections.last(2).map { _1[:connected] }).to eq([false, false])
+    expect(connections.last(3).map { _1[:connected] }).to eq([false, false, false])
   end
 
   it "does not borrow provider availability from another seller" do

--- a/spec/requests/social_connect_return_spec.rb
+++ b/spec/requests/social_connect_return_spec.rb
@@ -17,6 +17,7 @@ describe "Onboarding social connection return", js: true, type: :system do
     OmniAuth.config.mock_auth.delete(:twitter)
     OmniAuth.config.mock_auth.delete(:youtube)
     OmniAuth.config.mock_auth.delete(:instagram)
+    OmniAuth.config.mock_auth.delete(:tiktok)
   end
 
   it "clears the continuation when the seller leaves without connecting" do
@@ -31,34 +32,36 @@ describe "Onboarding social connection return", js: true, type: :system do
     expect(page).not_to have_css("form[action*='social_connect_return=']", visible: :all)
   end
 
-  %w[twitter youtube instagram].each do |provider|
+  %w[twitter youtube instagram tiktok].each do |provider|
     it "returns from #{provider} cancellation to Getting started" do
       Feature.activate_user(:"#{provider}_connect", seller) unless provider == "twitter"
       OmniAuth.config.mock_auth[provider.to_sym] = :access_denied
       visit dashboard_path
       click_on "Connect an account"
-      click_on "Connect to #{ { 'twitter' => 'X', 'youtube' => 'YouTube', 'instagram' => 'Instagram' }.fetch(provider)}"
+      click_on "Connect to #{ { 'twitter' => 'X', 'youtube' => 'YouTube', 'instagram' => 'Instagram', 'tiktok' => 'TikTok' }.fetch(provider)}"
       expect(page).to have_current_path(dashboard_path)
       expect(page).to have_text("Couldn't connect")
       expect(page).to have_link("Connect an account")
       expect(seller.reload.twitter_user_id).to be_nil
       expect(seller.youtube_identity).to be_nil
       expect(seller.instagram_identity).to be_nil
+      expect(seller.tiktok_identity).to be_nil
     end
   end
 
-  %w[youtube instagram].each do |provider|
+  %w[youtube instagram tiktok].each do |provider|
     it "returns to onboarding when #{provider} becomes unavailable before authorization" do
       OmniAuth.config.test_mode = false
       Feature.activate_user(:"#{provider}_connect", seller)
       visit dashboard_path
       click_on "Connect an account"
       Feature.deactivate_user(:"#{provider}_connect", seller)
-      click_on "Connect to #{provider == 'youtube' ? 'YouTube' : 'Instagram'}"
+      click_on "Connect to #{ { 'youtube' => 'YouTube', 'instagram' => 'Instagram', 'tiktok' => 'TikTok' }.fetch(provider)}"
       expect(page).to have_current_path(dashboard_path)
       expect(page).to have_text("Couldn't connect")
       expect(seller.reload.youtube_identity).to be_nil
       expect(seller.instagram_identity).to be_nil
+      expect(seller.tiktok_identity).to be_nil
       visit settings_social_connections_path
       expect(page).not_to have_css("form[action*='social_connect_return=']", visible: :all)
     end

--- a/spec/requests/tiktok_omniauth_flag_off_spec.rb
+++ b/spec/requests/tiktok_omniauth_flag_off_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Real OmniAuth path (test_mode false). Does not prove vendor consent.
+describe "TikTok OmniAuth flag-off", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:seller) { create(:user) }
+
+  around do |example|
+    previous = OmniAuth.config.test_mode
+    previous_forgery = ActionController::Base.allow_forgery_protection
+    OmniAuth.config.test_mode = false
+    ActionController::Base.allow_forgery_protection = false
+    example.run
+  ensure
+    OmniAuth.config.test_mode = previous
+    ActionController::Base.allow_forgery_protection = previous_forgery
+  end
+
+  it "sends a signed-in seller to Social connections without creating an identity" do
+    sign_in seller
+
+    post "/users/auth/tiktok"
+
+    expect(response).to redirect_to("/settings/social_connections")
+    expect(seller.reload.tiktok_identity).to be_nil
+    expect(seller.social_connect_verifications.find_by(platform: "tiktok")).to be_nil
+  end
+
+  it "uses the existing failure endpoint when onboarding return is present" do
+    sign_in seller
+
+    post "/users/auth/tiktok?social_connect_return=test-navigation-token"
+
+    expect(response).to redirect_to("/settings/social_connections")
+    expect(flash[:alert]).to eq("Couldn't connect TikTok. Please try again.")
+    expect(seller.reload.tiktok_identity).to be_nil
+    expect(seller.social_connect_verifications.find_by(platform: "tiktok")).to be_nil
+  end
+
+  it "does not create an identity on a flag-off callback" do
+    sign_in seller
+
+    get "/users/auth/tiktok/callback", params: { code: "authorization-code", state: "forged" }
+
+    expect(response).to redirect_to("/settings/social_connections")
+    expect(seller.reload.tiktok_identity).to be_nil
+    expect(seller.social_connect_verifications.find_by(platform: "tiktok")).to be_nil
+  end
+end

--- a/spec/requests/user/settings_spec.rb
+++ b/spec/requests/user/settings_spec.rb
@@ -167,6 +167,13 @@ describe "User profile settings page", type: :system, js: true do
       expect(page).to have_button("Connect to Instagram")
     end
 
+    it "shows Connect to TikTok when the tiktok_connect flag is on" do
+      Feature.activate_user(:tiktok_connect, @user)
+      visit profile_path
+
+      expect(page).to have_button("Connect to TikTok")
+    end
+
     context "when logged user has role admin" do
       include_context "with switching account to user as admin for seller" do
         let(:seller) { @user }

--- a/spec/services/gdpr_data_erasure_service_spec.rb
+++ b/spec/services/gdpr_data_erasure_service_spec.rb
@@ -693,6 +693,7 @@ describe GdprDataErasureService do
       user.update!(twitter_user_id: "12345", twitter_handle: "johndoe")
       create(:user_youtube_identity, user:, channel_id: "UC123", handle: "johndoe")
       create(:user_instagram_identity, user:, instagram_user_id: "17841400000000000", handle: "johndoe")
+      create(:user_tiktok_identity, user:, tiktok_open_id: "open-123", handle: "johndoe")
       verification = create(:social_connect_verification, user:, platform: "twitter", uid: "12345", handle: "johndoe")
       other_verification = create(:social_connect_verification, platform: "twitter", uid: "12345", handle: "johndoe")
 
@@ -704,6 +705,7 @@ describe GdprDataErasureService do
       expect(user.reload.twitter_user_id).to be_nil
       expect(user.youtube_identity).to be_nil
       expect(user.instagram_identity).to be_nil
+      expect(user.tiktok_identity).to be_nil
     end
 
     it "anonymizes all of the user's carts and credit card records" do

--- a/spec/services/social_score_shadow_evaluation_service_spec.rb
+++ b/spec/services/social_score_shadow_evaluation_service_spec.rb
@@ -25,6 +25,8 @@ describe SocialScoreShadowEvaluationService do
       create(:user_youtube_identity, user: verification.user, channel_id: verification.uid)
     when "instagram"
       create(:user_instagram_identity, user: verification.user, instagram_user_id: verification.uid)
+    when "tiktok"
+      create(:user_tiktok_identity, user: verification.user, tiktok_open_id: verification.uid)
     end
     verification
   end
@@ -95,9 +97,19 @@ describe SocialScoreShadowEvaluationService do
       expect(described_class.new(user).evaluate).to include(score: 0, would_have_released: false, signals: nil)
     end
 
-    it "ignores unsupported platforms even with strong verified signals" do
-      create(:social_connect_verification, user:, platform: "tiktok")
+    it "does not score a currently linked TikTok identity" do
+      verification = create(
+        :social_connect_verification,
+        user:,
+        platform: "tiktok",
+        account_created_at: 5.years.ago,
+        follower_count: 5_000,
+        post_count: 1_000,
+        last_posted_at: 1.week.ago,
+      )
+      create(:user_tiktok_identity, user:, tiktok_open_id: verification.uid)
 
+      expect(verification.reload.currently_linked?).to be(true)
       expect(described_class.new(user).evaluate).to include(score: 0, would_have_released: false, signals: nil)
     end
 

--- a/spec/services/tiktok_profile_fetcher_spec.rb
+++ b/spec/services/tiktok_profile_fetcher_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TiktokProfileFetcher do
+  let(:token) { "tiktok-test-token" }
+
+  def stub_user_info(body:, status: 200)
+    WebMock.stub_request(:get, %r{open\.tiktokapis\.com/v2/user/info/})
+           .to_return(status:, body: body.to_json, headers: { "Content-Type" => "application/json" })
+  end
+
+  def user_body(**overrides)
+    {
+      "data" => {
+        "user" => {
+          "open_id" => "open-123",
+          "display_name" => "Gumroad",
+          "username" => "gumroad",
+          "profile_web_link" => "https://www.tiktok.com/@gumroad",
+          "follower_count" => 250_000,
+          "video_count" => 1_200,
+        }.merge(overrides),
+      },
+      "error" => { "code" => "ok", "message" => "" },
+    }
+  end
+
+  it "returns verified profile data without inventing missing dates" do
+    stub_user_info(body: user_body)
+
+    result = described_class.new(token).fetch
+
+    expect(result).to include(
+      "open_id" => "open-123",
+      "username" => "gumroad",
+      "follower_count" => 250_000,
+      "video_count" => 1_200,
+    )
+    expect(result).not_to have_key("account_created_at")
+    expect(result).not_to have_key("last_posted_at")
+  end
+
+  it "returns nil when the profile has no open_id" do
+    stub_user_info(body: user_body("open_id" => ""))
+
+    expect(described_class.new(token).fetch).to be_nil
+  end
+
+  it "returns nil when the token is blank" do
+    expect(described_class.new(nil).fetch).to be_nil
+  end
+
+  it "returns nil when TikTok reports an API error on HTTP 200" do
+    stub_user_info(body: { "data" => {}, "error" => { "code" => "access_token_invalid", "message" => "private failure" } })
+    logged = []
+    allow(Rails.logger).to receive(:error) { |message| logged << message.to_s }
+
+    expect(described_class.new(token).fetch).to be_nil
+    expect(logged.join).to include("API access_token_invalid")
+    expect(logged.join).not_to include("private failure")
+    expect(logged.join).not_to include(token)
+  end
+
+  it "does not log the response body or token on an HTTP error" do
+    stub_user_info(body: { "error" => { "message" => "private failure" } }, status: 403)
+    logged = []
+    allow(Rails.logger).to receive(:error) { |message| logged << message.to_s }
+
+    expect(described_class.new(token).fetch).to be_nil
+    expect(logged.join).to include("HTTP 403")
+    expect(logged.join).not_to include("private failure")
+    expect(logged.join).not_to include(token)
+  end
+end

--- a/spec/services/tiktok_webhook_spec.rb
+++ b/spec/services/tiktok_webhook_spec.rb
@@ -38,7 +38,14 @@ describe TiktokWebhook do
     expect(described_class.new("").parse(body, signature_for(body))).to be_nil
   end
 
-  it "reads open_id from the documented user_openid field" do
+
+  it "reads open_id only from user_openid" do
     expect(webhook.open_id("user_openid" => "open-123")).to eq("open-123")
+    expect(webhook.open_id("content" => {"open_id" => "open-123"})).to be_nil
+    expect(webhook.open_id("user" => {"open_id" => "open-123"})).to be_nil
+  end
+
+  it "returns nil for string content without TypeError when user_openid is missing" do
+    expect(webhook.open_id("event" => "authorization.removed", "content" => "{\"open_id\":\"open-123\"}")).to be_nil
   end
 end

--- a/spec/services/tiktok_webhook_spec.rb
+++ b/spec/services/tiktok_webhook_spec.rb
@@ -6,21 +6,32 @@ describe TiktokWebhook do
   let(:secret) { "tiktok-client-secret" }
   let(:webhook) { described_class.new(secret) }
   let(:body) { { "event" => "authorization.removed", "user_openid" => "open-123" }.to_json }
+  let(:timestamp) { Time.current.to_i.to_s }
 
-  def signature_for(payload)
-    OpenSSL::HMAC.hexdigest("SHA256", secret, payload)
+  def signature_for(payload, ts = timestamp)
+    digest = OpenSSL::HMAC.hexdigest("SHA256", secret, "#{ts}.#{payload}")
+    "t=#{ts},s=#{digest}"
   end
 
-  it "parses a body whose HMAC matches" do
+  it "parses a body whose timestamped HMAC matches" do
     expect(webhook.parse(body, signature_for(body))).to include("user_openid" => "open-123")
   end
 
-  it "accepts a sha256= prefix on the signature header" do
-    expect(webhook.parse(body, "sha256=#{signature_for(body)}")).to include("user_openid" => "open-123")
+  it "rejects a body-only HMAC, which is not TikTok's wire format" do
+    bare = OpenSSL::HMAC.hexdigest("SHA256", secret, body)
+
+    expect(webhook.parse(body, bare)).to be_nil
+    expect(webhook.parse(body, "sha256=#{bare}")).to be_nil
   end
 
   it "rejects a mismatched signature" do
-    expect(webhook.parse(body, "a" * 64)).to be_nil
+    expect(webhook.parse(body, "t=#{timestamp},s=#{'a' * 64}")).to be_nil
+  end
+
+  it "rejects a stale timestamp even when the HMAC matches" do
+    stale = (Time.current - 6.minutes).to_i.to_s
+
+    expect(webhook.parse(body, signature_for(body, stale))).to be_nil
   end
 
   it "rejects a blank secret" do

--- a/spec/services/tiktok_webhook_spec.rb
+++ b/spec/services/tiktok_webhook_spec.rb
@@ -38,11 +38,10 @@ describe TiktokWebhook do
     expect(described_class.new("").parse(body, signature_for(body))).to be_nil
   end
 
-
   it "reads open_id only from user_openid" do
     expect(webhook.open_id("user_openid" => "open-123")).to eq("open-123")
-    expect(webhook.open_id("content" => {"open_id" => "open-123"})).to be_nil
-    expect(webhook.open_id("user" => {"open_id" => "open-123"})).to be_nil
+    expect(webhook.open_id("content" => { "open_id" => "open-123" })).to be_nil
+    expect(webhook.open_id("user" => { "open_id" => "open-123" })).to be_nil
   end
 
   it "returns nil for string content without TypeError when user_openid is missing" do

--- a/spec/services/tiktok_webhook_spec.rb
+++ b/spec/services/tiktok_webhook_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TiktokWebhook do
+  let(:secret) { "tiktok-client-secret" }
+  let(:webhook) { described_class.new(secret) }
+  let(:body) { { "event" => "authorization.removed", "user_openid" => "open-123" }.to_json }
+
+  def signature_for(payload)
+    OpenSSL::HMAC.hexdigest("SHA256", secret, payload)
+  end
+
+  it "parses a body whose HMAC matches" do
+    expect(webhook.parse(body, signature_for(body))).to include("user_openid" => "open-123")
+  end
+
+  it "accepts a sha256= prefix on the signature header" do
+    expect(webhook.parse(body, "sha256=#{signature_for(body)}")).to include("user_openid" => "open-123")
+  end
+
+  it "rejects a mismatched signature" do
+    expect(webhook.parse(body, "a" * 64)).to be_nil
+  end
+
+  it "rejects a blank secret" do
+    expect(described_class.new("").parse(body, signature_for(body))).to be_nil
+  end
+
+  it "reads open_id from the documented user_openid field" do
+    expect(webhook.open_id("user_openid" => "open-123")).to eq("open-123")
+  end
+end


### PR DESCRIPTION
Add TikTok OAuth connect behind `tiktok_connect`

> Draft status: code and focused specs are on the branch. Credentials (#2495), live sandbox QA, and human auth review remain before ready.

## What

Sellers with the `tiktok_connect` flag can connect, disconnect, and reconnect TikTok via Login Kit. The callback stores open_id, handle, follower count, and video count; account creation date and last-posted time stay unknown. Deauthorize unlinks the live identity and keeps the verification row as evidence. Shadow scoring does not start for TikTok.

Tracker: antiwork/gumroad-private#2496

## Why

Sahil added TikTok to the social-connect onboarding set. `SocialConnectVerification::PLATFORMS` already listed `tiktok` with no strategy, callback, identity, or disconnect.

## Before / after

- Before: TikTok is an enum placeholder. Connect UI, OAuth, and live identity do not exist.
- After: Flag-gated Connect to TikTok on Profile and the account-review prompt; callback persists `UserTiktokIdentity` + verification metadata; unlink and signed deauthorize drop the live link only.

## Checklist

- [x] Scope — TikTok Login Kit connect/disconnect/metadata/deauthorize behind `tiktok_connect`. Not credentials (#2495). Not a Settings page move (#2494 / gumroad#7541). Not a TikTok shadow threshold.
- [x] Design — Same shape as Instagram: custom OmniAuth OAuth2 strategy, profile fetcher, identity table, verification recorder. `currently_linked?` is live identity; scorer skips `tiktok`.
- [x] Build — `feat/tiktok-oauth-connect-2496` at this head.
- [ ] QA — Focused strategy/webhook/recorder specs green locally. Live OAuth needs #2495 keys. UI stills after a sandbox connect.
- [ ] Ship — Stays draft until sandbox QA and human auth review.
- [ ] Market — n/a, flag off.
- [ ] Sell — n/a, flag off.

## Tests

```text
bundle exec rspec spec/lib/omni_auth/strategies/tiktok_spec.rb spec/controllers/tiktok_callbacks_controller_spec.rb spec/services/tiktok_webhook_spec.rb
17 examples, 0 failures
```

Recorder, connections, omniauth callback, and shadow-scoring specs also passed in the same worktree. Purchase-factory reds in unrelated CreatorHomePresenter examples are the known merchant-account env collision.

## QA

Not preview-exercisable until TikTok client key/secret exist (#2495). Watch: authorize URL uses `client_key` and a query-free redirect URI; missing counts stay nil; a linked TikTok row does not change shadow `would_have_released`.

---

AI disclosure: Claude Opus 4.6. Prompt: implement TikTok connect to the Instagram/YouTube bar without extending shadow scoring; we-fix deauthorize event gate, user_openid-only open_id, and blank client_key guard.
