### PR TITLE
Restore seller-embed rationale on framing-header spec (Greptile #7584)

### DIFF
--- a/spec/requests/product_framing_headers_spec.rb
+++ b/spec/requests/product_framing_headers_spec.rb
@@ -2,8 +2,8 @@
 
 require "spec_helper"
 
-# Public product pages must omit framing headers; custom-HTML pages set them
-# (RendersCustomHtmlPages#apply_custom_html_response_headers, user_pages_spec).
+# Sellers embed public product pages, so they must omit framing headers; custom-HTML
+# pages set them (RendersCustomHtmlPages#apply_custom_html_response_headers, user_pages_spec).
 describe "framing headers on a public product page", type: :request do
   let(:seller) { create(:user) }
   let(:product) { create(:product, user: seller) }


### PR DESCRIPTION
## What

Restore the seller-embed rationale on `spec/requests/product_framing_headers_spec.rb` after #7584 trimmed it to a restatement of the example.

## Why

Follow-up to Greptile P2 on https://github.com/antiwork/gumroad/pull/7584#discussion_r3987394864. Public product pages omit framing headers so sellers can embed them; that why is not in the example.

## Before / After

docs-only — diff is the reviewable artifact

## Checklist

- [x] Scope — comment only in `spec/requests/product_framing_headers_spec.rb`
- [x] Design — keep seller-embed why; keep the custom-HTML pointer
- [x] Build — `10f626b5563` on `gumclaw/pr7584-restore-embed-rationale`
- [x] QA — comment-only; no runtime change
- [ ] Shipped
- [x] Market — n/a
- [x] Sell — n/a

Premerge review: exempt (comment-only trim)

comment-only (gate: COMMENT_ONLY); merging per Sahil 8/21.

Follow-up to #7584.

---

AI disclosure: grok-4.6. Prompt: handle Greptile P2 on antiwork/gumroad#7584 (restore seller-embed rationale).
