### PR TITLE
Let sellers send an incomplete email to the rest of its audience

### DIFF
--- a/app/controllers/api/internal/installments/remaining_sends_controller.rb
+++ b/app/controllers/api/internal/installments/remaining_sends_controller.rb
@@ -15,13 +15,22 @@ class Api::Internal::Installments::RemainingSendsController < Api::Internal::Bas
     unless blast&.delivery_status == "incomplete"
       return render json: { success: false, error: "This email is not waiting on any recipients." }, status: :unprocessable_entity
     end
-    if AlertOnStalledPostEmailBlastsJob.sender_visible?(blast.id)
-      return render json: { success: false, error: "This email is already sending. Check back in a few hours." }, status: :unprocessable_entity
+    # One path at a time: while the monitor will retry on its own, the page shows that and no button.
+    if AlertOnStalledPostEmailBlastsJob.auto_resume_eligible?(blast)
+      return render json: { success: false, error: "We are retrying this automatically." }, status: :unprocessable_entity
     end
-    # The monitor's own once-per-window marker, so the seller and the monitor cannot both enqueue.
+
+    # Claim the monitor's once-per-window marker BEFORE looking for a live sender: the monitor
+    # claims the same marker before it enqueues, so holding it first means nothing else can
+    # start a sender while the Sidekiq scans run.
     marker = RedisKey.stalled_blast_auto_resumed(blast.id)
-    unless $redis.set(marker, "seller:#{current_seller.id}", nx: true, ex: AlertOnStalledPostEmailBlastsJob::STALL_THRESHOLD.to_i)
+    claim = "seller:#{current_seller.id}"
+    unless $redis.set(marker, claim, nx: true, ex: AlertOnStalledPostEmailBlastsJob::STALL_THRESHOLD.to_i)
       return render json: { success: false, error: "A send was started recently. Check back in a few hours." }, status: :unprocessable_entity
+    end
+    if AlertOnStalledPostEmailBlastsJob.sender_visible?(blast.id)
+      $redis.eval(RELEASE_CLAIM_IF_HELD, keys: [marker], argv: [claim])
+      return render json: { success: false, error: "This email is already sending. Check back in a few hours." }, status: :unprocessable_entity
     end
 
     SendPostBlastEmailsJob.perform_async(blast.id)
@@ -29,6 +38,13 @@ class Api::Internal::Installments::RemainingSendsController < Api::Internal::Bas
   end
 
   private
+    RELEASE_CLAIM_IF_HELD = <<~LUA
+      if redis.call("GET", KEYS[1]) == ARGV[1] then
+        return redis.call("DEL", KEYS[1])
+      end
+      return 0
+    LUA
+
     def set_installment
       @installment = current_seller.installments.alive.published.not_workflow_installment.find_by_external_id(params[:id])
       (skip_authorization and e404_json) if @installment.nil?

--- a/app/controllers/api/internal/installments/remaining_sends_controller.rb
+++ b/app/controllers/api/internal/installments/remaining_sends_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Api::Internal::Installments::RemainingSendsController < Api::Internal::BaseController
+  before_action :authenticate_user!
+  before_action :set_installment
+  after_action :verify_authorized
+
+  # Resumes an incomplete send at the seller's request. The job skips everyone who already
+  # received the email, so this cannot double-send; the guards below only keep two senders
+  # from running at once.
+  def create
+    authorize @installment, :send_to_remaining?
+
+    blast = @installment.latest_regular_blast
+    unless blast&.delivery_status == "incomplete"
+      return render json: { success: false, error: "This email is not waiting on any recipients." }, status: :unprocessable_entity
+    end
+    if AlertOnStalledPostEmailBlastsJob.sender_visible?(blast.id)
+      return render json: { success: false, error: "This email is already sending. Check back in a few hours." }, status: :unprocessable_entity
+    end
+    # The monitor's own once-per-window marker, so the seller and the monitor cannot both enqueue.
+    marker = RedisKey.stalled_blast_auto_resumed(blast.id)
+    unless $redis.set(marker, "seller:#{current_seller.id}", nx: true, ex: AlertOnStalledPostEmailBlastsJob::STALL_THRESHOLD.to_i)
+      return render json: { success: false, error: "A send was started recently. Check back in a few hours." }, status: :unprocessable_entity
+    end
+
+    SendPostBlastEmailsJob.perform_async(blast.id)
+    render json: { success: true }
+  end
+
+  private
+    def set_installment
+      @installment = current_seller.installments.alive.published.not_workflow_installment.find_by_external_id(params[:id])
+      (skip_authorization and e404_json) if @installment.nil?
+    end
+end

