### PR TITLE
Split RepairOrderChargeOutcomesJob candidate lookup

### DIFF
--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -121,6 +121,8 @@ class RedisKey
     # Fixed at lap start so the walk keeps making forward progress even while new failing orders
     # keep arriving above it. See RepairOrderChargeOutcomesJob.
     def order_charge_outcome_repair_lap_ceiling = "order_charge_outcome_repair:lap_ceiling"
+    # High-water mark for RepairOrderChargeOutcomesJob's recent pass: the last purchases id it walked.
+    def order_charge_outcome_repair_recent_mark = "order_charge_outcome_repair:recent_mark"
     # High-water mark for AlertOnStripeDobDriftJob: the last merchant_accounts id it compared.
     def stripe_dob_drift_sweep_cursor = "stripe_dob_drift_sweep:cursor"
     # Purchases whose notice was claimed but never transmitted. The cursor is already past their

--- a/app/sidekiq/repair_order_charge_outcomes_job.rb
+++ b/app/sidekiq/repair_order_charge_outcomes_job.rb
@@ -22,70 +22,108 @@ class RepairOrderChargeOutcomesJob
   # reconciled in one invocation with no cap at all.
   MAX_BACKLOG_SCANNED = 2_000
 
+  # WHERE id IN (...) against purchases/order_purchases flips off the range plan past ~2k ids.
+  FAILED_ORDER_ID_BATCH = 1_000
+
+  # Caps how many failed-order id pages the backlog walk issues per run. Each page is bounded;
+  # without this a sparse stretch would keep paging until the wall clock blew the hourly slot.
+  MAX_FAILED_ORDER_BATCHES = 40
+
+  QUERY_TIME_BUDGET = 2.minutes.to_i
+
   def perform
     ApplicationRecord.connected_to(role: :writing) do
-      recent_ids = recent_candidate_ids
-      backlog_ids = backlog_candidate_ids(remaining_budget: MAX_BACKLOG_SCANNED - recent_ids.size)
+      WithMaxExecutionTime.timeout_queries(seconds: QUERY_TIME_BUDGET) do
+        recent_ids = recent_candidate_ids
+        backlog_ids = backlog_candidate_ids(remaining_budget: MAX_BACKLOG_SCANNED - recent_ids.size)
 
-      (recent_ids + backlog_ids).uniq.each { Order.find_by(id: _1)&.record_charge_outcome! }
+        (recent_ids + backlog_ids).uniq.each { Order.find_by(id: _1)&.record_charge_outcome! }
+      end
     end
   end
 
   private
-    # A failed line item is the cheap half of the predicate and the rarer one; `record_charge_outcome!`
-    # is authoritative about the rest, so narrowing further here would only duplicate it.
-    #
-    # Also excludes orders where EVERY purchase is already checkout-failed: `record_charge_outcome!`
-    # requires a succeeded sibling too, so such an order can never leave this scope. Left in, a
-    # persistent set of these (Greptile reproduced 2,000) would resurface at the same low IDs on
-    # every recent-pass run and permanently crowd out real candidates plus the whole backlog budget.
-    def candidates
-      Order.not_partially_successful
-           .joins(:purchases).merge(Purchase.checkout_failed)
-           .where(id: Order.joins(:purchases).where.not(purchases: { purchase_state: Purchase::CHECKOUT_FAILURE_STATES }).select(:id))
-           .distinct
-    end
-
     def recent_candidate_ids
-      candidates.where(created_at: RECENT_WINDOW.ago..).order(:id).limit(MAX_BACKLOG_SCANNED).pluck(:id)
+      failed_purchase_ids = Purchase.checkout_failed.where(created_at: RECENT_WINDOW.ago..).pluck(:id)
+      filter_candidates(order_ids_for_purchases(failed_purchase_ids), created_at: RECENT_WINDOW.ago..)
+        .first(MAX_BACKLOG_SCANNED)
     end
 
     def backlog_candidate_ids(remaining_budget:)
       return [] if remaining_budget <= 0
 
       after_id = current_cursor
-      # Pin the lap's upper bound at its start so a steady stream of new old-side failures can't
-      # keep every forward page non-empty forever — Greptile reproduced the cursor stalling below a
-      # skipped order across five runs while newer IDs kept it from ever reaching empty-and-wrap.
-      # Bounding each lap to what existed when it started guarantees the lap terminates.
       ceiling = lap_ceiling(after_id)
-      ids = backlog_page(after_id, ceiling, remaining_budget)
+      ids, _scan_to, exhausted = backlog_page(after_id, ceiling, remaining_budget)
 
-      if ids.empty? && after_id.positive?
+      if ids.empty? && exhausted && after_id.positive?
         save_cursor(0)
         ceiling = lap_ceiling(0)
-        ids = backlog_page(0, ceiling, remaining_budget)
+        ids, _scan_to, exhausted = backlog_page(0, ceiling, remaining_budget)
       end
 
-      # Advanced before the repairs run, so a run that dies partway cannot wedge on the same page.
-      # Safe only because the walk wraps: a skipped order comes back on the next lap.
       save_cursor(ids.last) if ids.any?
       ids
     end
 
     def backlog_page(after_id, ceiling, limit)
-      candidates.where(created_at: ...RECENT_WINDOW.ago)
-                .where("orders.id > ? AND orders.id <= ?", after_id, ceiling)
-                .order(:id)
-                .limit(limit)
-                .pluck(:id)
+      ids = []
+      cursor = after_id
+      exhausted = false
+      batches = 0
+
+      while ids.size < limit && batches < MAX_FAILED_ORDER_BATCHES
+        failed_order_ids = order_ids_with_checkout_failed(after_id: cursor, ceiling:, limit: FAILED_ORDER_ID_BATCH)
+        if failed_order_ids.empty?
+          exhausted = true
+          break
+        end
+
+        batches += 1
+        cursor = failed_order_ids.last
+        ids.concat(filter_candidates(failed_order_ids, created_at: ...RECENT_WINDOW.ago))
+      end
+
+      [ids.first(limit), cursor, exhausted]
     end
 
