### PR TITLE
Drop the envelope icon from Send to the rest

### DIFF
--- a/app/javascript/components/EmailsPage/shared.tsx
+++ b/app/javascript/components/EmailsPage/shared.tsx
@@ -232,10 +232,7 @@ export const SendToRemainingButton = ({
 
   return (
     <>
-      <Button onClick={() => setConfirming(true)}>
-        <Envelope pack="filled" className="size-5" />
-        Send to the rest
-      </Button>
+      <Button onClick={() => setConfirming(true)}>Send to the rest</Button>
       {confirming ? (
         <Modal
           open


### PR DESCRIPTION
Tracker: antiwork/gumroad-private#2520

Follow-up to #7579 from its post-merge review. The commit was pushed after the merge, so it did not land with the PR.

## What

"Send to the rest" no longer carries an envelope icon. "View email" sits beside it with the same icon, so the icon stopped telling the two apart.

## Before / After

The "before" shots predate #7579 and show the sheet without the button; the "after" shots show the button as it now renders.

| | Before | After |
|---|---|---|
| **Desktop, light** | ![Before, desktop light](https://github.com/user-attachments/assets/bef8d4e1-88f7-41dc-81ae-1bc9679f1895) | ![After, desktop light](https://github.com/user-attachments/assets/145b06a4-6009-4f23-b789-efd5bea6aa2d) |
| **Desktop, dark** | ![Before, desktop dark](https://github.com/user-attachments/assets/8baf1398-fc56-4a83-9dfa-978db9895ef3) | ![After, desktop dark](https://github.com/user-attachments/assets/8f71f539-caef-49a7-b74b-8f32f1ff534b) |
| **Mobile, dark** | ![Before, mobile dark](https://github.com/user-attachments/assets/0cf8ae20-fd46-48b6-a99e-1ca549fc8e3b) | ![After, mobile dark](https://github.com/user-attachments/assets/1f5dd233-baa5-4260-ad10-49e581e771bc) |

## Test Results

```text
DISABLE_TYPE_CHECKED=1 npx eslint app/javascript/components/EmailsPage/shared.tsx
bin/test-confidence
```

---

AI disclosure: Claude Fable 5.1.
