### PR TITLE
Rebuild a blast's audience as of started_at when its snapshot is gone

### DIFF
--- a/app/models/audience_member.rb
+++ b/app/models/audience_member.rb
@@ -43,11 +43,9 @@ class AudienceMember < ApplicationRecord
   # the unrestricted filter over the whole audience would be slow. Used by blast retries
   # to revalidate their snapshotted recipient lists.
   #
-  # as_of: optionally restricts the audience to what it was at that time: the row must have
-  # existed, and the purchase, follow or affiliation that qualifies the member must predate
-  # it too — `refresh!` adds a later purchase to an existing row without touching
-  # `created_at`. Anyone who has since left is still dropped. Used by blast resumes that
-  # have lost their snapshot, so a late send cannot reach later joiners.
+  # as_of: the audience as it stood then. The row and the purchase, follow or affiliation that
+  # qualifies the member must predate it; `refresh!` adds later purchases to an existing row
+  # without touching `created_at`, so the row bound alone is not enough.
   def self.filter(seller_id:, params: {}, with_ids: false, ids: nil, as_of: nil)
     params = normalize_filter_params(params)
     base_scope = where(seller_id:)
@@ -226,10 +224,8 @@ class AudienceMember < ApplicationRecord
         json_filter = json_filter.where(where_conditions, date: params[:created_before])
       end
       if as_of
