### PR TITLE
Let a PayPal payout that never reached PayPal fail without a correlation id

### DIFF
--- a/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
+++ b/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
@@ -359,6 +359,11 @@ class PaypalPayoutProcessor
 
     errors = errors_for_parsed_paypal_response(parsed_paypal_response) if ack_status != "Success"
     Rails.logger.info("PayPal payouts: Payout errors for user IDs #{user_ids}: #{errors.inspect}") if errors.present?
+  rescue Socket::ResolutionError, Errno::ECONNREFUSED, Errno::ENETUNREACH, Errno::EHOSTUNREACH, Net::OpenTimeout => e
+    # DNS / connect failures never handed MassPay to PayPal. A read timeout is NOT in this
+    # list: PayPal may have accepted the request, and failing the slice would let a retry
+    # send the same money twice.
+    mark_payments_processor_unavailable!(payments, e)
   end
 
   # Public: Sends the money in `split_payment_by_cents(payment.user)` increments.
@@ -444,6 +449,15 @@ class PaypalPayoutProcessor
 
   def self.paypal_auth_params
     PAYPAL_API_PARAMS.merge("METHOD" => "MassPay", "RECEIVERTYPE" => "EmailAddress")
+  end
+
+  def self.mark_payments_processor_unavailable!(payments, error)
+    Rails.logger.error("PayPal payouts: MassPay never reached PayPal (#{error.class}: #{error.message}) for payment IDs #{payments.map(&:id)}")
+    ErrorNotifier.notify(error)
+    payments.each do |payment|
+      payment.error_message = "#{error.class}: #{error.message}".truncate(1000)
+      payment.mark_failed!(Payment::FailureReason::PROCESSOR_UNAVAILABLE)
+    end
   end
 
   def self.errors_for_parsed_paypal_response(parsed_paypal_response)

--- a/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
+++ b/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
@@ -457,6 +457,10 @@ class PaypalPayoutProcessor
     payments.each do |payment|
       payment.error_message = "#{error.class}: #{error.message}".truncate(1000)
       payment.mark_failed!(Payment::FailureReason::PROCESSOR_UNAVAILABLE)
+    rescue => e
+      # One bad row must not leave the rest of the slice stuck in processing.
+      Rails.logger.error("PayPal payouts: could not mark payment #{payment.id} processor_unavailable (#{e.class}: #{e.message})")
+      ErrorNotifier.notify(e)
     end
   end
 
@@ -624,6 +628,12 @@ class PaypalPayoutProcessor
     end
 
     response = Rack::Utils.parse_nested_query(paypal_response.parsed_response)
+
+    # Fail closed: a non-Success ACK with no L_STATUS* looks identical to "not found", and treating
+    # that as not-found marks the payout failed so the next batch can pay the same money twice.
+    unless %w[Success SuccessWithWarning].include?(response["ACK"])
+      raise "PayPal TransactionSearch failed (ACK=#{response["ACK"].inspect})"
+    end
 
     if response["L_STATUS0"].present? && response["L_STATUS1"].present? && response["L_STATUS2"].blank? &&
       transaction_id.in?([response["L_TRANSACTIONID0"], response["L_TRANSACTIONID1"]]) &&

--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -578,7 +578,10 @@ class StripePayoutProcessor
       action_required:
     )
     payment.instance_variable_set(:@payout_reversal_failure_notified, true)
-    raise hold_error if hold_error && reraise
+    # reraise: false only swallows the reversal, and only because the hold already paused the
+    # seller. A failed hold must still raise: mark_failed! returned the balances to unpaid, and
+    # the next scheduled batch does not read failure_reason.
+    raise hold_error if hold_error
     raise if reraise
   end
 

--- a/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
+++ b/app/business/payments/payouts/processor/stripe/stripe_payout_processor.rb
@@ -553,15 +553,32 @@ class StripePayoutProcessor
     if failure_reason.in?(Payment::FailureReason::REQUEUEABLE_REASONS)
       payment.update!(failure_reason: Payment::FailureReason::UNREVERSED_INTERNAL_TRANSFER)
     end
-    hold_payouts_for_unaccounted_money!(payment, failure_reason)
+    hold_error = nil
+    begin
+      hold_payouts_for_unaccounted_money!(payment, failure_reason)
+    rescue => he
+      hold_error = he
+    end
+    # One Sentry event for this incident. Prefer the hold-setup failure when present — that is the
+    # part ops still needs to finish by hand. SyncStuckPayoutsJob skips a second "rejected sync"
+    # alert once @payout_reversal_failure_notified is set.
+    action_required = if hold_error
+      "Payout reversal failed and the automatic payout hold could not be set. Pause this seller and reconcile at Stripe by hand."
+    else
+      "Payouts are paused for this seller. Reverse or reconcile this transfer at Stripe by hand, then resume payouts."
+    end
     ErrorNotifier.notify(
-      e,
+      hold_error || e,
       payment_id: payment.id,
       user_id: payment.user_id,
       stripe_internal_transfer_id: payment.stripe_internal_transfer_id,
       original_failure_reason: failure_reason,
-      action_required: "Payouts are paused for this seller. Reverse or reconcile this transfer at Stripe by hand, then resume payouts."
+      reverse_error: e.message,
+      hold_setup_failed: !hold_error.nil?,
+      action_required:
     )
