### PR TITLE
Don't 500 a membership page when the default recurrence price is missing

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -845,7 +845,8 @@ class Link < ApplicationRecord
   def recurrences
     return nil unless is_recurring_billing
 
-    enabled = prices.alive.is_buy.sort_by { |price| BasePrice::Recurrence.number_of_months_in_recurrence(price.recurrence) }.map { |price| { recurrence: price.recurrence, price_cents: price.price_cents, id: price.external_id } }
+    enabled_prices = prices.alive.is_buy.select { |price| BasePrice::Recurrence.number_of_months_in_recurrence(price.recurrence) }
+    enabled = enabled_prices.sort_by { |price| BasePrice::Recurrence.number_of_months_in_recurrence(price.recurrence) }.map { |price| { recurrence: price.recurrence, price_cents: price.price_cents, id: price.external_id } }
     default = default_price_recurrence&.recurrence || enabled.first&.fetch(:recurrence, nil)
     return nil if default.nil?
 
@@ -1419,9 +1420,10 @@ class Link < ApplicationRecord
     variant = attrs[:option] ? Variant.find_by_external_id(attrs[:option][:id]) : nil
     prices = (is_tiered_membership && variant ? variant : self).prices.is_buy.alive
     recurrence = if is_recurring_billing
-      prices.find { |price| price.recurrence == params[:recurrence] } ||
-        prices.find { |price| price.recurrence == default_price_recurrence&.recurrence } ||
-        prices.min_by { |price| BasePrice::Recurrence.number_of_months_in_recurrence(price.recurrence) }
+      recurring_prices = prices.select { |price| BasePrice::Recurrence.number_of_months_in_recurrence(price.recurrence) }
+      recurring_prices.find { |price| price.recurrence == params[:recurrence] } ||
+        recurring_prices.find { |price| price.recurrence == default_price_recurrence&.recurrence } ||
+        recurring_prices.min_by { |price| BasePrice::Recurrence.number_of_months_in_recurrence(price.recurrence) }
     end
     attrs[:recurrence] = recurrence&.recurrence
     attrs[:pay_in_installments] = !!params[:pay_in_installments] && allow_installment_plan?

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -843,10 +843,13 @@ class Link < ApplicationRecord
   end
 
   def recurrences
-    is_recurring_billing ? {
-      default: default_price_recurrence.recurrence,
-      enabled: prices.alive.is_buy.sort_by { |price| BasePrice::Recurrence.number_of_months_in_recurrence(price.recurrence) }.map { |price| { recurrence: price.recurrence, price_cents: price.price_cents, id: price.external_id } }
-    } : nil
+    return nil unless is_recurring_billing
+
+    enabled = prices.alive.is_buy.sort_by { |price| BasePrice::Recurrence.number_of_months_in_recurrence(price.recurrence) }.map { |price| { recurrence: price.recurrence, price_cents: price.price_cents, id: price.external_id } }
+    default = default_price_recurrence&.recurrence || enabled.first&.fetch(:recurrence, nil)
+    return nil if default.nil?
+
+    { default:, enabled: }
   end
 
   def rental
@@ -1415,12 +1418,16 @@ class Link < ApplicationRecord
     attrs[:option] = attrs[:options].find { |o| o[:id] == params[:option] } || (native_type != NATIVE_TYPE_COFFEE ? attrs[:options].find { |o| o[:quantity_left] != 0 } : nil)
     variant = attrs[:option] ? Variant.find_by_external_id(attrs[:option][:id]) : nil
     prices = (is_tiered_membership && variant ? variant : self).prices.is_buy.alive
-    recurrence = is_recurring_billing ? prices.find { |price| price.recurrence == params[:recurrence] } || prices.find { |price| price.recurrence == default_price_recurrence.recurrence } : nil
+    recurrence = if is_recurring_billing
+      prices.find { |price| price.recurrence == params[:recurrence] } ||
+        prices.find { |price| price.recurrence == default_price_recurrence&.recurrence } ||
+        prices.first
+    end
     attrs[:recurrence] = recurrence&.recurrence
     attrs[:pay_in_installments] = !!params[:pay_in_installments] && allow_installment_plan?
     attrs[:price] = [
       customizable_price.present? || variant&.customizable_price.present? ? params[:price].to_i : 0,
-      (recurrence&.price_cents || (attrs[:rental] ? rental_price_cents : price_cents)) +
+      (recurrence&.price_cents || (attrs[:rental] ? rental_price_cents : price_cents).to_i) +
       (attrs[:option]&.fetch(:price_difference_cents) || 0)
     ].max
     attrs[:price] = currency["min_price"] if purchasing_power_parity_enabled? && attrs[:price] != 0 && attrs[:price] < currency["min_price"]

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1421,7 +1421,7 @@ class Link < ApplicationRecord
     recurrence = if is_recurring_billing
       prices.find { |price| price.recurrence == params[:recurrence] } ||
         prices.find { |price| price.recurrence == default_price_recurrence&.recurrence } ||