-        # Sibling JSON_TABLE paths expand into disjoint rows, so a follower's or affiliate's
-        # own timestamp is NULL on the purchase rows a purchase predicate keeps. Read the
-        # follow time from its own expansion, and bound the qualifying purchase row only when
-        # a purchase predicate has narrowed `jt` to purchases.
+        # Purchase predicates keep only purchase rows, on which the follower and affiliate
+        # timestamps are NULL, so bound the purchase row only once `jt` is narrowed to purchases.
         purchase_predicate = params.values_at(
           :bought_product_ids, :bought_variant_ids, :paid_more_than_cents, :paid_less_than_cents,
           :bought_from, :active_customers_only, :minimum_license_uses
@@ -238,11 +234,10 @@ class AudienceMember < ApplicationRecord
         when "customer"
           json_filter = json_filter.where("jt.purchase_created_at <= ?", as_of)
         when "follower"
-          # The stored date is the follow, not its confirmation, so a member who already had a
-          # row and confirmed a pending follow after as_of still passes. Accepted: a new
-          # follower has no earlier row, and the row bound above catches them.
-          follower_json_table = "JSON_TABLE(details, '$.follower' COLUMNS (created_at DATETIME PATH '$.created_at'))"
-          json_filter = json_filter.joins("INNER JOIN #{follower_json_table} AS follower_jt").where("follower_jt.created_at <= ?", as_of)
+          # The details JSON stores the follow date; eligibility begins at confirmation.
+          json_filter = json_filter
+            .joins("INNER JOIN followers ON followers.followed_id = audience_members.seller_id AND followers.email = audience_members.email")
+            .where("followers.confirmed_at <= ?", as_of)
           json_filter = json_filter.where("jt.purchase_created_at <= ?", as_of) if purchase_predicate
         when "affiliate"
           json_filter = json_filter.where("affiliate_jt.affiliate_created_at <= ?", as_of)

--- a/app/models/audience_member.rb
+++ b/app/models/audience_member.rb
@@ -42,10 +42,17 @@ class AudienceMember < ApplicationRecord
   # resolved member list against the CURRENT filter criteria is cheap even when running
   # the unrestricted filter over the whole audience would be slow. Used by blast retries
   # to revalidate their snapshotted recipient lists.
-  def self.filter(seller_id:, params: {}, with_ids: false, ids: nil)
+  #
+  # as_of: optionally restricts the audience to what it was at that time: the row must have
+  # existed, and the purchase, follow or affiliation that qualifies the member must predate
+  # it too — `refresh!` adds a later purchase to an existing row without touching
+  # `created_at`. Anyone who has since left is still dropped. Used by blast resumes that
+  # have lost their snapshot, so a late send cannot reach later joiners.
+  def self.filter(seller_id:, params: {}, with_ids: false, ids: nil, as_of: nil)
     params = normalize_filter_params(params)
     base_scope = where(seller_id:)
     base_scope = base_scope.where(id: ids) if ids
+    base_scope = base_scope.where(created_at: ..as_of) if as_of
 
     if params[:type]
       types_sql = base_scope.where(params[:type] => true).to_sql
@@ -134,7 +141,7 @@ class AudienceMember < ApplicationRecord
     filter_purchases_when ||= (params[:paid_more_than_cents] && params[:paid_less_than_cents])
     filter_purchases_when ||= (params[:created_after] && params[:created_before])
     filter_purchases_when ||= params[:active_customers_only] || params[:minimum_license_uses]
-    if filter_purchases_when || with_ids
+    if filter_purchases_when || with_ids || as_of
       json_filter = base_scope
       json_table = <<~SQL.squish
         JSON_TABLE(details, '$' COLUMNS (
@@ -217,6 +224,32 @@ class AudienceMember < ApplicationRecord
       if params[:created_before] && timestamp_columns.any?
         where_conditions = timestamp_columns.map { "jt.#{_1} < :date" }.join(" OR ")
         json_filter = json_filter.where(where_conditions, date: params[:created_before])
+      end
+      if as_of
+        # Sibling JSON_TABLE paths expand into disjoint rows, so a follower's or affiliate's
+        # own timestamp is NULL on the purchase rows a purchase predicate keeps. Read the
+        # follow time from its own expansion, and bound the qualifying purchase row only when
+        # a purchase predicate has narrowed `jt` to purchases.
+        purchase_predicate = params.values_at(
+          :bought_product_ids, :bought_variant_ids, :paid_more_than_cents, :paid_less_than_cents,
+          :bought_from, :active_customers_only, :minimum_license_uses
+        ).any?
+        case params[:type]
+        when "customer"
+          json_filter = json_filter.where("jt.purchase_created_at <= ?", as_of)
+        when "follower"
+          # The stored date is the follow, not its confirmation, so a member who already had a
+          # row and confirmed a pending follow after as_of still passes. Accepted: a new
+          # follower has no earlier row, and the row bound above catches them.
+          follower_json_table = "JSON_TABLE(details, '$.follower' COLUMNS (created_at DATETIME PATH '$.created_at'))"
+          json_filter = json_filter.joins("INNER JOIN #{follower_json_table} AS follower_jt").where("follower_jt.created_at <= ?", as_of)
+          json_filter = json_filter.where("jt.purchase_created_at <= ?", as_of) if purchase_predicate
+        when "affiliate"
+          json_filter = json_filter.where("affiliate_jt.affiliate_created_at <= ?", as_of)
+          json_filter = json_filter.where("jt.purchase_created_at <= ?", as_of) if purchase_predicate
+        else
+          json_filter = json_filter.where("COALESCE(jt.purchase_created_at, jt.follower_created_at, jt.affiliate_created_at) <= ?", as_of)
+        end
       end
       if params[:bought_product_ids] && params[:bought_variant_ids]
         json_filter = json_filter.where("jt.purchase_product_id IN (?) OR jt.purchase_variant_id IN (?)", params[:bought_product_ids], params[:bought_variant_ids])

--- a/app/sidekiq/concerns/post_blast_sending.rb
+++ b/app/sidekiq/concerns/post_blast_sending.rb
@@ -13,8 +13,10 @@ module PostBlastSending
   # unlike the audience snapshot, it is tiny and is the only evidence for late safe resumes.
   PENDING_RECIPIENTS_TTL = AlertOnStalledPostEmailBlastsJob::LOOKBACK
 
-  # How long a sent-in-this-blast marker survives for a non-opener resend's dedupe.
-  BLAST_DEDUPE_TTL = 7.days
+  # How long a sent-in-this-blast marker survives for a non-opener resend's dedupe. Kept for
+  # the full scan window: it is the only record of who already received the resend, so a
+  # late resume with no audience snapshot refuses to run once it is gone.
+  BLAST_DEDUPE_TTL = AlertOnStalledPostEmailBlastsJob::LOOKBACK
 
   # How long the per-chunk completion set survives. Long enough that the last children of a
   # multi-hour blast can finish and stamp `completed_at`; an abandoned shell just expires and

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -30,6 +30,8 @@ class SendPostBlastEmailsJob
     Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} post_id=#{@post.id}")
     return unless @post.alive? && @post.published? && @post.send_emails? && @blast.completed_at.nil?
 
+    # Captured before the stamp: a first-run crash and a late resume both arrive without a snapshot.
+    @resume_without_snapshot = @blast.started_at.present?
     @blast.update!(started_at: Time.current) if @blast.started_at.nil?
 
     # A retry that finds a live partition re-enqueues its stored chunks as-is; loading and
@@ -86,6 +88,9 @@ class SendPostBlastEmailsJob
     # seller's audience. Once it is gone, `load_audience_members` rebuilds from MySQL.
     AUDIENCE_SNAPSHOT_TTL = AlertOnStalledPostEmailBlastsJob::LOOKBACK
 
+    # A resume older than this, or one that already owes recipients, cannot be a first-run crash.
+    AUDIENCE_SNAPSHOT_GRACE = 1.day
+
     # How many snapshotted member ids to revalidate per statement. Small on purpose:
     # MySQL's range optimizer silently drops the PK plan once an `IN (...)` list blows
     # its memory budget, and looks the rows up through (seller_id, email) instead —
@@ -98,13 +103,11 @@ class SendPostBlastEmailsJob
     # Redis list/set writes only — no SQL — so this can stay large.
     REDIS_WRITE_SLICE_SIZE = 10_000
 
-    # Audience filter params whose eligibility `AudienceMember.filter(as_of:)` cannot rewind:
-    # each reads state outside the dated purchase, follow or affiliation, or the absence of
-    # one. Edits to a relationship that already existed before the send (a variant swap on
-    # an old purchase, a pending follow confirmed later) are accepted: the member was already
-    # the seller's, and the send is late by days, not to a stranger.
+    # Filter params `AudienceMember.filter(as_of:)` cannot rewind: each reads state outside the
+    # dated purchase, follow or affiliation (a live counter, a variant swap, a refund, an added
+    # product affiliation), or the absence of one.
     UNREBUILDABLE_FILTER_KEYS = %i[
-      minimum_license_uses active_customers_only not_bought_product_ids not_bought_variant_ids affiliate_product_ids
+      minimum_license_uses active_customers_only bought_variant_ids not_bought_product_ids not_bought_variant_ids affiliate_product_ids
     ].freeze
 
     # Blasts above this many recipients are split into slice jobs. Small blasts send
@@ -204,34 +207,21 @@ class SendPostBlastEmailsJob
       snapshotted_ids = $redis.lrange(snapshot_key, 0, -1)
 
       if snapshotted_ids.empty?
-        # Fully delivered (`fully_delivered?`) with the snapshot gone: every recipient the
-        # original attempt picked is already with the ESP, and this resume exists only to
-        # stamp `completed_at`. Hand back nothing — `perform` completes the blast on an
-        # empty audience without paying for the scan.
+        # Fully delivered: nothing left to send, so skip the scan and let `perform` stamp it.
         pending = $redis.get(RedisKey.blast_pending_recipients(@blast.id))
         return [] if pending.present? && pending.to_i <= 0
 
-        # A non-opener resend dedupes only through its per-blast sent set; the SentPostEmail
-        # rows belong to the original send. Once that set is gone as well, nothing records who
-        # already received the resend, and a rebuild would mail them a second time.
-        if @blast.to_non_openers? && @blast.first_email_delivered_at.present? && !$redis.exists?(RedisKey.blast_sent_emails(@blast.id))
-          raise "missing audience snapshot and sent set for non-opener resend #{@blast.id}; refusing to rebuild"
+        if stale_resume?(pending)
+          # The per-blast sent set is a resend's only dedupe; SentPostEmail rows belong to the original send.
+          if @blast.to_non_openers? && !$redis.exists?(RedisKey.blast_sent_emails(@blast.id))
+            raise "missing audience snapshot and sent set for non-opener resend #{@blast.id}; refusing to rebuild"
+          end
+          if @filters.values_at(*UNREBUILDABLE_FILTER_KEYS).any?(&:present?)
+            raise "missing audience snapshot for blast #{@blast.id}; its filter's eligibility cannot be rebuilt"
+          end
         end
 
-        # Some filters read state no timestamp can rewind: a live license-use count, a
-        # subscription that was cancelled and then resumed, a refund that lifts a not-bought
-        # exclusion, a product affiliation added later under the affiliate's original date.
-        # Once something was delivered, a rebuild would admit people who qualified after the
-        # send, so those blasts keep failing closed.
-        if @blast.first_email_delivered_at.present? && @filters.values_at(*UNREBUILDABLE_FILTER_KEYS).any?(&:present?)
-          raise "missing audience snapshot for blast #{@blast.id}; its filter's eligibility cannot be rebuilt"
-        end
-
-        # The snapshot is a fast path, not the source of truth. Bounding the filter to
-        # `started_at` recovers the audience as it stood when the send began, so a resume
-        # days later (snapshot expired or evicted) cannot reach people who joined or became
-        # eligible after the original send (gumroad-private#2520). On a first run
-        # `started_at` was stamped moments ago and the bound changes nothing.
+        # Bounded to `started_at`: a resume days later must not reach people who joined after the send.
         members = WithMaxExecutionTime.timeout_queries(seconds: audience_load_timeout_seconds) do
           AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true, as_of: @blast.started_at)
             .select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
@@ -243,6 +233,13 @@ class SendPostBlastEmailsJob
         $redis.expire(snapshot_key, AUDIENCE_SNAPSHOT_TTL.to_i)
         revalidate_snapshotted_members(snapshotted_ids.map(&:to_i))
       end
+    end
+
+    # A first-run crash may still rebuild the live audience; a resume that delivered, owes
+    # recipients, or is past the grace window has an original audience the rebuild must respect.
+    def stale_resume?(pending)
+      @resume_without_snapshot &&
+        (@blast.first_email_delivered_at.present? || (pending.present? && pending.to_i.positive?) || @blast.started_at < AUDIENCE_SNAPSHOT_GRACE.ago)
     end
 
     # Existence of the audience_members row is not enough: a customer who also

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -30,9 +30,6 @@ class SendPostBlastEmailsJob
     Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} post_id=#{@post.id}")
     return unless @post.alive? && @post.published? && @post.send_emails? && @blast.completed_at.nil?
 
