### PR TITLE
Expire stale EUR settlement-mismatch marker after 1 day (gp#2541)

### DIFF
--- a/app/models/merchant_account.rb
+++ b/app/models/merchant_account.rb
@@ -60,10 +60,7 @@ class MerchantAccount < ApplicationRecord
     !user_id
   end
 
-  # Skip doomed FX quotes this long. 30 days left EUR dark for 10 days after
-  # Stripe started accepting EUR→USD quotes again (gumroad-private#2541);
-  # account.updated never fired. One extra doomed quote/day per marked
-  # currency is cheaper than a dark picker.
+  # One extra doomed FX quote/day per marked currency is cheaper than a dark picker.
   SETTLEMENT_CURRENCY_MISMATCH_TTL = 1.day
 
   def settlement_currency_mismatch_active?(currency)

--- a/app/models/merchant_account.rb
+++ b/app/models/merchant_account.rb
@@ -60,8 +60,11 @@ class MerchantAccount < ApplicationRecord
     !user_id
   end
 
-  # Stale marker costs a USD checkout instead of buyer currency; account.updated clears early.
-  SETTLEMENT_CURRENCY_MISMATCH_TTL = 30.days
+  # Skip doomed FX quotes this long. 30 days left EUR dark for 10 days after
+  # Stripe started accepting EUR→USD quotes again (gumroad-private#2541);
+  # account.updated never fired. One extra doomed quote/day per marked
+  # currency is cheaper than a dark picker.
+  SETTLEMENT_CURRENCY_MISMATCH_TTL = 1.day
 
   def settlement_currency_mismatch_active?(currency)
     return false if currency.blank?

--- a/spec/models/merchant_account_spec.rb
+++ b/spec/models/merchant_account_spec.rb
@@ -401,6 +401,13 @@ describe MerchantAccount do
         expect(merchant_account.settlement_currency_mismatch_active?("eur")).to be(false)
       end
 
+      it "expires a 10-day-old per-currency marker so a recovered Stripe config is re-probed" do
+        # gp#2541: platform EUR marker from 2026-09-01 still hid the picker 10 days
+        # later while StripeFxQuote.create(to_currency: usd, from_currency: eur) succeeded.
+        travel_to(10.days.ago) { merchant_account.record_settlement_currency_mismatch!("eur") }
+        expect(merchant_account.reload.settlement_currency_mismatch_active?("eur")).to be(false)
+      end
+
       it "treats a malformed timestamp as no marker instead of raising" do
         merchant_account.update!(settlement_currency_mismatch_map: { "eur" => "not-a-timestamp" })
         expect(merchant_account.settlement_currency_mismatch_active?("eur")).to be(false)

--- a/spec/models/merchant_account_spec.rb
+++ b/spec/models/merchant_account_spec.rb
@@ -401,10 +401,9 @@ describe MerchantAccount do
         expect(merchant_account.settlement_currency_mismatch_active?("eur")).to be(false)
       end
 
-      it "expires a 10-day-old per-currency marker so a recovered Stripe config is re-probed" do
-        # gp#2541: platform EUR marker from 2026-09-01 still hid the picker 10 days
-        # later while StripeFxQuote.create(to_currency: usd, from_currency: eur) succeeded.
-        travel_to(10.days.ago) { merchant_account.record_settlement_currency_mismatch!("eur") }
+      it "expires a marker just older than one day so a recovered Stripe config is re-probed" do
+        expect(described_class::SETTLEMENT_CURRENCY_MISMATCH_TTL).to eq(1.day)
+        travel_to(25.hours.ago) { merchant_account.record_settlement_currency_mismatch!("eur") }
         expect(merchant_account.reload.settlement_currency_mismatch_active?("eur")).to be(false)
       end
 


### PR DESCRIPTION
Premerge review: clean @ 0df0bbc746a4cf44a8ff8c77ce1e4e3764af6202

Expire stale EUR settlement-mismatch marker after 1 day (gp#2541)

CI and premerge are clean at `0df0bbc746a`. After merge, confirm EUR on a platform-account checkout picker.

## What

Shortens `MerchantAccount::SETTLEMENT_CURRENCY_MISMATCH_TTL` from 30 days to 1 day so a recovered Stripe settlement config is re-probed the next day instead of staying dark for a month.

## Why

The shared platform Stripe account had `settlement_currency_mismatch_map = { eur => 2026-09-01T11:13:37Z }`. That hid EUR from the buyer-currency picker on every checkout that charges through Gumroad (all non-Connect sellers).

Live probe 2026-09-11: `StripeFxQuote.create(to_currency: usd, from_currency: eur)` on the platform account succeeded (rate 1.14831). GBP control also succeeded. `account.updated` never cleared the marker. The 30-day TTL is what kept euros off the picker.

KRW and TWD were also missing from that picker. They are a different, permanent gate (`StripeChargeProcessor.charge_minor_units_compatible?` is false for both) and are not this change.

## Before / after

- Before: a 10-day-old EUR marker on the platform account still returns `settlement_currency_mismatch_active?("eur") == true`, so the picker omits EUR.
- After: a marker older than 1 day is inactive; the next checkout re-probes Stripe. If Stripe still rejects, the marker is rewritten. If it accepts, EUR is offered.

## Checklist

- [x] Scope — TTL only. Does not clear the live marker in production (that is a separate console write). Does not change KRW/TWD compatibility.
- [x] Design — shorter TTL is the re-probe. Rejected a console-only clear: it would not stop the next stale 30-day hide.
- [x] Build — `0df0bbc746a` on `gp2541-stale-eur-mismatch-ttl`
- [ ] QA — MerchantAccount specs including the 25-hour marker example and `TTL == 1.day`. Preview checkout after deploy.
- [ ] Shipped — money-path: human merge, no automerge
- [x] Market — n/a (restores advertised EUR presentment)
- [ ] Sell — follow up with the reporting seller after deploy

## Tests

```text
DISABLE_SPRING=1 bundle exec rspec spec/models/merchant_account_spec.rb
52 examples, 0 failures
bundle exec rubocop app/models/merchant_account.rb spec/models/merchant_account_spec.rb
2 files inspected, no offenses detected
```

New example: a 25-hour-old per-currency marker is inactive, and the constant is asserted as `1.day`.

Greptile P2s at `6b6188d6890`: trimmed the constant comment (no incident/ticket narration); replaced the 10-day example with the 25-hour pin.

## QA

No rendered surface until deploy: the live hide is a json_data marker on MerchantAccount id=1. After merge, confirm EUR appears on a USD-priced platform-account checkout picker.

Tracked in antiwork/gumroad-private#2541.

---

AI disclosure: grok-4.6. Prompt: GitHub issues webhook for gumroad-private#2541; autonomous-product-dev. Greptile review on #7582.

