### PR TITLE
Stop sending nested currency on PaymentIntent e-mandate options

### DIFF
--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -1539,13 +1539,14 @@ class StripeChargeProcessor
       inner = mandate_options.dig(:payment_method_options, :card, :mandate_options) ||
         mandate_options.dig("payment_method_options", "card", "mandate_options")
       return mandate_options if inner.blank?
+      return mandate_options unless inner.key?(:currency) || inner.key?("currency")
 
-      cleaned = inner.except(:currency, "currency")
-      return mandate_options if cleaned.equal?(inner) || cleaned == inner
-
-      mandate_options.deep_merge(
-        payment_method_options: { card: { mandate_options: cleaned } }
-      )
+      cleaned = mandate_options.deep_dup
+      target = cleaned.dig(:payment_method_options, :card, :mandate_options) ||
+        cleaned.dig("payment_method_options", "card", "mandate_options")
+      target.delete(:currency)
+      target.delete("currency")
+      cleaned
     end
 
     # https://stripe.com/docs/api/files/object#file_object-purpose

--- a/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
+++ b/app/business/payments/charging/implementations/stripe/stripe_charge_processor.rb
@@ -371,7 +371,11 @@ class StripeChargeProcessor
 
     # Stripe does not update a mandate. Use the mandate from a completed SetupIntent instead
     # of asking the PaymentIntent to create different terms.
-    params.merge!(mandate_options) if mandate_options.present? && !upi_autopay && mandate.blank?
+    # Nested `currency` is valid on SetupIntent mandate_options only. PaymentIntent
+    # inherits currency from the intent; Stripe 400s the extra field.
+    if mandate_options.present? && !upi_autopay && mandate.blank?
+      params.merge!(mandate_options_without_nested_currency(mandate_options))
+    end
     params.merge!(chargeable.stripe_charge_params)
 
     if off_session && chargeable.requires_mandate? && !upi_autopay
@@ -1531,6 +1535,19 @@ class StripeChargeProcessor
   end
 
   private
+    def mandate_options_without_nested_currency(mandate_options)
+      inner = mandate_options.dig(:payment_method_options, :card, :mandate_options) ||
+        mandate_options.dig("payment_method_options", "card", "mandate_options")
+      return mandate_options if inner.blank?
+
+      cleaned = inner.except(:currency, "currency")
+      return mandate_options if cleaned.equal?(inner) || cleaned == inner
+
+      mandate_options.deep_merge(
+        payment_method_options: { card: { mandate_options: cleaned } }
+      )
+    end
+
     # https://stripe.com/docs/api/files/object#file_object-purpose
     STRIPE_FILE_PURPOSE_DISPUTE_EVIDENCE = "dispute_evidence"
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -4952,9 +4952,7 @@ class Purchase < ApplicationRecord
 
       inner = mandate_options[:payment_method_options][:card][:mandate_options]
                 .merge(amount: presentment_cap_cents)
-      unless india_card_mandate_reliability_enabled?
-        inner = inner.merge(currency: presentment_currency)
-      end
+                .except(:currency)
       mandate_options.deep_merge(
         payment_method_options: { card: { mandate_options: inner } }
       )

--- a/app/services/charge/create_service.rb
+++ b/app/services/charge/create_service.rb
@@ -252,15 +252,13 @@ class Charge::CreateService
     deep_merged_mandate_options(presentment_cap_cents, presentment_currency)
   end
 
-  # Stripe uses the PaymentIntent currency for mandate options. Older code added an unsupported
-  # nested currency field, so preserve that behavior until the reliability flag is active.
-  def deep_merged_mandate_options(cap_cents, currency)
+  # Stripe uses the PaymentIntent currency for card mandate options. Nested
+  # `currency` is a SetupIntent-only field; sending it on a PaymentIntent 400s
+  # with "Received unknown parameter: currency" and the buyer sees a generic
+  # temporary-problem error after a successful 0.00 e-mandate OTP.
+  def deep_merged_mandate_options(cap_cents, _currency)
     card_options = mandate_options[:payment_method_options][:card]
