### PR TITLE
Spread deferred large blasts across an overnight window

### DIFF
--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -138,6 +138,8 @@ class RedisKey
     def workflow_immediate_enqueue_per_second = "workflow_immediate_enqueue_per_second"
     def workflow_immediate_fanout_max_spread_seconds = "workflow_immediate_fanout_max_spread_seconds"
     def seller_large_blast_threshold = "seller_large_blast_threshold"
+    def seller_large_blast_deferral_window_start_seconds = "seller_large_blast_deferral_window_start_seconds"
+    def seller_large_blast_deferral_window_length_seconds = "seller_large_blast_deferral_window_length_seconds"
     def seller_large_blast_quota(seller_id, day) = "seller_large_blast_quota:#{seller_id}:#{day}"
     # LIST of JSON {i: installment_id, p: purchase_id, t: epoch} pending an email_infos delivered UPDATE.
     def email_info_delivered_buffer = "email_info:delivered_buffer"

--- a/app/services/seller_large_blast_quota.rb
+++ b/app/services/seller_large_blast_quota.rb
@@ -5,6 +5,13 @@
 class SellerLargeBlastQuota
   DEFAULT_THRESHOLD = 10_000
 
+  # Measured from UTC midnight because that is when `claim` frees the next day's slot — run
+  # a deferred blast earlier and it hits the same claimed key and defers again. 3-7h past it
+  # is 23:00-03:00 ET on EDT, 22:00-02:00 ET on EST, both in the traffic trough; the old
+  # target of 00:00 UTC exactly was the busiest shopper hour (gumroad-private#2513).
+  DEFERRAL_WINDOW_START = 3.hours
+  DEFERRAL_WINDOW_LENGTH = 4.hours
+
   def self.allow?(seller_id:, blast_id:, recipient_count:, kind: "blast")
     return true if recipient_count.to_i < threshold
 
@@ -28,6 +35,29 @@ class SellerLargeBlastQuota
     return if blast_id.blank?
 
     "#{kind}:#{blast_id}"
+  end
+
+  # Each caller draws independently — that, not any coordination, is what spreads the herd.
+  def self.deferred_run_at
+    Time.zone.tomorrow.beginning_of_day + deferral_window_start_seconds + rand(deferral_window_length_seconds)
+  end
+
+  def self.deferral_window_start_seconds
+    tunable_seconds(RedisKey.seller_large_blast_deferral_window_start_seconds, DEFERRAL_WINDOW_START, minimum: 0)
+  end
+
+  def self.deferral_window_length_seconds
+    tunable_seconds(RedisKey.seller_large_blast_deferral_window_length_seconds, DEFERRAL_WINDOW_LENGTH, minimum: 1)
+  end
+
+  def self.tunable_seconds(key, default, minimum:)
+    raw = $redis.get(key)
+    return default.to_i if raw.blank?
+
+    value = raw.to_i
+    value >= minimum ? value : default.to_i
+  rescue Redis::BaseError, RedisClient::Error
+    default.to_i
   end
 
   def self.threshold

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -327,7 +327,7 @@ class SendPostBlastEmailsJob
     end
 
     def requeue_for_daily_blast_limit
-      job_id = self.class.perform_at(Time.zone.tomorrow.beginning_of_day, @blast.id)
+      job_id = self.class.perform_at(SellerLargeBlastQuota.deferred_run_at, @blast.id)
       return if job_id.present?
 
       raise "Sidekiq did not requeue the blast for the daily limit"

--- a/app/sidekiq/send_workflow_post_emails_job.rb
+++ b/app/sidekiq/send_workflow_post_emails_job.rb
@@ -363,7 +363,7 @@ class SendWorkflowPostEmailsJob
     end
 
     def requeue_for_daily_blast_limit(*args)
-      run_at = Time.zone.tomorrow.beginning_of_day
+      run_at = SellerLargeBlastQuota.deferred_run_at
       return unless defer_schedule_intent_until(run_at)
 
       job_id = self.class.perform_at(run_at, *args)

--- a/spec/services/seller_large_blast_quota_spec.rb
+++ b/spec/services/seller_large_blast_quota_spec.rb
@@ -10,6 +10,8 @@ describe SellerLargeBlastQuota, :freeze_time do
   after do
     $redis.del(RedisKey.seller_large_blast_quota(seller_id, Date.current))
     $redis.del(RedisKey.seller_large_blast_threshold)
+    $redis.del(RedisKey.seller_large_blast_deferral_window_start_seconds)
+    $redis.del(RedisKey.seller_large_blast_deferral_window_length_seconds)
   end
 
   it "lets any send under the threshold through without claiming the day" do