-    # Established once per lap and cached in Redis so restarts mid-lap don't reset it. A lap covers
-    # only IDs that existed when it started; anything created afterward waits for the next lap.
+    # Failed purchases are the rare side and sit on (purchase_state, created_at). Sibling and
+    # flag checks are separate PK lookups so MySQL never rebuilds the old DISTINCT double-join
+    # (primary EXPLAIN: type=ALL, 116M orders).
+    def order_ids_with_checkout_failed(after_id:, ceiling:, limit:)
+      rel = OrderPurchase.joins(:purchase)
+                         .merge(Purchase.checkout_failed)
+                         .where("order_purchases.order_id > ?", after_id)
+      rel = rel.where("order_purchases.order_id <= ?", ceiling) if ceiling&.positive?
+      rel.order("order_purchases.order_id").limit(limit).pluck(:order_id).uniq
+    end
+
+    def order_ids_for_purchases(purchase_ids)
+      purchase_ids.each_slice(FAILED_ORDER_ID_BATCH).flat_map do |slice|
+        OrderPurchase.where(purchase_id: slice).pluck(:order_id)
+      end.uniq
+    end
+
+    def filter_candidates(order_ids, created_at:)
+      return [] if order_ids.empty?
+
+      with_sibling = order_ids.each_slice(FAILED_ORDER_ID_BATCH).flat_map do |slice|
+        OrderPurchase.joins(:purchase)
+                     .where(order_id: slice)
+                     .where.not(purchases: { purchase_state: Purchase::CHECKOUT_FAILURE_STATES })
+                     .distinct
+                     .pluck(:order_id)
+      end
+      return [] if with_sibling.empty?
+
+      with_sibling.each_slice(FAILED_ORDER_ID_BATCH).flat_map do |slice|
+        Order.not_partially_successful.where(id: slice, created_at:).pluck(:id)
+      end.sort
+    end
+
     def lap_ceiling(after_id)
       if after_id.zero?
-        ceiling = candidates.where(created_at: ...RECENT_WINDOW.ago).maximum("orders.id") || 0
+        ceiling = Order.maximum(:id) || 0
         save_lap_ceiling(ceiling)
         ceiling
       else
@@ -96,7 +134,6 @@ class RepairOrderChargeOutcomesJob
     def current_cursor
       $redis.get(RedisKey.order_charge_outcome_repair_cursor).to_i
     rescue => e
-      # A lost cursor re-walks from the oldest page, which is wasted work but not a wrong outcome.
       ErrorNotifier.notify(e)
       0
     end

--- a/app/sidekiq/repair_order_charge_outcomes_job.rb
+++ b/app/sidekiq/repair_order_charge_outcomes_job.rb
@@ -34,32 +34,94 @@ class RepairOrderChargeOutcomesJob
   def perform
     ApplicationRecord.connected_to(role: :writing) do
       WithMaxExecutionTime.timeout_queries(seconds: QUERY_TIME_BUDGET) do
-        recent_ids = recent_candidate_ids
+        recent_ids, recent_after, recent_scan_to = recent_candidate_ids
         backlog_ids = backlog_candidate_ids(remaining_budget: MAX_BACKLOG_SCANNED - recent_ids.size)
 
         (recent_ids + backlog_ids).uniq.each { Order.find_by(id: _1)&.record_charge_outcome! }
+
+        # Persist the recent mark only after repairs land. Saving earlier would skip purchases
+        # whose repair never ran when newer failures keep the wrap from firing.
+        save_recent_mark(recent_scan_to) if recent_scan_to > recent_after
       end
     end
   end
 
   private
+    # Walk checkout-failed purchases by PRIMARY id from a Redis high-water mark. A created_at
+    # window on purchases would restart at the oldest row every hour; under volume that never
+    # reaches fresh failures within MAX_FAILED_ORDER_BATCHES. id > mark stays selective and
+    # advances toward the head; once caught up, each run only sees new failures.
+    #
+    # Fully-failed / already-flagged purchases never grow `ids`, so the candidate cap cannot stop
+    # this walk. Cap pages the same way the backlog does. A purchase whose id the mark has already
+    # passed and that only later becomes checkout-failed is repaired by the backlog lap once its
+    # order leaves RECENT_WINDOW — same trade-off as dropping the unindexed updated_at scan.
     def recent_candidate_ids
-      ids = []
-      batches = 0
       since = RECENT_WINDOW.ago
-      # Failed purchases sit on (purchase_state, created_at). An updated_at window
-      # is unindexed and would abort this 2-minute cap before backlog runs.
-      # A pre-existing purchase that fails later on a new order is repaired by
-      # the backlog lap once the order leaves RECENT_WINDOW.
-      #
-      # Fully-failed / already-flagged purchases never grow `ids`, so the candidate
-      # cap cannot stop this walk. Cap pages the same way the backlog does.
-      Purchase.checkout_failed.where(created_at: since..).in_batches(of: FAILED_ORDER_ID_BATCH) do |batch|
-        ids.concat(filter_candidates(order_ids_for_purchases(batch.pluck(:id)), created_at: since..))
-        batches += 1
-        break if ids.size >= MAX_BACKLOG_SCANNED || batches >= MAX_FAILED_ORDER_BATCHES
+      after_id = recent_mark_start
+      ids, scan_to, exhausted = recent_page(after_id, since:)
+
+      if ids.empty? && exhausted && after_id.positive?
+        save_recent_mark(0)
+        after_id = recent_mark_start
+        ids, scan_to, exhausted = recent_page(after_id, since:)
       end