-    # Capture before the first-run stamp: a late resume with no Redis snapshot must
-    # not rebuild the live audience (people who joined after the original send).
-    @resume_without_snapshot = @blast.started_at.present?
     @blast.update!(started_at: Time.current) if @blast.started_at.nil?
 
     # A retry that finds a live partition re-enqueues its stored chunks as-is; loading and
@@ -84,15 +81,10 @@ class SendPostBlastEmailsJob
   end
 
   private
-    # How long the point-in-time audience snapshot survives in Redis. It must cover the
-    # stalled-blast scan window: a late resume is only safe while the original audience
-    # still exists, otherwise the sender would rebuild the audience and include later joins.
+    # How long the audience snapshot survives in Redis. Covers the stalled-blast scan window
+    # so every retry and auto-resume in it takes the PK-bound path instead of rescanning the
+    # seller's audience. Once it is gone, `load_audience_members` rebuilds from MySQL.
     AUDIENCE_SNAPSHOT_TTL = AlertOnStalledPostEmailBlastsJob::LOOKBACK
-
-    # How long after `started_at` a resume may still rebuild the live audience. Covers the
-    # first-run crash (stamp written, snapshot not yet) without covering a stalled blast that
-    # only auto-resumes days later, by which point the audience has moved on.
-    AUDIENCE_SNAPSHOT_GRACE = 1.day
 
     # How many snapshotted member ids to revalidate per statement. Small on purpose:
     # MySQL's range optimizer silently drops the PK plan once an `IN (...)` list blows