-        prices.first
+        prices.min_by { |price| BasePrice::Recurrence.number_of_months_in_recurrence(price.recurrence) }
     end
     attrs[:recurrence] = recurrence&.recurrence
     attrs[:pay_in_installments] = !!params[:pay_in_installments] && allow_installment_plan?

--- a/app/services/pages/buy_button_params.rb
+++ b/app/services/pages/buy_button_params.rb
@@ -102,6 +102,6 @@ class Pages::BuyButtonParams
     end
 
     def enabled_recurrences
-      @enabled_recurrences ||= (product.recurrences[:enabled] || []).map { |r| r[:recurrence].to_s }.to_set
+      @enabled_recurrences ||= (product.recurrences&.[](:enabled) || []).map { |r| r[:recurrence].to_s }.to_set
     end
 end

--- a/spec/services/pages/buy_button_params_spec.rb
+++ b/spec/services/pages/buy_button_params_spec.rb
@@ -143,6 +143,13 @@ describe Pages::BuyButtonParams do
         node = node_for(%(<a data-gumroad-action="buy" data-gumroad-recurrence="monthly">Buy</a>))
         expect(described_class.from(node, product:)).to eq({})
       end
+
+      it "does not raise when recurrences is nil on a recurring product" do
+        product = create(:membership_product)
+        allow(product).to receive(:recurrences).and_return(nil)
+        node = node_for(%(<a data-gumroad-action="buy" data-gumroad-recurrence="monthly">Buy</a>))
+        expect(described_class.from(node, product:)).to eq({})
+      end
     end
 
     context "multiple attributes together" do

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -3960,6 +3960,25 @@ class LinkTest < ActiveSupport::TestCase
     assert result[:price].is_a?(Integer)
   end
 
+  test "cart_item falls back to the same shortest interval recurrences advertises" do
+    product = create_membership_product
+    default_tier = product.default_tier
+    default_tier.prices.alive.each(&:mark_deleted!)
+    product.prices.alive.each(&:mark_deleted!)
+    default_tier.save_recurring_prices!(
+      BasePrice::Recurrence::YEARLY => { enabled: true, price: "10" },
+      BasePrice::Recurrence::MONTHLY => { enabled: true, price: "1" }
+    )
+    product.update_column(:subscription_duration, BasePrice::Recurrence::QUARTERLY)
+    product.reload
+    assert_nil product.default_price_recurrence
+    assert_equal "yearly", default_tier.prices.is_buy.alive.order(:id).first.recurrence
+    recurrences = product.recurrences
+    result = product.cart_item({})
+    assert_equal "monthly", recurrences[:default]
+    assert_equal recurrences[:default], result[:recurrence]
+  end
+
   # --- currencies ------------------------------------------------------------
 
   test "prices round-trip through price_range for every supported currency" do

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -3979,6 +3979,29 @@ class LinkTest < ActiveSupport::TestCase
     assert_equal recurrences[:default], result[:recurrence]
   end
 
+  test "recurrences ignores buy prices with a blank recurrence when picking the default interval" do
+    product = create_membership_product
+    product.update_column(:subscription_duration, BasePrice::Recurrence::YEARLY)
+    blank = product.prices.build(price_cents: 999, recurrence: nil)
+    blank.save!(validate: false)
+    product.reload
+    recurrences = product.recurrences
+    assert_equal "monthly", recurrences[:default]
+    assert recurrences[:enabled].none? { |entry| entry[:recurrence].blank? }
+  end
+
+  test "cart_item does not raise when a variant has a blank-recurrence buy price" do
+    product = create_membership_product
+    product.update_column(:subscription_duration, BasePrice::Recurrence::YEARLY)
+    product.reload
+    blank = product.default_tier.prices.build(price_cents: 999, recurrence: nil)
+    blank.save!(validate: false)
+    result = product.cart_item({})
+    assert_kind_of Hash, result
+    assert_equal "monthly", result[:recurrence]
+    assert result[:price].is_a?(Integer)
+  end
+
   # --- currencies ------------------------------------------------------------
 
   test "prices round-trip through price_range for every supported currency" do

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -1993,6 +1993,23 @@ class LinkTest < ActiveSupport::TestCase
     assert_nil product.default_price_recurrence
   end
 