-      ids.uniq.sort.first(MAX_BACKLOG_SCANNED)
+
+      # Caller persists scan_to after repairs. Returning after_id lets it distinguish a no-op scan.
+      [ids.uniq.sort.first(MAX_BACKLOG_SCANNED), after_id, scan_to]
+    end
+
+    def recent_page(after_id, since:)
+      ids = []
+      cursor = after_id
+      exhausted = false
+      batches = 0
+
+      while ids.size < MAX_BACKLOG_SCANNED && batches < MAX_FAILED_ORDER_BATCHES
+        purchase_ids = Purchase.checkout_failed
+                               .where("purchases.id > ?", cursor)
+                               .order(:id)
+                               .limit(FAILED_ORDER_ID_BATCH)
+                               .pluck(:id)
+        if purchase_ids.empty?
+          exhausted = true
+          break
+        end
+
+        batches += 1
+        batch_candidates = filter_candidates(order_ids_for_purchases(purchase_ids), created_at: since..)
+        if ids.size + batch_candidates.size <= MAX_BACKLOG_SCANNED
+          cursor = purchase_ids.last
+          ids.concat(batch_candidates)
+          next
+        end
+
+        # Stop the mark at the purchase that filled the budget so overflow
+        # candidates on this page are still above the mark next hour.
+        purchase_ids.each do |purchase_id|
+          room = MAX_BACKLOG_SCANNED - ids.size
+          break if room <= 0
+
+          fresh = filter_candidates(order_ids_for_purchases([purchase_id]), created_at: since..)
+                   .reject { ids.include?(_1) }
+          ids.concat(fresh.first(room))
+          cursor = purchase_id
+          break if ids.size >= MAX_BACKLOG_SCANNED
+        end
+        break
+      end
+
+      [ids, cursor, exhausted]
+    end
+
+    # When the mark is unset or wrapped to 0, start just below the oldest checkout-failed purchase
+    # still inside the freshness window so the first page does not walk pre-window history.
+    def recent_mark_start
+      mark = current_recent_mark
+      return mark if mark.positive?
+
+      floor = Purchase.checkout_failed.where(created_at: RECENT_WINDOW.ago..).minimum(:id)
+      floor.to_i.positive? ? floor - 1 : (Purchase.maximum(:id) || 0)
     end
 
     def backlog_candidate_ids(remaining_budget:)
@@ -148,7 +210,14 @@ class RepairOrderChargeOutcomesJob
         save_lap_ceiling(ceiling)
         ceiling
       else
-        current_lap_ceiling
+        ceiling = current_lap_ceiling
+        if ceiling.zero?
+          # Lost ceiling mid-lap would leave the page unbounded above; new failed rows then keep
+          # every page non-empty and the wrap never fires. Recompute once and pin it again.
+          ceiling = Order.maximum(:id) || 0
+          save_lap_ceiling(ceiling)
+        end
+        ceiling
       end
     end
 
@@ -161,6 +230,19 @@ class RepairOrderChargeOutcomesJob
 
     def save_cursor(cursor_id)
       $redis.set(RedisKey.order_charge_outcome_repair_cursor, cursor_id)
+    rescue => e
+      ErrorNotifier.notify(e)
+    end
+
+    def current_recent_mark
+      $redis.get(RedisKey.order_charge_outcome_repair_recent_mark).to_i
+    rescue => e
+      ErrorNotifier.notify(e)
+      0
+    end
+
+    def save_recent_mark(mark)
+      $redis.set(RedisKey.order_charge_outcome_repair_recent_mark, mark)
     rescue => e
       ErrorNotifier.notify(e)
     end

--- a/app/sidekiq/repair_order_charge_outcomes_job.rb
+++ b/app/sidekiq/repair_order_charge_outcomes_job.rb
@@ -18,8 +18,7 @@ class RepairOrderChargeOutcomesJob
   RECENT_WINDOW = 3.days
 
   # Shared per-run budget for BOTH passes. Without this, a burst of failures makes the fresh pass
-  # pluck and reconcile every candidate in the window — Greptile reproduced 2,001 fresh candidates
-  # reconciled in one invocation with no cap at all.
+  # pluck and reconcile every candidate in the window.
   MAX_BACKLOG_SCANNED = 2_000
 
   # WHERE id IN (...) against purchases/order_purchases flips off the range plan past ~2k ids.
@@ -47,15 +46,9 @@ class RepairOrderChargeOutcomesJob
   end
 
   private
-    # Walk checkout-failed purchases by PRIMARY id from a Redis high-water mark. A created_at
-    # window on purchases would restart at the oldest row every hour; under volume that never
-    # reaches fresh failures within MAX_FAILED_ORDER_BATCHES. id > mark stays selective and
-    # advances toward the head; once caught up, each run only sees new failures.
-    #
-    # Fully-failed / already-flagged purchases never grow `ids`, so the candidate cap cannot stop
-    # this walk. Cap pages the same way the backlog does. A purchase whose id the mark has already
-    # passed and that only later becomes checkout-failed is repaired by the backlog lap once its
-    # order leaves RECENT_WINDOW — same trade-off as dropping the unindexed updated_at scan.
+    # PRIMARY-id walk from a Redis mark. A created_at window restarts at the oldest row each hour
+    # and never reaches the head within MAX_FAILED_ORDER_BATCHES. Fully-failed purchases never grow
+    # `ids`, so this walk is page-capped like the backlog.
     def recent_candidate_ids
       since = RECENT_WINDOW.ago
       after_id = recent_mark_start
@@ -64,7 +57,7 @@ class RepairOrderChargeOutcomesJob
       if ids.empty? && exhausted && after_id.positive?
         save_recent_mark(0)
         after_id = recent_mark_start
-        ids, scan_to, exhausted = recent_page(after_id, since:)
+        ids, scan_to, _exhausted = recent_page(after_id, since:)
       end
 
       # Caller persists scan_to after repairs. Returning after_id lets it distinguish a no-op scan.
@@ -171,8 +164,7 @@ class RepairOrderChargeOutcomesJob
     end
 
     # Failed purchases are the rare side and sit on (purchase_state, created_at). Sibling and
