### PR TITLE
Keep the Connect button visible in dark mode on Social connections

### DIFF
--- a/app/javascript/components/SocialAuthButton.test.tsx
+++ b/app/javascript/components/SocialAuthButton.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SocialAuthButton } from "$app/components/SocialAuthButton";
+
+vi.mock("@inertiajs/react", () => ({
+  usePage: () => ({ props: { authenticity_token: "test-csrf" } }),
+}));
+
+afterEach(cleanup);
+
+describe("SocialAuthButton", () => {
+  it("uses the provider brand color when no override is passed", () => {
+    render(
+      <SocialAuthButton href="/auth/twitter" provider="twitter">
+        Connect
+      </SocialAuthButton>,
+    );
+
+    expect(screen.getByRole("button", { name: "Connect" }).className).toContain("bg-black");
+  });
+
+  it("uses the color override so Connect stays visible in dark mode", () => {
+    // X/Twitter brand fill is black. On Settings → Social connections that is
+    // black-on-black in dark mode; the page passes primary instead.
+    render(
+      <SocialAuthButton href="/auth/twitter" provider="twitter" color="primary">
+        Connect
+      </SocialAuthButton>,
+    );
+
+    const className = screen.getByRole("button", { name: "Connect" }).className;
+    expect(className).toContain("bg-primary");
+    expect(className).not.toContain("bg-black");
+  });
+});

--- a/app/javascript/components/SocialAuthButton.tsx
+++ b/app/javascript/components/SocialAuthButton.tsx
@@ -7,6 +7,7 @@ import { BrandName, Button, ButtonProps } from "$app/components/Button";
 export const SocialAuthButton = ({
   href,
   provider,
+  color,
   ...props
 }: {
   href: string;
@@ -27,7 +28,7 @@ export const SocialAuthButton = ({
             document.body,
           )
         : null}
-      <Button {...props} color={provider} onClick={() => formRef.current?.submit()}>
+      <Button {...props} color={color ?? provider} onClick={() => formRef.current?.submit()}>
         {props.children}
       </Button>
     </>

--- a/app/javascript/pages/Settings/SocialConnections/Show.tsx
+++ b/app/javascript/pages/Settings/SocialConnections/Show.tsx
@@ -168,7 +168,12 @@ export default function SocialConnectionsPage() {
                           Remove
                         </Button>
                       ) : null}
-                      <SocialAuthButton provider={key} href={connectHref} aria-label={`Connect to ${name}`}>
+                      <SocialAuthButton
+                        provider={key}
+                        href={connectHref}
+                        color="primary"
+                        aria-label={`Connect to ${name}`}
+                      >
                         Connect
                       </SocialAuthButton>
                     </>


### PR DESCRIPTION
## What

`SocialAuthButton` now accepts a `color` override. Settings → Social connections passes `primary`, so the Connect button uses the theme's primary fill and stays distinct from the outline Disconnect button in both color schemes.

## Why

`SocialAuthButton` forces the provider's brand color. For X, YouTube, and Instagram that color is a fixed black. In light mode the button reads as a filled primary action. In dark mode it is black on black, and the Connect and Disconnect buttons in the same row list look identical. Login and signup keep the brand colors, since they pass no override.

## Before / After

Desktop, Settings → Social connections, X connected and YouTube and Instagram not connected.

### Before

![Before, dark](https://github.com/user-attachments/assets/a481aaa3-57df-4d45-b6c9-8614375e4945)

![Before, light](https://github.com/user-attachments/assets/994ac0b3-07d3-4831-935b-4227640c3271)

### After

![After, dark](https://github.com/user-attachments/assets/6ea713d9-6a7f-4804-ba86-990f29e76c67)

![After, light](https://github.com/user-attachments/assets/04cf3b6b-b698-4321-8f79-6fa38854192c)

## Test results

- `bin/rspec spec/requests/settings/social_connections_spec.rb`: 5 examples, 0 failures
- `npx tsc --noEmit`, eslint, prettier: clean
- `/autoreview` (Codex) on the branch against `main`: clean

## QA steps

1. Sign in as a seller and open Settings → Social connections.
2. Switch the system color scheme to dark. Confirm the Connect button is filled and the Disconnect button is outlined.
3. Open the login page. Confirm the X button still uses the black brand style.

---
AI assistance: Claude Fable 5.1.
