### PR TITLE
Show combined commission total on the sales list row

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -205,7 +205,10 @@ class CustomersController < Sellers::BaseController
           :url_redirect,
           :variant_attributes,
           affiliate: :affiliate_user,
-          commission_as_deposit: [:completion_purchase, { files_attachments: :blob }],
+          commission_as_deposit: [
+            { completion_purchase: [:tip, :purchase_offer_code_discount] },
+            { files_attachments: :blob },
+          ],
           link: :alive_variants,
           product_review: [:response, { alive_videos: [:video_file] }],
           purchase_custom_fields: { files_attachments: :blob },

--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -183,12 +183,15 @@ class CustomerPresenter
   private
     # Completions are excluded from the sales-list query so they don't get their own
     # row; fold a charged completion into the deposit row so the list matches the
-    # detail charges.
+    # detail charges. `!failed?` is not enough: create_completion_purchase! links the
+    # completion before it is successful, including in_progress rows that are still
+    # waiting on SCA. Pending presentment settlement is already charged.
     def charged_commission_completion_purchase
       return unless purchase.is_commission_deposit_purchase?
 
       completion = purchase.commission&.completion_purchase
-      return if completion.blank? || completion.failed?
+      return unless completion
+      return unless completion.successful? || completion.pending_buyer_presentment_settlement?
 
       completion
     end

--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -64,12 +64,12 @@ class CustomerPresenter
       created_at: purchase.created_at.iso8601,
       price:
         {
-          cents: purchase.subscription&.current_subscription_price_cents || purchase.displayed_price_cents,
-          cents_before_offer_code: purchase.displayed_price_cents_before_offer_code(include_deleted: true) || purchase.displayed_price_cents,
+          cents: listed_price_cents,
+          cents_before_offer_code: listed_price_cents_before_offer_code,
           cents_refundable: purchase.amount_refundable_cents_in_currency,
           currency_type: purchase.displayed_price_currency_type.to_s,
           recurrence: (purchase.subscription || purchase.price)&.recurrence,
-          tip_cents: purchase.tip&.value_cents,
+          tip_cents: listed_tip_cents,
         },
       quantity: purchase.quantity,
       discount: offer_code.present? ?
@@ -181,6 +181,39 @@ class CustomerPresenter
   end
 
   private
