### PR TITLE
Trim Rails 8 header-spec comments (Greptile #7565)

### DIFF
--- a/spec/config/rails_default_headers_spec.rb
+++ b/spec/config/rails_default_headers_spec.rb
@@ -2,13 +2,9 @@
 
 require "spec_helper"
 
-# config/application.rb assigns action_dispatch.default_headers instead of an initializer
-# because since Rails 8.0.5 the action_controller.live_streaming_excluded_keys initializer
-# loads ActionDispatch::Response before config/initializers run, so the response class
-# captures the hash early (rails/rails#58145). SecureHeaders then deletes its conflicting
-# keys from that hash in place, which only reaches the response if both sides are the same
-# object. Move the assignment back into an initializer and Rails starts emitting its own
-# X-Frame-Options again, which is what stops sellers framing product pages.
+# Same object as config.action_dispatch.default_headers: Response captures that hash
+# before initializers run (rails/rails#58145), so SecureHeaders' in-place deletes only
+# reach responses if the assignment lives in application.rb, not an initializer.
 describe "Rails default_headers wiring" do
   let(:config_headers) { Rails.application.config.action_dispatch.default_headers }
 

--- a/spec/requests/product_framing_headers_spec.rb
+++ b/spec/requests/product_framing_headers_spec.rb
@@ -2,11 +2,8 @@
 
 require "spec_helper"
 
-# Sellers embed product pages in their own sites, so the standard product page must carry
-# no framing headers. SecureHeaders opts X-Frame-Options out globally and leaves
-# Referrer-Policy unset; only the custom-HTML path sets them (see
-# RendersCustomHtmlPages#apply_custom_html_response_headers, covered in user_pages_spec).
-# The wiring this depends on is asserted in spec/config/rails_default_headers_spec.rb.
+# Public product pages must omit framing headers; custom-HTML pages set them
+# (RendersCustomHtmlPages#apply_custom_html_response_headers, user_pages_spec).
 describe "framing headers on a public product page", type: :request do
   let(:seller) { create(:user) }
   let(:product) { create(:product, user: seller) }


### PR DESCRIPTION
## What

Trim oversized comments in the two Rails 8 framing-header specs Greptile flagged on #7565 after that PR merged.

## Why

Follow-up to Greptile P2 on https://github.com/antiwork/gumroad/pull/7565#discussion_r3987317725. The specs still pin the identity/placement constraint; the comments drop version-history narration.

## Before / After

docs-only — diff is the reviewable artifact

## Checklist

- [x] Scope — comments only in `spec/config/rails_default_headers_spec.rb` and `spec/requests/product_framing_headers_spec.rb`
- [x] Design — keep the identity/placement why; drop Rails version-history narration
- [x] Build — `1729af264b` on `gumclaw/pr7565-trim-spec-comments`
- [x] Ship — comment-only
- [x] Market — n/a
- [x] Sell — n/a

Premerge review: exempt (comment-only trim)

---

AI disclosure: grok-4.6. Prompt: handle Greptile P2 on antiwork/gumroad#7565 (condense spec comments).
