### PR TITLE
Fix Apple Sign In 500 from pwned-password JSON user param

### DIFF
--- a/config/initializers/005_apple.rb
+++ b/config/initializers/005_apple.rb
@@ -45,18 +45,30 @@ OmniAuth::Strategies::Apple.class_eval do
 
   def callback_phase
     env["omniauth.params"] = cookie_data.except("nonce") if cookie_data
-
-    # Apple sends `user` as a JSON string; parse it so Devise sees a hash.
-    # Without this devise-pwned_password raises errors as it assumes user is a hash.
-    form_hash = env["rack.request.form_hash"]
-    if form_hash&.dig("user").is_a?(String)
-      form_hash["user"] = JSON.parse(form_hash["user"]) rescue form_hash["user"]
-    end
-
+    coerce_apple_user_param!
     super
   end
 
   private
+    def coerce_apple_user_param!
+      # Rails 8 builds ActionDispatch params from form_pairs/form_vars, not
+      # rack.request.form_hash. Devise makes Warden use ActionDispatch::Request,
+      # so the pwned-password hook never sees a form_hash-only rewrite.
+      ActionDispatch::Request.new(env).POST
+
+      [
+        "rack.request.form_hash",
+        "action_dispatch.request.request_parameters",
+        "action_dispatch.request.parameters"
+      ].each do |key|
+        hash = env[key]
+        next unless hash.is_a?(Hash) && hash["user"].is_a?(String)
+
+        parsed = JSON.parse(hash["user"]) rescue nil
+        hash["user"] = parsed if parsed.is_a?(Hash)
+      end
+    end
+
     def user_info
       user = request.params["user"]
       @user_info ||= if user.is_a?(String)

--- a/config/initializers/devise_pwned_password_safe_params.rb
+++ b/config/initializers/devise_pwned_password_safe_params.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# devise-pwned_password does params.fetch(scope, {}).fetch(:password, nil).
+# Apple (and other OAuth callbacks) post `user` as a JSON string, which 500s
+# sign-in. Skip the gem hook unless the scoped params are a Hash — OAuth has
+# no password to check.
+Warden::Manager._after_set_user.each do |pair|
+  block, _conditions = pair
+  next unless block.source_location&.first&.include?("devise/pwned_password/hooks/pwned_password")
+
+  pair[0] = lambda do |user, auth, opts|
+    scoped = auth.request.params[opts[:scope]]
+    next unless scoped.is_a?(Hash)
+
+    block.call(user, auth, opts)
+  end
+end

--- a/spec/config/initializers/apple_strategy_patch_spec.rb
+++ b/spec/config/initializers/apple_strategy_patch_spec.rb
@@ -100,6 +100,29 @@ describe "Apple OmniAuth strategy cookie-based nonce patch" do
       expect(env["rack.request.form_hash"]["user"]["email"]).to eq("jane@example.com")
     end
 
+    it "parses JSON user param on ActionDispatch request_parameters" do
+      user_json = '{"name":{"firstName":"Jane","lastName":"Appleseed"},"email":"jane@example.com"}'
+      cookie_value = sign_cookie({ "nonce" => "test" })
+
+      env = build_env(
+        "/users/auth/apple/callback",
+        cookies: "#{APPLE_OAUTH_COOKIE_NAME}=#{Rack::Utils.escape(cookie_value)}"
+      )
+      env["action_dispatch.request.request_parameters"] = { "user" => user_json }
+      env["action_dispatch.request.parameters"] = { "user" => user_json }
+      prepare_strategy(env)
+
+      begin
+        strategy.callback_phase
+      rescue
+      end
+
+      expect(env["action_dispatch.request.request_parameters"]["user"]).to be_a(Hash)
+      expect(env["action_dispatch.request.request_parameters"]["user"]["email"]).to eq("jane@example.com")
+      expect(ActionDispatch::Request.new(env).params["user"]).to be_a(Hash)
+      expect(ActionDispatch::Request.new(env).params["user"]["email"]).to eq("jane@example.com")
+    end
+
     it "leaves non-JSON user param as-is" do
       cookie_value = sign_cookie({ "nonce" => "test" })
 

--- a/spec/config/initializers/devise_pwned_password_safe_params_spec.rb
+++ b/spec/config/initializers/devise_pwned_password_safe_params_spec.rb
@@ -29,33 +29,47 @@ describe "devise-pwned_password OAuth-safe after_set_user wrap" do
     request = instance_double(ActionDispatch::Request, params: request_params)
     Object.new.tap do |proxy|
       proxy.define_singleton_method(:request) { request }
-      proxy.define_singleton_method(:session) { @session ||= {} }
       proxy.define_singleton_method(:authenticated?) { |_scope| true }
     end
   end
 
-  def run_after_set_user
-    Warden::Manager._run_callbacks(:after_set_user, user, auth, { scope: :user, event: :authentication })
+  def pwned_hook
+    pair = Warden::Manager._after_set_user.find do |block, _conditions|
+      block.source_location&.first&.include?("devise_pwned_password_safe_params.rb")
+    end
+    raise "pwned-password wrap not installed" unless pair
+
+    pair[0]
+  end
+
+  def run_pwned_hook
+    pwned_hook.call(user, auth, { scope: :user, event: :authentication })
+  end
+
+  it "replaces the gem after_set_user hook with the wrap" do
+    sources = Warden::Manager._after_set_user.map { |block, _| block.source_location&.first }
+    expect(sources.grep(/devise_pwned_password_safe_params\.rb/).size).to eq(1)
+    expect(sources.grep(%r{devise/pwned_password/hooks/pwned_password})).to be_empty
   end
 
   it "does not 500 when params[:user] is a JSON string" do
     request_params["user"] = '{"email":"jane@example.com"}'
 