-    # flag checks are separate PK lookups so MySQL never rebuilds the old DISTINCT double-join
-    # (primary EXPLAIN: type=ALL, 116M orders).
+    # flag checks are separate PK lookups, not a DISTINCT double-join.
     def order_ids_with_checkout_failed(after_id:, ceiling:, limit:)
       rel = OrderPurchase.joins(:purchase)
                          .merge(Purchase.checkout_failed)

--- a/app/sidekiq/repair_order_charge_outcomes_job.rb
+++ b/app/sidekiq/repair_order_charge_outcomes_job.rb
@@ -45,17 +45,23 @@ class RepairOrderChargeOutcomesJob
   private
     def recent_candidate_ids
       ids = []
+      batches = 0
       since = RECENT_WINDOW.ago
       # created_at covers lost-enqueue at checkout. updated_at covers an older purchase that
       # fails later (SCA/restart attached to a new order). orders.created_at is unindexed, so
       # the recent cohort cannot be keyed off the order timestamp without a 116M-row scan.
+      #
+      # Fully-failed / already-flagged purchases never grow `ids`, so the candidate cap
+      # cannot stop this walk. Cap pages the same way the backlog does or a sparse recent
+      # cohort never reaches backlog repair.
       [Purchase.checkout_failed.where(created_at: since..),
        Purchase.checkout_failed.where(updated_at: since..)].each do |rel|
         rel.in_batches(of: FAILED_ORDER_ID_BATCH) do |batch|
           ids.concat(filter_candidates(order_ids_for_purchases(batch.pluck(:id)), created_at: since..))
-          break if ids.size >= MAX_BACKLOG_SCANNED
+          batches += 1
+          break if ids.size >= MAX_BACKLOG_SCANNED || batches >= MAX_FAILED_ORDER_BATCHES
         end
-        break if ids.size >= MAX_BACKLOG_SCANNED
+        break if ids.size >= MAX_BACKLOG_SCANNED || batches >= MAX_FAILED_ORDER_BATCHES
       end
       ids.uniq.sort.first(MAX_BACKLOG_SCANNED)
     end
@@ -74,11 +80,12 @@ class RepairOrderChargeOutcomesJob
         ids, scan_to, exhausted = backlog_page(0, ceiling, remaining_budget)
       end
 
+      # Truncated pages must resume at ids.last or we skip remaining candidates.
+      # Otherwise scan_to is already fully filtered. An empty exhausted wrap must
+      # keep cursor 0 so the next lap can see a newly-stranded order.
       if ids.any?
-        save_cursor(ids.last)
+        save_cursor(ids.size < remaining_budget ? [ids.last, scan_to].max : ids.last)
       elsif !exhausted && scan_to > after_id
-        # 40 failed-order pages with no qualifying candidate used to discard scan_to, so the
-        # next hour rescanned the same stretch and starved everything past it.
         save_cursor(scan_to)
       end
       ids

--- a/app/sidekiq/repair_order_charge_outcomes_job.rb
+++ b/app/sidekiq/repair_order_charge_outcomes_job.rb
@@ -47,20 +47,16 @@ class RepairOrderChargeOutcomesJob
       ids = []
       batches = 0
       since = RECENT_WINDOW.ago
-      # created_at covers lost-enqueue at checkout. updated_at covers an older purchase that
-      # fails later (SCA/restart attached to a new order). orders.created_at is unindexed, so
-      # the recent cohort cannot be keyed off the order timestamp without a 116M-row scan.
+      # Failed purchases sit on (purchase_state, created_at). An updated_at window
+      # is unindexed and would abort this 2-minute cap before backlog runs.
+      # A pre-existing purchase that fails later on a new order is repaired by
+      # the backlog lap once the order leaves RECENT_WINDOW.
       #
-      # Fully-failed / already-flagged purchases never grow `ids`, so the candidate cap
-      # cannot stop this walk. Cap pages the same way the backlog does or a sparse recent
-      # cohort never reaches backlog repair.
-      [Purchase.checkout_failed.where(created_at: since..),
-       Purchase.checkout_failed.where(updated_at: since..)].each do |rel|
-        rel.in_batches(of: FAILED_ORDER_ID_BATCH) do |batch|
-          ids.concat(filter_candidates(order_ids_for_purchases(batch.pluck(:id)), created_at: since..))
-          batches += 1
-          break if ids.size >= MAX_BACKLOG_SCANNED || batches >= MAX_FAILED_ORDER_BATCHES
-        end
+      # Fully-failed / already-flagged purchases never grow `ids`, so the candidate
+      # cap cannot stop this walk. Cap pages the same way the backlog does.
+      Purchase.checkout_failed.where(created_at: since..).in_batches(of: FAILED_ORDER_ID_BATCH) do |batch|
+        ids.concat(filter_candidates(order_ids_for_purchases(batch.pluck(:id)), created_at: since..))
+        batches += 1
         break if ids.size >= MAX_BACKLOG_SCANNED || batches >= MAX_FAILED_ORDER_BATCHES
       end
       ids.uniq.sort.first(MAX_BACKLOG_SCANNED)

--- a/app/sidekiq/repair_order_charge_outcomes_job.rb
+++ b/app/sidekiq/repair_order_charge_outcomes_job.rb
@@ -44,9 +44,20 @@ class RepairOrderChargeOutcomesJob
 
   private
     def recent_candidate_ids
-      failed_purchase_ids = Purchase.checkout_failed.where(created_at: RECENT_WINDOW.ago..).pluck(:id)
-      filter_candidates(order_ids_for_purchases(failed_purchase_ids), created_at: RECENT_WINDOW.ago..)
-        .first(MAX_BACKLOG_SCANNED)
+      ids = []
+      since = RECENT_WINDOW.ago
+      # created_at covers lost-enqueue at checkout. updated_at covers an older purchase that
+      # fails later (SCA/restart attached to a new order). orders.created_at is unindexed, so
+      # the recent cohort cannot be keyed off the order timestamp without a 116M-row scan.
+      [Purchase.checkout_failed.where(created_at: since..),
+       Purchase.checkout_failed.where(updated_at: since..)].each do |rel|
+        rel.in_batches(of: FAILED_ORDER_ID_BATCH) do |batch|
+          ids.concat(filter_candidates(order_ids_for_purchases(batch.pluck(:id)), created_at: since..))
+          break if ids.size >= MAX_BACKLOG_SCANNED
+        end
+        break if ids.size >= MAX_BACKLOG_SCANNED
+      end
+      ids.uniq.sort.first(MAX_BACKLOG_SCANNED)
     end
 
     def backlog_candidate_ids(remaining_budget:)
