### PR TITLE
Admit a blast to the daily quota once, and track its deferral

### DIFF
--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -46,6 +46,7 @@ class RedisKey
     def blast_non_opener_emails(blast_id) = "blast:#{blast_id}:non_opener_emails"
     def blast_pending_recipients(blast_id) = "blast:#{blast_id}:pending_recipients"
     def blast_quota_deferred_until(blast_id) = "blast:#{blast_id}:quota_deferred_until"
+    def blast_quota_admitted(blast_id) = "blast:#{blast_id}:quota_admitted"
     def blast_active_slice_partition(blast_id) = "blast:#{blast_id}:active_slice_partition"
     def blast_slice_partition_chunks(blast_id, partition_key) = "blast:#{blast_id}:slice_partition:#{partition_key}:chunks"
     def blast_slice_claim(blast_id, partition_key, chunk_index) = "blast:#{blast_id}:slice_claim:#{partition_key}:#{chunk_index}"

--- a/app/services/redis_key.rb
+++ b/app/services/redis_key.rb
@@ -45,6 +45,7 @@ class RedisKey
     def blast_audience_snapshot(blast_id) = "blast:#{blast_id}:audience_snapshot"
     def blast_non_opener_emails(blast_id) = "blast:#{blast_id}:non_opener_emails"
     def blast_pending_recipients(blast_id) = "blast:#{blast_id}:pending_recipients"
+    def blast_quota_deferred_until(blast_id) = "blast:#{blast_id}:quota_deferred_until"
     def blast_active_slice_partition(blast_id) = "blast:#{blast_id}:active_slice_partition"
     def blast_slice_partition_chunks(blast_id, partition_key) = "blast:#{blast_id}:slice_partition:#{partition_key}:chunks"
     def blast_slice_claim(blast_id, partition_key, chunk_index) = "blast:#{blast_id}:slice_claim:#{partition_key}:#{chunk_index}"

--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -159,9 +159,7 @@ class AlertOnStalledPostEmailBlastsJob
       emailed_at.present? && emailed_at > STALL_THRESHOLD.ago
     end
 
-    # The sender parks a blast that missed the seller's daily large-blast slot in the
-    # scheduled set, which none of the scans above read. Without the marker such a blast
-    # reads as UNACCOUNTED and gets a duplicate resume on every scan.
+    # A quota-deferred blast waits in the scheduled set, which none of the scans read.
     def quota_deferred_until(blast)
       deferred_until = $redis.get(RedisKey.blast_quota_deferred_until(blast.id))
       Time.zone.parse(deferred_until) if deferred_until.present?

--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -95,6 +95,7 @@ class AlertOnStalledPostEmailBlastsJob
           if last_email_recent?(blast) || busy.include?(blast.id) then :running
           elsif queued.include?(blast.id) then :queued
           elsif retrying.include?(blast.id) then :retrying
+          elsif quota_deferred_until(blast)&.future? then :deferred
           elsif @dead_entries.key?(blast.id) then :dead
           else :unaccounted
           end
@@ -138,7 +139,9 @@ class AlertOnStalledPostEmailBlastsJob
       return :held_non_opener if entry[:disposition] == :unaccounted && blast.to_non_openers?
       # Recipients still owed cannot double-send (SentPostEmail unique / per-blast sent set),
       # so a late resume is the remaining delivery, not a time-boxed surprise.
-      return :held_past_window if blast.requested_at < AUTO_RESUME_WINDOW.ago && !recipients_still_owed?(blast)
+      # A deferral whose time has passed means the scheduled job is late or lost. The quota
+      # gate sits before any send, so resuming cannot double-send either.
+      return :held_past_window if blast.requested_at < AUTO_RESUME_WINDOW.ago && !recipients_still_owed?(blast) && !quota_deferred_until(blast)&.past?
       return :held_already_resumed if $redis.exists?(RedisKey.stalled_blast_auto_resumed(blast.id))
       return :would_resume unless live
       # Re-read the live sets at action time — the scan's snapshots are already stale by now.
@@ -154,6 +157,14 @@ class AlertOnStalledPostEmailBlastsJob
     def last_email_recent?(blast)
       emailed_at = blast.last_email_delivered_at
       emailed_at.present? && emailed_at > STALL_THRESHOLD.ago