+    payment.instance_variable_set(:@payout_reversal_failure_notified, true)
+    raise hold_error if hold_error && reraise
     raise if reraise
   end
 

--- a/app/models/concerns/payment/failure_reason.rb
+++ b/app/models/concerns/payment/failure_reason.rb
@@ -28,7 +28,7 @@ module Payment::FailureReason
   # details. They must not count toward MAX_CONSECUTIVE_FAILED_PAYOUTS, and they get no
   # STRIPE_FAILURE_SOLUTIONS entry, because there is nothing for the seller to fix.
   TRANSIENT_REASONS = [PROCESSOR_RATE_LIMITED, PROCESSOR_UNAVAILABLE, UNREVERSED_INTERNAL_TRANSFER,
-                       PAYOUT_OUTCOME_UNKNOWN].freeze
+                       PAYOUT_OUTCOME_UNKNOWN, TRANSACTION_NOT_FOUND].freeze
 
   # Failures where money may ALREADY have left Gumroad and we cannot tell from our own records:
   #   UNREVERSED_INTERNAL_TRANSFER — funds are on the seller's connected account because the

--- a/app/models/concerns/payment/failure_reason.rb
+++ b/app/models/concerns/payment/failure_reason.rb
@@ -13,8 +13,14 @@ module Payment::FailureReason
   STRIPE_INTERVENTION_REQUIRED = "stripe_intervention_required"
   PROCESSOR_RATE_LIMITED = "processor_rate_limited"
   PROCESSOR_UNAVAILABLE = "processor_unavailable"
+  # Search found no MassPay on PayPal. Distinct from PROCESSOR_UNAVAILABLE (the POST never left
+  # the box): this one is the sync-job verdict after looking, and it is not auto-retried.
+  TRANSACTION_NOT_FOUND = "Transaction not found"
   UNREVERSED_INTERNAL_TRANSFER = "unreversed_internal_transfer"
   PAYOUT_OUTCOME_UNKNOWN = "payout_outcome_unknown"
+  # Failures where PayPal never assigned a correlation id, so requiring one on `failed` would
+  # leave the row in `processing` and block the next payout. Completed/unclaimed still need one.
+  NEVER_DISPATCHED_REASONS = [TRANSACTION_NOT_FOUND, PROCESSOR_UNAVAILABLE].freeze
   DESTINATION_LEDGER_NEGATIVE = "destination_ledger_negative"
   PAYPAL_PAYOUT_FAILED = "PAYPAL payout failed"
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -260,7 +260,10 @@ class Payment < ApplicationRecord
 
   def humanized_failure_reason
     if processor == PayoutProcessorType::PAYPAL
-      failure_reason.present? ? "#{failure_reason}: #{PAYPAL_MASS_PAY[failure_reason]}" : nil
+      return nil if failure_reason.blank?
+
+      description = PAYPAL_MASS_PAY[failure_reason]
+      description.present? ? "#{failure_reason}: #{description}" : failure_reason
     else
       failure_reason
     end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -109,7 +109,9 @@ class Payment < ApplicationRecord
     end
 
     state any - %i[creating processing] do
-      validates_presence_of :correlation_id, if: proc { |p| p.processor == PayoutProcessorType::PAYPAL }
+      validates_presence_of :correlation_id, if: ->(p) {
+        p.processor == PayoutProcessorType::PAYPAL && FailureReason::NEVER_DISPATCHED_REASONS.exclude?(p.failure_reason)
+      }
     end
 
     state any - %i[creating processing cancelled failed] do
@@ -610,7 +612,7 @@ class Payment < ApplicationRecord
       mark!(PROCESSING) if state?(CREATING)
 
       if new_state == FAILED && transaction_id.blank?
-        mark_failed!("Transaction not found")
+        mark_failed!(FailureReason::TRANSACTION_NOT_FOUND)
       else
         mark!(new_state)
       end

--- a/app/sidekiq/retry_failed_paypal_payouts_worker.rb
+++ b/app/sidekiq/retry_failed_paypal_payouts_worker.rb
@@ -17,11 +17,11 @@ class RetryFailedPaypalPayoutsWorker
                                 .where({
                                          payments: {
                                            state: "failed",
-                                           failure_reason: nil,
                                            processor: PayoutProcessorType::PAYPAL,
                                            payout_period_end_date:
                                          }
                                        })
+                                .where("payments.failure_reason IS NULL OR payments.failure_reason = ?", Payment::FailureReason::PROCESSOR_UNAVAILABLE)
                                 .uniq
     return if failed_payments_users.empty?
 

--- a/app/sidekiq/sync_stuck_payouts_job.rb
+++ b/app/sidekiq/sync_stuck_payouts_job.rb
@@ -22,10 +22,6 @@ class SyncStuckPayoutsJob
       end
 
       if payment.errors.any?
-        # Stripe reverse_internal_transfer_or_hold_payouts! already notified before re-raising into
-        # sync_with_stripe's errors. A second "rejected sync" alert is wrong once the row is terminal.
-        next if Payment::NON_TERMINAL_STATES.exclude?(payment.state)
-
         message = "Syncing #{processor} payout #{payment.id} rejected: #{payment.errors.full_messages.join(', ')}"
         Rails.logger.error(message)
         ErrorNotifier.notify(message)