@@ -54,15 +65,22 @@ class RepairOrderChargeOutcomesJob
 
       after_id = current_cursor
       ceiling = lap_ceiling(after_id)
-      ids, _scan_to, exhausted = backlog_page(after_id, ceiling, remaining_budget)
+      ids, scan_to, exhausted = backlog_page(after_id, ceiling, remaining_budget)
 
       if ids.empty? && exhausted && after_id.positive?
         save_cursor(0)
+        after_id = 0
         ceiling = lap_ceiling(0)
-        ids, _scan_to, exhausted = backlog_page(0, ceiling, remaining_budget)
+        ids, scan_to, exhausted = backlog_page(0, ceiling, remaining_budget)
       end
 
-      save_cursor(ids.last) if ids.any?
+      if ids.any?
+        save_cursor(ids.last)
+      elsif !exhausted && scan_to > after_id
+        # 40 failed-order pages with no qualifying candidate used to discard scan_to, so the
+        # next hour rescanned the same stretch and starved everything past it.
+        save_cursor(scan_to)
+      end
       ids
     end
 

--- a/spec/sidekiq/repair_order_charge_outcomes_job_spec.rb
+++ b/spec/sidekiq/repair_order_charge_outcomes_job_spec.rb
@@ -49,8 +49,7 @@ describe RepairOrderChargeOutcomesJob do
     expect(order.reload).to be_partially_successful
   end
 
-  # nyomanjyotisa reproduced this at 120 days: a preorder has no maximum release date, so any
-  # old-side horizon permanently excludes whatever settles after it. The walk now has none.
+  # Preorders have no maximum release date, so the walk has no old-side horizon.
   it "flags an order that settled beyond every settlement horizon" do
     order = settle_with_lost_enqueue(create(:order))
     order.update_column(:created_at, 120.days.ago)
@@ -101,10 +100,7 @@ describe RepairOrderChargeOutcomesJob do
     described_class.new.perform
   end
 
-  # Greptile (P1): an order all of whose purchases are already checkout-failed (both hard-declined,
-  # no successful sibling ever) can never satisfy `record_charge_outcome!`'s succeeded-and-failed
-  # check, so it can never leave the candidate set. A persistent pile of these would resurface every
-  # run and crowd out real repairable orders and the whole shared budget.
+  # All-failed orders can never become partial, so they must not consume the shared budget.
   it "excludes an order whose purchases are all checkout-failed, since it can never become partial" do
     order = create(:order)
     one = create(:purchase_in_progress, link: product_1, seller: seller_1)
@@ -123,9 +119,6 @@ describe RepairOrderChargeOutcomesJob do
     expect(real.reload).to be_partially_successful
   end
 
-  # Greptile (P1): the fresh pass had no cap and reconciled every candidate created in the last
-  # three days in one invocation — a burst of failures could make this hourly low-priority job
-  # perform an unbounded number of primary reads and writes. Both passes now share one budget.
   it "caps the fresh pass at the shared per-run budget rather than reconciling every candidate" do
     stub_const("#{described_class}::MAX_BACKLOG_SCANNED", 1)
     first = settle_with_lost_enqueue(create(:order))
@@ -138,19 +131,12 @@ describe RepairOrderChargeOutcomesJob do
     expect(second.reload).to be_partially_successful
   end
 
-  # Greptile (P1): the backlog cursor advances before the repair runs, so a process exiting between
-  # `save_cursor` and the actual write can leave a low-id order permanently below the cursor — the
-  # wrap that would revisit it only fires once a page comes back empty, which never happens while
-  # newer old-side failures keep arriving above the cursor. Fixing this needs the lap's upper bound
-  # pinned at lap start: once the cursor passes THAT ceiling the page is empty regardless of what
-  # arrived after, so the wrap (and the revisit) is guaranteed rather than starvable.
+  # Pin the lap upper bound at start so the wrap cannot starve while newer failures arrive.
   it "still repairs a stale order left below the cursor, even as new old-side failures keep arriving above it" do
     stale = settle_with_lost_enqueue(create(:order))
     stale.update_column(:created_at, 30.days.ago)
     stub_const("#{described_class}::MAX_BACKLOG_SCANNED", 1)
 
-    # Mirrors the crash Greptile reproduced: the cursor and lap ceiling already advanced past
-    # `stale`, but its repair itself never landed.
     $redis.set(RedisKey.order_charge_outcome_repair_cursor, stale.id)
     $redis.set(RedisKey.order_charge_outcome_repair_lap_ceiling, stale.id)
     expect(stale.reload).not_to be_partially_successful
@@ -191,9 +177,6 @@ describe RepairOrderChargeOutcomesJob do
     expect(combined).to be_empty
   end
 
-  # An unindexed updated_at scan would abort the 2-minute cap. A new order
-  # whose failed purchase predates RECENT_WINDOW is repaired once the order
-  # itself is old enough for the backlog pass.
   it "repairs via backlog an old order whose failed purchase predates the freshness window" do
     order = create(:order)
     succeeded = create(:purchase_in_progress, link: product_1, seller: seller_1)
@@ -209,8 +192,6 @@ describe RepairOrderChargeOutcomesJob do
     expect(order.reload).to be_partially_successful
   end
 