+    end
+
+    # The sender parks a blast that missed the seller's daily large-blast slot in the
+    # scheduled set, which none of the scans above read. Without the marker such a blast
+    # reads as UNACCOUNTED and gets a duplicate resume on every scan.
+    def quota_deferred_until(blast)
+      deferred_until = $redis.get(RedisKey.blast_quota_deferred_until(blast.id))
+      Time.zone.parse(deferred_until) if deferred_until.present?
     end
 
     def recipients_still_owed?(blast)
@@ -238,7 +249,8 @@ class AlertOnStalledPostEmailBlastsJob
         *lines,
         (omitted.positive? ? "…and #{omitted} more." : nil),
         "",
-        "RUNNING/QUEUED may just be a very large blast mid-pass. DEAD/UNACCOUNTED blasts requested " \
+        "RUNNING/QUEUED may just be a very large blast mid-pass. DEFERRED is waiting for the seller's " \
+          "next daily large-blast slot. DEAD/UNACCOUNTED blasts requested " \
           "within #{AUTO_RESUME_WINDOW.inspect} are resumed automatically, once per blast " \
           "(gumroad-private#2106) — except UNACCOUNTED non-opener resends, which a concurrent " \
           "duplicate sender would double-deliver. UNACCOUNTED usually means a lost enqueue, a " \

--- a/app/sidekiq/concerns/post_blast_sending.rb
+++ b/app/sidekiq/concerns/post_blast_sending.rb
@@ -245,7 +245,7 @@ module PostBlastSending
     $redis.del(*[snapshot_key, "#{snapshot_key}:tmp", checkpoint_key, "#{checkpoint_key}:tmp",
                  RedisKey.blast_pending_recipients(@blast.id), RedisKey.blast_done_slices(@blast.id),
                  RedisKey.blast_active_slice_partition(@blast.id), partition_chunks_key,
-                 RedisKey.blast_quota_deferred_until(@blast.id)].compact)
+                 RedisKey.blast_quota_deferred_until(@blast.id), RedisKey.blast_quota_admitted(@blast.id)].compact)
   end
 
   # Re-checked right before each provider call: the chunk-level filter ran once at the start

--- a/app/sidekiq/concerns/post_blast_sending.rb
+++ b/app/sidekiq/concerns/post_blast_sending.rb
@@ -244,7 +244,8 @@ module PostBlastSending
     partition_chunks_key = active_partition_key && RedisKey.blast_slice_partition_chunks(@blast.id, active_partition_key)
     $redis.del(*[snapshot_key, "#{snapshot_key}:tmp", checkpoint_key, "#{checkpoint_key}:tmp",
                  RedisKey.blast_pending_recipients(@blast.id), RedisKey.blast_done_slices(@blast.id),
-                 RedisKey.blast_active_slice_partition(@blast.id), partition_chunks_key].compact)
+                 RedisKey.blast_active_slice_partition(@blast.id), partition_chunks_key,
+                 RedisKey.blast_quota_deferred_until(@blast.id)].compact)
   end
 
   # Re-checked right before each provider call: the chunk-level filter ran once at the start

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -67,7 +67,7 @@ class SendPostBlastEmailsJob
     end
 
     return mark_blast_as_completed if @members.empty?