-    inner = card_options[:mandate_options].merge(amount: cap_cents)
-    unless Feature.active?(StripeChargeProcessor::INDIA_CARD_MANDATE_RELIABILITY_FEATURE, seller) &&
-           !StripeIntentChargeRouting.direct_charge_account?(merchant_account)
-      inner = inner.merge(currency:)
-    end
+    inner = card_options[:mandate_options].merge(amount: cap_cents).except(:currency)
 
     mandate_options.merge(
       payment_method_options: mandate_options[:payment_method_options].merge(

--- a/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
+++ b/spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb
@@ -54,6 +54,43 @@ describe StripeChargeProcessor, :vcr do
     end
   end
 
+  describe "#mandate_options_without_nested_currency" do
+    it "strips nested currency from string-keyed options without adding a symbol-keyed branch" do
+      options = {
+        "payment_method_options" => {
+          "card" => {
+            "mandate_options" => { "amount" => 100, "currency" => "inr", "interval" => "month" }
+          }
+        }
+      }
+
+      cleaned = subject.send(:mandate_options_without_nested_currency, options)
+
+      expect(cleaned.dig("payment_method_options", "card", "mandate_options")).to eq(
+        "amount" => 100,
+        "interval" => "month"
+      )
+      expect(cleaned).not_to have_key(:payment_method_options)
+    end
+
+    it "strips nested currency from symbol-keyed options" do
+      options = {
+        payment_method_options: {
+          card: {
+            mandate_options: { amount: 100, currency: "inr", interval: "month" }
+          }
+        }
+      }
+
+      cleaned = subject.send(:mandate_options_without_nested_currency, options)
+
+      expect(cleaned.dig(:payment_method_options, :card, :mandate_options)).to eq(
+        amount: 100,
+        interval: "month"
+      )
+    end
+  end
+
   describe ".charge_minor_units_compatible?" do
     it "allows currencies whose stored minor units match what Stripe charges" do
       expect(described_class.charge_minor_units_compatible?("usd")).to be(true)

--- a/spec/services/charge/create_service_spec.rb
+++ b/spec/services/charge/create_service_spec.rb
@@ -503,6 +503,7 @@ describe Charge::CreateService, :vcr do
               reference: "gumroad-ref",
               amount_type: "maximum",
               amount: 10_00,
+              currency: Currency::USD,
               start_date: Time.current.to_i,
               interval: "month",
               interval_count: 1,
@@ -532,7 +533,7 @@ describe Charge::CreateService, :vcr do
         inner = kwargs[:mandate_options][:payment_method_options][:card][:mandate_options]
         # 10_00 canonical scaled by the charge's own 12_50/10_00 ratio.
         expect(inner[:amount]).to eq 12_50
-        expect(inner[:currency]).to eq Currency::CAD
+        expect(inner).not_to have_key(:currency)
         # Everything else about the mandate is untouched.
         expect(inner[:amount_type]).to eq "maximum"
         expect(inner[:reference]).to eq "gumroad-ref"
@@ -639,7 +640,7 @@ describe Charge::CreateService, :vcr do
       expect(ChargeProcessor).to receive(:create_payment_intent_or_charge!) do |*, **kwargs|
         inner = kwargs[:mandate_options][:payment_method_options][:card][:mandate_options]
         expect(inner[:amount]).to be >= 277_77
-        expect(inner[:currency]).to eq Currency::INR
+        expect(inner).not_to have_key(:currency)
         nil
       end
 


### PR DESCRIPTION
> Draft status: Greptile P2 fixed at `9e5042a7cb9`. Stays draft until CI, run-all-specs, and Astra+Fable panel at head.

## What
Stripe 400s PaymentIntents that include nested `payment_method_options.card.mandate_options.currency` (`Received unknown parameter: currency`). That field is valid on SetupIntents only. After a successful 0.00 India e-mandate OTP, the follow-on membership charge then fails with "There is a temporary problem, please try again (your card was not charged)."

Stop attaching nested `currency` on PaymentIntent mandate options (the intent currency is used). Keep converting the cap into the charge currency. Strip the field at the Stripe PaymentIntent boundary if a caller still passes it. SetupIntent registration is unchanged.

The boundary sanitizer deletes `currency` on a deep copy of the original hash so string-keyed options keep their shape. Nested `deep_merge` cannot drop a key that exists only on the original inner hash.

## Why
India membership checkout: SetupIntent (0.00 OTP) succeeds and registers an active mandate, then Charge::CreateService submits a PaymentIntent with nested `currency` and Stripe rejects the request. No money is captured. The old flag-gated "preserve the unsupported field" path is the live failure.

Tracks antiwork/gumroad-private#2517

## Before / after
- Before: PaymentIntent mandate options can carry nested `currency`; Stripe 400s; buyer sees the generic temporary-problem copy after OTP.
- After: PaymentIntent mandate options have no nested `currency`; cap still converts into the charge currency. String-keyed mandate options are stripped in place rather than growing a second symbol-keyed branch.

## Checklist
- [x] Scope — PaymentIntent e-mandate options only. SetupIntent `currency` stays.
- [x] Design — Stop adding the field; strip at the Stripe PaymentIntent boundary. Rejected leaving it behind the reliability flag (that path still 400s).
- [x] Build — `9e5042a7cb9` on `fix/pi-mandate-options-unknown-currency-2517`
- [x] QA — Local rspec on presentment-mandate examples (2 examples, 0 failures) at `df19e662daa`; sanitizer examples (2 examples, 0 failures) at `9e5042a7cb9`
- [ ] Shipped — money-path; human merge after panel + CI
- [x] Market — n/a, checkout processor payload
- [x] Sell — n/a, no storefront copy change

## Tests
```text
bundle exec rspec spec/services/charge/create_service_spec.rb -e "converts the e-mandate cap" -e "never registers an e-mandate cap"
2 examples, 0 failures @ df19e662daa

bundle exec rspec spec/business/payments/charging/implementations/stripe/stripe_charge_processor_spec.rb -e mandate_options_without_nested_currency
2 examples, 0 failures @ 9e5042a7cb9
```

Mutation (both killed):
```text
symbol-keyed deep_merge writeback (Greptile P2)  yes  both sanitizer examples
leave nested currency in place                   yes  both sanitizer examples
```

## QA
No rendered surface. Proof is the Stripe 400 text plus the specs that now forbid nested `currency` on the PaymentIntent payload, including string-keyed options.

AI disclosure: grok-4.6 via xai. Instructions: autonomous-product-dev webhook on gumroad#7570 Greptile P2.