@@ -38,6 +40,46 @@ describe SellerLargeBlastQuota, :freeze_time do
     expect(ErrorNotifier).to receive(:notify)
 
     expect(described_class.allow?(seller_id:, blast_id: first_blast, recipient_count: described_class::DEFAULT_THRESHOLD)).to eq(false)
+  end
+
+  describe ".deferred_run_at" do
+    let(:window_start) { Time.zone.tomorrow.beginning_of_day + described_class::DEFERRAL_WINDOW_START }
+    let(:window_end) { window_start + described_class::DEFERRAL_WINDOW_LENGTH }
+
+    it "lands inside the overnight window, past the UTC midnight that frees the next day's slot" do
+      100.times do
+        run_at = described_class.deferred_run_at
+        expect(run_at).to be >= window_start
+        expect(run_at).to be < window_end
+        expect(run_at.to_date).to eq(Date.current + 1)
+      end
+    end
+
+    it "spreads sends across the window instead of stacking them on one instant" do
+      run_ats = Array.new(50) { described_class.deferred_run_at }
+
+      expect(run_ats.uniq.size).to be > 1
+      expect(run_ats.max - run_ats.min).to be > 1.hour
+    end
+
+    it "honors a Redis override of the window" do
+      $redis.set(RedisKey.seller_large_blast_deferral_window_start_seconds, 8.hours.to_i)
+      $redis.set(RedisKey.seller_large_blast_deferral_window_length_seconds, 1.hour.to_i)
+
+      run_at = described_class.deferred_run_at
+
+      expect(run_at).to be >= Time.zone.tomorrow.beginning_of_day + 8.hours
+      expect(run_at).to be < Time.zone.tomorrow.beginning_of_day + 9.hours
+    end
+
+    it "falls back to the default window when Redis is down" do
+      allow($redis).to receive(:get).and_raise(Redis::CannotConnectError, "no connection")
+
+      run_at = described_class.deferred_run_at
+
+      expect(run_at).to be >= window_start
+      expect(run_at).to be < window_end
+    end
   end
 
   it "opens a new slot the next day" do

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -992,14 +992,16 @@ describe SendPostBlastEmailsJob, :freeze_time do
   end
 
   describe "one large blast per seller per day" do
-    it "holds a second large blast until tomorrow" do
+    it "holds a second large blast until the quota's overnight window" do
       blast = create(:blast, :just_requested, post: basic_post_with_audience)
       allow(SellerLargeBlastQuota).to receive(:allow?).and_return(false)
+      run_at = Time.zone.tomorrow.beginning_of_day + 5.hours
+      allow(SellerLargeBlastQuota).to receive(:deferred_run_at).and_return(run_at)
 
       described_class.new.perform(blast.id)
 
       expect(PostSendgridApi.mails).to be_empty
-      expect(described_class).to have_enqueued_sidekiq_job(blast.id).at(Time.zone.tomorrow.beginning_of_day)
+      expect(described_class).to have_enqueued_sidekiq_job(blast.id).at(run_at)
       expect(blast.reload.completed_at).to be_nil
     end
   end

--- a/spec/sidekiq/send_workflow_post_emails_job_spec.rb
+++ b/spec/sidekiq/send_workflow_post_emails_job_spec.rb
@@ -850,6 +850,8 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
   end
 
   describe "one large blast per seller per day" do
+    let(:deferred_run_at) { Time.zone.tomorrow.beginning_of_day + 5.hours }
+
     before do
       @product = create(:product, user: @seller, price_cents: 0)
       @post.update!(
@@ -867,11 +869,12 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
 
     after { $redis.del(RedisKey.seller_large_blast_quota(@seller.id, Date.current)) }
 
-    it "fans out the first large post and holds the next one until tomorrow" do
+    it "fans out the first large post and holds the next one until the quota's overnight window" do
       second_post = create(:installment, :published, seller: @seller, link: @product, workflow: @workflow,
                                                      installment_type: Installment::PRODUCT_TYPE,
                                                      bought_products: [@product.unique_permalink])
       create(:post_rule, installment: second_post, delayed_delivery_time: 0)
+      allow(SellerLargeBlastQuota).to receive(:deferred_run_at).and_return(deferred_run_at)
 
       described_class.new.perform(@post.id)
       expect(SendWorkflowInstallmentWorker.jobs.size).to eq(4)
@@ -883,7 +886,7 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       expect(SendWorkflowInstallmentWorker.jobs).to be_empty
       expect(described_class).to have_enqueued_sidekiq_job(
         second_post.id, nil, false, nil, nil, nil
-      ).at(Time.zone.tomorrow.beginning_of_day)
+      ).at(deferred_run_at)
     end
 
     it "does not consume the day for a small audience" do
@@ -896,6 +899,7 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
     end
 
     it "holds a started schedule intent until the deferred job, so recovery cannot steal it" do