-    unless SellerLargeBlastQuota.allow?(
+    unless admitted_earlier? || SellerLargeBlastQuota.allow?(
       seller_id: @post.seller_id,
       kind: "post_blast",
       blast_id: @blast.id,
@@ -76,6 +76,7 @@ class SendPostBlastEmailsJob
       requeue_for_daily_blast_limit
       return
     end
+    $redis.del(RedisKey.blast_quota_deferred_until(@blast.id))
 
     split_blast? ? enqueue_slice_jobs : send_inline
   end
@@ -337,10 +338,32 @@ class SendPostBlastEmailsJob
       ($redis.get(RedisKey.audience_member_load_max_execution_time_seconds) || 1.hour).to_i
     end
 
-    def requeue_for_daily_blast_limit
-      job_id = self.class.perform_at(SellerLargeBlastQuota.deferred_run_at, @blast.id)
-      return if job_id.present?
+    # Admission to the daily quota is per blast, once. A resume of a blast that already
+    # delivered was admitted the day it started; claiming a second day would take the slot
+    # from the post the seller scheduled, and that post's own deferral then re-claims every
+    # following midnight, so the seller's schedule never recovers (gumroad-private#2520).
+    def admitted_earlier?
+      @blast.first_email_delivered_at.present?
+    end
 
-      raise "Sidekiq did not requeue the blast for the daily limit"
+    # One deferred job per blast. Every retry and auto-resume that meets the same closed
+    # quota would otherwise schedule its own copy, and the monitor cannot see the scheduled
+    # set to tell them apart. The marker also lets the monitor report DEFERRED instead of
+    # resuming a blast that is only waiting for its slot, and, once its time has passed,
+    # tells the monitor the scheduled job is late or lost. It lives for the scan window.
+    def requeue_for_daily_blast_limit
+      deferred_key = RedisKey.blast_quota_deferred_until(@blast.id)
+      deferred_until = $redis.get(deferred_key)
+      if deferred_until.present? && Time.zone.parse(deferred_until).future?
+        Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} already deferred until #{deferred_until} by the daily large-blast quota")
+        return
+      end
+
+      run_at = SellerLargeBlastQuota.deferred_run_at
+      job_id = self.class.perform_at(run_at, @blast.id)
+      raise "Sidekiq did not requeue the blast for the daily limit" if job_id.blank?
+
+      $redis.set(deferred_key, run_at.iso8601, ex: AlertOnStalledPostEmailBlastsJob::LOOKBACK.to_i)
+      Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} deferred until #{run_at.iso8601} by the daily large-blast quota")
     end
 end

--- a/app/sidekiq/send_post_blast_emails_job.rb
+++ b/app/sidekiq/send_post_blast_emails_job.rb
@@ -69,16 +69,10 @@ class SendPostBlastEmailsJob
     end
 
     return mark_blast_as_completed if @members.empty?
-    unless admitted_earlier? || SellerLargeBlastQuota.allow?(
-      seller_id: @post.seller_id,
-      kind: "post_blast",
-      blast_id: @blast.id,
-      recipient_count: @members.size
-    )
+    unless admitted?
       requeue_for_daily_blast_limit
       return
     end
-    $redis.del(RedisKey.blast_quota_deferred_until(@blast.id))
 
     split_blast? ? enqueue_slice_jobs : send_inline
   end
@@ -335,32 +329,54 @@ class SendPostBlastEmailsJob
       ($redis.get(RedisKey.audience_member_load_max_execution_time_seconds) || 1.hour).to_i
     end
 
-    # Admission to the daily quota is per blast, once. A resume of a blast that already
-    # delivered was admitted the day it started; claiming a second day would take the slot
-    # from the post the seller scheduled, and that post's own deferral then re-claims every
-    # following midnight, so the seller's schedule never recovers (gumroad-private#2520).
-    def admitted_earlier?
-      @blast.first_email_delivered_at.present?
+    # Admission to the daily quota is per blast, once, and recorded when granted: the
+    # delivery stamp arrives from the ESP later, so a kill in between must not send a
+    # resume back through the quota to claim a second day.
+    def admitted?
+      admitted_key = RedisKey.blast_quota_admitted(@blast.id)
+      unless @blast.first_email_delivered_at.present? || $redis.exists?(admitted_key)
+        return false unless SellerLargeBlastQuota.allow?(
+          seller_id: @post.seller_id,
+          kind: "post_blast",
+          blast_id: @blast.id,
+          recipient_count: @members.size
+        )
+        $redis.set(admitted_key, Time.current.utc.iso8601, ex: AlertOnStalledPostEmailBlastsJob::LOOKBACK.to_i)
+      end
+      $redis.del(RedisKey.blast_quota_deferred_until(@blast.id))
+      true
     end
 