-  # Greptile (P1): a full failed-order scan budget of non-qualifying rows used to
-  # discard the scan cursor, so the next hour rescanned the same stretch.
   it "advances the backlog cursor across a sparse stretch of non-qualifying failed orders" do
     stub_const("#{described_class}::MAX_FAILED_ORDER_BATCHES", 1)
     stub_const("#{described_class}::FAILED_ORDER_ID_BATCH", 1)
@@ -237,8 +218,6 @@ describe RepairOrderChargeOutcomesJob do
     expect(real.reload).to be_partially_successful
   end
 
-  # One qualifying row used to pin the cursor at ids.last, so the rest of a
-  # fully-filtered 40-page window was walked again next hour.
   it "advances the backlog cursor to the last scanned failed order when a candidate sits in an otherwise sparse window" do
     stub_const("#{described_class}::MAX_FAILED_ORDER_BATCHES", 2)
     stub_const("#{described_class}::FAILED_ORDER_ID_BATCH", 1)
@@ -341,8 +320,6 @@ describe RepairOrderChargeOutcomesJob do
     expect(newest.reload).to be_partially_successful
   end
 
-  # A lost lap-ceiling key mid-lap used to leave the page unbounded above, so
-  # new failed rows kept every page non-empty and the wrap never fired.
   it "recomputes a missing lap ceiling mid-lap so the backlog walk can still wrap" do
     older = settle_with_lost_enqueue(create(:order))
     newer = settle_with_lost_enqueue(create(:order))

--- a/spec/sidekiq/repair_order_charge_outcomes_job_spec.rb
+++ b/spec/sidekiq/repair_order_charge_outcomes_job_spec.rb
@@ -156,4 +156,32 @@ describe RepairOrderChargeOutcomesJob do
 
     expect(stale.reload).to be_partially_successful
   end