--- a/app/sidekiq/sync_stuck_payouts_job.rb
+++ b/app/sidekiq/sync_stuck_payouts_job.rb
@@ -24,7 +24,9 @@ class SyncStuckPayoutsJob
       if payment.errors.any?
         message = "Syncing #{processor} payout #{payment.id} rejected: #{payment.errors.full_messages.join(', ')}"
         Rails.logger.error(message)
-        ErrorNotifier.notify(message)
+        # Stripe reverse_internal_transfer_or_hold_payouts! already sent the rich Sentry event.
+        # A second "rejected sync" alert is noise for that same incident.
+        ErrorNotifier.notify(message) unless payment.instance_variable_get(:@payout_reversal_failure_notified)
         next
       end
 

--- a/app/sidekiq/sync_stuck_payouts_job.rb
+++ b/app/sidekiq/sync_stuck_payouts_job.rb
@@ -22,6 +22,10 @@ class SyncStuckPayoutsJob
       end
 
       if payment.errors.any?
+        # Stripe reverse_internal_transfer_or_hold_payouts! already notified before re-raising into
+        # sync_with_stripe's errors. A second "rejected sync" alert is wrong once the row is terminal.
+        next if Payment::NON_TERMINAL_STATES.exclude?(payment.state)
+
         message = "Syncing #{processor} payout #{payment.id} rejected: #{payment.errors.full_messages.join(', ')}"
         Rails.logger.error(message)
         ErrorNotifier.notify(message)

--- a/app/sidekiq/sync_stuck_payouts_job.rb
+++ b/app/sidekiq/sync_stuck_payouts_job.rb
@@ -17,6 +17,14 @@ class SyncStuckPayoutsJob
         payment.sync_with_payout_processor
       rescue => e
         Rails.logger.error("Error syncing #{processor} payout #{payment.id}: #{e.message}")
+        ErrorNotifier.notify(e)
+        next
+      end
+
+      if payment.errors.any?
+        message = "Syncing #{processor} payout #{payment.id} rejected: #{payment.errors.full_messages.join(', ')}"
+        Rails.logger.error(message)
+        ErrorNotifier.notify(message)
         next
       end
 

--- a/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
@@ -1404,6 +1404,38 @@ describe PaypalPayoutProcessor do
     end
   end
 
+  describe "#search_payment_on_paypal ACK handling" do
+    it "raises when TransactionSearch ACK is not Success or SuccessWithWarning" do
+      allow(HTTParty).to receive(:post).and_return(
+        instance_double(HTTParty::Response, parsed_response: "ACK=Failure&CORRELATIONID=c51c5e0cecbce")
+      )
+
+      expect do
+        described_class.search_payment_on_paypal(
+          amount_cents: 1000,
+          payment_address: "seller@example.com",
+          start_date: 1.day.ago,
+          end_date: Time.current
+        )
+      end.to raise_error(RuntimeError, /PayPal TransactionSearch failed \(ACK="Failure"\)/)
+    end
+
+    it "returns nil when ACK is Success but no transactions are returned" do
+      allow(HTTParty).to receive(:post).and_return(
+        instance_double(HTTParty::Response, parsed_response: "ACK=Success&CORRELATIONID=c51c5e0cecbce")
+      )
+
+      expect(
+        described_class.search_payment_on_paypal(
+          amount_cents: 1000,
+          payment_address: "seller@example.com",
+          start_date: 1.day.ago,
+          end_date: Time.current
+        )
+      ).to be_nil
+    end
+  end
+
   describe ".perform_payments" do
     let(:payment) { create(:payment, correlation_id: nil) }
 
@@ -1425,6 +1457,20 @@ describe PaypalPayoutProcessor do
       expect { described_class.perform_payments([payment]) }.to raise_error(Net::ReadTimeout)
       expect(payment.reload.state).to eq("processing")
       expect(payment.failure_reason).to be_nil
+    end
+
+    it "still marks the rest of the slice processor_unavailable when one mark_failed! raises" do
+      payment_ok = create(:payment, correlation_id: nil)
+      payment_bad = create(:payment, correlation_id: nil)
+      allow(ErrorNotifier).to receive(:notify)
+      allow(HTTParty).to receive(:post).and_raise(Socket::ResolutionError)
+      allow(payment_bad).to receive(:mark_failed!).and_raise(RuntimeError, "mark_failed boom")
+
+      described_class.perform_payments([payment_bad, payment_ok])
+
+      expect(payment_ok.reload.state).to eq("failed")
+      expect(payment_ok.failure_reason).to eq(Payment::FailureReason::PROCESSOR_UNAVAILABLE)
+      expect(payment_bad.reload.state).to eq("processing")
     end
   end
 

--- a/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
@@ -1404,6 +1404,30 @@ describe PaypalPayoutProcessor do
     end
   end
 