-    # One deferred job per blast. Every retry and auto-resume that meets the same closed
-    # quota would otherwise schedule its own copy, and the monitor cannot see the scheduled
-    # set to tell them apart. The marker also lets the monitor report DEFERRED instead of
-    # resuming a blast that is only waiting for its slot, and, once its time has passed,
-    # tells the monitor the scheduled job is late or lost. It lives for the scan window.
+    # Overwrites a marker only once its time has passed. ISO 8601 UTC strings order as times.
+    RESERVE_QUOTA_DEFERRAL = <<~LUA
+      local current = redis.call("GET", KEYS[1])
+      if current and current > ARGV[2] then return 0 end
+      redis.call("SET", KEYS[1], ARGV[1], "EX", ARGV[3])
+      return 1
+    LUA
+
+    # One deferred copy per blast: the marker is reserved before the enqueue, so concurrent
+    # attempts that meet the same closed quota cannot each schedule the blast. The monitor
+    # reads the marker as DEFERRED while it is ahead and as a lost job once it has passed.
     def requeue_for_daily_blast_limit
       deferred_key = RedisKey.blast_quota_deferred_until(@blast.id)
-      deferred_until = $redis.get(deferred_key)
-      if deferred_until.present? && Time.zone.parse(deferred_until).future?
-        Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} already deferred until #{deferred_until} by the daily large-blast quota")
+      run_at = SellerLargeBlastQuota.deferred_run_at
+      argv = [run_at.utc.iso8601, Time.current.utc.iso8601, AlertOnStalledPostEmailBlastsJob::LOOKBACK.to_i]
+      unless $redis.eval(RESERVE_QUOTA_DEFERRAL, keys: [deferred_key], argv:).to_i == 1
+        Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} already deferred until #{$redis.get(deferred_key)} by the daily large-blast quota")
         return
       end
 
-      run_at = SellerLargeBlastQuota.deferred_run_at
-      job_id = self.class.perform_at(run_at, @blast.id)
-      raise "Sidekiq did not requeue the blast for the daily limit" if job_id.blank?
-
-      $redis.set(deferred_key, run_at.iso8601, ex: AlertOnStalledPostEmailBlastsJob::LOOKBACK.to_i)
-      Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} deferred until #{run_at.iso8601} by the daily large-blast quota")
+      job_id = begin
+        self.class.perform_at(run_at, @blast.id)
+      rescue StandardError
+        $redis.del(deferred_key)
+        raise
+      end
+      if job_id.blank?
+        $redis.del(deferred_key)
+        raise "Sidekiq did not requeue the blast for the daily limit"
+      end
+      Rails.logger.info("[#{self.class.name}] blast_id=#{@blast.id} deferred until #{run_at.utc.iso8601} by the daily large-blast quota")
     end
 end

--- a/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
+++ b/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
@@ -241,6 +241,33 @@ describe AlertOnStalledPostEmailBlastsJob do
         expect(InternalNotificationWorker).not_to have_received(:perform_async)
       end
 
+      it "reports a quota-deferred blast as DEFERRED and leaves it alone" do
+        blast = stalled_blast
+        $redis.set(RedisKey.blast_quota_deferred_until(blast.id), 5.hours.from_now.iso8601)
+        stub_sidekiq
+
+        described_class.new.perform
+
+        expect(SendPostBlastEmailsJob).not_to have_received(:perform_async)
+        expect($redis.exists?(RedisKey.stalled_blast_auto_resumed(blast.id))).to eq(false)
+      ensure
+        $redis.del(RedisKey.blast_quota_deferred_until(blast.id)) if blast
+      end
+
+      it "resumes a quota-deferred blast whose recorded deferral has passed, even past the window" do
+        # Quota rejection happens before any recipients are recorded as owed, so only the
+        # lapsed marker says this blast is late; without it the row would be HELD.
+        blast = stalled_blast(requested_hours_ago: 30)
+        $redis.set(RedisKey.blast_quota_deferred_until(blast.id), 1.minute.ago.iso8601)
+        stub_sidekiq
+
+        described_class.new.perform
+
+        expect(SendPostBlastEmailsJob).to have_received(:perform_async).with(blast.id)
+      ensure
+        $redis.del(RedisKey.blast_quota_deferred_until(blast.id)) if blast
+      end
+
       it "resumes a blast past the window when recipients are still owed" do
         blast = stalled_blast(requested_hours_ago: 30)
         $redis.set(RedisKey.blast_pending_recipients(blast.id), 12)

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -1095,6 +1095,51 @@ describe SendPostBlastEmailsJob, :freeze_time do
       expect_sent_count 1
       expect(blast.reload.completed_at).to be_present
     end