+
+  it "wraps candidate lookups in WithMaxExecutionTime" do
+    expect(WithMaxExecutionTime).to receive(:timeout_queries)
+      .with(seconds: described_class::QUERY_TIME_BUDGET)
+      .and_call_original
+
+    described_class.new.perform
+  end
+
+  it "keeps each purchase id lookup at or under the IN-list batch size" do
+    expect(described_class::FAILED_ORDER_ID_BATCH).to be <= 1_000
+    expect(described_class::FAILED_ORDER_ID_BATCH).to be < described_class::MAX_BACKLOG_SCANNED
+  end
+
+  it "does not emit the old DISTINCT double-join of failed and non-failed purchases" do
+    sqls = []
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      sqls << payload[:sql]
+    end
+    settle_with_lost_enqueue(create(:order))
+    described_class.new.perform
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+
+    purchase_sqls = sqls.select { _1.include?("purchase_state") }
+    expect(purchase_sqls).not_to be_empty
+    combined = purchase_sqls.select { |sql| sql.match?(/`purchase_state` IN \(/) && sql.match?(/NOT IN \(/) }
+    expect(combined).to be_empty
+  end
 end

--- a/spec/sidekiq/repair_order_charge_outcomes_job_spec.rb
+++ b/spec/sidekiq/repair_order_charge_outcomes_job_spec.rb
@@ -21,7 +21,13 @@ describe RepairOrderChargeOutcomesJob do
     order
   end
 
-  before { $redis.del(RedisKey.order_charge_outcome_repair_cursor) }
+  before do
+    $redis.del(
+      RedisKey.order_charge_outcome_repair_cursor,
+      RedisKey.order_charge_outcome_repair_lap_ceiling,
+      RedisKey.order_charge_outcome_repair_recent_mark
+    )
+  end
 
   it "flags a partial order whose reconciliation enqueue was lost" do
     order = settle_with_lost_enqueue(create(:order))
@@ -282,5 +288,73 @@ describe RepairOrderChargeOutcomesJob do
     job.perform
 
     expect(calls).to eq(1)
+  end
+
+  # A page that yields more candidates than the remaining budget must leave the
+  # high-water mark before the overflow purchases, otherwise those orders are
+  # skipped until a wrap that ongoing fresh failures can starve.
+  it "does not advance the recent mark past overflow candidates when the budget fills mid-page" do
+    stub_const("#{described_class}::MAX_BACKLOG_SCANNED", 1)
+    stub_const("#{described_class}::FAILED_ORDER_ID_BATCH", 10)
+    stub_const("#{described_class}::MAX_FAILED_ORDER_BATCHES", 1)
+
+    first = settle_with_lost_enqueue(create(:order))
+    second = settle_with_lost_enqueue(create(:order))
+    mark = first.purchases.minimum(:id) - 1
+    $redis.set(RedisKey.order_charge_outcome_repair_recent_mark, mark)
+
+    described_class.new.perform
+
+    expect(first.reload).to be_partially_successful
+    expect(second.reload).not_to be_partially_successful
+    saved = $redis.get(RedisKey.order_charge_outcome_repair_recent_mark).to_i
+    expect(saved).to be < second.purchases.minimum(:id)
+    expect(saved).to be >= first.purchases.maximum(:id)
+
+    described_class.new.perform
+    expect(second.reload).to be_partially_successful
+  end
+
+  # Oldest-first in_batches under a full page budget never reaches the head of
+  # the window. With the recent-pass high-water already past the older failures,
+  # one run still repairs the newest stranded order.
+  it "repairs the newest stranded recent order when older failed purchases exceed the page budget" do
+    stub_const("#{described_class}::MAX_FAILED_ORDER_BATCHES", 1)
+    stub_const("#{described_class}::FAILED_ORDER_ID_BATCH", 1)
+
+    3.times do
+      order = create(:order)
+      one = create(:purchase_in_progress, link: product_1, seller: seller_1)
+      two = create(:purchase_in_progress, link: product_2, seller: seller_2)
+      order.purchases << one << two
+      one.update_columns(purchase_state: "failed")
+      two.update_columns(purchase_state: "failed")
+      RecordOrderChargeOutcomeJob.jobs.clear
+    end
+
+    newest = settle_with_lost_enqueue(create(:order))
+    mark = newest.purchases.minimum(:id) - 1
+    $redis.set(RedisKey.order_charge_outcome_repair_recent_mark, mark)
+
+    described_class.new.perform
+
+    expect(newest.reload).to be_partially_successful
+  end
+
+  # A lost lap-ceiling key mid-lap used to leave the page unbounded above, so
+  # new failed rows kept every page non-empty and the wrap never fired.
+  it "recomputes a missing lap ceiling mid-lap so the backlog walk can still wrap" do
+    older = settle_with_lost_enqueue(create(:order))
+    newer = settle_with_lost_enqueue(create(:order))
+    [older, newer].each { _1.update_column(:created_at, 30.days.ago) }
+    stub_const("#{described_class}::MAX_BACKLOG_SCANNED", 1)
+
+    $redis.set(RedisKey.order_charge_outcome_repair_cursor, older.id)
+    $redis.del(RedisKey.order_charge_outcome_repair_lap_ceiling)
+
+    described_class.new.perform
+
+    expect(newer.reload).to be_partially_successful
+    expect($redis.get(RedisKey.order_charge_outcome_repair_lap_ceiling).to_i).to be >= newer.id
   end
 end

--- a/spec/sidekiq/repair_order_charge_outcomes_job_spec.rb
+++ b/spec/sidekiq/repair_order_charge_outcomes_job_spec.rb
@@ -229,4 +229,57 @@ describe RepairOrderChargeOutcomesJob do
     described_class.new.perform
     expect(real.reload).to be_partially_successful
   end
+
+  # One qualifying row used to pin the cursor at ids.last, so the rest of a
+  # fully-filtered 40-page window was walked again next hour.
+  it "advances the backlog cursor to the last scanned failed order when a candidate sits in an otherwise sparse window" do
+    stub_const("#{described_class}::MAX_FAILED_ORDER_BATCHES", 2)
+    stub_const("#{described_class}::FAILED_ORDER_ID_BATCH", 1)
+    stub_const("#{described_class}::MAX_BACKLOG_SCANNED", 10)
+
+    real = settle_with_lost_enqueue(create(:order))
+    real.update_column(:created_at, 30.days.ago)
+
+    blocker = create(:order)
+    one = create(:purchase_in_progress, link: product_1, seller: seller_1)
+    two = create(:purchase_in_progress, link: product_2, seller: seller_2)
+    blocker.purchases << one << two
+    one.update_columns(purchase_state: "failed")
+    two.update_columns(purchase_state: "failed")
+    blocker.update_column(:created_at, 30.days.ago)
+    RecordOrderChargeOutcomeJob.jobs.clear
+
+    described_class.new.perform
+    expect(real.reload).to be_partially_successful
+    expect(blocker.reload).not_to be_partially_successful
+    expect($redis.get(RedisKey.order_charge_outcome_repair_cursor).to_i).to eq(blocker.id)
+  end
+
+  # Fully-failed recent purchases never grow the candidate cap, so without a
+  # page bound the recent pass can consume the whole run before backlog.
+  it "stops the recent failed-purchase scan at the failed-order batch cap" do
+    stub_const("#{described_class}::MAX_FAILED_ORDER_BATCHES", 1)
+    stub_const("#{described_class}::FAILED_ORDER_ID_BATCH", 1)
+
+    3.times do
+      order = create(:order)
+      one = create(:purchase_in_progress, link: product_1, seller: seller_1)
+      two = create(:purchase_in_progress, link: product_2, seller: seller_2)
+      order.purchases << one << two
+      one.update_columns(purchase_state: "failed")
+      two.update_columns(purchase_state: "failed")
+      RecordOrderChargeOutcomeJob.jobs.clear
+    end
+
+    job = described_class.new
+    calls = 0
+    allow(job).to receive(:order_ids_for_purchases).and_wrap_original do |method, *args|
+      calls += 1
+      method.call(*args)
+    end
+
+    job.perform
+
+    expect(calls).to eq(1)
+  end
 end

--- a/spec/sidekiq/repair_order_charge_outcomes_job_spec.rb
+++ b/spec/sidekiq/repair_order_charge_outcomes_job_spec.rb
@@ -185,16 +185,17 @@ describe RepairOrderChargeOutcomesJob do
     expect(combined).to be_empty
   end
 
-  # Greptile (P1): a pre-existing purchase can fail after being attached to a new order
-  # (SCA/restart). The recent pass keys off purchase created_at/updated_at, not the
-  # unindexed orders.created_at, so a recent updated_at still has to catch it.
-  it "flags a recent order whose failed purchase was created before the freshness window" do
+  # An unindexed updated_at scan would abort the 2-minute cap. A new order
+  # whose failed purchase predates RECENT_WINDOW is repaired once the order
+  # itself is old enough for the backlog pass.
+  it "repairs via backlog an old order whose failed purchase predates the freshness window" do
     order = create(:order)
     succeeded = create(:purchase_in_progress, link: product_1, seller: seller_1)
     failed = create(:purchase_in_progress, link: product_2, seller: seller_2)
     order.purchases << succeeded << failed
     succeeded.update_columns(purchase_state: "successful")
     failed.update_columns(purchase_state: "failed", created_at: 30.days.ago, updated_at: Time.current)
+    order.update_column(:created_at, 4.days.ago)
     RecordOrderChargeOutcomeJob.jobs.clear
 
     described_class.new.perform

--- a/spec/sidekiq/repair_order_charge_outcomes_job_spec.rb
+++ b/spec/sidekiq/repair_order_charge_outcomes_job_spec.rb
@@ -181,7 +181,52 @@ describe RepairOrderChargeOutcomesJob do
 
     purchase_sqls = sqls.select { _1.include?("purchase_state") }
     expect(purchase_sqls).not_to be_empty
-    combined = purchase_sqls.select { |sql| sql.match?(/`purchase_state` IN \(/) && sql.match?(/NOT IN \(/) }
+    combined = purchase_sqls.select { |sql| sql.include?("`purchase_state` IN (") && sql.include?("NOT IN (") }
     expect(combined).to be_empty
+  end
+
+  # Greptile (P1): a pre-existing purchase can fail after being attached to a new order
+  # (SCA/restart). The recent pass keys off purchase created_at/updated_at, not the
+  # unindexed orders.created_at, so a recent updated_at still has to catch it.
+  it "flags a recent order whose failed purchase was created before the freshness window" do
+    order = create(:order)
+    succeeded = create(:purchase_in_progress, link: product_1, seller: seller_1)
+    failed = create(:purchase_in_progress, link: product_2, seller: seller_2)
+    order.purchases << succeeded << failed
+    succeeded.update_columns(purchase_state: "successful")
+    failed.update_columns(purchase_state: "failed", created_at: 30.days.ago, updated_at: Time.current)
+    RecordOrderChargeOutcomeJob.jobs.clear
+
+    described_class.new.perform
+
+    expect(order.reload).to be_partially_successful
+  end
+
+  # Greptile (P1): a full failed-order scan budget of non-qualifying rows used to
+  # discard the scan cursor, so the next hour rescanned the same stretch.
+  it "advances the backlog cursor across a sparse stretch of non-qualifying failed orders" do
+    stub_const("#{described_class}::MAX_FAILED_ORDER_BATCHES", 1)
+    stub_const("#{described_class}::FAILED_ORDER_ID_BATCH", 1)
+    stub_const("#{described_class}::MAX_BACKLOG_SCANNED", 1)
+
+    blocker = create(:order)
+    one = create(:purchase_in_progress, link: product_1, seller: seller_1)
+    two = create(:purchase_in_progress, link: product_2, seller: seller_2)
+    blocker.purchases << one << two
+    one.update_columns(purchase_state: "failed")
+    two.update_columns(purchase_state: "failed")
+    blocker.update_column(:created_at, 30.days.ago)
+    RecordOrderChargeOutcomeJob.jobs.clear
+
+    real = settle_with_lost_enqueue(create(:order))
+    real.update_column(:created_at, 30.days.ago)
+
+    described_class.new.perform
+    expect(blocker.reload).not_to be_partially_successful
+    expect(real.reload).not_to be_partially_successful
+    expect($redis.get(RedisKey.order_charge_outcome_repair_cursor).to_i).to eq(blocker.id)
+
+    described_class.new.perform
+    expect(real.reload).to be_partially_successful
   end
 end


### PR DESCRIPTION
# Split RepairOrderChargeOutcomesJob candidate lookup

Draft. Head 08bfb17471: trimmed review-history comments (job, query, spec) and renamed unused wrap-pass exhausted (Lint Ruby UselessAssignment). Premerge owed at this head.

> Next: CI, Astra+Fable panel.

## What

Replaces `RepairOrderChargeOutcomesJob#candidates` (one DISTINCT double-join of checkout-failed and non-failed purchases) with three indexed lookups: materialize checkout-failed order ids, then PK-lookup siblings, then `not_partially_successful` + `created_at`. IN lists stay at 1,000. `lap_ceiling` is `Order.maximum(:id)` instead of MAX over the double-join. Candidate collection is wrapped in `WithMaxExecutionTime` (2 minutes per statement). Recent pass walks `purchases.id` from a Redis high-water mark. Cohort, 2,000-row cap, both passes, and cursor wrap are unchanged.

## Why

Addresses antiwork/gumroad-private#2519. The job dies hourly on `:low` with `ActiveRecord::StatementTimeout`. It is the backstop for lost `RecordOrderChargeOutcomeJob` enqueues. Pre-existing, not a Rails 7.2 regression.

## Before / after (primary, `DATABASE_HOST`, 2026-09-10)

- Before `lap_ceiling` EXPLAIN: `orders` type=ALL, key=null, **116,218,137 rows**. Session `max_execution_time` is 300s; that statement is the hourly death (cursor stays 0, same scan next hour).
- Before recent-pass EXPLAIN: `orders` type=index on PRIMARY, LIMIT-optimistic 5,575 rows — walks oldest ids first with no `created_at` index.
- After recent pipeline (equivalent SQL, timed on primary): 12,159 failed purchases in 3 days in 62ms; map to 9,488 order ids 627ms; sibling check 387ms; flag+window filter 121ms; **1,198ms total**, 29 unflagged mixed orders.
- After backlog failed-order-id page (LIMIT 1,000, `order_purchases.order_id` range): **554ms**, 868 unique ids. Sibling/flag lookups on 1,000 ids: EXPLAIN type=range, 1,000 rows, PRIMARY.
- After `Order.maximum(:id)`: EXPLAIN Extra=`Select tables optimized away`.

Replica EXPLAIN was not used; this job `connected_to(role: :writing)`.

## Checklist

- [x] Scope — job + spec only; no schema, no money-path writes beyond the existing set-only flag
- [x] Design — split the double-join; rejected raising `WithMaxExecutionTime` alone (no cap had been raised; shrinking the statement is the fix)
- [x] Build — `gumclaw/gp2519-repair-charge-outcomes`
- [ ] QA — local specs previously green; CI in flight at this head
- [ ] Shipped
- [x] Market — n/a, backend job
- [x] Sell — n/a

## Tests

```text
DISABLE_SPRING=1 bundle exec rspec spec/sidekiq/repair_order_charge_outcomes_job_spec.rb
```

Cap, both passes, wrap, cursor advance, all-failed exclusion, and no combined failed+NOT IN statement. This head is comment/lint only; examples unchanged.

## QA

Backend-only; no rendered surface. Proof is primary EXPLAIN/timings above plus the spec file. After deploy: no hourly `RepairOrderChargeOutcomesJob` / `StatementTimeout` deaths.

---

AI disclosure: grok-4.6 (xai). Prompt/instructions: autonomous-product-dev on gp#2519; shrink the statement, measure on primary, draft PR early.