+      allow(SellerLargeBlastQuota).to receive(:deferred_run_at).and_return(deferred_run_at)
       described_class.new.perform(@post.id)
       SendWorkflowInstallmentWorker.jobs.clear
       described_class.jobs.clear
@@ -917,12 +921,10 @@ describe SendWorkflowPostEmailsJob, :freeze_time do
       expect(SendWorkflowInstallmentWorker.jobs).to be_empty
       expect(described_class).to have_enqueued_sidekiq_job(
         second_post.id, nil, false, nil, intent.token, fanout_token
-      ).at(Time.zone.tomorrow.beginning_of_day)
+      ).at(deferred_run_at)
       expect(intent.reload.processed_at).to be_nil
       expect(intent.fanout_token).to eq(fanout_token)
-      expect(intent.fanout_expires_at).to eq(
-        Time.zone.tomorrow.beginning_of_day + WorkflowInstallmentScheduleIntent::FANOUT_LEASE
-      )
+      expect(intent.fanout_expires_at).to eq(deferred_run_at + WorkflowInstallmentScheduleIntent::FANOUT_LEASE)
       expect(WorkflowInstallmentScheduleIntent.dispatchable).not_to include(intent)
     end
   end


### PR DESCRIPTION
Tracker: antiwork/gumroad-private#2513

## What

`SellerLargeBlastQuota` admits one large audience send per seller per day. Everything over
that quota is requeued for the next day, and until now every requeued blast was scheduled
for the exact same moment: `Time.zone.tomorrow.beginning_of_day`.

Two problems with that timestamp. It is 00:00 UTC, which is 8pm ET — one of the busiest
hours for shopper traffic, not a quiet one. And it is a single shared instant, so blasts
held back across several different days and several different sellers all fire together.

Both requeue paths — `SendPostBlastEmailsJob` and `SendWorkflowPostEmailsJob` — now ask the
quota when to run instead of computing midnight themselves:

```ruby
def self.deferred_run_at
  Time.zone.tomorrow.beginning_of_day + deferral_window_start_seconds + rand(deferral_window_length_seconds)
end
```

That is UTC midnight + 3h + `rand(4h)`, so deferred blasts land somewhere in 23:00–03:00 ET
during EDT, or 22:00–02:00 ET during EST, each one at its own randomly drawn second.

The window's start and length are Redis-tunable
(`seller_large_blast_deferral_window_start_seconds` and `…_length_seconds`), matching how
the quota's own threshold already works, so the window can be moved or collapsed without a
deploy.

## Why

A large blast generates a delivery callback per recipient, and each callback enqueues work
on the shared `low` Sidekiq queue. The Sidekiq autoscaler sizes the fleet directly off that
queue's depth, so a pile of blasts releasing at one instant expands the worker fleet hard
and fast, and the resulting database load lands on shopper-serving requests. Shopper page
response times rise for the few minutes it takes to drain.

Spreading the releases across a four-hour window attacks that at the source: the same
volume of email goes out, but the callback load arrives as a series of much smaller waves
instead of one spike, and it arrives during the daily traffic trough rather than on top of
the peak. Nothing about the autoscaler changes — burst scaling for callbacks stays exactly
as it is, which is deliberate: excluding these jobs from autoscaling was proposed in #7462
and rejected.

**Why the offset is measured from UTC midnight rather than an ET wall-clock time.**
`SellerLargeBlastQuota.claim` keys on `Date.current` and expires at end of UTC day, so the
next day's slot only opens at the UTC date rollover. A deferred blast that ran before that
rollover would find the same claimed key, be rejected again, and defer itself another full
day. Anchoring the window in ET directly would do exactly that to any blast deferred
between 20:00 and 24:00 UTC. Measuring from UTC midnight keeps the guarantee the old code
got for free, and the resulting ET window sits in the overnight trough under both EDT and
EST, so no DST handling is needed.

## Scope

This fixes the aggregate herd, not a single seller's burst. One large blast still fans out
unpaced in 2,000-member slices, so a single big send can still drive a substantial
scale-out on its own. Pacing that fan-out — the way `SendWorkflowPostEmailsJob` already
paces its immediate path with `MAX_IMMEDIATE_SPREAD` — is separate work.

## Test Results

```text
spec/services/seller_large_blast_quota_spec.rb
spec/sidekiq/send_post_blast_emails_job_spec.rb
spec/sidekiq/send_workflow_post_emails_job_spec.rb
```

New coverage on `.deferred_run_at`: it lands inside the window, it lands past the UTC
midnight that frees the next day's quota slot, repeated calls actually spread rather than
returning one instant, a Redis override moves the window, and a Redis failure falls back to
the default window. The three existing deferral assertions now stub `deferred_run_at` and
assert against it, so reverting either call site to `Time.zone.tomorrow.beginning_of_day`
fails them.

---

This PR was implemented with AI assistance using Claude Opus 5.