+  describe ".perform_payments" do
+    let(:payment) { create(:payment, correlation_id: nil) }
+
+    it "marks the slice processor_unavailable when MassPay never leaves the box" do
+      allow(ErrorNotifier).to receive(:notify)
+      allow(HTTParty).to receive(:post).and_raise(Socket::ResolutionError)
+
+      described_class.perform_payments([payment])
+
+      expect(payment.reload.state).to eq("failed")
+      expect(payment.failure_reason).to eq(Payment::FailureReason::PROCESSOR_UNAVAILABLE)
+      expect(payment.correlation_id).to be_nil
+      expect(ErrorNotifier).to have_received(:notify).with(an_instance_of(Socket::ResolutionError))
+    end
+
+    it "does not fail the slice on a read timeout, because PayPal may have accepted the MassPay" do
+      allow(HTTParty).to receive(:post).and_raise(Net::ReadTimeout)
+
+      expect { described_class.perform_payments([payment]) }.to raise_error(Net::ReadTimeout)
+      expect(payment.reload.state).to eq("processing")
+      expect(payment.failure_reason).to be_nil
+    end
+  end
+
   describe "IPN item-level failure without a reason code" do
     let(:user) { create(:singaporean_user_with_compliance_info, payment_address: "seller@example.com") }
     let(:payment) { create(:payment, user:, payment_address: user.payment_address, amount_cents: 5_000) }

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -87,5 +87,34 @@ describe StripePayoutProcessor do
         hash_including(hold_setup_failed: true, reverse_error: "boom")
       )
     end
+
+    it "raises a hold-setup failure even when the reversal error is suppressed" do
+      payment = create(:payment, processor: PayoutProcessorType::STRIPE,
+                                 stripe_internal_transfer_id: "tr_hold_reraise_false")
+      allow(described_class).to receive(:reverse_internal_transfer!).and_raise(Stripe::APIConnectionError.new("boom"))
+      allow(described_class).to receive(:hold_payouts_for_unaccounted_money!)
+        .and_raise(ActiveRecord::Deadlocked.new("Deadlock found when trying to get lock"))
+      allow(ErrorNotifier).to receive(:notify)
+
+      expect do
+        described_class.reverse_internal_transfer_or_hold_payouts!(payment, "account_closed")
+      end.to raise_error(ActiveRecord::Deadlocked)
+
+      expect(ErrorNotifier).to have_received(:notify).once
+    end
+
+    it "does not raise a reversal failure when reraise is false and the hold succeeds" do
+      payment = create(:payment, processor: PayoutProcessorType::STRIPE,
+                                 stripe_internal_transfer_id: "tr_hold_ok")
+      allow(described_class).to receive(:reverse_internal_transfer!).and_raise(Stripe::APIConnectionError.new("boom"))
+      allow(described_class).to receive(:hold_payouts_for_unaccounted_money!)
+      allow(ErrorNotifier).to receive(:notify)
+
+      expect do
+        described_class.reverse_internal_transfer_or_hold_payouts!(payment, "account_closed")
+      end.not_to raise_error
+
+      expect(ErrorNotifier).to have_received(:notify).once
+    end
   end
 end

--- a/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb
@@ -44,4 +44,48 @@ describe StripePayoutProcessor do
       expect(bank_account.reload).to be_deleted
     end
   end
+
+  describe ".reverse_internal_transfer_or_hold_payouts!" do
+    it "notifies once for a reverse failure after a successful hold" do
+      payment = create(:payment, processor: PayoutProcessorType::STRIPE,
+                                 stripe_internal_transfer_id: "tr_once")
+      allow(described_class).to receive(:reverse_internal_transfer!).and_raise(Stripe::APIConnectionError.new("boom"))
+      allow(described_class).to receive(:hold_payouts_for_unaccounted_money!)
+      allow(ErrorNotifier).to receive(:notify)
+
+      expect do
+        described_class.reverse_internal_transfer_or_hold_payouts!(
+          payment, "account_closed", reraise: true
+        )
+      end.to raise_error(Stripe::APIConnectionError, "boom")
+
+      expect(ErrorNotifier).to have_received(:notify).once
+      expect(ErrorNotifier).to have_received(:notify).with(
+        an_instance_of(Stripe::APIConnectionError),
+        hash_including(hold_setup_failed: false, payment_id: payment.id)
+      )
+      expect(payment.instance_variable_get(:@payout_reversal_failure_notified)).to be(true)
+    end
+
+    it "prefers the hold-setup failure in the single notify when both fail" do
+      payment = create(:payment, processor: PayoutProcessorType::STRIPE,
+                                 stripe_internal_transfer_id: "tr_both")
+      allow(described_class).to receive(:reverse_internal_transfer!).and_raise(Stripe::APIConnectionError.new("boom"))
+      allow(described_class).to receive(:hold_payouts_for_unaccounted_money!)
+        .and_raise(ActiveRecord::Deadlocked.new("Deadlock found when trying to get lock"))
+      allow(ErrorNotifier).to receive(:notify)
+
+      expect do
+        described_class.reverse_internal_transfer_or_hold_payouts!(
+          payment, "account_closed", reraise: true
+        )
+      end.to raise_error(ActiveRecord::Deadlocked)
+
+      expect(ErrorNotifier).to have_received(:notify).once
+      expect(ErrorNotifier).to have_received(:notify).with(
+        an_instance_of(ActiveRecord::Deadlocked),
+        hash_including(hold_setup_failed: true, reverse_error: "boom")
+      )
+    end
+  end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -799,7 +799,32 @@ describe Payment do
           expect do
             payment.send(:sync_with_paypal)
           end.to change { payment.reload.state }.from("processing").to("failed")
