### PR TITLE
Trim ProductFile comments to the storage-presence traps

### DIFF
--- a/app/models/product_file.rb
+++ b/app/models/product_file.rb
@@ -185,68 +185,39 @@ class ProductFile < ApplicationRecord
     filetype == "link"
   end
 
-  # Whether there is really something in storage behind this row, i.e. whether a
-  # buyer could be given the file.
+  # Alive ProductFile ≠ deliverable. save_files! takes the storage URL from the
+  # browser, so an in-flight or abandoned multipart upload leaves a row pointing
+  # at a key that was never written; analyze gives up and the row stays alive
+  # (gumroad#6320).
   #
-  # A ProductFile can outlive its upload. The product-save API takes the storage
-  # URL from the browser (see `WithProductFiles#save_files!`), so a save that
-  # lands while a multipart upload is still in flight — or that never finishes
-  # because the tab was closed — leaves a row pointing at a key that was never
-  # written. Nothing later deletes it: `analyze` gives up on the missing object
-  # and the row stays alive. So "an alive ProductFile exists" is not the same
-  # claim as "the buyer receives a file", and anything treating a file as proof
-  # that a listing delivers something has to ask this instead (gumroad#6320).
-  #
-  # `analyze_completed` is set by `analyze` only after it has successfully read
-  # the stored object, and unlike `size` it is a server-side flag rather than
-  # something the save API accepts from the client (see LinkPolicy's permitted
-  # `files` attributes, which include `size`). So a completed analysis proves the
-  # upload finished and needs no request to storage. Only a file we have never
-  # analyzed — which includes one uploaded seconds ago, before AnalyzeFileWorker
-  # has run — costs a lookup. A file whose object has since been purged keeps its
-  # flag, so that case is answered from `deleted_from_cdn_at` first.
-  #
-  # A lookup that comes back absent is not thrown away: it enqueues
-  # RecordProductFileMissingFromStorageJob, which writes `deleted_from_cdn_at` on
-  # rows whose upload can no longer be in flight. That is how a never-finished
-  # upload stops costing a lookup on every later save (gumroad-private#1370).
-  #
-  # External links are always considered present: there is no storage object to
-  # look for, and the URL is the deliverable.
+  # Presence is answered from the row first: analyze_completed is set only after
+  # analyze successfully reads the object (unlike client-supplied `size` —
+  # LinkPolicy permits `size` on save). A later purge keeps that flag, so
+  # deleted_from_cdn_at is checked first. Only never-analyzed files hit storage,
+  # including ones uploaded seconds ago before AnalyzeFileWorker. A miss enqueues
+  # RecordProductFileMissingFromStorageJob to stamp deleted_from_cdn_at once the
+  # upload can no longer be in flight (gumroad-private#1370). External links have
+  # no object; the URL is the deliverable.
   def stored_file_present?
     known_from_row = stored_file_presence_known_from_row
     return known_from_row unless known_from_row.nil?
 
     present = s3_object.exists?
-    # A lookup that proves the object is absent is the only place we ever learn
-    # that this row's upload never finished, and right now nothing remembers it:
-    # the next caller pays the same lookup to reach the same answer. Hand the
-    # finding to a job so the row can record it and answer for itself from then
-    # on (gumroad-private#1370). This runs in the middle of a save, so it must
-    # not write here — the job re-checks and does the write.
+    # Mid-save: don't write here. The job re-checks and stamps the row.
     if !present && RecordProductFileMissingFromStorageJob.eligible?(self)
       begin
         RecordProductFileMissingFromStorageJob.perform_async(id)
       rescue StandardError => e
-        # This method is called from a product validation, so a queueing problem
-        # (Redis down) must not fail the seller's save. We already have the
-        # answer the caller asked for; recording it is an optimization, and a
-        # later save will enqueue again.
+        # Product validation: a Redis outage must not fail the seller's save.
+        # Recording is an optimization; a later save will enqueue again.
         Rails.logger.warn("RecordProductFileMissingFromStorageJob enqueue failed (#{id}): #{e.class} => #{e.message}")
-        # Redis being unreachable is the failure this rescue exists for, and it
-        # needs no alert: it is already visible as an outage and it resolves on
-        # its own. Anything else reaching here is a bug in how we enqueue (a bad
-        # argument, a serialization error), which would otherwise sit in the logs
-        # silently skipping retirement forever, so report it.
+        # Expected errors are the outage (already visible). Anything else is an
+        # enqueue bug that would skip retirement forever — report it.
         unless EXPECTED_ENQUEUE_ERRORS.any? { e.is_a?(_1) }
           begin
             ErrorNotifier.notify(e, product_file_id: id)
           rescue StandardError => notifier_error
