### PR TITLE
Lead the incomplete-send sentence with what the seller does not know

### DIFF
--- a/app/javascript/pages/Emails/Published.tsx
+++ b/app/javascript/pages/Emails/Published.tsx
@@ -86,11 +86,10 @@ export default function EmailsPublished() {
             })}, when your daily limit for large emails resets.`
           : "Sends when your daily limit for large emails resets.";
       case "incomplete": {
+        // The Emailed row above already carries the delivered count; lead with what is new.
         const missing =
           delivery.remaining_count !== null ? `${people(delivery.remaining_count)} have` : "Some people have";
-        return `${people(delivery.delivered_count)} got this email. ${missing} not received it yet.${
-          delivery.retrying ? " We are retrying automatically." : ""
-        }`;
+        return `${missing} not received it yet.${delivery.retrying ? " We are retrying automatically." : ""}`;
       }
     }
   };

--- a/spec/requests/emails/list_spec.rb
+++ b/spec/requests/emails/list_spec.rb
@@ -129,7 +129,8 @@ describe("Email List", :js, :sidekiq_inline, :elasticsearch_wait_for_refresh, ty
 
         within_modal "Email 1 (sent)" do
           expect(page).to have_text("Status Incomplete", normalize_ws: true)
-          expect(page).to have_text("6,798 people got this email. 16,212 people have not received it yet. We are retrying automatically.")
+          expect(page).to have_text("16,212 people have not received it yet. We are retrying automatically.")
+          expect(page).not_to have_text("6,798 people got this email")
         end
       ensure
         $redis.del(RedisKey.blast_pending_recipients(blast.id)) if blast


### PR DESCRIPTION
Tracker: antiwork/gumroad-private#2520

Follow-up to #7578 from its post-merge review.

## What

The detail sheet's sentence for an incomplete send no longer repeats the delivered count that the Emailed row shows directly above it. It leads with what is new: how many people have not received the email, and, when true, that we are retrying automatically.

Before: "6,798 people got this email. 16,212 people have not received it yet. We are retrying automatically."
After: "16,212 people have not received it yet. We are retrying automatically."

## Why

Same number twice in one viewport adds nothing. The remaining count and the retry are the facts the seller does not already have.

The review also asked for a pill or color on the unfinished states and for dropping the Status column. Both were decided against in #7578 on purpose: every status column in the app is plain text, and no table cell carries a pill. That choice stands.

## Before / After

| | Before | After |
|---|---|---|
| **Desktop, light** | ![Before, desktop light](https://github.com/user-attachments/assets/3ad6684b-7fb3-4016-bec8-2aa952c2c6e6) | ![After, desktop light](https://github.com/user-attachments/assets/432f2c4a-52ed-4bb0-b866-22d7e9e03a65) |
| **Desktop, dark** | ![Before, desktop dark](https://github.com/user-attachments/assets/9076111f-ea62-42d4-bb01-3f211da1f501) | ![After, desktop dark](https://github.com/user-attachments/assets/b47fad15-c8df-44f2-9732-46077434c9a7) |
| **Mobile, dark** | ![Before, mobile dark](https://github.com/user-attachments/assets/485cd117-f130-46a2-8417-6df90bcae527) | ![After, mobile dark](https://github.com/user-attachments/assets/295af25b-4f93-4979-8be6-bb50a2f658e7) |

## Test Results

```text
bundle exec rspec spec/requests/emails/list_spec.rb -e "flags a blast that stopped short"
DISABLE_TYPE_CHECKED=1 npx eslint app/javascript/pages/Emails/Published.tsx
```

---

AI disclosure: Claude Fable 5.1.
