### PR TITLE
Trim Rails 8.1 pin comments (Greptile on #7568)

### DIFF
--- a/app/controllers/affiliate_redirect_controller.rb
+++ b/app/controllers/affiliate_redirect_controller.rb
@@ -30,12 +30,8 @@ class AffiliateRedirectController < ApplicationController
       uri.to_s
     end
 
-    # A per-product destination_url is creator-supplied and unvalidated: unlike DirectAffiliate,
-    # ProductAffiliate does not include Affiliate::DestinationUrlValidations, and
-    # final_destination_url prefers it. So it can be path-relative ("products/foo"), which
-    # Rails 8.1 refuses to redirect to. Before 8.1 those did not work either — they became
-    # "https://gumroad.comproducts/foo" — so treat them as paths on this host, the same repair
-    # SafeRedirectPathService makes for `next` params.
+    # ProductAffiliate destination_url is unvalidated and can be path-relative; Rails 8.1
+    # raises on those. Prefix with / like SafeRedirectPathService does for next params.
     def host_relative(destination)
       return destination if destination.blank?
       return destination if destination.match?(%r{\A([a-z][a-z\d\-+.]*:|//)}i)

--- a/spec/config/rails_load_defaults_pins_spec.rb
+++ b/spec/config/rails_load_defaults_pins_spec.rb
@@ -2,15 +2,9 @@
 
 require "spec_helper"
 
-# config/application.rb advances load_defaults ahead of the behaviour the app has adopted,
-# then pins each deferred default back. Assert the runtime destinations rather than
-# Rails.application.config: a pin can sit in the config object and never reach the framework
-# if it is applied after the railtie has read it, which is the same failure rails/rails#58145
-# produces for default_headers.
-#
-# to_time_preserves_timezone is deliberately absent: Rails 8.1 deletes
-# DateAndTime::Compatibility.preserve_timezone and leaves only a deprecated accessor over an
-# ivar, so there is no runtime destination left to assert.
+# Assert runtime destinations, not Rails.application.config: a pin can sit on the
+# config object and never reach the framework (rails/rails#58145).
+# to_time_preserves_timezone has no runtime destination left in 8.1.
 describe "load_defaults pins" do
   it "runs the framework defaults for the version application.rb declares" do
     # Stored verbatim from the load_defaults argument, so it is the Float 8.1, not "8.1".


### PR DESCRIPTION
## What
Trim two comments Greptile flagged on #7568 after that PR merged: the `host_relative` discovery narrative and the load_defaults pin-spec header. Pin one-liners in `config/application.rb` stay — they are the deferred-default inventory, not restatement.

## Why
Follow-up to Greptile P2 on https://github.com/antiwork/gumroad/pull/7568 (review 5178859914). Comment-only; no behavior change.

## Before / after
- Before: six-line discovery comment on `host_relative`; eight-line spec header
- After: two-line why on `host_relative`; three-line runtime-destination trap on the spec
- docs-only — diff is the reviewable artifact

## Checklist
- [x] Scope — comments only; no executable change
- [x] Design — hold pin one-liners in application.rb
- [x] Build — this diff
- [x] QA — `git diff` is comment lines only
- [ ] Shipped — comment-only merge
- [x] Market — n/a
- [x] Sell — n/a

## Tests
Comment-only; no spec behavior change. Existing `spec/config/rails_load_defaults_pins_spec.rb` assertions untouched.

## QA
Not preview-exercisable. Diff is the reviewable artifact.

Premerge review: exempt (comment-only)

---

## AI disclosure

Generated with Grok 4.6 (xAI), running as gumclaw. Prompts/instructions: GitHub webhook for Greptile review 5178859914 on antiwork/gumroad#7568; autonomous-product-dev post-merge bot-review follow-up.