@@ -105,6 +97,15 @@ class SendPostBlastEmailsJob
 
     # Redis list/set writes only — no SQL — so this can stay large.
     REDIS_WRITE_SLICE_SIZE = 10_000
+
+    # Audience filter params whose eligibility `AudienceMember.filter(as_of:)` cannot rewind:
+    # each reads state outside the dated purchase, follow or affiliation, or the absence of
+    # one. Edits to a relationship that already existed before the send (a variant swap on
+    # an old purchase, a pending follow confirmed later) are accepted: the member was already
+    # the seller's, and the send is late by days, not to a stranger.
+    UNREBUILDABLE_FILTER_KEYS = %i[
+      minimum_license_uses active_customers_only not_bought_product_ids not_bought_variant_ids affiliate_product_ids
+    ].freeze
 
     # Blasts above this many recipients are split into slice jobs. Small blasts send
     # inline (one short-lived job); large ones must not run for hours as a single unit.
@@ -203,27 +204,37 @@ class SendPostBlastEmailsJob
       snapshotted_ids = $redis.lrange(snapshot_key, 0, -1)
 
       if snapshotted_ids.empty?
-        pending = $redis.get(RedisKey.blast_pending_recipients(@blast.id))
-
         # Fully delivered (`fully_delivered?`) with the snapshot gone: every recipient the
         # original attempt picked is already with the ESP, and this resume exists only to
-        # stamp `completed_at`. Rebuilding the audience here would email everyone who joined
-        # since, so hand back nothing — `perform` completes the blast on an empty audience.
-        # Age is irrelevant: there is nothing left to send at any age.
-        return [] if @resume_without_snapshot && pending.present? && pending.to_i <= 0
+        # stamp `completed_at`. Hand back nothing — `perform` completes the blast on an
+        # empty audience without paying for the scan.
+        pending = $redis.get(RedisKey.blast_pending_recipients(@blast.id))
+        return [] if pending.present? && pending.to_i <= 0
 
-        # First-run crash (started_at just set, no snapshot yet) must still load.
-        # A stalled auto-resume days later must not pick up people who joined after.
-        # A positive pending count means an earlier attempt got past the snapshot write
-        # with recipients still owed, so a missing snapshot is lost Redis state, not a
-        # first run — refuse inside the grace window too. The age check stands alone for
-        # the reverse loss: MySQL keeps `started_at` when Redis drops both keys.
-        if @resume_without_snapshot &&
-           (@blast.started_at < AUDIENCE_SNAPSHOT_GRACE.ago || (pending.present? && pending.to_i.positive?))
-          raise "missing audience snapshot for blast #{@blast.id}; refusing to rebuild the live audience"
+        # A non-opener resend dedupes only through its per-blast sent set; the SentPostEmail
+        # rows belong to the original send. Once that set is gone as well, nothing records who
+        # already received the resend, and a rebuild would mail them a second time.
+        if @blast.to_non_openers? && @blast.first_email_delivered_at.present? && !$redis.exists?(RedisKey.blast_sent_emails(@blast.id))
+          raise "missing audience snapshot and sent set for non-opener resend #{@blast.id}; refusing to rebuild"
         end
+
+        # Some filters read state no timestamp can rewind: a live license-use count, a
+        # subscription that was cancelled and then resumed, a refund that lifts a not-bought
+        # exclusion, a product affiliation added later under the affiliate's original date.
+        # Once something was delivered, a rebuild would admit people who qualified after the
+        # send, so those blasts keep failing closed.
+        if @blast.first_email_delivered_at.present? && @filters.values_at(*UNREBUILDABLE_FILTER_KEYS).any?(&:present?)
+          raise "missing audience snapshot for blast #{@blast.id}; its filter's eligibility cannot be rebuilt"
+        end
+
+        # The snapshot is a fast path, not the source of truth. Bounding the filter to
+        # `started_at` recovers the audience as it stood when the send began, so a resume
+        # days later (snapshot expired or evicted) cannot reach people who joined or became
+        # eligible after the original send (gumroad-private#2520). On a first run
+        # `started_at` was stamped moments ago and the bound changes nothing.
         members = WithMaxExecutionTime.timeout_queries(seconds: audience_load_timeout_seconds) do