+
+    it "records admission when the quota grants it, so a resume before the first delivery stamp skips the quota" do
+      blast = create(:blast, :just_requested, post: basic_post_with_audience)
+      admitted_key = RedisKey.blast_quota_admitted(blast.id)
+      expect(SellerLargeBlastQuota).to receive(:allow?).once.and_return(true)
+      admitted_during_run = nil
+      allow(PostEmailApi).to receive(:provider_for).and_return(MailerInfo::EMAIL_PROVIDER_SENDGRID)
+      allow(PostSendgridApi).to receive(:process) { admitted_during_run = $redis.ttl(admitted_key) }
+
+      described_class.new.perform(blast.id)
+
+      expect(admitted_during_run).to be_between(13.days.to_i, AlertOnStalledPostEmailBlastsJob::LOOKBACK.to_i).inclusive
+      expect($redis.exists?(admitted_key)).to eq(false)
+
+      # Same blast, admission recorded, no delivery stamp yet: the quota is not consulted again.
+      $redis.set(admitted_key, Time.current.utc.iso8601)
+      blast.update!(completed_at: nil)
+      described_class.new.perform(blast.id)
+    ensure
+      $redis.del(admitted_key) if admitted_key
+    end
+
+    it "releases the deferral marker when the requeue fails" do
+      blast = create(:blast, :just_requested, post: basic_post_with_audience)
+      allow(SellerLargeBlastQuota).to receive(:allow?).and_return(false)
+      allow(described_class).to receive(:perform_at).and_return(nil)
+
+      expect do
+        described_class.new.perform(blast.id)
+      end.to raise_error(RuntimeError, /did not requeue/)
+
+      expect($redis.exists?(RedisKey.blast_quota_deferred_until(blast.id))).to eq(false)
+    end
+
+    it "releases the deferral marker when the requeue raises" do
+      blast = create(:blast, :just_requested, post: basic_post_with_audience)
+      allow(SellerLargeBlastQuota).to receive(:allow?).and_return(false)
+      allow(described_class).to receive(:perform_at).and_raise(Redis::CannotConnectError)
+
+      expect do
+        described_class.new.perform(blast.id)
+      end.to raise_error(Redis::CannotConnectError)
+
+      expect($redis.exists?(RedisKey.blast_quota_deferred_until(blast.id))).to eq(false)
+    end
   end
 
   describe "splitting large blasts into slice jobs" do

--- a/spec/sidekiq/send_post_blast_emails_job_spec.rb
+++ b/spec/sidekiq/send_post_blast_emails_job_spec.rb
@@ -1015,6 +1015,61 @@ describe SendPostBlastEmailsJob, :freeze_time do
       expect(PostSendgridApi.mails).to be_empty
       expect(described_class).to have_enqueued_sidekiq_job(blast.id).at(run_at)
       expect(blast.reload.completed_at).to be_nil