-            # Reporting the problem must not become a bigger problem than the one
-            # being reported. Sentry talks over the network and can fail on its
-            # own, and this whole path runs inside a seller's save, so an
-            # exception from the notifier would fail that save for a reason the
-            # seller has nothing to do with. Log and move on.
+            # Notifier talks over the network; its failure must not fail the save.
             Rails.logger.warn("RecordProductFileMissingFromStorageJob enqueue failure could not be reported (#{id}): #{notifier_error.class} => #{notifier_error.message}")
           end
         end
@@ -254,20 +225,13 @@ class ProductFile < ApplicationRecord
     end
     present
   rescue Aws::Errors::ServiceError, Seahorse::Client::NetworkingError => e
-    # Storage being unreachable is not evidence that the file is missing, and a
-    # caller deciding whether a seller may publish should not turn our own
-    # outage into a rejection. Assume the file is there and log it.
+    # Unreachable storage is not evidence the file is missing. Fail open.
     Rails.logger.warn("ProductFile#stored_file_present? failed (#{id}): #{e.class} => #{e.message}")
     true
   end
 
-  # Whether this row on its own already answers `stored_file_present?`, with no
-  # request to storage: `true` for known-present, `false` for known-missing, and
-  # `nil` when only storage can say.
-  #
-  # A caller checking many files uses this to answer from the rows first and
-  # spend its storage requests only on the files that genuinely need one, instead
-  # of giving up on the check because the list is long.
+  # true / false from the row, nil when only storage can say. Lets a multi-file
+  # caller spend S3 requests only on files that need one.
   def stored_file_presence_known_from_row
     return true if external_link?
     return false unless s3?


### PR DESCRIPTION
## Status

- [x] Scope — n/a, comments-only trim
- [x] Design — n/a, comments-only trim
- [x] Build
- [ ] Ship
- [x] Market — n/a, internal-only
- [x] Sell — n/a, internal-only

## What

Trim `ProductFile#stored_file_present?` comments to the storage-presence traps. Comments only, no behaviour change.

`app/models/product_file.rb`: 597 → 561 lines (−36).

## Why

The method had a 28-line essay plus a second copy of the enqueue story on the next line, then nested rescue essays. The traps stay.

## Kept

- Alive ProductFile ≠ deliverable: `save_files!` takes the browser URL, so an in-flight or abandoned multipart leaves a row pointing at a never-written key; analyze gives up and the row stays alive (gumroad#6320).
- `analyze_completed` is server-set after a successful read (unlike client-supplied `size`, which LinkPolicy permits on save). A later purge keeps that flag, so `deleted_from_cdn_at` is checked first.
- Only never-analyzed files hit storage, including ones uploaded seconds ago before AnalyzeFileWorker.
- A miss enqueues `RecordProductFileMissingFromStorageJob` to stamp `deleted_from_cdn_at` once the upload can no longer be in flight (gumroad-private#1370). Do not write mid-save; the job re-checks.
- External links have no object; the URL is the deliverable.
- Product validation: a Redis outage must not fail the seller's save. Expected enqueue errors are the outage; anything else is an enqueue bug that would skip retirement — report it. Notifier failure must not fail the save.
- Unreachable storage is not evidence the file is missing. Fail open.

## Test Results

- `ruby -c app/models/product_file.rb` — Syntax OK
- `bundle exec rubocop app/models/product_file.rb` — no offenses
- `bundle exec rspec spec/models/product_file_spec.rb:901` (`#stored_file_present?`) — 15 examples, 0 failures
- Full `spec/models/product_file_spec.rb` — 161 examples, 10 failures, all `Aws::S3::Errors::NotFound` on fixture key `specs/billion-dollar-company-chapter-0.pdf` (local test-bucket contents, not this diff)

## QA steps

docs-only — diff is the reviewable artifact

## Risk

LOW RISK, comments only. gumclaw + `working`. No `awaiting-human`.

Premerge review: exempt (comments only, no behaviour change)

---

AI disclosure: Grok 4.6 via ai-slop-reducer cron. Prompt: cut AI slop comments in already-merged antiwork/gumroad code; comments only, no behaviour change.