+    # Completions are excluded from the sales-list query so they don't get their own
+    # row; fold a charged completion into the deposit row so the list matches the
+    # detail charges.
+    def charged_commission_completion_purchase
+      return unless purchase.is_commission_deposit_purchase?
+
+      completion = purchase.commission&.completion_purchase
+      return if completion.blank? || completion.failed?
+
+      completion
+    end
+
+    def listed_price_cents
+      (purchase.subscription&.current_subscription_price_cents || purchase.displayed_price_cents) +
+        charged_commission_completion_purchase&.displayed_price_cents.to_i
+    end
+
+    def listed_price_cents_before_offer_code
+      deposit = purchase.displayed_price_cents_before_offer_code(include_deleted: true) || purchase.displayed_price_cents
+      completion = charged_commission_completion_purchase
+      return deposit unless completion
+
+      deposit + (completion.displayed_price_cents_before_offer_code(include_deleted: true) || completion.displayed_price_cents)
+    end
+
+    def listed_tip_cents
+      deposit = purchase.tip&.value_cents
+      completion = charged_commission_completion_purchase&.tip&.value_cents
+      return deposit if completion.blank?
+
+      deposit.to_i + completion
+    end
+
     def file_details(file)
       {
         id: file.signed_id,

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -344,18 +344,35 @@ describe CustomerPresenter do
         expect(props[:commission][:status]).to eq("in_progress")
         expect(props[:commission][:files_are_editable]).to be false
       end
+    end
+
+    context "commission list price" do
+      let(:commission_product) { create(:commission_product) }
+      let(:deposit) do
+        create(
+          :purchase,
+          link: commission_product,
+          seller: commission_product.user,
+          is_commission_deposit_purchase: true,
+          price_cents: 500,
+          displayed_price_cents: 500
+        )
+      end
+      let!(:commission) { create(:commission, deposit_purchase: deposit) }
 
       it "uses the deposit amount while the commission has no completion charge" do
-        deposit = commission.deposit_purchase
-        deposit.update!(displayed_price_cents: 500)
-
         expect(described_class.new(purchase: deposit).customer(pundit_user:)[:price][:cents]).to eq(500)
       end
 
       it "includes the charged completion amount on the deposit row" do
-        deposit = commission.deposit_purchase
-        deposit.update!(displayed_price_cents: 500)
-        completion = create(:purchase, link: deposit.link, seller: deposit.seller, is_commission_completion_purchase: true, displayed_price_cents: 500)
+        completion = create(
+          :purchase,
+          link: commission_product,
+          seller: commission_product.user,
+          is_commission_completion_purchase: true,
+          price_cents: 500,
+          displayed_price_cents: 500
+        )
         create(:tip, purchase: deposit, value_cents: 50)
         create(:tip, purchase: completion, value_cents: 50)
         commission.update!(completion_purchase: completion)
@@ -368,9 +385,14 @@ describe CustomerPresenter do
       end
 
       it "does not include a failed completion charge" do
-        deposit = commission.deposit_purchase
-        deposit.update!(displayed_price_cents: 500)
-        completion = create(:failed_purchase, link: deposit.link, seller: deposit.seller, is_commission_completion_purchase: true, displayed_price_cents: 500)
+        completion = create(
+          :failed_purchase,
+          link: commission_product,
+          seller: commission_product.user,
+          is_commission_completion_purchase: true,
+          price_cents: 500,
+          displayed_price_cents: 500
+        )
         commission.update!(completion_purchase: completion)
 
         expect(described_class.new(purchase: deposit.reload).customer(pundit_user:)[:price][:cents]).to eq(500)

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -344,6 +344,37 @@ describe CustomerPresenter do
         expect(props[:commission][:status]).to eq("in_progress")
         expect(props[:commission][:files_are_editable]).to be false
       end
+
+      it "uses the deposit amount while the commission has no completion charge" do
+        deposit = commission.deposit_purchase
+        deposit.update!(displayed_price_cents: 500)
+
+        expect(described_class.new(purchase: deposit).customer(pundit_user:)[:price][:cents]).to eq(500)
+      end
+
+      it "includes the charged completion amount on the deposit row" do
+        deposit = commission.deposit_purchase
+        deposit.update!(displayed_price_cents: 500)
+        completion = create(:purchase, link: deposit.link, seller: deposit.seller, is_commission_completion_purchase: true, displayed_price_cents: 500)
+        create(:tip, purchase: deposit, value_cents: 50)
+        create(:tip, purchase: completion, value_cents: 50)
+        commission.update!(completion_purchase: completion)
+
+        props = described_class.new(purchase: deposit.reload).customer(pundit_user:)
+
+        expect(props[:price][:cents]).to eq(1000)
+        expect(props[:price][:cents_before_offer_code]).to eq(1000)
+        expect(props[:price][:tip_cents]).to eq(100)
+      end
+
+      it "does not include a failed completion charge" do
+        deposit = commission.deposit_purchase
+        deposit.update!(displayed_price_cents: 500)
+        completion = create(:failed_purchase, link: deposit.link, seller: deposit.seller, is_commission_completion_purchase: true, displayed_price_cents: 500)
+        commission.update!(completion_purchase: completion)
+
+        expect(described_class.new(purchase: deposit.reload).customer(pundit_user:)[:price][:cents]).to eq(500)
+      end
     end
 
     context "purchase has an installment plan" do

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -397,6 +397,38 @@ describe CustomerPresenter do
 
         expect(described_class.new(purchase: deposit.reload).customer(pundit_user:)[:price][:cents]).to eq(500)
       end
+
+      it "does not include an uncharged in-progress completion" do
+        completion = create(
+          :purchase_in_progress,
+          link: commission_product,
+          seller: commission_product.user,
+          is_commission_completion_purchase: true,
+          price_cents: 500,
+          displayed_price_cents: 500
+        )
+        commission.update!(completion_purchase: completion)
+
+        expect(completion).not_to be_pending_buyer_presentment_settlement
+        expect(described_class.new(purchase: deposit.reload).customer(pundit_user:)[:price][:cents]).to eq(500)
+      end
+
+      it "includes a completion still settling in the buyer's presentment currency" do
+        completion = create(
+          :purchase_in_progress,
+          link: commission_product,
+          seller: commission_product.user,
+          is_commission_completion_purchase: true,
+          price_cents: 500,
+          displayed_price_cents: 500,
+          flow_of_funds: nil,
+          merchant_account: nil
+        )
+        commission.update!(completion_purchase: completion)
+
+        expect(completion).to be_pending_buyer_presentment_settlement
+        expect(described_class.new(purchase: deposit.reload).customer(pundit_user:)[:price][:cents]).to eq(1000)
+      end
     end
 
     context "purchase has an installment plan" do


### PR DESCRIPTION
Show combined commission total on the sales list row

> Draft: local presenter specs green at `a9da0bd73617`. Preview is live at that revision. Sales-list screenshots still owed before ready.

## What

The seller Sales list shows one row per commission (the deposit purchase). That row now displays deposit + charged completion combined, matching the detail view's charges. In-progress commissions with no completion still show the deposit only. Failed completion attempts are not added.

## Why

Completions are excluded from the list query so they don't get their own row. The row was rendering only `displayed_price_cents` of the deposit, so a completed commission looked like half of what the buyer paid. Tracked in antiwork/gumroad-private#2551.

## Before / after

- Before: completed commission list row shows the deposit amount only.
- After: the same row shows deposit + charged completion. Detail still lists each charge separately. Screenshots owed on preview.

## Checklist

- [x] Scope — list/detail price on commission deposit rows; not amount filters, sort, mobile `as_json` list, or refund flags
- [x] Design — fold a non-failed completion into `CustomerPresenter` price cents (and before-offer / tip so the detail Price/Tip split stays consistent)
- [x] Build — `gp2551-commission-sales-list`
- [ ] QA — presenter specs done; preview sales list stills owed
- [ ] Shipped — not ready
- [x] Market — n/a (seller dashboard display)
- [x] Sell — n/a

## Tests

```text
bundle exec rspec spec/presenters/customer_presenter_spec.rb
26 examples, 0 failures at a9da0bd73617260ff53237f42fce28a5feac66e1
```

Commission list-price cases covered: deposit-only, charged completion folded in (price + tip), failed completion excluded, uncharged in-progress excluded, presentment-settling completion included.

## QA

Preview `https://gp2551-commission-sales-list.apps.staging.gumroad.org` serves `x-revision: a9da0bd73617` (200). Hosted sales-list stills for a completed commission still owed; staying draft.

---

## AI disclosure

Generated with grok-4.6 (xAI), running as an autonomous product-dev session.
Prompts/instructions given: GitHub issues webhook for antiwork/gumroad-private#2551; autonomous-product-dev build loop; sales list row should show deposit + completion combined, matching the detail view.

Premerge review: clean @ a9da0bd73617260ff53237f42fce28a5feac66e1