+  test "recurrences falls back to the first enabled interval when no default price row exists" do
+    product = create_membership_product
+    product.update_column(:subscription_duration, BasePrice::Recurrence::YEARLY)
+    product.reload
+    assert_nil product.default_price_recurrence
+    recurrences = product.recurrences
+    assert_equal "monthly", recurrences[:default]
+    assert recurrences[:enabled].any? { |entry| entry[:recurrence] == "monthly" }
+  end
+
+  test "recurrences returns nil when recurring billing has no alive buy prices" do
+    product = create_membership_product
+    product.prices.alive.each { |price| price.update!(deleted_at: Time.current) }
+    product.reload
+    assert_nil product.recurrences
+  end
+
   # --- #price_range ----------------------------------------------------------
 
   test "price_range can be assigned a number" do
@@ -3930,6 +3947,17 @@ class LinkTest < ActiveSupport::TestCase
     assert_kind_of Hash, result
     assert result.key?(:option)
     assert result.key?(:price)
+  end
+
+  test "cart_item does not raise when no default recurrence price exists" do
+    product = create_membership_product
+    product.update_column(:subscription_duration, BasePrice::Recurrence::YEARLY)
+    product.reload
+    assert_nil product.default_price_recurrence
+    result = product.cart_item({})
+    assert_kind_of Hash, result
+    assert_equal "monthly", result[:recurrence]
+    assert result[:price].is_a?(Integer)
   end
 
   # --- currencies ------------------------------------------------------------


### PR DESCRIPTION
# Don't 500 a membership page when the default recurrence price is missing

Fixes antiwork/gumroad-private#2549.


## What

`Link#recurrences` and `Link#cart_item` no longer call `.recurrence` on a nil default price. Recurring products with no `is_default_recurrence?` row render instead of 500ing. If enabled intervals still exist, the shortest one with a known duration is the default. Buy prices with a blank recurrence are ignored in that fallback (`VariantPrice` allows nil). `Pages::BuyButtonParams` also tolerates `recurrences` being nil.

## Why

A public membership product page 500s for every visitor when `is_recurring_billing` is true but no alive price matches `subscription_duration`. Two Sentry groups, same nil, same `LinksController#show` path.

## Before / after

- Before: `NoMethodError: undefined method 'recurrence' for nil` in `Link#recurrences` / `Link#cart_item`. A blank-recurrence buy price also made `sort_by` raise `comparison of Integer with nil failed`, or made `min_by` pick the blank row.
- After: those methods return a recurrence hash (or nil) and a cart-item hash; no raise. Blank recurrence rows are skipped.

Deviated from the issue snippet: if enabled prices exist, use the shortest known interval as default instead of returning nil (that would hide the interval picker). Also `.to_i` on the cart price addend — `&` alone still 500s on `nil + n` when `price_cents` is also nil.

Mutation:

```
mutant                                               reddened
drop duration filter in recurrences#sort_by          yes (Integer vs nil)
drop duration filter in cart_item#min_by             yes (picked nil recurrence)
```

## Checklist

- [x] Scope — nil-guards on recurrences, cart_item, and buy-button recurrence lookup; skip blank recurrence durations. Does not repair why the default price row is missing.
- [x] Design — fallback to shortest enabled interval with a known duration; empty enabled list still returns nil.
- [x] Build — `gp2549-default-recurrence-nil-guard` @ c2d74bb394b1c60e10c6ed5c553651ce6cd8c916
- [x] QA — focused specs + mutants killed (no preview fixture for this row shape). Astra+Fable panel clean at this head.
- [ ] Shipped
- [x] Market — n/a, bugfix
- [x] Sell — n/a, bugfix

## Tests

```text
bin/rails test test/models/link_test.rb --name "/recurrences falls back|recurrences returns nil|recurrences ignores buy prices|cart_item does not raise|cart_item falls back/"
6 runs, 17 assertions, 0 failures, 0 errors
```

## QA

Not preview-exercisable without crafting a membership whose alive prices do not match `subscription_duration`. Specs construct that row with `update_column(:subscription_duration, yearly)` and pin no-raise plus monthly fallback, including a blank-recurrence sibling row. Watch after deploy: GUMROAD-1JX / GUMROAD-1K2 lastSeen predates the release.

---

## AI disclosure

Generated with grok-4.6 (xAI), running as Gumclaw on a sentry-daily-sweep issue.
Prompts/instructions given: autonomous-product-dev build of gumroad-private#2549; nil-guard default recurrence on Link#recurrences and Link#cart_item; skip blank recurrence durations after Greptile P1; no production permalinks in the public body.

Premerge review: clean @ c2d74bb394b1c60e10c6ed5c553651ce6cd8c916