--- a/app/javascript/components/EmailsPage/shared.tsx
+++ b/app/javascript/components/EmailsPage/shared.tsx
@@ -2,7 +2,13 @@ import { Envelope, FileDetail } from "@boxicons/react";
 import { router, useForm } from "@inertiajs/react";
 import React from "react";
 
-import { SavedInstallment, getAudienceCount, getNonOpenerCount, resendToNonOpeners } from "$app/data/installments";
+import {
+  SavedInstallment,
+  getAudienceCount,
+  getNonOpenerCount,
+  resendToNonOpeners,
+  sendToRemaining,
+} from "$app/data/installments";
 import { formatStatNumber } from "$app/utils/formatStatNumber";
 import { asyncVoid } from "$app/utils/promise";
 import { assertResponseError } from "$app/utils/request";
@@ -194,15 +200,78 @@ export const ResendToNonOpenersButton = ({ installment }: { installment: SavedIn
   );
 };
 
+export const SendToRemainingButton = ({
+  installment,
+  remainingCount,
+}: {
+  installment: SavedInstallment;
+  remainingCount: number | null;
+}) => {
+  const [confirming, setConfirming] = React.useState(false);
+  const [sending, setSending] = React.useState(false);
+
+  const handleSend = asyncVoid(async () => {
+    setSending(true);
+    try {
+      await sendToRemaining(installment.external_id);
+      showAlert("Sending to everyone who has not received this yet. This may take a while.", "success");
+      setConfirming(false);
+      router.reload();
+    } catch (error) {
+      assertResponseError(error);
+      showAlert(error.message, "error");
+    } finally {
+      setSending(false);
+    }
+  });
+
+  const recipients =
+    remainingCount !== null
+      ? `the ${formatStatNumber({ value: remainingCount })} ${remainingCount === 1 ? "person" : "people"} who`
+      : "everyone who";
+
+  return (
+    <>
+      <Button onClick={() => setConfirming(true)}>
+        <Envelope pack="filled" className="size-5" />
+        Send to the rest
+      </Button>
+      {confirming ? (
+        <Modal
+          open
+          allowClose={!sending}
+          onClose={() => setConfirming(false)}
+          title="Send to the rest?"
+          footer={
+            <>
+              <Button disabled={sending} onClick={() => setConfirming(false)}>
+                Cancel
+              </Button>
+              <Button color="accent" disabled={sending} onClick={handleSend}>
+                {sending ? "Sending..." : "Send"}
+              </Button>
+            </>
+          }
+        >
+          <h4>{`This will send "${installment.name}" to ${recipients} ${remainingCount === 1 ? "has" : "have"} not received it yet.`}</h4>
+        </Modal>
+      ) : null}
+    </>
+  );
+};
+
 type EmailSheetActionsProps = {
   installment: SavedInstallment;
   onDelete: () => void;
+  // Set when the latest send is incomplete; the count is the recipients still owed when known.
+  remainingSend?: { count: number | null } | null;
 };
 