-          AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true).select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
+          AudienceMember.filter(seller_id: @post.seller_id, params: @filters, with_ids: true, as_of: @blast.started_at)
+            .select(:id, :email, :purchase_id, :follower_id, :affiliate_id).to_a
         end
         write_audience_snapshot(snapshot_key, members)
         members

--- a/spec/models/audience_member_spec.rb
+++ b/spec/models/audience_member_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe AudienceMember, :freeze_time do
       # An old follower row that picked up its first purchase after as_of: the row predates
       # the bound, the purchase that would qualify it does not.
       late_buyer = create_member(follower: { "created_at" => 3.days.ago.iso8601 }, purchases: [{ "product_id" => 1, "created_at" => 1.hour.ago.iso8601 }])
+      create(:active_follower, user: seller, email: late_buyer.email, confirmed_at: 3.days.ago)
       [early_buyer, late_buyer].each { _1.update_column(:created_at, 4.days.ago) }
 
       expect(described_class.filter(seller_id:, params: { bought_product_ids: [1] }, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([early_buyer])
@@ -119,14 +120,27 @@ RSpec.describe AudienceMember, :freeze_time do
 
     it "bounds the follow and the qualifying purchase separately for follower blasts" do
       # Purchase predicates keep only purchase rows, on which the follower timestamp is NULL.
-      old_follower_old_buyer = create_member(follower: { "created_at" => 3.days.ago.iso8601 }, purchases: [{ "product_id" => 1, "price_cents" => 200, "created_at" => 3.days.ago.iso8601 }])
-      create_member(follower: { "created_at" => 1.hour.ago.iso8601 }, purchases: [{ "product_id" => 1, "price_cents" => 200, "created_at" => 3.days.ago.iso8601 }])
-      old_follower_new_buyer = create_member(follower: { "created_at" => 3.days.ago.iso8601 }, purchases: [{ "product_id" => 1, "price_cents" => 200, "created_at" => 1.hour.ago.iso8601 }])
+      old_follower_old_buyer = create_member(follower: {}, purchases: [{ "product_id" => 1, "price_cents" => 200, "created_at" => 3.days.ago.iso8601 }])
+      new_follower_old_buyer = create_member(follower: {}, purchases: [{ "product_id" => 1, "price_cents" => 200, "created_at" => 3.days.ago.iso8601 }])
+      old_follower_new_buyer = create_member(follower: {}, purchases: [{ "product_id" => 1, "price_cents" => 200, "created_at" => 1.hour.ago.iso8601 }])
+      create(:active_follower, user: seller, email: old_follower_old_buyer.email, confirmed_at: 3.days.ago)
+      create(:active_follower, user: seller, email: new_follower_old_buyer.email, confirmed_at: 1.hour.ago)
+      create(:active_follower, user: seller, email: old_follower_new_buyer.email, confirmed_at: 3.days.ago)
       described_class.where(seller_id:).update_all(created_at: 4.days.ago)
 
       expect(described_class.filter(seller_id:, params: { type: "follower", paid_more_than_cents: 100 }, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([old_follower_old_buyer])
       expect(described_class.filter(seller_id:, params: { type: "follower", bought_product_ids: [1] }, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([old_follower_old_buyer])
       expect(described_class.filter(seller_id:, params: { type: "follower" }, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([old_follower_old_buyer, old_follower_new_buyer])
+    end
+
+    it "bounds follower eligibility by confirmation, not by the follow date" do
+      confirmed_late = create_member(follower: { "created_at" => 3.days.ago.iso8601 })
+      confirmed_early = create_member(follower: { "created_at" => 3.days.ago.iso8601 })
+      create(:active_follower, user: seller, email: confirmed_late.email, created_at: 3.days.ago, confirmed_at: 1.hour.ago)
+      create(:active_follower, user: seller, email: confirmed_early.email, created_at: 3.days.ago, confirmed_at: 2.days.ago)
+      described_class.where(seller_id:).update_all(created_at: 4.days.ago)
+
+      expect(described_class.filter(seller_id:, params: { type: "follower" }, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([confirmed_early])
     end
 
     it "bounds the qualifying purchase for affiliate blasts with a purchase filter" do

--- a/spec/models/audience_member_spec.rb
+++ b/spec/models/audience_member_spec.rb
@@ -95,6 +95,49 @@ RSpec.describe AudienceMember, :freeze_time do
       expect(filtered).to eq([member])
     end
 
+    it "drops rows created after as_of, with and without ids" do
+      original = create_member(follower: {})
+      original.update_column(:created_at, 2.days.ago)
+      later_joiner = create_member(follower: {})
+
+      expect(described_class.filter(seller_id:, as_of: 1.day.ago).order(:id).to_a).to eq([original])
+      expect(described_class.filter(seller_id:, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([original])
+      expect(described_class.filter(seller_id:, as_of: Time.current).order(:id).to_a).to eq([original, later_joiner])
+    end
+
+    it "requires the qualifying purchase to predate as_of, not only the row" do
+      early_buyer = create_member(purchases: [{ "product_id" => 1, "created_at" => 3.days.ago.iso8601 }])
+      # An old follower row that picked up its first purchase after as_of: the row predates
+      # the bound, the purchase that would qualify it does not.
+      late_buyer = create_member(follower: { "created_at" => 3.days.ago.iso8601 }, purchases: [{ "product_id" => 1, "created_at" => 1.hour.ago.iso8601 }])
+      [early_buyer, late_buyer].each { _1.update_column(:created_at, 4.days.ago) }
+
+      expect(described_class.filter(seller_id:, params: { bought_product_ids: [1] }, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([early_buyer])
+      expect(described_class.filter(seller_id:, params: { type: "customer" }, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([early_buyer])
+      expect(described_class.filter(seller_id:, params: { type: "follower" }, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([late_buyer])
+    end
+
+    it "bounds the follow and the qualifying purchase separately for follower blasts" do
+      # Purchase predicates keep only purchase rows, on which the follower timestamp is NULL.
+      old_follower_old_buyer = create_member(follower: { "created_at" => 3.days.ago.iso8601 }, purchases: [{ "product_id" => 1, "price_cents" => 200, "created_at" => 3.days.ago.iso8601 }])
+      create_member(follower: { "created_at" => 1.hour.ago.iso8601 }, purchases: [{ "product_id" => 1, "price_cents" => 200, "created_at" => 3.days.ago.iso8601 }])
+      old_follower_new_buyer = create_member(follower: { "created_at" => 3.days.ago.iso8601 }, purchases: [{ "product_id" => 1, "price_cents" => 200, "created_at" => 1.hour.ago.iso8601 }])
+      described_class.where(seller_id:).update_all(created_at: 4.days.ago)
+
+      expect(described_class.filter(seller_id:, params: { type: "follower", paid_more_than_cents: 100 }, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([old_follower_old_buyer])
+      expect(described_class.filter(seller_id:, params: { type: "follower", bought_product_ids: [1] }, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([old_follower_old_buyer])
+      expect(described_class.filter(seller_id:, params: { type: "follower" }, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([old_follower_old_buyer, old_follower_new_buyer])
+    end
+
+    it "bounds the qualifying purchase for affiliate blasts with a purchase filter" do
+      old_affiliate_old_buyer = create_member(affiliates: [{ "product_id" => 1, "created_at" => 3.days.ago.iso8601 }], purchases: [{ "product_id" => 2, "country" => "France", "created_at" => 3.days.ago.iso8601 }])
+      old_affiliate_new_buyer = create_member(affiliates: [{ "product_id" => 1, "created_at" => 3.days.ago.iso8601 }], purchases: [{ "product_id" => 2, "country" => "France", "created_at" => 1.hour.ago.iso8601 }])
+      described_class.where(seller_id:).update_all(created_at: 4.days.ago)
+
+      expect(described_class.filter(seller_id:, params: { type: "affiliate", affiliate_product_ids: [1], bought_from: "France" }, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([old_affiliate_old_buyer])
+      expect(described_class.filter(seller_id:, params: { type: "affiliate", affiliate_product_ids: [1] }, with_ids: true, as_of: 1.day.ago).order(:id).to_a).to eq([old_affiliate_old_buyer, old_affiliate_new_buyer])
+    end
+
     it "filters by type" do
       customer = create_member(purchases: [{}])
       follower = create_member(follower: {})

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -639,6 +639,30 @@ describe SendPostBlastEmailsJob, :freeze_time do
       expect_sent_count 0
     end
 
+    it "treats a resume past the grace window as stale even before the first delivery" do
+      post = basic_post_with_audience
+      allow_any_instance_of(Installment).to receive(:audience_members_filter_params).and_return({ minimum_license_uses: 1 })
+      blast = create(:blast, :just_requested, post:)
+      blast.update!(started_at: 2.days.ago)
+
+      expect do
+        described_class.new.perform(blast.id)
+      end.to raise_error(RuntimeError, /filter's eligibility cannot be rebuilt/)
+
+      expect_sent_count 0
+    end
+
+    it "lets a first-run crash inside the grace window rebuild even for an unrebuildable filter" do
+      post = basic_post_with_audience
+      allow_any_instance_of(Installment).to receive(:audience_members_filter_params).and_return({ minimum_license_uses: 1 })
+      blast = create(:blast, :just_requested, post:)
+      blast.update!(started_at: 1.hour.ago)
+
+      described_class.new.perform(blast.id)
+
+      expect(blast.reload.completed_at).to be_present
+    end
+
     it "completes without a live rebuild when a resume with no snapshot owes no more recipients" do
       post = basic_post_with_audience
       blast = create(:blast, :just_requested, post:)

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -436,6 +436,45 @@ describe SendPostBlastEmailsJob, :freeze_time do
       expect(SentPostEmail.where(post:).count).to eq(3)
     end
 
+    it "refuses to rebuild a partially delivered resend once its sent set is gone" do
+      blast = create(:blast, :just_requested, post:, recipient_filter: "unopened")
+      # An earlier attempt delivered some of the resend; with both the snapshot and the
+      # per-blast sent set gone, nothing says who those were.
+      blast.update!(started_at: Time.current, first_email_delivered_at: Time.current)
+
+      expect do
+        described_class.new.perform(blast.id)
+      end.to raise_error(RuntimeError, /sent set for non-opener resend #{blast.id}/)
+
+      expect_sent_count 0
+      expect(blast.reload.completed_at).to be_nil
+    end
+
+    it "rebuilds a partially delivered resend while its sent set survives, skipping who already got it" do
+      blast = create(:blast, :just_requested, post:, recipient_filter: "unopened")
+      blast.update!(started_at: Time.current, first_email_delivered_at: Time.current)
+      $redis.sadd(RedisKey.blast_sent_emails(blast.id), delivered_sale.email)
+
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 1
+      expect(PostSendgridApi.mails[sent_sale.email]).to be_present
+      expect(blast.reload.completed_at).to be_present
+    ensure
+      $redis.del(RedisKey.blast_sent_emails(blast.id)) if blast
+    end
+
+    it "keeps the per-blast sent set for the stalled-blast scan window" do
+      blast = create(:blast, :just_requested, post:, recipient_filter: "unopened")
+
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 2
+      expect($redis.ttl(RedisKey.blast_sent_emails(blast.id))).to be_between(13.days.to_i, AlertOnStalledPostEmailBlastsJob::LOOKBACK.to_i).inclusive
+    ensure
+      $redis.del(RedisKey.blast_sent_emails(blast.id)) if blast
+    end
+
     it "resolves the unopened-recipient emails under the raised statement execution cap" do
       blast = create(:blast, :just_requested, post:, recipient_filter: "unopened")
 
@@ -560,71 +599,44 @@ describe SendPostBlastEmailsJob, :freeze_time do
       expect(blast.reload.completed_at).to be_present
     end
 
-    it "does not rebuild the live audience when a late resume finds no snapshot" do
-      post = basic_post_with_audience
+    it "rebuilds the audience as it stood at started_at when a late resume finds no snapshot" do
+      post = create(:audience_post, :published, seller: @seller)
+      original_follower = create(:active_follower, user: @seller, created_at: 13.days.ago)
+      AudienceMember.find_by!(seller_id: post.seller_id, email: original_follower.email).update_column(:created_at, 13.days.ago)
       blast = create(:blast, :just_requested, post:)
-      blast.update!(started_at: 2.days.ago)
-      create(:active_follower, user: @seller)
+      # Twelve days in, well past any snapshot TTL, with recipients still owed from the
+      # first attempt — the shape of gumroad-private#2520.
+      blast.update!(started_at: 12.days.ago)
+      $redis.set(RedisKey.blast_pending_recipients(blast.id), 1)
+      later_joiner = create(:active_follower, user: @seller)
 
-      unrestricted = false
-      allow(AudienceMember).to receive(:filter).and_wrap_original do |original, **kwargs|
-        unrestricted = true unless kwargs.key?(:ids)
-        original.call(**kwargs)
-      end
-
-      expect do
-        described_class.new.perform(blast.id)
-      end.to raise_error(RuntimeError, /missing audience snapshot for blast #{blast.id}/)
-
-      expect(unrestricted).to eq(false)
-      expect_sent_count 0
-      expect(blast.reload.completed_at).to be_nil
-    end
-
-    it "rebuilds the audience when a resume finds no snapshot inside the grace window" do
-      post = basic_post_with_audience
-      blast = create(:blast, :just_requested, post:)
-      blast.update!(started_at: 1.hour.ago)
-      create(:active_follower, user: @seller)
-
-      unrestricted = false
-      allow(AudienceMember).to receive(:filter).and_wrap_original do |original, **kwargs|
-        unrestricted = true unless kwargs.key?(:ids)
-        original.call(**kwargs)
-      end
+      expect(AudienceMember).to receive(:filter).with(hash_including(as_of: blast.started_at)).and_call_original
 
       described_class.new.perform(blast.id)
 
-      expect(unrestricted).to eq(true)
-      expect_sent_count 2
+      expect_sent_count 1
+      expect_sent_email(original_follower.email)
+      expect(PostSendgridApi.mails).not_to have_key(later_joiner.email)
       expect(blast.reload.completed_at).to be_present
+    ensure
+      $redis.del(RedisKey.blast_pending_recipients(blast.id)) if blast
     end
 
-    it "refuses a resume with no snapshot inside the grace window when recipients are still pending" do
+    it "refuses a late rebuild when the filter reads state no timestamp can rewind" do
       post = basic_post_with_audience
-      blast = create(:blast, :just_requested, post:)
-      blast.update!(started_at: 1.hour.ago)
-      pending_key = RedisKey.blast_pending_recipients(blast.id)
-      # An earlier attempt already published its recipient count, so it had a snapshot:
-      # the missing one is lost Redis state, not a first-run crash.
-      $redis.set(pending_key, 1)
-      create(:active_follower, user: @seller)
+      described_class::UNREBUILDABLE_FILTER_KEYS.each do |key|
+        allow_any_instance_of(Installment).to receive(:audience_members_filter_params).and_return({ key => [1] })
+        blast = create(:blast, :just_requested, post:)
+        blast.update!(started_at: Time.current, first_email_delivered_at: Time.current)
 
-      unrestricted = false
-      allow(AudienceMember).to receive(:filter).and_wrap_original do |original, **kwargs|
-        unrestricted = true unless kwargs.key?(:ids)
-        original.call(**kwargs)
+        expect do
+          described_class.new.perform(blast.id)
+        end.to raise_error(RuntimeError, /filter's eligibility cannot be rebuilt/)
+
+        expect(blast.reload.completed_at).to be_nil
       end
 
-      expect do
-        described_class.new.perform(blast.id)
-      end.to raise_error(RuntimeError, /missing audience snapshot for blast #{blast.id}/)
-
-      expect(unrestricted).to eq(false)
       expect_sent_count 0
-      expect(blast.reload.completed_at).to be_nil
-    ensure
-      $redis.del(pending_key) if pending_key
     end
 
     it "completes without a live rebuild when a resume with no snapshot owes no more recipients" do


### PR DESCRIPTION
Tracker: antiwork/gumroad-private#2520

## What

When a blast resume finds no audience snapshot in Redis, `SendPostBlastEmailsJob` now rebuilds the audience from MySQL as it stood at `started_at`, instead of raising `missing audience snapshot`.

- `AudienceMember.filter` takes an `as_of:` bound. The row must have existed at that time, and the purchase, follow, or affiliation that qualifies the member must predate it too. Follower blasts join the `followers` table and use `confirmed_at`, because eligibility begins at confirmation. An old follower who bought the product after the send does not qualify.
- The job passes `as_of: @blast.started_at` on the fresh-load path. On a first run the stamp is moments old and the bound changes nothing. On a resume days later it excludes everyone who joined or became eligible after the original send.
- The fail-closed guard and its grace window are gone for regular blasts. The Redis snapshot stays as the fast path for retries.
- A non-opener resend keeps one guard: it dedupes only through its per-blast sent set, so when that set is gone too, the job still refuses to rebuild. That set now lives for the 14-day scan window like the snapshot and the pending count.
- Some filters read state no timestamp can rewind: a live license-use count, a subscription cancelled and then resumed, a variant swap on an old purchase, a refund that lifts a not-bought exclusion, a product affiliation added later under the affiliate's original date. A stale resume keeps failing closed for those (`UNREBUILDABLE_FILTER_KEYS`). Whole-audience, customer, follower, and affiliate blasts with plain product or price filters rebuild.
- A resume is stale when it already delivered, still owes recipients, or is older than the one-day grace window. A first-run crash inside the window still rebuilds, as before.
- The "fully delivered, nothing left to send" shortcut stays.

## Why

The snapshot was the only record of who a blast was for, and it lives in Redis with a TTL. Blast 460447 lost its snapshot to the 3-day TTL on 2026-09-01, two hours before the 14-day TTL from #7433 went live. The guard then refused every resume for nine days, four times a day, while 16,212 recipients stayed owed.

`audience_members` rows are updated in place by `refresh!`, so `created_at` is a stable "joined" time. Bounding the filter to `created_at <= started_at` is the same point-in-time audience the snapshot recorded, minus anyone who has since left, and it is available at any age. That makes a resume safe without Redis, which is the property the guard was standing in for.

## Before / After

Backend only. There is no rendered surface.

| | Before | After |
|---|---|---|
| Resume with snapshot present | Revalidates snapshotted ids | Same |
| Resume, snapshot gone, blast older than one day | Raises, retries to the dead set, auto-resume repeats it | Rebuilds the audience as of `started_at` and sends the remainder |
| Resume, snapshot gone, recipients still owed inside one day | Raises | Same rebuild |
| Member who joined or became eligible after the original send | Never emailed | Never emailed |
| Non-opener resend, snapshot and sent set both gone | Raises | Still raises, now naming the sent set |
| Filter in `UNREBUILDABLE_FILTER_KEYS`, stale resume | Raises | Still raises |

## Test Results

```text
bundle exec rspec spec/models/audience_member_spec.rb spec/sidekiq/send_post_blast_emails_job_spec.rb spec/sidekiq/send_post_blast_emails_slice_job_spec.rb
bin/test-confidence
```

Mutation checks: the late-resume job spec fails on the previous code with the `missing audience snapshot` raise. The filter specs fail when either the row bound or the qualifying-relationship bound is dropped. The non-opener spec fails when its guard is dropped.

---

AI disclosure: Claude Fable 5.1.
