### PR TITLE
Show sellers when an email blast is still sending, waiting, or incomplete

### DIFF
--- a/app/javascript/data/installments.ts
+++ b/app/javascript/data/installments.ts
@@ -65,6 +65,7 @@ export type PublishedInstallment = SavedInstallment & {
     delivered_count: number;
     remaining_count: number | null;
     scheduled_for: string | null;
+    retrying: boolean;
   } | null;
 };
 

--- a/app/javascript/data/installments.ts
+++ b/app/javascript/data/installments.ts
@@ -60,6 +60,12 @@ export type PublishedInstallment = SavedInstallment & {
     open_count: number | null;
     open_rate: number | null;
   }[];
+  delivery: {
+    status: "sent" | "sending" | "waiting" | "incomplete";
+    delivered_count: number;
+    remaining_count: number | null;
+    scheduled_for: string | null;
+  } | null;
 };
 
 export type ScheduledInstallment = SavedInstallment & {

--- a/app/javascript/pages/Emails/Published.tsx
+++ b/app/javascript/pages/Emails/Published.tsx
@@ -69,7 +69,6 @@ export default function EmailsPublished() {
   const isUnfinished = (installment: PublishedInstallment) =>
     installment.send_emails && installment.delivery !== null && installment.delivery.status !== "sent";
 
-  // Answers the two questions an unfinished row raises: what happened, and what happens next.
   const deliveryNote = (delivery: PublishedInstallment["delivery"]) => {
     if (!delivery || delivery.status === "sent") return null;
     const people = (count: number) => `${formatStatNumber({ value: count })} ${count === 1 ? "person" : "people"}`;

--- a/app/javascript/pages/Emails/Published.tsx
+++ b/app/javascript/pages/Emails/Published.tsx
@@ -85,10 +85,13 @@ export default function EmailsPublished() {
               timeStyle: "short",
             })}, when your daily limit for large emails resets.`
           : "Sends when your daily limit for large emails resets.";
-      case "incomplete":
-        return `${people(delivery.delivered_count)} got this email. ${
-          delivery.remaining_count !== null ? `${people(delivery.remaining_count)} have` : "Some people have"
-        } not received it yet. If this stays the same, contact support.`;
+      case "incomplete": {
+        const missing =
+          delivery.remaining_count !== null ? `${people(delivery.remaining_count)} have` : "Some people have";
+        return `${people(delivery.delivered_count)} got this email. ${missing} not received it yet.${
+          delivery.retrying ? " We are retrying automatically." : ""
+        }`;
+      }
     }
   };
 

--- a/app/javascript/pages/Emails/Published.tsx
+++ b/app/javascript/pages/Emails/Published.tsx
@@ -57,6 +57,42 @@ export default function EmailsPublished() {
 
   const userAgentInfo = useUserAgentInfo();
 
+  const deliveryLabel = (installment: PublishedInstallment) => {
+    if (!installment.send_emails) return "n/a";
+    if (!installment.delivery) return "Sent";
+    return { sent: "Sent", sending: "Sending", waiting: "Waiting to send", incomplete: "Incomplete" }[
+      installment.delivery.status
+    ];
+  };
+  // On mobile every row is a card, so a finished send keeps the lines it has today and only an
+  // unfinished one earns a Status line. Desktop shows the column for every row.
+  const isUnfinished = (installment: PublishedInstallment) =>
+    installment.send_emails && installment.delivery !== null && installment.delivery.status !== "sent";
+
+  // Answers the two questions an unfinished row raises: what happened, and what happens next.
+  const deliveryNote = (delivery: PublishedInstallment["delivery"]) => {
+    if (!delivery || delivery.status === "sent") return null;
+    const people = (count: number) => `${formatStatNumber({ value: count })} ${count === 1 ? "person" : "people"}`;
+    switch (delivery.status) {
+      case "sending":
+        return delivery.remaining_count !== null
+          ? `Still sending. ${people(delivery.remaining_count)} left.`
+          : "Still sending.";
+      case "waiting":
+        return delivery.scheduled_for
+          ? `Sends ${new Date(delivery.scheduled_for).toLocaleString(userAgentInfo.locale, {
+              timeZone: currentSeller.timeZone.name,
+              dateStyle: "medium",
+              timeStyle: "short",
+            })}, when your daily limit for large emails resets.`
+          : "Sends when your daily limit for large emails resets.";
+      case "incomplete":
+        return `${people(delivery.delivered_count)} got this email. ${
+          delivery.remaining_count !== null ? `${people(delivery.remaining_count)} have` : "Some people have"
+        } not received it yet. If this stays the same, contact support.`;
+    }
+  };
+
   return (
     <EmailsLayout selectedTab="published" hasPosts={has_posts} query={query} onQueryChange={setQuery}>
       <div className="space-y-4 p-4 md:p-8">
@@ -68,6 +104,7 @@ export default function EmailsPublished() {
                   <TableHead>Subject</TableHead>
                   <TableHead>Date</TableHead>
                   <TableHead>Emailed</TableHead>
+                  <TableHead>Status</TableHead>
                   <TableHead>Opened</TableHead>
                   <TableHead>Clicks</TableHead>
                   <TableHead>
@@ -100,6 +137,11 @@ export default function EmailsPublished() {
                       </TableCell>
                       <TableCell className="whitespace-nowrap">
                         {installment.send_emails ? formatStatNumber({ value: installment.sent_count }) : "n/a"}
+                      </TableCell>
+                      <TableCell
+                        className={isUnfinished(installment) ? "whitespace-nowrap" : "whitespace-nowrap max-lg:hidden"}
+                      >
+                        {deliveryLabel(installment)}
                       </TableCell>
                       <TableCell className="whitespace-nowrap">
                         {installment.send_emails
@@ -180,6 +222,7 @@ export default function EmailsPublished() {
                           <TableCell className="whitespace-nowrap text-muted">
                             {formatStatNumber({ value: resend.delivery_count })}
                           </TableCell>
+                          <TableCell className="whitespace-nowrap text-muted">n/a</TableCell>
                           <TableCell className="whitespace-nowrap text-muted">
                             {formatStatNumber({ value: resend.open_rate, suffix: "%", placeholder: "n/a" })}
                           </TableCell>
@@ -208,6 +251,15 @@ export default function EmailsPublished() {
                       ? formatStatNumber({ value: selectedInstallment.sent_count })
                       : "n/a"}
                   </CardContent>
+                  <CardContent>
+                    <h5 className="grow font-bold">Status</h5>
+                    {deliveryLabel(selectedInstallment)}
+                  </CardContent>
+                  {selectedInstallment.send_emails && deliveryNote(selectedInstallment.delivery) ? (
+                    <CardContent>
+                      <p className="text-sm text-muted">{deliveryNote(selectedInstallment.delivery)}</p>
+                    </CardContent>
+                  ) : null}
                   <CardContent>
                     <h5 className="grow font-bold">Opened</h5>
                     {selectedInstallment.send_emails

--- a/app/presenters/installment_presenter.rb
+++ b/app/presenters/installment_presenter.rb
@@ -100,7 +100,7 @@ class InstallmentPresenter
     def delivery_props
       blast = installment.blasts.reject(&:to_non_openers?).max_by(&:requested_at)
       return if blast&.requested_at.nil?
-      sent = { status: "sent", delivered_count: blast.delivery_count, remaining_count: nil, scheduled_for: nil }
+      sent = { status: "sent", delivered_count: blast.delivery_count, remaining_count: nil, scheduled_for: nil, retrying: false }
       return sent if blast.completed_at.present?
 
       # A zero pending count means every recipient reached the ESP and only the completion
@@ -120,6 +120,7 @@ class InstallmentPresenter
         delivered_count: blast.delivery_count,
         remaining_count: pending.present? ? pending.to_i : nil,
         scheduled_for: status == "waiting" ? scheduled_for : nil,
+        retrying: status == "incomplete" && AlertOnStalledPostEmailBlastsJob.auto_resume_eligible?(blast),
       }
     end
 

--- a/app/presenters/installment_presenter.rb
+++ b/app/presenters/installment_presenter.rb
@@ -67,6 +67,7 @@ class InstallmentPresenter
         has_been_blasted: installment.has_been_blasted?,
         shown_in_profile_sections: seller.seller_profile_posts_sections.filter_map { _1.external_id if _1.shown_posts.include?(installment.id) },
         non_opener_resends: non_opener_resend_props,
+        delivery: delivery_props,
       )
 
       unless installment.published?
@@ -94,6 +95,39 @@ class InstallmentPresenter
   end
 
   private
+    # State of the latest regular send. Without it an incomplete blast reads as a finished one:
+    # the Emailed column only ever showed the delivered count. Resends have their own rows.
+    def delivery_props
+      blast = installment.blasts.reject(&:to_non_openers?).max_by(&:requested_at)
+      return if blast&.requested_at.nil?
+      sent = { status: "sent", delivered_count: blast.delivery_count, remaining_count: nil, scheduled_for: nil }
+      return sent if blast.completed_at.present?
+
+      # A zero pending count means every recipient reached the ESP and only the completion
+      # stamp is missing (see SendPostBlastEmailsJob.fully_delivered?).
+      pending = $redis.get(RedisKey.blast_pending_recipients(blast.id))
+      return sent if pending.present? && pending.to_i <= 0
+
+      scheduled_for = quota_deferred_until(blast)
+      status =
+        if scheduled_for&.future? then "waiting"
+        elsif [blast.requested_at, blast.last_email_delivered_at].compact.max > AlertOnStalledPostEmailBlastsJob::STALL_THRESHOLD.ago then "sending"
+        else "incomplete"
+        end
+
+      {
+        status:,
+        delivered_count: blast.delivery_count,
+        remaining_count: pending.present? ? pending.to_i : nil,
+        scheduled_for: status == "waiting" ? scheduled_for : nil,
+      }
+    end
+
+    def quota_deferred_until(blast)
+      deferred_until = $redis.get(RedisKey.blast_quota_deferred_until(blast.id))
+      Time.zone.parse(deferred_until) if deferred_until.present?
+    end
+
     # Stats for each "resend to non-openers" blast on this post, oldest first.
     #
     # Open events don't record which blast delivered the email — open tracking is

--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -45,6 +45,11 @@ class AlertOnStalledPostEmailBlastsJob
   # (time-boxed sales), so the resume decision goes back to a human.
   AUTO_RESUME_WINDOW = 24.hours
 
+  # Time between scans (the cron fires at 05:40, 11:40, 17:40 and 23:40 UTC). Eligibility shown
+  # to sellers is evaluated one scan ahead, so a blast that leaves a window before the next scan
+  # is never promised a retry.
+  SCAN_INTERVAL = 6.hours
+
   # Rows the run acted on (or would have) are the audit trail; message_for never truncates them.
   AUDITED_ACTIONS = [:resumed, :resumed_to_complete, :would_resume, :would_complete, :skipped_reappeared].freeze
 
@@ -55,6 +60,23 @@ class AlertOnStalledPostEmailBlastsJob
 
   def post_blast_sender?(klass)
     klass.in?(BLAST_SENDER_CLASSES)
+  end
+
+  # Whether the next scan can still resume this blast on its own. The seller-facing page uses
+  # it to decide whether to promise a retry, so it must never be more generous than
+  # `resolve_action`. Windows are checked as of the next scan; the lookback keeps a second
+  # scan in reserve because a resume marker holds a blast for one stall window.
+  def self.auto_resume_eligible?(blast)
+    return false unless Feature.active?(:auto_resume_stalled_post_blasts)
+    return false if blast.completed_at.present? || blast.requested_at.nil? || blast.to_non_openers?
+    return false unless blast.requested_at > (LOOKBACK - 2 * SCAN_INTERVAL).ago
+
+    blast.requested_at > (AUTO_RESUME_WINDOW - SCAN_INTERVAL).ago || recipients_still_owed?(blast)
+  end
+
+  def self.recipients_still_owed?(blast)
+    pending = $redis.get(RedisKey.blast_pending_recipients(blast.id))
+    pending.present? && pending.to_i.positive?
   end
 
   def perform
@@ -166,8 +188,7 @@ class AlertOnStalledPostEmailBlastsJob
     end
 
     def recipients_still_owed?(blast)
-      pending = $redis.get(RedisKey.blast_pending_recipients(blast.id))
-      pending.present? && pending.to_i.positive?
+      self.class.recipients_still_owed?(blast)
     end
 
     def sender_visible_now?(blast_id)

--- a/spec/presenters/installment_presenter_spec.rb
+++ b/spec/presenters/installment_presenter_spec.rb
@@ -240,7 +240,7 @@ describe InstallmentPresenter do
         create(:blast, post: installment, completed_at: 5.minutes.ago, delivery_count: 1500)
 
         expect(described_class.new(seller:, installment:).props[:delivery]).to eq(
-          { status: "sent", delivered_count: 1500, remaining_count: nil, scheduled_for: nil }
+          { status: "sent", delivered_count: 1500, remaining_count: nil, scheduled_for: nil, retrying: false }
         )
       end
 
@@ -258,7 +258,7 @@ describe InstallmentPresenter do
         $redis.set(RedisKey.blast_pending_recipients(blast.id), 16_212)
 
         expect(described_class.new(seller:, installment:).props[:delivery]).to eq(
-          { status: "sending", delivered_count: 6_798, remaining_count: 16_212, scheduled_for: nil }
+          { status: "sending", delivered_count: 6_798, remaining_count: 16_212, scheduled_for: nil, retrying: false }
         )
       ensure
         $redis.del(RedisKey.blast_pending_recipients(blast.id)) if blast
@@ -269,8 +269,27 @@ describe InstallmentPresenter do
                        last_email_delivered_at: 2.days.ago, completed_at: nil, delivery_count: 6_798)
 
         expect(described_class.new(seller:, installment:).props[:delivery]).to eq(
-          { status: "incomplete", delivered_count: 6_798, remaining_count: nil, scheduled_for: nil }
+          { status: "incomplete", delivered_count: 6_798, remaining_count: nil, scheduled_for: nil, retrying: false }
         )
+      end
+
+      it "promises a retry only while the monitor will resume the blast" do
+        blast = create(:blast, post: installment, requested_at: 2.days.ago, started_at: 2.days.ago, first_email_delivered_at: 2.days.ago,
+                               last_email_delivered_at: 2.days.ago, completed_at: nil, delivery_count: 6_798)
+        $redis.set(RedisKey.blast_pending_recipients(blast.id), 16_212)
+
+        Feature.deactivate(:auto_resume_stalled_post_blasts)
+        expect(described_class.new(seller:, installment:).props[:delivery]).to include(status: "incomplete", retrying: false)
+
+        Feature.activate(:auto_resume_stalled_post_blasts)
+        expect(described_class.new(seller:, installment:).props[:delivery]).to include(status: "incomplete", remaining_count: 16_212, retrying: true)
+
+        blast.update!(requested_at: 15.days.ago)
+        installment.blasts.reset
+        expect(described_class.new(seller:, installment:).props[:delivery]).to include(status: "incomplete", retrying: false)
+      ensure
+        $redis.del(RedisKey.blast_pending_recipients(blast.id)) if blast
+        Feature.deactivate(:auto_resume_stalled_post_blasts)
       end
 
       it "is waiting while the blast is deferred by the daily large-blast quota" do
@@ -280,7 +299,7 @@ describe InstallmentPresenter do
         $redis.set(RedisKey.blast_quota_deferred_until(blast.id), run_at.utc.iso8601)
 
         expect(described_class.new(seller:, installment:).props[:delivery]).to eq(
-          { status: "waiting", delivered_count: 0, remaining_count: nil, scheduled_for: run_at }
+          { status: "waiting", delivered_count: 0, remaining_count: nil, scheduled_for: run_at, retrying: false }
         )
       ensure
         $redis.del(RedisKey.blast_quota_deferred_until(blast.id)) if blast

--- a/spec/presenters/installment_presenter_spec.rb
+++ b/spec/presenters/installment_presenter_spec.rb
@@ -231,6 +231,69 @@ describe InstallmentPresenter do
       end
     end
 
+    context "delivery state of the latest regular send" do
+      it "is nil when the post was never blasted" do
+        expect(described_class.new(seller:, installment:).props[:delivery]).to be_nil
+      end
+
+      it "is sent once the blast completed" do
+        create(:blast, post: installment, completed_at: 5.minutes.ago, delivery_count: 1500)
+
+        expect(described_class.new(seller:, installment:).props[:delivery]).to eq(
+          { status: "sent", delivered_count: 1500, remaining_count: nil, scheduled_for: nil }
+        )
+      end
+
+      it "is sent when every recipient was handed off and only the completion stamp is missing" do
+        blast = create(:blast, post: installment, requested_at: 2.days.ago, last_email_delivered_at: 2.days.ago, completed_at: nil, delivery_count: 1500)
+        $redis.set(RedisKey.blast_pending_recipients(blast.id), 0)
+
+        expect(described_class.new(seller:, installment:).props[:delivery]).to include(status: "sent", remaining_count: nil)
+      ensure
+        $redis.del(RedisKey.blast_pending_recipients(blast.id)) if blast
+      end
+
+      it "is sending while the last email is inside the stall threshold, with the remaining count when known" do
+        blast = create(:blast, post: installment, requested_at: 1.hour.ago, last_email_delivered_at: 10.minutes.ago, completed_at: nil, delivery_count: 6_798)
+        $redis.set(RedisKey.blast_pending_recipients(blast.id), 16_212)
+
+        expect(described_class.new(seller:, installment:).props[:delivery]).to eq(
+          { status: "sending", delivered_count: 6_798, remaining_count: 16_212, scheduled_for: nil }
+        )
+      ensure
+        $redis.del(RedisKey.blast_pending_recipients(blast.id)) if blast
+      end
+
+      it "is incomplete once an unfinished blast has been idle past the stall threshold" do
+        create(:blast, post: installment, requested_at: 2.days.ago, started_at: 2.days.ago, first_email_delivered_at: 2.days.ago,
+                       last_email_delivered_at: 2.days.ago, completed_at: nil, delivery_count: 6_798)
+
+        expect(described_class.new(seller:, installment:).props[:delivery]).to eq(
+          { status: "incomplete", delivered_count: 6_798, remaining_count: nil, scheduled_for: nil }
+        )
+      end
+
+      it "is waiting while the blast is deferred by the daily large-blast quota" do
+        blast = create(:blast, :just_requested, post: installment)
+        blast.update!(started_at: Time.current)
+        run_at = 5.hours.from_now.change(usec: 0)
+        $redis.set(RedisKey.blast_quota_deferred_until(blast.id), run_at.utc.iso8601)
+
+        expect(described_class.new(seller:, installment:).props[:delivery]).to eq(
+          { status: "waiting", delivered_count: 0, remaining_count: nil, scheduled_for: run_at }
+        )
+      ensure
+        $redis.del(RedisKey.blast_quota_deferred_until(blast.id)) if blast
+      end
+
+      it "describes the latest regular blast, not a later non-opener resend" do
+        create(:blast, post: installment, requested_at: 2.days.ago, completed_at: 2.days.ago, delivery_count: 900)
+        create(:blast, post: installment, recipient_filter: "unopened", requested_at: 1.hour.ago, completed_at: nil, delivery_count: 0)
+
+        expect(described_class.new(seller:, installment:).props[:delivery]).to include(status: "sent", delivered_count: 900)
+      end
+    end
+
     context "when the installment has non-opener resends" do
       it "returns each unopened blast in non_opener_resends ordered by requested_at" do
         older = create(:blast, post: installment, recipient_filter: "unopened", requested_at: 2.days.ago, started_at: 2.days.ago, completed_at: 2.days.ago, delivery_count: 5)

--- a/spec/requests/emails/list_spec.rb
+++ b/spec/requests/emails/list_spec.rb
@@ -116,6 +116,7 @@ describe("Email List", :js, :sidekiq_inline, :elasticsearch_wait_for_refresh, ty
         blast = create(:blast, post: installment1, requested_at: 2.days.ago, started_at: 2.days.ago, first_email_delivered_at: 2.days.ago,
                                last_email_delivered_at: 2.days.ago, completed_at: nil, delivery_count: 6_798)
         $redis.set(RedisKey.blast_pending_recipients(blast.id), 16_212)
+        Feature.activate(:auto_resume_stalled_post_blasts)
         create(:blast, post: installment3, completed_at: 3.days.ago, delivery_count: 1)
 
         visit "#{emails_path}/published"
@@ -128,10 +129,11 @@ describe("Email List", :js, :sidekiq_inline, :elasticsearch_wait_for_refresh, ty
 
         within_modal "Email 1 (sent)" do
           expect(page).to have_text("Status Incomplete", normalize_ws: true)
-          expect(page).to have_text("6,798 people got this email. 16,212 people have not received it yet. If this stays the same, contact support.")
+          expect(page).to have_text("6,798 people got this email. 16,212 people have not received it yet. We are retrying automatically.")
         end
       ensure
         $redis.del(RedisKey.blast_pending_recipients(blast.id)) if blast
+        Feature.deactivate(:auto_resume_stalled_post_blasts)
       end
 
       it "loads more emails" do

--- a/spec/requests/emails/list_spec.rb
+++ b/spec/requests/emails/list_spec.rb
@@ -112,6 +112,28 @@ describe("Email List", :js, :sidekiq_inline, :elasticsearch_wait_for_refresh, ty
         expect(page).to have_table_row({ "Subject" => "Email 3 (sent)", "Emailed" => "--", "Opened" => "--", "Clicks" => "0", "Views" => "1" })
       end
 
+      it "flags a blast that stopped short instead of passing it off as finished" do
+        blast = create(:blast, post: installment1, requested_at: 2.days.ago, started_at: 2.days.ago, first_email_delivered_at: 2.days.ago,
+                               last_email_delivered_at: 2.days.ago, completed_at: nil, delivery_count: 6_798)
+        $redis.set(RedisKey.blast_pending_recipients(blast.id), 16_212)
+        create(:blast, post: installment3, completed_at: 3.days.ago, delivery_count: 1)
+
+        visit "#{emails_path}/published"
+
+        within_table "Published" do
+          expect(page).to have_table_row({ "Subject" => "Email 1 (sent)", "Emailed" => "--", "Status" => "Incomplete" })
+          expect(page).to have_table_row({ "Subject" => "Email 3 (sent)", "Emailed" => "--", "Status" => "Sent" })
+          find(:table_row, { "Subject" => "Email 1 (sent)" }).click
+        end
+
+        within_modal "Email 1 (sent)" do
+          expect(page).to have_text("Status Incomplete", normalize_ws: true)
+          expect(page).to have_text("6,798 people got this email. 16,212 people have not received it yet. If this stays the same, contact support.")
+        end
+      ensure
+        $redis.del(RedisKey.blast_pending_recipients(blast.id)) if blast
+      end
+
       it "loads more emails" do
         stub_const("PaginatedInstallmentsPresenter::PER_PAGE", 2)
 

--- a/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
+++ b/spec/sidekiq/alert_on_stalled_post_email_blasts_job_spec.rb
@@ -126,6 +126,44 @@ describe AlertOnStalledPostEmailBlastsJob do
     end
   end
 
+  describe ".auto_resume_eligible?" do
+    before { Feature.activate(:auto_resume_stalled_post_blasts) }
+    after { Feature.deactivate(:auto_resume_stalled_post_blasts) }
+
+    it "is true while the next scan still lands inside the resume window, and past it only while recipients are still owed" do
+      recent = stalled_blast(requested_hours_ago: 6)
+      # Inside the window now, but the next scan (up to six hours away) will find it past 24h.
+      leaving = stalled_blast(requested_hours_ago: 23)
+      old = stalled_blast(requested_hours_ago: 30)
+
+      expect(described_class.auto_resume_eligible?(recent)).to eq(true)
+      expect(described_class.auto_resume_eligible?(leaving)).to eq(false)
+      expect(described_class.auto_resume_eligible?(old)).to eq(false)
+
+      $redis.set(RedisKey.blast_pending_recipients(old.id), 12)
+      expect(described_class.auto_resume_eligible?(old)).to eq(true)
+    ensure
+      $redis.del(RedisKey.blast_pending_recipients(old.id)) if old
+    end
+
+    it "is false once fewer than two scans remain inside the lookback, so a held resume cannot be promised" do
+      blast = stalled_blast(requested_hours_ago: (described_class::LOOKBACK - 8.hours).in_hours)
+      $redis.set(RedisKey.blast_pending_recipients(blast.id), 12)
+
+      expect(described_class.auto_resume_eligible?(blast)).to eq(false)
+    ensure
+      $redis.del(RedisKey.blast_pending_recipients(blast.id)) if blast
+    end
+
+    it "is false for completed blasts, non-opener resends, and when auto-resume is off" do
+      expect(described_class.auto_resume_eligible?(stalled_blast.tap { _1.update!(completed_at: Time.current) })).to eq(false)
+      expect(described_class.auto_resume_eligible?(stalled_blast.tap { _1.update!(recipient_filter: "unopened") })).to eq(false)
+
+      Feature.deactivate(:auto_resume_stalled_post_blasts)
+      expect(described_class.auto_resume_eligible?(stalled_blast)).to eq(false)
+    end
+  end
+
   describe "auto-resume" do
     context "when :auto_resume_stalled_post_blasts is active" do
       before { Feature.activate(:auto_resume_stalled_post_blasts) }


### PR DESCRIPTION
Tracker: antiwork/gumroad-private#2520

Stacked on #7576.

## What

The Published emails page now shows the state of the latest regular send for each email.

- The Emailed column keeps the delivered count and adds a small pill for the three unfinished states: Sending, Waiting to send, and Incomplete. A finished send looks as it did before.
- The detail sheet adds one sentence under Emailed that says what happened and what happens next. For an incomplete send: how many people got the email, how many have not received it yet, and to contact support if that stays the same. For a waiting send: the date and time it sends, and why. For a live send: how many people are left.
- `InstallmentPresenter` derives the state from the preloaded blasts. A blast is sending while its last email is inside the four-hour stall threshold, waiting while its quota deferral marker is ahead, and incomplete once it has been idle past the threshold without completing. The remaining count comes from the pending-recipient key when it exists.

## Why

The page rendered only the delivered count, so a send that stopped short looked like a finished one. Sixteen daily sends for one seller sat at 6,798 of about 23,000 for two weeks with a healthy open rate and nothing on the page to show it. The seller found out about a different problem first.

The copy follows plain-language guidance: short sentences, the fact first, then what to do. The state names are the words a seller would use.

## Before / After

| | Before | After |
|---|---|---|
| **Desktop, light** | ![Before, desktop light](https://github.com/user-attachments/assets/6244186f-80c3-47e9-912c-f045fcf250dc) | ![After, desktop light](https://github.com/user-attachments/assets/32b9ada1-f276-400d-9ccd-d4143db36e27) |
| **Desktop, dark** | ![Before, desktop dark](https://github.com/user-attachments/assets/325072e7-c97d-4933-a3ed-67713355bf88) | ![After, desktop dark](https://github.com/user-attachments/assets/72549362-da72-44dd-a721-965a6f1047e0) |
| **Detail sheet, light** | ![Before, detail sheet light](https://github.com/user-attachments/assets/1eed4c9b-77b7-4871-8cad-9b5bda77a8fa) | ![After, detail sheet light](https://github.com/user-attachments/assets/52483cde-b998-4bd3-8d64-0490a4acc107) |
| **Detail sheet, dark** | ![Before, detail sheet dark](https://github.com/user-attachments/assets/7a6a4ce3-a2f7-4517-a28d-fa2e6e701663) | ![After, detail sheet dark](https://github.com/user-attachments/assets/d804232f-1c6b-4600-b0d7-9dbb109a13e4) |
| **Mobile list, light** | ![Before, mobile light](https://github.com/user-attachments/assets/2b1411ef-838f-4906-8efd-ef42a61d4f5e) | ![After, mobile light (full list)](https://github.com/user-attachments/assets/b8949b09-e326-4df1-a442-db507a49788c) |
| **Mobile sheet, dark** | ![Before, mobile sheet dark](https://github.com/user-attachments/assets/8b0bc394-2e8c-4f21-9f69-28a130cacd47) | ![After, mobile sheet dark](https://github.com/user-attachments/assets/bb16aa75-dcfa-449f-9465-6c15a9839223) |

The incomplete sentence adds "We are retrying automatically" only when the stalled-blast monitor will resume the blast. On mobile the Status line appears only on unfinished sends; the finished card at the bottom of the mobile list keeps today's six lines.

## Test Results

```text
bundle exec rspec spec/presenters/installment_presenter_spec.rb
bundle exec rspec spec/requests/emails/list_spec.rb -e "flags a blast that stopped short"
npm run typecheck
DISABLE_TYPE_CHECKED=1 npx eslint app/javascript/pages/Emails/Published.tsx app/javascript/data/installments.ts
```

---

AI disclosure: Claude Fable 5.1.