+      expect($redis.get(RedisKey.blast_quota_deferred_until(blast.id))).to eq(run_at.iso8601)
+      expect($redis.ttl(RedisKey.blast_quota_deferred_until(blast.id))).to be_between(13.days.to_i, AlertOnStalledPostEmailBlastsJob::LOOKBACK.to_i).inclusive
+    ensure
+      $redis.del(RedisKey.blast_quota_deferred_until(blast.id)) if blast
+    end
+
+    it "schedules one deferred copy per blast while the recorded deferral is still ahead" do
+      blast = create(:blast, :just_requested, post: basic_post_with_audience)
+      allow(SellerLargeBlastQuota).to receive(:allow?).and_return(false)
+      run_at = Time.zone.tomorrow.beginning_of_day + 5.hours
+      allow(SellerLargeBlastQuota).to receive(:deferred_run_at).and_return(run_at)
+
+      described_class.new.perform(blast.id)
+      described_class.new.perform(blast.id)
+
+      expect(described_class.jobs.count { _1["args"] == [blast.id] }).to eq(1)
+    ensure
+      $redis.del(RedisKey.blast_quota_deferred_until(blast.id)) if blast
+    end
+
+    it "schedules again once the recorded deferral has passed" do
+      blast = create(:blast, :just_requested, post: basic_post_with_audience)
+      $redis.set(RedisKey.blast_quota_deferred_until(blast.id), 1.minute.ago.iso8601)
+      allow(SellerLargeBlastQuota).to receive(:allow?).and_return(false)
+      run_at = Time.zone.tomorrow.beginning_of_day + 5.hours
+      allow(SellerLargeBlastQuota).to receive(:deferred_run_at).and_return(run_at)
+
+      described_class.new.perform(blast.id)
+
+      expect(described_class).to have_enqueued_sidekiq_job(blast.id).at(run_at)
+      expect($redis.get(RedisKey.blast_quota_deferred_until(blast.id))).to eq(run_at.iso8601)
+    ensure
+      $redis.del(RedisKey.blast_quota_deferred_until(blast.id)) if blast
+    end
+
+    it "clears the deferral marker when the blast is admitted" do
+      blast = create(:blast, :just_requested, post: basic_post_with_audience)
+      $redis.set(RedisKey.blast_quota_deferred_until(blast.id), 1.hour.from_now.iso8601)
+      allow(SellerLargeBlastQuota).to receive(:allow?).and_return(true)
+
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 1
+      expect($redis.exists?(RedisKey.blast_quota_deferred_until(blast.id))).to eq(false)
+    end
+
+    it "does not consult the quota again for a blast that already delivered" do
+      blast = create(:blast, :just_requested, post: basic_post_with_audience)
+      blast.update!(first_email_delivered_at: 1.day.ago)
+      expect(SellerLargeBlastQuota).not_to receive(:allow?)
+
+      described_class.new.perform(blast.id)
+
+      expect_sent_count 1
+      expect(blast.reload.completed_at).to be_present
     end
   end
 


### PR DESCRIPTION
Tracker: antiwork/gumroad-private#2520

Stacked on #7575.

## What

- `SendPostBlastEmailsJob` records admission in Redis (`blast:<id>:quota_admitted`, 14 days) the moment `SellerLargeBlastQuota` grants it. A resume skips the quota when that marker or `first_email_delivered_at` exists. Admission is per blast, once, and does not depend on the ESP's delivery stamp arriving before a kill.
- A blast that misses the quota reserves its deferral in Redis (`blast:<id>:quota_deferred_until`) before enqueuing, with an atomic compare so concurrent attempts cannot each schedule a copy. A marker still ahead makes later attempts log and return. Both markers clear when the blast completes.
- `AlertOnStalledPostEmailBlastsJob` reads the marker. While its time is ahead, the blast is reported as DEFERRED and left alone. Once its time has passed, the scheduled job is late or lost, and the blast is resumed even past the 24-hour window. The quota gate sits before any send, so that resume cannot double-send. The marker lives for the 14-day scan window.
- Deferrals now log the run time.

## Why

The quota keys on the UTC day. Blast 460447's resumes carried 16k owed recipients, so each one claimed the seller's single daily slot before their scheduled 14:00 post ran. That post deferred to midnight, claimed the next day's slot there, and the seller's own schedule has run one day late ever since. A blast admitted on the day it started should not compete again.

The monitor cannot read the scheduled set, so a quota-deferred blast looked UNACCOUNTED and was auto-resumed on every scan. Each resume met the same closed quota and scheduled its own copy. One blast had four copies waiting for the same midnight.

## Before / After

Backend only. There is no rendered surface.

| | Before | After |
|---|---|---|
| Resume of a blast that delivered earlier | Claims a new daily slot or defers | Proceeds without touching the quota |
| Second attempt meets the closed quota | Schedules another copy | Logs and returns while the first copy is still ahead |
| Monitor sees a quota-deferred blast | UNACCOUNTED, auto-resumed each scan | DEFERRED, left alone |
| Deferred job lost, blast older than 24 hours | HELD for a human | Resumed, the lapsed marker is the evidence |

## Test Results

```text
bundle exec rspec spec/sidekiq/send_post_blast_emails_job_spec.rb spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
bin/test-confidence
```

---

AI disclosure: Claude Fable 5.1.