-        end.to change { payment.reload.failure_reason }.from(nil).to("Transaction not found")
+        end.to change { payment.reload.failure_reason }.from(nil).to(Payment::FailureReason::TRANSACTION_NOT_FOUND)
+      end
+
+      it "marks a never-dispatched PayPal payout failed even when correlation_id is blank" do
+        payment = create(:payment, processor_fee_cents: 10, txn_id: nil, correlation_id: nil)
+
+        expect(PaypalPayoutProcessor).to(
+          receive(:search_payment_on_paypal).with(amount_cents: payment.amount_cents, transaction_id: payment.txn_id,
+                                                  payment_address: payment.payment_address,
+                                                  start_date: payment.created_at.beginning_of_day - 1.day,
+                                                  end_date: payment.created_at.end_of_day + 1.day).and_return(nil))
+
+        expect do
+          payment.send(:sync_with_paypal)
+        end.to change { payment.reload.state }.from("processing").to("failed")
+        expect(payment.failure_reason).to eq(Payment::FailureReason::TRANSACTION_NOT_FOUND)
+        expect(payment.correlation_id).to be_nil
+      end
+
+      it "still requires correlation_id when failing a PayPal payout for any other reason" do
+        payment = create(:payment, correlation_id: nil)
+
+        expect do
+          payment.mark_failed!(Payment::FailureReason::CANNOT_PAY)
+        end.to raise_error(ActiveRecord::RecordInvalid, /Correlation can't be blank/)
+        expect(payment.reload.state).to eq("processing")
       end
 
       it "does not change the payment if multiple txns are found on PayPal" do

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -478,6 +478,13 @@ describe Payment do
 
         expect(payment.humanized_failure_reason).to eq(nil)
       end
+
+      it "returns the reason alone when it has no PAYPAL_MASS_PAY description" do
+        payment = create(:payment_failed, processor: "PAYPAL",
+                                          failure_reason: Payment::FailureReason::TRANSACTION_NOT_FOUND)
+
+        expect(payment.humanized_failure_reason).to eq(Payment::FailureReason::TRANSACTION_NOT_FOUND)
+      end
     end
   end
 
@@ -839,6 +846,18 @@ describe Payment do
         expect do
           payment.send(:sync_with_paypal)
         end.not_to change { payment.reload.state }
+      end
+
+      it "does not mark the payment failed when TransactionSearch raises (failed ACK)" do
+        payment = create(:payment, processor_fee_cents: 10, txn_id: nil, correlation_id: nil)
+
+        expect(PaypalPayoutProcessor).to(
+          receive(:search_payment_on_paypal).and_raise(RuntimeError, 'PayPal TransactionSearch failed (ACK="Failure")'))
+
+        expect do
+          payment.send(:sync_with_paypal)
+        end.not_to change { payment.reload.state }
+        expect(payment.errors.full_messages.join).to include("PayPal TransactionSearch failed")
       end
     end
 
@@ -1255,6 +1274,17 @@ describe Payment do
       (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS - 1).times { failed_payout }
 
       failed_payout_with_reason(Payment::FailureReason::PROCESSOR_UNAVAILABLE)
+
+      expect(user.reload.payouts_paused?).to be(false)
+      expect(user.comments.with_type_on_probation).to be_empty
+    end
+
+    it "does not count a PayPal payout that sync marked Transaction not found" do
+      (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS - 1).times { failed_payout }
+
+      payment = create(:payment, user:, processor: PayoutProcessorType::PAYPAL, payment_address: "seller@example.com",
+                                 state: "processing", correlation_id: nil)
+      payment.mark_failed!(Payment::FailureReason::TRANSACTION_NOT_FOUND)
 
       expect(user.reload.payouts_paused?).to be(false)
       expect(user.comments.with_type_on_probation).to be_empty

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -823,7 +823,7 @@ describe Payment do
 
         expect do
           payment.mark_failed!(Payment::FailureReason::CANNOT_PAY)
-        end.to raise_error(ActiveRecord::RecordInvalid, /Correlation can't be blank/)
+        end.to raise_error(StateMachines::InvalidTransition, /Correlation can't be blank/)
         expect(payment.reload.state).to eq("processing")
       end
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1280,7 +1280,7 @@ describe Payment do
     end
 
     it "does not count a PayPal payout that sync marked Transaction not found" do
-      (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS - 1).times { failed_payout }
+      (Payment::MAX_CONSECUTIVE_FAILED_PAYOUTS - 1).times { failed_paypal_payout }
 
       payment = create(:payment, user:, processor: PayoutProcessorType::PAYPAL, payment_address: "seller@example.com",
                                  state: "processing", correlation_id: nil)

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -645,7 +645,8 @@ describe Payment do
         expect(payment.errors[:base]).to include("Connection refused")
         expect(payment.user.reload.payouts_paused_internally?).to be(true)
         expect(payment.user.payouts_paused_by).to eq(User::PAYOUT_PAUSE_SOURCE_SYSTEM)
-        expect(ErrorNotifier).to have_received(:notify)
+        expect(ErrorNotifier).to have_received(:notify).once
+        expect(payment.instance_variable_get(:@payout_reversal_failure_notified)).to be(true)
       end
 
       it "still pauses payouts end to end when the failure email's real save raises" do

--- a/spec/sidekiq/retry_failed_paypal_payouts_worker_spec.rb
+++ b/spec/sidekiq/retry_failed_paypal_payouts_worker_spec.rb
@@ -14,5 +14,23 @@ describe RetryFailedPaypalPayoutsWorker do
       expect(Payouts).to_not receive(:create_payments_for_balances_up_to_date_for_users)
       described_class.new.perform
     end
+
+    it "retries a PayPal payout that failed because MassPay never reached PayPal" do
+      payout_period_end_date = User::PayoutSchedule.manual_payout_end_date
+      failed_payment = create(:payment_failed, user: create(:user), payout_period_end_date:,
+                                               failure_reason: Payment::FailureReason::PROCESSOR_UNAVAILABLE)
+
+      expect(Payouts).to receive(:create_payments_for_balances_up_to_date_for_users).with(payout_period_end_date, PayoutProcessorType::PAYPAL, [failed_payment.user], { perform_async: true, retrying: true })
+      described_class.new.perform
+    end
+
+    it "does not retry a PayPal payout whose MassPay search found nothing" do
+      payout_period_end_date = User::PayoutSchedule.manual_payout_end_date
+      create(:payment_failed, user: create(:user), payout_period_end_date:,
+                              failure_reason: Payment::FailureReason::TRANSACTION_NOT_FOUND)
+
+      expect(Payouts).to_not receive(:create_payments_for_balances_up_to_date_for_users)
+      described_class.new.perform
+    end
   end
 end

--- a/spec/sidekiq/sync_stuck_payouts_job_spec.rb
+++ b/spec/sidekiq/sync_stuck_payouts_job_spec.rb
@@ -275,6 +275,22 @@ describe SyncStuckPayoutsJob do
 
         expect(Rails.logger).to have_received(:error).with(/rejected:.*API error/).exactly(2).times
       end
+
+      it "does not re-notify when sync left errors on an already-terminal payout" do
+        payment = create(:payment, processor: PayoutProcessorType::STRIPE, state: "processing",
+                                   stripe_transfer_id: "po_dup", stripe_connect_account_id: "acct_dup",
+                                   created_at: 5.days.ago)
+        allow(ErrorNotifier).to receive(:notify)
+        allow_any_instance_of(Payment).to receive(:sync_with_payout_processor) do |p|
+          p.update!(state: "failed", failure_reason: "account_closed")
+          p.errors.add(:base, "reverse failed")
+        end
+
+        described_class.new.perform(PayoutProcessorType::STRIPE)
+
+        expect(ErrorNotifier).not_to have_received(:notify)
+        expect(payment.reload.state).to eq("failed")
+      end
     end
   end
 end

--- a/spec/sidekiq/sync_stuck_payouts_job_spec.rb
+++ b/spec/sidekiq/sync_stuck_payouts_job_spec.rb
@@ -276,21 +276,6 @@ describe SyncStuckPayoutsJob do
         expect(Rails.logger).to have_received(:error).with(/rejected:.*API error/).exactly(2).times
       end
 
-      it "does not re-notify when sync left errors on an already-terminal payout" do
-        payment = create(:payment, processor: PayoutProcessorType::STRIPE, state: "processing",
-                                   stripe_transfer_id: "po_dup", stripe_connect_account_id: "acct_dup",
-                                   created_at: 5.days.ago)
-        allow(ErrorNotifier).to receive(:notify)
-        allow_any_instance_of(Payment).to receive(:sync_with_payout_processor) do |p|
-          p.update!(state: "failed", failure_reason: "account_closed")
-          p.errors.add(:base, "reverse failed")
-        end
-
-        described_class.new.perform(PayoutProcessorType::STRIPE)
-
-        expect(ErrorNotifier).not_to have_received(:notify)
-        expect(payment.reload.state).to eq("failed")
-      end
     end
   end
 end

--- a/spec/sidekiq/sync_stuck_payouts_job_spec.rb
+++ b/spec/sidekiq/sync_stuck_payouts_job_spec.rb
@@ -268,10 +268,12 @@ describe SyncStuckPayoutsJob do
                          created_at: 5.days.ago)
 
         allow(Stripe::Payout).to receive(:retrieve).and_raise(Stripe::StripeError.new("API error"))
-
-        expect(Rails.logger).to receive(:error).with(/Error syncing Stripe payout/).exactly(2).times
+        allow(Rails.logger).to receive(:error)
+        allow(ErrorNotifier).to receive(:notify)
 
         described_class.new.perform(PayoutProcessorType::STRIPE)
+
+        expect(Rails.logger).to have_received(:error).with(/rejected:.*API error/).exactly(2).times
       end
     end
   end

--- a/spec/sidekiq/sync_stuck_payouts_job_spec.rb
+++ b/spec/sidekiq/sync_stuck_payouts_job_spec.rb
@@ -275,7 +275,6 @@ describe SyncStuckPayoutsJob do
 
         expect(Rails.logger).to have_received(:error).with(/rejected:.*API error/).exactly(2).times
       end
-
     end
   end
 end

--- a/spec/sidekiq/sync_stuck_payouts_job_spec.rb
+++ b/spec/sidekiq/sync_stuck_payouts_job_spec.rb
@@ -259,6 +259,71 @@ describe SyncStuckPayoutsJob do
         described_class.new.perform(PayoutProcessorType::STRIPE)
       end
 
+      it "logs a Stripe reverse failure once without a second rejected-sync Sentry alert" do
+        payment = create(:payment, processor: PayoutProcessorType::STRIPE, state: "processing",
+                                   stripe_transfer_id: "po_rev_dup", stripe_connect_account_id: "acct_rev_dup",
+                                   stripe_internal_transfer_id: "tr_rev_dup", created_at: 5.days.ago)
+        payment.update!(arrival_date: 1.day.ago.to_i)
+
+        stripe_payout = { "status" => "failed", "failure_code" => "account_closed" }
+        allow(Stripe::Payout).to receive(:retrieve)
+          .with("po_rev_dup", { stripe_account: "acct_rev_dup" }).and_return(stripe_payout)
+        allow(StripePayoutProcessor).to receive(:reverse_internal_transfer!)
+          .and_raise(Stripe::APIConnectionError.new("Connection refused"))
+        allow_any_instance_of(Payment).to receive(:send_payout_failure_email)
+        allow(Rails.logger).to receive(:error)
+        allow(ErrorNotifier).to receive(:notify)
+
+        described_class.new.perform(PayoutProcessorType::STRIPE)
+
+        expect(ErrorNotifier).to have_received(:notify).once
+        expect(ErrorNotifier).not_to have_received(:notify).with(/rejected:/)
+        expect(Rails.logger).to have_received(:error).with(/rejected:.*Connection refused/)
+        expect(payment.user.reload.payouts_paused_internally?).to be(true)
+      end
+
+      it "still notifies rejected sync when Stripe errors without a prior reverse alert" do
+        payment = create(:payment, processor: PayoutProcessorType::STRIPE, state: "processing",
+                                   stripe_transfer_id: "po_plain_err", stripe_connect_account_id: "acct_plain_err",
+                                   created_at: 5.days.ago)
+
+        allow(Stripe::Payout).to receive(:retrieve).and_raise(Stripe::StripeError.new("API error"))
+        allow(Rails.logger).to receive(:error)
+        allow(ErrorNotifier).to receive(:notify)
+
+        described_class.new.perform(PayoutProcessorType::STRIPE)
+
+        expect(ErrorNotifier).to have_received(:notify).with(/rejected:.*API error/).once
+        expect(payment.reload.state).to eq("processing")
+      end
+
+      it "notifies once when hold setup fails after a reverse failure (still visible)" do
+        payment = create(:payment, processor: PayoutProcessorType::STRIPE, state: "processing",
+                                   stripe_transfer_id: "po_hold_fail", stripe_connect_account_id: "acct_hold_fail",
+                                   stripe_internal_transfer_id: "tr_hold_fail", created_at: 5.days.ago)
+        payment.update!(arrival_date: 1.day.ago.to_i)
+
+        stripe_payout = { "status" => "failed", "failure_code" => "account_closed" }
+        allow(Stripe::Payout).to receive(:retrieve)
+          .with("po_hold_fail", { stripe_account: "acct_hold_fail" }).and_return(stripe_payout)
+        allow(StripePayoutProcessor).to receive(:reverse_internal_transfer!)
+          .and_raise(Stripe::APIConnectionError.new("Connection refused"))
+        allow(StripePayoutProcessor).to receive(:hold_payouts_for_unaccounted_money!)
+          .and_raise(ActiveRecord::Deadlocked.new("Deadlock found when trying to get lock"))
+        allow_any_instance_of(Payment).to receive(:send_payout_failure_email)
+        allow(Rails.logger).to receive(:error)
+        allow(ErrorNotifier).to receive(:notify)
+
+        described_class.new.perform(PayoutProcessorType::STRIPE)
+
+        expect(ErrorNotifier).to have_received(:notify).once
+        expect(ErrorNotifier).to have_received(:notify).with(
+          an_instance_of(ActiveRecord::Deadlocked),
+          hash_including(hold_setup_failed: true, reverse_error: "Connection refused")
+        )
+        expect(ErrorNotifier).not_to have_received(:notify).with(/rejected:/)
+      end
+
       it "processes all stuck payouts even if any of them raises an error" do
         create(:payment, processor: PayoutProcessorType::STRIPE, state: "processing",
                          stripe_transfer_id: "po_err1", stripe_connect_account_id: "acct_err1",

--- a/spec/sidekiq/sync_stuck_payouts_job_spec.rb
+++ b/spec/sidekiq/sync_stuck_payouts_job_spec.rb
@@ -73,9 +73,25 @@ describe SyncStuckPayoutsJob do
 
         allow(PaypalPayoutProcessor).to receive(:search_payment_on_paypal).and_raise ActiveRecord::RecordInvalid
         expect(PaypalPayoutProcessor).to receive(:search_payment_on_paypal).exactly(7).times
+        allow(Rails.logger).to receive(:error)
         expect(Rails.logger).to receive(:error).with(/Error syncing PayPal payout/).exactly(7).times
+        allow(ErrorNotifier).to receive(:notify)
 
         described_class.new.perform(PayoutProcessorType::PAYPAL)
+        expect(ErrorNotifier).to have_received(:notify).exactly(7).times
+      end
+
+      it "notifies when a sync attempt is rejected onto the payment without raising" do
+        payment = create(:payment, processor: PayoutProcessorType::PAYPAL, state: "processing")
+        allow_any_instance_of(Payment).to receive(:sync_with_payout_processor) do |p|
+          p.errors.add(:base, "Correlation can't be blank")
+        end
+        allow(ErrorNotifier).to receive(:notify)
+
+        described_class.new.perform(PayoutProcessorType::PAYPAL)
+
+        expect(ErrorNotifier).to have_received(:notify).with(/rejected:.*Correlation can't be blank/)
+        expect(payment.reload.state).to eq("processing")
       end
     end
 


### PR DESCRIPTION
# Let a PayPal payout that never reached PayPal fail without a correlation id

> Draft. Money path — stays with Gianfranco. Greptile P1 (failed hold swallowed on reraise: false) fixed at 1aa7887cac.

Closes antiwork/gumroad-private#2515

## What

A PayPal MassPay that never left the box (DNS / connect failure) saved `Payment` rows in `processing` with a blank `correlation_id`. `SyncStuckPayoutsJob` correctly searched PayPal, found nothing, and called `mark_failed!("Transaction not found")` — then the failed-state `validates_presence_of :correlation_id` rejected the transition. Those sellers stayed blocked on "already payouts in processing".

This PR:

- Lets `processing -> failed` through when the reason is `TRANSACTION_NOT_FOUND` or `PROCESSOR_UNAVAILABLE` (completed / unclaimed still require a correlation id).
- Rescues MassPay DNS / connect failures in `PaypalPayoutProcessor.perform_payments` and marks the slice `PROCESSOR_UNAVAILABLE`. A read timeout is left in `processing` on purpose: PayPal may have accepted the request.
- Extends `RetryFailedPaypalPayoutsWorker` to retry `PROCESSOR_UNAVAILABLE` the same day (it previously selected only `failure_reason IS NULL`).
- Notifies when `SyncStuckPayoutsJob` sees validation errors on the model instead of logging "synced".
- Raises a Stripe payout-hold setup failure even when the reversal error is suppressed (`reraise: false`). `PayoutUsersService` still rescues per seller.

## Why

Nine sellers in the 2026-09-04 PayPal batch ($1,820.86) were stuck this way after `getaddrinfo api-3t.paypal.com` killed `PayoutUsersWorker` (`retry: 0`). Incident recovery is gumroad-private#2453; this is the supported path so the next DNS blip does not need a console workaround.

## Before / after

- Before: `mark_failed!("Transaction not found")` on a blank `correlation_id` raises `Correlation can't be blank`; weekly sync logs the error and leaves the row processing.
- After: that transition succeeds; a DNS-failed MassPay slice fails as `processor_unavailable` and is same-day retried; a rejected sync notifies instead of claiming success.
- Before: `prepare_payment_and_set_amount` swallowed a failed payout hold when `reraise: false`, after `mark_failed!` returned balances to `unpaid`.
- After: the hold error raises; scheduled selection still only honors `payouts_paused?`, so a silent return was the hole.

## Greptile (review 5166723708 @ 49fd635)

- P1 Failed Hold Is Suppressed — real. Fixed in 1aa7887cac. Mutant `raise hold_error if hold_error && reraise` reddens the new example.
- P2 Comment Violates Repository Guidance — declined. The TRANSACTION_NOT_FOUND comment is the trap vs PROCESSOR_UNAVAILABLE.
- P2 Duplicate Stripe Failure Alerts — already fixed at 49fd635 via `@payout_reversal_failure_notified`.

## Checklist

- [x] Scope — PayPal never-dispatched fail path, MassPay connect/DNS rescue, stuck-sync notify, PayPal requeue of PROCESSOR_UNAVAILABLE, Stripe hold-error raise on reraise false. Not split-payment HTTParty. Not read-timeout fail-and-retry.
- [x] Design — skip correlation_id only for NEVER_DISPATCHED_REASONS, not all `failed`. Rejected: sentinel correlation_id. Rejected: failing the slice on Net::ReadTimeout.
- [x] Build — `gp2515-paypal-never-dispatched`
- [x] QA — focused Stripe hold specs: 5 examples, 0 failures. Mutant killed.
- [ ] Shipped — money path, human merge
- [x] Market — n/a, payout plumbing
- [x] Sell — n/a

## Tests

```text
bundle exec rspec \
  spec/models/payment_spec.rb \
  spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb \
  spec/business/payments/payouts/processor/stripe/stripe_payout_processor_spec.rb \
  spec/sidekiq/sync_stuck_payouts_job_spec.rb \
  spec/sidekiq/retry_failed_paypal_payouts_worker_spec.rb
```

Local this round: `stripe_payout_processor_spec.rb` — 5 examples, 0 failures.

## QA

Backend-only. No preview app. Proof is the focused specs, including: blank-correlation_id `Transaction not found` now fails the payment; MassPay `Socket::ResolutionError` marks PROCESSOR_UNAVAILABLE; hold-setup failure raises when reraise is false; reversal stays swallowed when the hold succeeds.

---

## AI disclosure

Generated with grok-4.6 (xAI), running as gumclaw from the github-event-routing webhook on antiwork/gumroad-private#2515. Prompts/instructions: the issue body as spec plus standing autonomous-product-dev / ownership-contract rules.