-export const EmailSheetActions = ({ installment, onDelete }: EmailSheetActionsProps) => (
+export const EmailSheetActions = ({ installment, onDelete, remainingSend = null }: EmailSheetActionsProps) => (
   <>
     <div className="grid grid-flow-col gap-4">
       {installment.send_emails ? <ViewEmailButton installment={installment} /> : null}
+      {remainingSend ? <SendToRemainingButton installment={installment} remainingCount={remainingSend.count} /> : null}
       {canResendToNonOpeners(installment) ? <ResendToNonOpenersButton installment={installment} /> : null}
       {installment.shown_on_profile ? (
         <NavigationButton href={installment.full_url} target="_blank" rel="noopener noreferrer">

--- a/app/javascript/data/installments.ts
+++ b/app/javascript/data/installments.ts
@@ -184,6 +184,18 @@ export async function resendToNonOpeners(externalId: string) {
   return typia.assert<{ success: boolean }>(json);
 }
 
+export async function sendToRemaining(externalId: string) {
+  const response = await request({
+    method: "POST",
+    accept: "json",
+    url: Routes.internal_installment_remaining_send_path(externalId),
+  });
+
+  const json: unknown = await response.json();
+  if (!response.ok) throw new ResponseError(typia.assert<{ error: string }>(json).error);
+  return typia.assert<{ success: boolean }>(json);
+}
+
 export async function previewInstallment(externalId: string) {
   const response = await request({
     method: "POST",

--- a/app/javascript/pages/Emails/Published.tsx
+++ b/app/javascript/pages/Emails/Published.tsx
@@ -310,7 +310,7 @@ export default function EmailsPublished() {
                 <EmailSheetActions
                   installment={selectedInstallment}
                   remainingSend={
-                    selectedInstallment.delivery?.status === "incomplete"
+                    selectedInstallment.delivery?.status === "incomplete" && !selectedInstallment.delivery.retrying
                       ? { count: selectedInstallment.delivery.remaining_count }
                       : null
                   }

--- a/app/javascript/pages/Emails/Published.tsx
+++ b/app/javascript/pages/Emails/Published.tsx
@@ -309,6 +309,11 @@ export default function EmailsPublished() {
                 </Card>
                 <EmailSheetActions
                   installment={selectedInstallment}
+                  remainingSend={
+                    selectedInstallment.delivery?.status === "incomplete"
+                      ? { count: selectedInstallment.delivery.remaining_count }
+                      : null
+                  }
                   onDelete={() =>
                     setDeletingInstallment({
                       id: selectedInstallment.external_id,

--- a/app/javascript/pages/Emails/Published.tsx
+++ b/app/javascript/pages/Emails/Published.tsx
@@ -69,7 +69,7 @@ export default function EmailsPublished() {
   const isUnfinished = (installment: PublishedInstallment) =>
     installment.send_emails && installment.delivery !== null && installment.delivery.status !== "sent";
 
-  const deliveryNote = (delivery: PublishedInstallment["delivery"]) => {
+  const deliveryNote = (delivery: PublishedInstallment["delivery"], sentCount: number | null) => {
     if (!delivery || delivery.status === "sent") return null;
     const people = (count: number) => `${formatStatNumber({ value: count })} ${count === 1 ? "person" : "people"}`;
     switch (delivery.status) {
@@ -86,10 +86,13 @@ export default function EmailsPublished() {
             })}, when your daily limit for large emails resets.`
           : "Sends when your daily limit for large emails resets.";
       case "incomplete": {
-        // The Emailed row above already carries the delivered count; lead with what is new.
+        // Emailed shows the post's total, which can differ from this send's own count after a
+        // resend; repeat the count only when it adds something.
+        const got =
+          delivery.delivered_count === sentCount ? "" : `${people(delivery.delivered_count)} got this email. `;
         const missing =
           delivery.remaining_count !== null ? `${people(delivery.remaining_count)} have` : "Some people have";
-        return `${missing} not received it yet.${delivery.retrying ? " We are retrying automatically." : ""}`;
+        return `${got}${missing} not received it yet.${delivery.retrying ? " We are retrying automatically." : ""}`;
       }
     }
   };
@@ -256,9 +259,12 @@ export default function EmailsPublished() {
                     <h5 className="grow font-bold">Status</h5>
                     {deliveryLabel(selectedInstallment)}
                   </CardContent>
-                  {selectedInstallment.send_emails && deliveryNote(selectedInstallment.delivery) ? (
+                  {selectedInstallment.send_emails &&
+                  deliveryNote(selectedInstallment.delivery, selectedInstallment.sent_count) ? (
                     <CardContent>
-                      <p className="text-sm text-muted">{deliveryNote(selectedInstallment.delivery)}</p>
+                      <p className="text-sm text-muted">
+                        {deliveryNote(selectedInstallment.delivery, selectedInstallment.sent_count)}
+                      </p>
                     </CardContent>
                   ) : null}
                   <CardContent>

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -1054,6 +1054,9 @@ class Installment < ApplicationRecord
   end
 
   def has_been_blasted? = blasts.loaded? ? blasts.any? : blasts.exists?
+
+  # The send whose state the seller sees; resends to non-openers have their own rows.
+  def latest_regular_blast = blasts.reject(&:to_non_openers?).max_by(&:requested_at)
   def can_be_blasted? = send_emails? && !has_been_blasted?
 
   def featured_image_url

--- a/app/models/post_email_blast.rb
+++ b/app/models/post_email_blast.rb
@@ -31,10 +31,8 @@ class PostEmailBlast < ApplicationRecord
     recipient_filter == RECIPIENT_FILTER_UNOPENED
   end
 
-  # Seller-facing state of this send. "sent" also covers a blast whose every recipient reached
-  # the ESP and only lacks the completion stamp (a zero pending count, see
-  # SendPostBlastEmailsJob.fully_delivered?). "incomplete" means idle past the stall threshold
-  # with recipients unaccounted for.
+  # Seller-facing state of this send. A zero pending count reads as "sent": every recipient
+  # reached the ESP and only the completion stamp is missing (SendPostBlastEmailsJob.fully_delivered?).
   def delivery_status
     return "sent" if completed_at.present?
     return "sent" if remaining_recipient_count&.<=(0)

--- a/app/models/post_email_blast.rb
+++ b/app/models/post_email_blast.rb
@@ -31,6 +31,34 @@ class PostEmailBlast < ApplicationRecord
     recipient_filter == RECIPIENT_FILTER_UNOPENED
   end
 
+  # Seller-facing state of this send. "sent" also covers a blast whose every recipient reached
+  # the ESP and only lacks the completion stamp (a zero pending count, see
+  # SendPostBlastEmailsJob.fully_delivered?). "incomplete" means idle past the stall threshold
+  # with recipients unaccounted for.
+  def delivery_status
+    return "sent" if completed_at.present?
+    return "sent" if remaining_recipient_count&.<=(0)
+    return "waiting" if quota_deferred_until&.future?
+    return "sending" if [requested_at, last_email_delivered_at].compact.max > AlertOnStalledPostEmailBlastsJob::STALL_THRESHOLD.ago
+
+    "incomplete"
+  end
+
+  # Recipients the sender still owes, from its pending count; nil once that key is gone.
+  def remaining_recipient_count
+    return @remaining_recipient_count if defined?(@remaining_recipient_count)
+
+    pending = $redis.get(RedisKey.blast_pending_recipients(id))
+    @remaining_recipient_count = pending.present? ? pending.to_i : nil
+  end
+
+  def quota_deferred_until
+    return @quota_deferred_until if defined?(@quota_deferred_until)
+
+    deferred_until = $redis.get(RedisKey.blast_quota_deferred_until(id))
+    @quota_deferred_until = deferred_until.present? ? Time.zone.parse(deferred_until) : nil
+  end
+
   scope :aggregated, -> {
     select(
       "DATE(requested_at) AS date",

--- a/app/policies/installment_policy.rb
+++ b/app/policies/installment_policy.rb
@@ -67,4 +67,8 @@ class InstallmentPolicy < ApplicationPolicy
   def resend_to_non_openers?
     create?
   end
+
+  def send_to_remaining?
+    create?
+  end
 end

--- a/app/presenters/installment_presenter.rb
+++ b/app/presenters/installment_presenter.rb
@@ -98,35 +98,17 @@ class InstallmentPresenter
     # State of the latest regular send. Without it an incomplete blast reads as a finished one:
     # the Emailed column only ever showed the delivered count. Resends have their own rows.
     def delivery_props
-      blast = installment.blasts.reject(&:to_non_openers?).max_by(&:requested_at)
+      blast = installment.latest_regular_blast
       return if blast&.requested_at.nil?
-      sent = { status: "sent", delivered_count: blast.delivery_count, remaining_count: nil, scheduled_for: nil, retrying: false }
-      return sent if blast.completed_at.present?
 
-      # A zero pending count means every recipient reached the ESP and only the completion
-      # stamp is missing (see SendPostBlastEmailsJob.fully_delivered?).
-      pending = $redis.get(RedisKey.blast_pending_recipients(blast.id))
-      return sent if pending.present? && pending.to_i <= 0
-
-      scheduled_for = quota_deferred_until(blast)
-      status =
-        if scheduled_for&.future? then "waiting"
-        elsif [blast.requested_at, blast.last_email_delivered_at].compact.max > AlertOnStalledPostEmailBlastsJob::STALL_THRESHOLD.ago then "sending"
-        else "incomplete"
-        end
-
+      status = blast.delivery_status
       {
         status:,
         delivered_count: blast.delivery_count,
-        remaining_count: pending.present? ? pending.to_i : nil,
-        scheduled_for: status == "waiting" ? scheduled_for : nil,
+        remaining_count: status == "sent" ? nil : blast.remaining_recipient_count,
+        scheduled_for: status == "waiting" ? blast.quota_deferred_until : nil,
         retrying: status == "incomplete" && AlertOnStalledPostEmailBlastsJob.auto_resume_eligible?(blast),
       }
-    end
-
-    def quota_deferred_until(blast)
-      deferred_until = $redis.get(RedisKey.blast_quota_deferred_until(blast.id))
-      Time.zone.parse(deferred_until) if deferred_until.present?
     end
 
     # Stats for each "resend to non-openers" blast on this post, oldest first.

--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -74,6 +74,11 @@ class AlertOnStalledPostEmailBlastsJob
     blast.requested_at > (AUTO_RESUME_WINDOW - SCAN_INTERVAL).ago || recipients_still_owed?(blast)
   end
 
+  # Whether a sender for this blast is busy, queued or retrying right now. Three Sidekiq scans.
+  def self.sender_visible?(blast_id)
+    new.send(:sender_visible_now?, blast_id)
+  end
+
   def self.recipients_still_owed?(blast)
     pending = $redis.get(RedisKey.blast_pending_recipients(blast.id))
     pending.present? && pending.to_i.positive?

--- a/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
+++ b/app/sidekiq/alert_on_stalled_post_email_blasts_job.rb
@@ -196,8 +196,15 @@ class AlertOnStalledPostEmailBlastsJob
       self.class.recipients_still_owed?(blast)
     end
 
+    # A job moves between the retry set, the queue and a worker in both directions, so a single
+    # pass can miss one that moved between two scans. Two passes in opposite orders see a job
+    # that moved once, whichever way it went.
     def sender_visible_now?(blast_id)
-      @live_blast_ids ||= (busy_blast_ids + queued_blast_ids + retrying_blast_ids).to_set
+      @live_blast_ids ||= begin
+        forward = retrying_blast_ids + queued_blast_ids + busy_blast_ids
+        backward = busy_blast_ids + queued_blast_ids + retrying_blast_ids
+        (forward + backward).to_set
+      end
       @live_blast_ids.include?(blast_id)
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1243,6 +1243,7 @@ Rails.application.routes.draw do
             resource :audience_count, only: [:show], controller: "installments/audience_counts", as: :installment_audience_count
             resource :preview_email, only: [:create], controller: "installments/preview_emails", as: :installment_preview_email
             resource :non_opener_resend, only: [:show, :create], controller: "installments/non_opener_resends", as: :installment_non_opener_resend
+            resource :remaining_send, only: [:create], controller: "installments/remaining_sends", as: :installment_remaining_send
           end
           collection do
             resource :recipient_count, only: [:show], controller: "installments/recipient_counts", as: :installment_recipient_count

--- a/spec/controllers/api/internal/installments/remaining_sends_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/remaining_sends_controller_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared_examples/authorize_called"
+require "shared_examples/authentication_required"
+
+describe Api::Internal::Installments::RemainingSendsController do
+  let(:seller) { create(:user) }
+
+  include_context "with user signed in as admin for seller"
+
+  let(:installment) { create(:audience_post, :published, seller:) }
+  let!(:blast) do
+    create(:blast, post: installment, requested_at: 2.days.ago, started_at: 2.days.ago, first_email_delivered_at: 2.days.ago,
+                   last_email_delivered_at: 2.days.ago, completed_at: nil, delivery_count: 6_798)
+  end
+
+  after { $redis.del(RedisKey.stalled_blast_auto_resumed(blast.id), RedisKey.blast_pending_recipients(blast.id)) }
+
+  describe "POST create" do
+    it_behaves_like "authentication required for action", :post, :create do
+      let(:request_params) { { id: installment.external_id } }
+    end
+
+    it_behaves_like "authorize called for action", :post, :create do
+      let(:record) { installment }
+      let(:policy_method) { :send_to_remaining? }
+      let(:request_params) { { id: installment.external_id } }
+    end
+
+    it "resumes an incomplete send and claims the monitor's once-per-window marker" do
+      post :create, params: { id: installment.external_id }
+
+      expect(response).to be_successful
+      expect(response.parsed_body).to eq({ "success" => true })
+      expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(blast.id)
+      expect($redis.get(RedisKey.stalled_blast_auto_resumed(blast.id))).to eq("seller:#{seller.id}")
+      expect($redis.ttl(RedisKey.stalled_blast_auto_resumed(blast.id))).to be_between(1, AlertOnStalledPostEmailBlastsJob::STALL_THRESHOLD.to_i).inclusive
+    end
+
+    it "refuses when the latest send is not incomplete" do
+      blast.update!(completed_at: 1.day.ago)
+
+      post :create, params: { id: installment.external_id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to eq("This email is not waiting on any recipients.")
+      expect(SendPostBlastEmailsJob.jobs.size).to eq(0)
+    end
+
+    it "refuses while a sender is still busy, queued or retrying" do
+      allow(AlertOnStalledPostEmailBlastsJob).to receive(:sender_visible?).with(blast.id).and_return(true)
+
+      post :create, params: { id: installment.external_id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to eq("This email is already sending. Check back in a few hours.")
+      expect(SendPostBlastEmailsJob.jobs.size).to eq(0)
+    end
+
+    it "refuses a second start inside the stall window, whoever started the first" do
+      $redis.set(RedisKey.stalled_blast_auto_resumed(blast.id), Time.current.iso8601, ex: 1.hour.to_i)
+
+      post :create, params: { id: installment.external_id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to eq("A send was started recently. Check back in a few hours.")
+      expect(SendPostBlastEmailsJob.jobs.size).to eq(0)
+    end
+
+    it "returns 404 for an unpublished post" do
+      installment.update!(published_at: nil)
+
+      post :create, params: { id: installment.external_id }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/controllers/api/internal/installments/remaining_sends_controller_spec.rb
+++ b/spec/controllers/api/internal/installments/remaining_sends_controller_spec.rb
@@ -38,6 +38,19 @@ describe Api::Internal::Installments::RemainingSendsController do
       expect($redis.ttl(RedisKey.stalled_blast_auto_resumed(blast.id))).to be_between(1, AlertOnStalledPostEmailBlastsJob::STALL_THRESHOLD.to_i).inclusive
     end
 
+    it "refuses while the monitor will retry on its own" do
+      Feature.activate(:auto_resume_stalled_post_blasts)
+      $redis.set(RedisKey.blast_pending_recipients(blast.id), 16_212)
+
+      post :create, params: { id: installment.external_id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to eq("We are retrying this automatically.")
+      expect(SendPostBlastEmailsJob.jobs.size).to eq(0)
+    ensure
+      Feature.deactivate(:auto_resume_stalled_post_blasts)
+    end
+
     it "refuses when the latest send is not incomplete" do
       blast.update!(completed_at: 1.day.ago)
 
@@ -48,7 +61,7 @@ describe Api::Internal::Installments::RemainingSendsController do
       expect(SendPostBlastEmailsJob.jobs.size).to eq(0)
     end
 
-    it "refuses while a sender is still busy, queued or retrying" do
+    it "refuses while a sender is still busy, queued or retrying, and gives the marker back" do
       allow(AlertOnStalledPostEmailBlastsJob).to receive(:sender_visible?).with(blast.id).and_return(true)
 
       post :create, params: { id: installment.external_id }
@@ -56,6 +69,19 @@ describe Api::Internal::Installments::RemainingSendsController do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body["error"]).to eq("This email is already sending. Check back in a few hours.")
       expect(SendPostBlastEmailsJob.jobs.size).to eq(0)
+      expect($redis.exists?(RedisKey.stalled_blast_auto_resumed(blast.id))).to eq(false)
+    end
+
+    it "holds the marker while it scans for a live sender, so the monitor cannot start one meanwhile" do
+      allow(AlertOnStalledPostEmailBlastsJob).to receive(:sender_visible?) do
+        expect($redis.get(RedisKey.stalled_blast_auto_resumed(blast.id))).to eq("seller:#{seller.id}")
+        false
+      end
+
+      post :create, params: { id: installment.external_id }
+
+      expect(response).to be_successful
+      expect(SendPostBlastEmailsJob).to have_enqueued_sidekiq_job(blast.id)
     end
 
     it "refuses a second start inside the stall window, whoever started the first" do

--- a/spec/models/post_email_blast_spec.rb
+++ b/spec/models/post_email_blast_spec.rb
@@ -39,6 +39,31 @@ RSpec.describe PostEmailBlast do
     end
   end
 
+  describe "#delivery_status", :freeze_time do
+    let(:post) { create(:installment) }
+
+    it "is sent once completed, or once every recipient was handed off" do
+      expect(create(:blast, post:, completed_at: 1.minute.ago).delivery_status).to eq("sent")
+
+      handed_off = create(:blast, post:, requested_at: 2.days.ago, last_email_delivered_at: 2.days.ago, completed_at: nil)
+      $redis.set(RedisKey.blast_pending_recipients(handed_off.id), 0)
+      expect(handed_off.delivery_status).to eq("sent")
+    ensure
+      $redis.del(RedisKey.blast_pending_recipients(handed_off.id)) if handed_off
+    end
+
+    it "is waiting while a quota deferral is ahead, sending inside the stall threshold, incomplete past it" do
+      deferred = create(:blast, :just_requested, post:, requested_at: 5.hours.ago)
+      $redis.set(RedisKey.blast_quota_deferred_until(deferred.id), 1.hour.from_now.utc.iso8601)
+      expect(deferred.delivery_status).to eq("waiting")
+
+      expect(create(:blast, post:, requested_at: 1.hour.ago, last_email_delivered_at: 10.minutes.ago, completed_at: nil).delivery_status).to eq("sending")
+      expect(create(:blast, post:, requested_at: 2.days.ago, last_email_delivered_at: 2.days.ago, completed_at: nil).delivery_status).to eq("incomplete")
+    ensure
+      $redis.del(RedisKey.blast_quota_deferred_until(deferred.id)) if deferred
+    end
+  end
+
   describe "Latency metrics", :freeze_time do
     describe "#start_latency" do
       it "returns the difference between requested_at and started_at" do

--- a/spec/requests/emails/list_spec.rb
+++ b/spec/requests/emails/list_spec.rb
@@ -117,12 +117,13 @@ describe("Email List", :js, :sidekiq_inline, :elasticsearch_wait_for_refresh, ty
                                last_email_delivered_at: 2.days.ago, completed_at: nil, delivery_count: 6_798)
         $redis.set(RedisKey.blast_pending_recipients(blast.id), 16_212)
         Feature.activate(:auto_resume_stalled_post_blasts)
+        installment1.update!(customer_count: 6_798)
         create(:blast, post: installment3, completed_at: 3.days.ago, delivery_count: 1)
 
         visit "#{emails_path}/published"
 
         within_table "Published" do
-          expect(page).to have_table_row({ "Subject" => "Email 1 (sent)", "Emailed" => "--", "Status" => "Incomplete" })
+          expect(page).to have_table_row({ "Subject" => "Email 1 (sent)", "Emailed" => "6,798", "Status" => "Incomplete" })
           expect(page).to have_table_row({ "Subject" => "Email 3 (sent)", "Emailed" => "--", "Status" => "Sent" })
           find(:table_row, { "Subject" => "Email 1 (sent)" }).click
         end
@@ -152,7 +153,8 @@ describe("Email List", :js, :sidekiq_inline, :elasticsearch_wait_for_refresh, ty
         end
 
         within_modal "Email 1 (sent)" do
-          expect(page).to have_text("16,212 people have not received it yet.")
+          # Emailed reads "--" here, so the send's own count is worth repeating.
+          expect(page).to have_text("6,798 people got this email. 16,212 people have not received it yet.")
           click_on "Send to the rest"
         end
 

--- a/spec/requests/emails/list_spec.rb
+++ b/spec/requests/emails/list_spec.rb
@@ -130,6 +130,28 @@ describe("Email List", :js, :sidekiq_inline, :elasticsearch_wait_for_refresh, ty
         within_modal "Email 1 (sent)" do
           expect(page).to have_text("Status Incomplete", normalize_ws: true)
           expect(page).to have_text("6,798 people got this email. 16,212 people have not received it yet. We are retrying automatically.")
+          # One path at a time: while the monitor retries, the seller is not offered a second sender.
+          expect(page).not_to have_button("Send to the rest")
+        end
+      ensure
+        $redis.del(RedisKey.blast_pending_recipients(blast.id)) if blast
+        Feature.deactivate(:auto_resume_stalled_post_blasts)
+      end
+
+      it "lets the seller send an incomplete email to the rest once no automatic retry is coming" do
+        blast = create(:blast, post: installment1, requested_at: 2.days.ago, started_at: 2.days.ago, first_email_delivered_at: 2.days.ago,
+                               last_email_delivered_at: 2.days.ago, completed_at: nil, delivery_count: 6_798)
+        $redis.set(RedisKey.blast_pending_recipients(blast.id), 16_212)
+        Feature.deactivate(:auto_resume_stalled_post_blasts)
+
+        visit "#{emails_path}/published"
+
+        within_table "Published" do
+          find(:table_row, { "Subject" => "Email 1 (sent)" }).click
+        end
+
+        within_modal "Email 1 (sent)" do
+          expect(page).to have_text("6,798 people got this email. 16,212 people have not received it yet.")
           click_on "Send to the rest"
         end
 
@@ -142,7 +164,6 @@ describe("Email List", :js, :sidekiq_inline, :elasticsearch_wait_for_refresh, ty
         expect($redis.get(RedisKey.stalled_blast_auto_resumed(blast.id))).to start_with("seller:")
       ensure
         $redis.del(RedisKey.blast_pending_recipients(blast.id), RedisKey.stalled_blast_auto_resumed(blast.id)) if blast
-        Feature.deactivate(:auto_resume_stalled_post_blasts)
       end
 
       it "loads more emails" do

--- a/spec/requests/emails/list_spec.rb
+++ b/spec/requests/emails/list_spec.rb
@@ -130,9 +130,18 @@ describe("Email List", :js, :sidekiq_inline, :elasticsearch_wait_for_refresh, ty
         within_modal "Email 1 (sent)" do
           expect(page).to have_text("Status Incomplete", normalize_ws: true)
           expect(page).to have_text("6,798 people got this email. 16,212 people have not received it yet. We are retrying automatically.")
+          click_on "Send to the rest"
         end
+
+        within_modal "Send to the rest?" do
+          expect(page).to have_text('This will send "Email 1 (sent)" to the 16,212 people who have not received it yet.')
+          click_on "Send"
+        end
+
+        expect(page).to have_alert(text: "Sending to everyone who has not received this yet. This may take a while.")
+        expect($redis.get(RedisKey.stalled_blast_auto_resumed(blast.id))).to start_with("seller:")
       ensure
-        $redis.del(RedisKey.blast_pending_recipients(blast.id)) if blast
+        $redis.del(RedisKey.blast_pending_recipients(blast.id), RedisKey.stalled_blast_auto_resumed(blast.id)) if blast
         Feature.deactivate(:auto_resume_stalled_post_blasts)
       end
 


### PR DESCRIPTION
Tracker: antiwork/gumroad-private#2520

Stacked on #7578.

## What

Sellers can finish an incomplete send themselves.

- The detail sheet for an incomplete email gets a "Send to the rest" button next to "View email", only when no automatic retry is coming, so the seller sees one path at a time. A dialog states how many people have not received the email and asks to confirm. On confirm the page reloads and the row moves to Sending.
- `Api::Internal::Installments::RemainingSendsController#create` resumes the latest regular blast. It refuses when the send is not incomplete, when the monitor will retry on its own, when a sender is already busy, queued, or retrying, and when a send was started inside the last stall window. It then enqueues `SendPostBlastEmailsJob`, the same resume the monitor makes. The job skips everyone who already received the email, so the action cannot double-send.
- The once-per-window guard is the monitor's own `stalled_blast_auto_resumed` marker, claimed with NX before the Sidekiq scans and released if a live sender turns up. The scans run twice in opposite orders so a job moving between the retry set, the queue, and a worker is still seen. The seller and the monitor can never both start a sender for one blast.
- `PostEmailBlast#delivery_status`, `#remaining_recipient_count`, and `#quota_deferred_until` move the state rules out of the presenter so the page and the endpoint agree. `Installment#latest_regular_blast` names the blast both of them describe.
- New policy method `send_to_remaining?`, same rule as resending to non-openers.

## Why

#7578 shows a seller that a send stopped short, and says a retry is coming only when the monitor will make one. When it will not, the seller was left with a fact and no next step, and "contact support" buried in a sheet is not a path. This gives them the step, in the place they already see the problem.

## Before / After

The list and the Status column are unchanged from #7578. Both sides show an incomplete send with no automatic retry coming. The sentence repeats this send's delivered count only when Emailed shows a different number.

| | Before | After |
|---|---|---|
| **Sheet, desktop light** | ![Before, sheet desktop light](https://github.com/user-attachments/assets/38ded259-9a73-4a36-a98c-be87615d6d4d) | ![After, sheet desktop light (v2)](https://github.com/user-attachments/assets/a2751d03-29c1-44d8-9065-3f63d61a73f8) |
| **Sheet, desktop dark** | ![Before, sheet desktop dark](https://github.com/user-attachments/assets/e95fc662-6b89-4227-82dc-44d090b19ad6) | ![After, sheet desktop dark (v2)](https://github.com/user-attachments/assets/fb3f9d9f-7128-4e7f-b085-d3af14a9b641) |
| **Sheet, mobile dark** | ![Before, sheet mobile dark](https://github.com/user-attachments/assets/abda98f4-d5b3-412c-968f-cc686b8cec00) | ![After, sheet mobile dark (v2)](https://github.com/user-attachments/assets/8b7d3515-445f-4f50-be08-46a33dc4780e) |
| **Confirm dialog, desktop light** | | ![Confirm dialog, desktop light (v2)](https://github.com/user-attachments/assets/da5ea12a-ca64-4bf0-a97e-cf532159f24e) |
| **Confirm dialog, mobile dark** | | ![Confirm dialog, mobile dark (v2)](https://github.com/user-attachments/assets/d0785642-d16e-4760-97ab-e2ffbb036bc2) |

## Test Results

```text
bundle exec rspec spec/controllers/api/internal/installments/remaining_sends_controller_spec.rb
bundle exec rspec spec/models/post_email_blast_spec.rb spec/presenters/installment_presenter_spec.rb
bundle exec rspec spec/requests/emails/list_spec.rb -e "flags a blast that stopped short"
npm run typecheck
DISABLE_TYPE_CHECKED=1 npx eslint app/javascript/components/EmailsPage/shared.tsx app/javascript/pages/Emails/Published.tsx app/javascript/data/installments.ts
```

The system example clicks the button, confirms, and checks the marker the endpoint claims.

---

AI disclosure: Claude Fable 5.1.
