### PR TITLE
Show download file list next to the review card

### DIFF
--- a/app/javascript/components/Download/PageListLayout.test.tsx
+++ b/app/javascript/components/Download/PageListLayout.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { PageListLayout } from "$app/components/Download/PageListLayout";
+
+afterEach(cleanup);
+
+describe("PageListLayout", () => {
+  it("keeps the content pane from collapsing to height 0 next to the sidebar", () => {
+    render(
+      <PageListLayout pageList={<div>Liked it? Give it a rating:</div>}>
+        <a href="/download">Download</a>
+      </PageListLayout>,
+    );
+
+    expect(screen.getByRole("link", { name: "Download" })).toBeTruthy();
+    const contentPane = screen.getByRole("link", { name: "Download" }).parentElement;
+    expect(contentPane?.classList.contains("min-h-0")).toBe(true);
+    expect(contentPane?.classList.contains("min-w-0")).toBe(true);
+    expect(contentPane?.classList.contains("flex-1")).toBe(true);
+    expect(contentPane?.classList.contains("h-0")).toBe(false);
+  });
+});

--- a/app/javascript/components/Download/PageListLayout.tsx
+++ b/app/javascript/components/Download/PageListLayout.tsx
@@ -21,7 +21,8 @@ export const PageListLayout = React.forwardRef<
     <div className="flex flex-col gap-4 [scrollbar-gutter:stable] lg:sticky lg:top-0 lg:h-full lg:max-h-[calc(100vh-184px)] lg:w-80 lg:overflow-y-auto lg:pb-8">
       {pageList}
     </div>
-    <div className="h-0 flex-1">{children}</div>
+    {/* h-0 zeros height once this is lg:flex-row, hiding the file list beside the review card. */}
+    <div className="min-h-0 min-w-0 flex-1">{children}</div>
   </div>
 ));
 PageListLayout.displayName = "PageListLayout";


### PR DESCRIPTION
Premerge review: clean @ c4fbd87215b5abe845fbb2758ad56ec61a94cf5a

## What

Stops the download page content pane from collapsing to height 0 next to the rating card.

`PageListLayout` is `flex-col` on small screens and `lg:flex-row` on desktop. Its content wrapper used `h-0 flex-1`. In a row, `flex-1` grows width and `h-0` sets height to 0, so the file list / Download button occupy a 0px-tall column beside the review card. Zooming out then looks like the page ends at "Liked it? Give it a rating:".

The wrapper is now `min-h-0 min-w-0 flex-1`, the same shrink-and-grow pattern used in the nav scroller: it can still shrink inside a column flex parent, and it no longer zeros the cross-axis when the layout is a row.

## Why

Buyers on `/d/<token>` were reaching the page (view events) and never getting a usable Download control. Staff advice to "scroll past the rating box" cannot work when the files sit in a 0-height column beside that box, not below it.

Addresses antiwork/gumroad-private#2542.

## Before / after

- Before: content pane class `h-0 flex-1` — height 0 in `lg:flex-row`, rating card only.
- After: content pane class `min-h-0 min-w-0 flex-1` — file list stays visible beside (desktop) or above (mobile) the rating card.

## Screenshots (hosted preview app)

Served `x-revision` `c4fbd87215b5` at capture. OCR: desktop frame has the rating card and `pr7583-download` / Download; 375px frame stacks the file row above "Liked it? Give it a rating".

![Desktop lg: file list visible next to the rating card](https://github.com/user-attachments/assets/71f627d1-9e61-412d-bb6b-ac6c5aafe3b2)
![375px: files stacked above the rating card](https://github.com/user-attachments/assets/d25ef213-423e-4c19-b743-9aba89280c77)

## Checklist

- [x] Scope — PageListLayout content pane only. No presenter/content-payload change.
- [x] Design — drop `h-0`; keep `min-h-0` so column overflow still works.
- [x] Build — `c4fbd87215b5abe845fbb2758ad56ec61a94cf5a`
- [x] QA — hosted preview stills at this head (lg + 375px)
- [ ] Shipped
- [x] Market — n/a (bugfix)
- [x] Sell — n/a

## Test Results

At `c4fbd87215b5abe845fbb2758ad56ec61a94cf5a`:

- `npx eslint --fix` on `PageListLayout.tsx` and `PageListLayout.test.tsx` (clean)
- `npm test -- app/javascript/components/Download/PageListLayout.test.tsx` — 1 passed
- Mutation: restoring `h-0 flex-1` reddens `keeps the content pane from collapsing to height 0 next to the sidebar` (`min-h-0` expected true, got false). Restored, reran green.

## QA

1. Open a purchase `/d/` page at lg width: file list and Download are visible next to the rating card (not a 0-height column).
2. At 375px: files stack above the rating card.

---

## AI disclosure

Built by Gumclaw using grok-4.6 (xAI). Prompted to handle the GitHub issues webhook for antiwork/gumroad-private#2542 (download page shows only the rating card) and ship a generic layout fix. Premerge panel (gpt-6-astra + claude-fable-5) plus hosted-preview stills run by the premerge-owed wake.