-    expect { run_after_set_user }.not_to raise_error
+    expect { run_pwned_hook }.not_to raise_error
     expect(user.pwned_password_checked).to be_nil
   end
 
   it "does not 500 when params[:user] is an Array" do
     request_params["user"] = ["not-a-hash"]
 
-    expect { run_after_set_user }.not_to raise_error
+    expect { run_pwned_hook }.not_to raise_error
     expect(user.pwned_password_checked).to be_nil
   end
 
   it "still checks pwned passwords when params[:user] is a Hash" do
     request_params["user"] = { "password" => "secret-pass" }
 
-    expect { run_after_set_user }.not_to raise_error
+    expect { run_pwned_hook }.not_to raise_error
     expect(user.pwned_password_checked).to eq("secret-pass")
   end
 end

--- a/spec/config/initializers/devise_pwned_password_safe_params_spec.rb
+++ b/spec/config/initializers/devise_pwned_password_safe_params_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "devise-pwned_password OAuth-safe after_set_user wrap" do
+  let(:user_class) do
+    Class.new do
+      def self.pwned_password_check_on_sign_in
+        true
+      end
+    end
+  end
+
+  let(:user) do
+    instance = Object.new
+    klass = user_class
+    instance.define_singleton_method(:class) { klass }
+    instance.define_singleton_method(:password_pwned?) do |password|
+      @pwned_password_checked = password
+      false
+    end
+    instance.define_singleton_method(:pwned_password_checked) { @pwned_password_checked }
+    instance
+  end
+
+  let(:request_params) { ActiveSupport::HashWithIndifferentAccess.new }
+
+  let(:auth) do
+    request = instance_double(ActionDispatch::Request, params: request_params)
+    Object.new.tap do |proxy|
+      proxy.define_singleton_method(:request) { request }
+      proxy.define_singleton_method(:session) { @session ||= {} }
+      proxy.define_singleton_method(:authenticated?) { |_scope| true }
+    end
+  end
+
+  def run_after_set_user
+    Warden::Manager._run_callbacks(:after_set_user, user, auth, { scope: :user, event: :authentication })
+  end
+
+  it "does not 500 when params[:user] is a JSON string" do
+    request_params["user"] = '{"email":"jane@example.com"}'
+
+    expect { run_after_set_user }.not_to raise_error
+    expect(user.pwned_password_checked).to be_nil
+  end
+
+  it "does not 500 when params[:user] is an Array" do
+    request_params["user"] = ["not-a-hash"]
+
+    expect { run_after_set_user }.not_to raise_error
+    expect(user.pwned_password_checked).to be_nil
+  end
+
+  it "still checks pwned passwords when params[:user] is a Hash" do
+    request_params["user"] = { "password" => "secret-pass" }
+
+    expect { run_after_set_user }.not_to raise_error
+    expect(user.pwned_password_checked).to eq("secret-pass")
+  end
+end


### PR DESCRIPTION
Draft: Apple Sign In 500s after Rails 8 because devise-pwned_password treats `params[:user]` as a Hash. Coerce ActionDispatch param caches and skip the hook when scoped params are not a Hash.

## What

Apple's first-time Sign In callback POSTs `user` as a JSON string. After Devise `sign_in`, `devise-pwned_password`'s Warden `after_set_user` hook does `params.fetch(:user, {}).fetch(:password, nil)`. A String has no `#fetch`, so the callback 500s and the visitor never finishes Sign In.

This PR:

- Coerces Apple's JSON-string `user` on `rack.request.form_hash`, `action_dispatch.request.request_parameters`, and `action_dispatch.request.parameters` (Rails 8 builds ActionDispatch params from form_pairs/form_vars, so rewriting only `form_hash` never reaches Warden).
- Wraps the gem's hook so a non-Hash `params[scope]` is skipped. OAuth has no password to check.

## Why

Production Sentry GUMROAD-1K9: Apple callback 500s in `devise/pwned_password/hooks/pwned_password.rb:5`. First seen in the Rails 8.0.5.1 window. Devise makes Warden use `ActionDispatch::Request`, not Rack::Request, so the old `form_hash`-only workaround is ignored.

Tracker: antiwork/gumroad-private#2548.

## Before / After

Before: first-time Apple Sign In POSTs `user` as JSON, Warden hook raises `NoMethodError` on `String#fetch`, callback 500s.

After: ActionDispatch `params[:user]` is a Hash when Apple sent JSON, and a leftover String/Array does not 500 login.

No rendered surface — Apple's callback is a cross-site POST we cannot drive in the preview app. Specs pin the Rails 8 param-cache path and the hook skip.

## Test Results

At `82f4cb8ca19237a46cdbfe726dfbe284491affc0`:

- `bundle exec rspec spec/config/initializers/apple_strategy_patch_spec.rb spec/config/initializers/devise_pwned_password_safe_params_spec.rb` — 18 examples, 0 failures
- `ruby -c` clean on the four touched files

## QA

Not preview-exercisable (real Apple id_token + first-time `user` JSON string). After deploy, GUMROAD-1K9 lastSeen should predate the release and `POST /users/auth/apple/callback` should stop 500ing on the pwned-password hook.

## Status

- [x] Scope
- [x] Design
- [x] Build
- [ ] QA — local specs green; premerge panel + CI owed; Sentry after deploy
- [ ] Shipped
- [ ] Market
- [ ] Sell

---

## AI disclosure

Generated with **grok-4.6** (xAI), running as Gumclaw on antiwork/gumroad-private#2548 (Sentry GUMROAD-1K9 Apple Sign In 500).

Prompts/instructions given: webhook `issues.opened` on gp#2548; issue body used as spec (coerce ActionDispatch `user` + skip pwned hook when scoped params are not a Hash).
