### PR TITLE
Fix store-agent reply and stream reliability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -509,8 +509,9 @@ jobs:
         ports:
           - 9200:9200
       # MinIO (S3-compatible object storage) is started as a step below rather than
-      # a service: the official minio/minio image needs a `server /data` command
-      # that GitHub Actions service containers can't supply.
+      # a service: the official quay.io/minio/minio image needs a `server /data` command
+      # that GitHub Actions service containers can't supply. MinIO images are pulled from
+      # quay.io because the Docker Hub repositories were removed (pulls fail with access denied).
 
     env:
       RAILS_ENV: test
@@ -547,7 +548,7 @@ jobs:
         run: |
           docker run -d --name minio -p 9000:9000 -p 9001:9001 \
             -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data --console-address ":9001"
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data --console-address ":9001"
           for i in $(seq 1 30); do curl -fsS http://localhost:9000/minio/health/ready >/dev/null 2>&1 && break; sleep 2; done
           curl -fsS http://localhost:9000/minio/health/ready || { echo "MinIO did not become ready"; exit 1; }
           # Provision the buckets the app's :test storage service expects (see
@@ -562,7 +563,7 @@ jobs:
           # `mc anonymous set` and `mc version enable` each take exactly ONE bucket — passing
           # two makes mc print its usage text and exit 1 — so they run per bucket in a loop.
           # (`mc mb` does accept several.)
-          docker run --rm --network host --entrypoint /bin/sh minio/mc:RELEASE.2025-08-13T08-35-41Z -c "
+          docker run --rm --network host --entrypoint /bin/sh quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z -c "
             set -e
             mc alias set local http://localhost:9000 minioadmin minioadmin
             mc mb --ignore-existing local/gumroad-specs local/gumroad-invoices

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -510,8 +510,7 @@ jobs:
           - 9200:9200
       # MinIO (S3-compatible object storage) is started as a step below rather than
       # a service: the official quay.io/minio/minio image needs a `server /data` command
-      # that GitHub Actions service containers can't supply. MinIO images are pulled from
-      # quay.io because the Docker Hub repositories were removed (pulls fail with access denied).
+      # that GitHub Actions service containers can't supply.
 
     env:
       RAILS_ENV: test

--- a/app/controllers/api/internal/agent_message_streams_controller.rb
+++ b/app/controllers/api/internal/agent_message_streams_controller.rb
@@ -152,6 +152,7 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
       turn_persisted = false
       assistant_message = nil
       unpersisted_proposal = false
+      done_written = false
       on_reply_complete = lambda do |turn|
         conversation, assistant_message = persist_agent_turn!(
           conversation,
@@ -167,6 +168,32 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
         ErrorNotifier.notify(e)
         unpersisted_proposal = replace_unpersisted_proposal_reply!(turn)
       end
+      flush_done = lambda do |turn|
+        next if done_written
+
+        turn = turn.with_indifferent_access if turn.respond_to?(:with_indifferent_access)
+        # conversation_id is omitted entirely (not null) when creating the conversation itself
+        # failed above — the client validates this frame against a schema where conversation_id
+        # is an optional string, so a null would fail validation and turn a benign persistence
+        # failure into a spurious interrupted-stream recovery. proposed_action stays present even
+        # when nil: the client schema requires it (nullable, not optional). A generated proposal is
+        # returned only when its assistant message persisted and has a claimable id.
+        #
+        # Suggestions are optional follow-up chips generated AFTER this frame. done.suggestions
+        # stays [] here so the composer can unlock without waiting on that extra model call; the
+        # later `suggestions` event fills the chips. A persistence failure still sends empty
+        # suggestions and suppresses that later event.
+        done_payload = {
+          reply: turn[:reply],
+          proposed_action: assistant_message ? turn[:proposed_action] : nil,
+          objects: turn[:objects] || [],
+          suggestions: [],
+        }
+        done_payload[:conversation_id] = conversation.external_id if conversation
+        done_payload[:proposal_message_id] = assistant_message.external_id if turn[:proposed_action] && assistant_message
+        write_event.call(done_payload, "done")
+        done_written = true
+      end
       result = ::Ai::StoreAgentService.new(seller: current_seller, pundit_user:)
         .respond_streaming(messages: history, on_reply_complete:) do |event, payload|
         # Extend only a marker that is still in progress. on_reply_complete runs before trailing
@@ -180,24 +207,14 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
         # The suggestion call still used the discarded confirmation wording. Do not pair the
         # honest fallback with prompts derived from a write that cannot be confirmed.
         next if event.to_s == "suggestions" && unpersisted_proposal
+        if event.to_s == "turn_ready"
+          flush_done.call(payload)
+          next
+        end
 
         write_event.call(payload, event)
       end
-      # conversation_id is omitted entirely (not null) when creating the conversation itself
-      # failed above — the client validates this frame against a schema where conversation_id
-      # is an optional string, so a null would fail validation and turn a benign persistence
-      # failure into a spurious interrupted-stream recovery. proposed_action stays present even
-      # when nil: the client schema requires it (nullable, not optional). A generated proposal is
-      # returned only when its assistant message persisted and has a claimable id.
-      done_payload = {
-        reply: result[:reply],
-        proposed_action: assistant_message ? result[:proposed_action] : nil,
-        objects: result[:objects] || [],
-        suggestions: unpersisted_proposal ? [] : result[:suggestions] || [],
-      }
-      done_payload[:conversation_id] = conversation.external_id if conversation
-      done_payload[:proposal_message_id] = assistant_message.external_id if result[:proposed_action] && assistant_message
-      write_event.call(done_payload, "done")
+      flush_done.call(result)
     rescue ::Ai::StoreAgentService::Error => e
       mark_agent_turn_failed!(client_turn_id) unless turn_persisted
       write_event.call({ message: e.message }, "error")

--- a/app/controllers/api/internal/agent_message_streams_controller.rb
+++ b/app/controllers/api/internal/agent_message_streams_controller.rb
@@ -172,17 +172,9 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
         next if done_written
 
         turn = turn.with_indifferent_access if turn.respond_to?(:with_indifferent_access)
-        # conversation_id is omitted entirely (not null) when creating the conversation itself
-        # failed above — the client validates this frame against a schema where conversation_id
-        # is an optional string, so a null would fail validation and turn a benign persistence
-        # failure into a spurious interrupted-stream recovery. proposed_action stays present even
-        # when nil: the client schema requires it (nullable, not optional). A generated proposal is
-        # returned only when its assistant message persisted and has a claimable id.
-        #
-        # Suggestions are optional follow-up chips generated AFTER this frame. done.suggestions
-        # stays [] here so the composer can unlock without waiting on that extra model call; the
-        # later `suggestions` event fills the chips. A persistence failure still sends empty
-        # suggestions and suppresses that later event.
+        # Omit conversation_id (do not send null) or the client schema rejects the frame.
+        # Keep proposed_action even when nil. Suggestions stay [] so the composer unlocks;
+        # chips arrive on a later event, skipped if persistence failed.
         done_payload = {
           reply: turn[:reply],
           proposed_action: assistant_message ? turn[:proposed_action] : nil,
@@ -196,13 +188,9 @@ class Api::Internal::AgentMessageStreamsController < Api::Internal::BaseControll
       end
       result = ::Ai::StoreAgentService.new(seller: current_seller, pundit_user:)
         .respond_streaming(messages: history, on_reply_complete:) do |event, payload|
-        # Extend only a marker that is still in progress. on_reply_complete runs before trailing
-        # object/proposal/suggestion events and can mark persistence failed; no later event may
-        # resurrect that terminal state.
+        # No-op if persistence already marked this turn failed.
         refresh_agent_turn_in_progress!(client_turn_id)
-        # finish_stream invokes on_reply_complete before emitting the proposal. If persistence
-        # failed, suppress that event: without a stored assistant message there is no proposal id
-        # the confirmation endpoint can claim.
+        # No stored assistant message means no proposal id the confirmation endpoint can claim.
         next if event.to_s == "proposed_action" && assistant_message.nil?
         # The suggestion call still used the discarded confirmation wording. Do not pair the
         # honest fallback with prompts derived from a write that cannot be confirmed.

--- a/app/controllers/api/mobile/agent_streams_controller.rb
+++ b/app/controllers/api/mobile/agent_streams_controller.rb
@@ -148,7 +148,7 @@ class Api::Mobile::AgentStreamsController < Api::Mobile::BaseController
           reply: turn[:reply],
           proposed_action: assistant_message ? turn[:proposed_action] : nil,
           objects: turn[:objects] || [],
-          suggestions: [],
+          suggestions: unpersisted_proposal ? [] : turn[:suggestions] || [],
         }
         done_payload[:conversation_id] = conversation.external_id if conversation
         done_payload[:proposal_message_id] = assistant_message.external_id if turn[:proposed_action] && assistant_message
@@ -168,10 +168,10 @@ class Api::Mobile::AgentStreamsController < Api::Mobile::BaseController
         # Suggestions generated from discarded confirmation wording would contradict the
         # replacement reply, so suppress them when no persisted proposal backs this turn.
         next if event.to_s == "suggestions" && unpersisted_proposal
-        if event.to_s == "turn_ready"
-          flush_done.call(payload)
-          next
-        end
+        # Web uses this internal marker to unlock early. Mobile's shipped reader stops at `done`
+        # and does not consume later suggestion events, so keep the public terminal frame until
+        # chips are populated and never forward the marker.
+        next if event.to_s == "turn_ready"
 
         write_event.call(payload, event)
       end

--- a/app/controllers/api/mobile/agent_streams_controller.rb
+++ b/app/controllers/api/mobile/agent_streams_controller.rb
@@ -124,6 +124,7 @@ class Api::Mobile::AgentStreamsController < Api::Mobile::BaseController
       turn_persisted = false
       assistant_message = nil
       unpersisted_proposal = false
+      done_written = false
       on_reply_complete = lambda do |turn|
         conversation, assistant_message = persist_agent_turn!(
           conversation,
@@ -139,6 +140,21 @@ class Api::Mobile::AgentStreamsController < Api::Mobile::BaseController
         ErrorNotifier.notify(e)
         unpersisted_proposal = replace_unpersisted_proposal_reply!(turn)
       end
+      flush_done = lambda do |turn|
+        next if done_written
+
+        turn = turn.with_indifferent_access if turn.respond_to?(:with_indifferent_access)
+        done_payload = {
+          reply: turn[:reply],
+          proposed_action: assistant_message ? turn[:proposed_action] : nil,
+          objects: turn[:objects] || [],
+          suggestions: [],
+        }
+        done_payload[:conversation_id] = conversation.external_id if conversation
+        done_payload[:proposal_message_id] = assistant_message.external_id if turn[:proposed_action] && assistant_message
+        write_event.call(done_payload, "done")
+        done_written = true
+      end
       result = ::Ai::StoreAgentService.new(seller:, pundit_user:)
         .respond_streaming(messages: history, on_reply_complete:) do |event, payload|
         # Extend only a marker that is still in progress. on_reply_complete runs before trailing
@@ -152,24 +168,14 @@ class Api::Mobile::AgentStreamsController < Api::Mobile::BaseController
         # Suggestions generated from discarded confirmation wording would contradict the
         # replacement reply, so suppress them when no persisted proposal backs this turn.
         next if event.to_s == "suggestions" && unpersisted_proposal
+        if event.to_s == "turn_ready"
+          flush_done.call(payload)
+          next
+        end
 
         write_event.call(payload, event)
       end
-      # conversation_id is omitted entirely (not null) when creating the conversation itself
-      # failed above — this matches the web streaming controller, whose client validates the
-      # done frame against a schema where conversation_id is an optional string (a null would
-      # fail validation and turn a benign persistence failure into a spurious interrupted-stream
-      # recovery). Keeping the mobile frame shape identical means one contract for both clients.
-      # A generated proposal is returned only when its assistant message persisted.
-      done_payload = {
-        reply: result[:reply],
-        proposed_action: assistant_message ? result[:proposed_action] : nil,
-        objects: result[:objects] || [],
-        suggestions: unpersisted_proposal ? [] : result[:suggestions] || [],
-      }
-      done_payload[:conversation_id] = conversation.external_id if conversation
-      done_payload[:proposal_message_id] = assistant_message.external_id if result[:proposed_action] && assistant_message
-      write_event.call(done_payload, "done")
+      flush_done.call(result)
     rescue ::Ai::StoreAgentService::Error => e
       mark_agent_turn_failed!(client_turn_id) unless turn_persisted
       write_event.call({ message: e.message }, "error")

--- a/app/javascript/components/Agent/AgentChat.streamSafety.test.tsx
+++ b/app/javascript/components/Agent/AgentChat.streamSafety.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment happy-dom
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$app/utils/request", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$app/utils/request")>();
+  return { ...actual, request: vi.fn() };
+});
+
+vi.mock("$app/data/agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$app/data/agent")>();
+  return {
+    ...actual,
+    fetchLatestAgentConversation: vi.fn().mockResolvedValue(null),
+    fetchAgentActionStatus: vi.fn(),
+    fetchAgentTurnStatus: vi.fn(),
+    fetchCustomHtmlProposalPreview: vi.fn(),
+    executeAgentAction: vi.fn(),
+  };
+});
+
+vi.mock("$app/components/server-components/Alert", () => ({ showAlert: vi.fn() }));
+
+vi.stubGlobal("Routes", {
+  internal_agent_messages_stream_path: () => "/internal/agent/messages/stream",
+});
+
+const { request } = vi.mocked(await import("$app/utils/request"));
+const { showAlert } = vi.mocked(await import("$app/components/server-components/Alert"));
+const { AgentChat } = await import("$app/components/Agent/AgentChat");
+
+const openSseResponse = () => {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  const encoder = new TextEncoder();
+  return {
+    response: new Response(body, { headers: { "content-type": "text/event-stream" } }),
+    push: (chunk: string) => controller.enqueue(encoder.encode(chunk)),
+    close: () => controller.close(),
+    error: (reason: unknown) => controller.error(reason),
+  };
+};
+
+const frame = (event: string, data: object) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+
+const doneFrame = (reply: string) =>
+  frame("done", { reply, proposed_action: null, suggestions: [], conversation_id: "conv1" });
+
+const sendMessage = async (text: string) => {
+  const calls = request.mock.calls.length;
+  fireEvent.change(screen.getByLabelText("Message"), { target: { value: text } });
+  fireEvent.click(screen.getByLabelText("Send"));
+  await waitFor(() => expect(request.mock.calls.length).toBeGreaterThan(calls));
+};
+
+const composerLocked = () => screen.getByLabelText("Message").hasAttribute("disabled");
+
+describe("AgentChat stream ownership after early done", () => {
+  beforeEach(() => {
+    request.mockReset();
+    showAlert.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("keeps same-turn late chips when the promise later settles with empty suggestions", async () => {
+    const stream = openSseResponse();
+    request.mockResolvedValue(stream.response);
+
+    render(<AgentChat greeting="Hi" suggestions={[]} />);
+    await sendMessage("how are sales");
+    expect(composerLocked()).toBe(true);
+
+    await act(async () => {
+      stream.push(frame("token", { text: "You have one product." }));
+      stream.push(doneFrame("You have one product."));
+    });
+    await waitFor(() => expect(screen.getByText("You have one product.")).toBeTruthy());
+    await waitFor(() => expect(composerLocked()).toBe(false));
+
+    await act(async () => {
+      stream.push(frame("suggestions", { suggestions: ["Show my sales"] }));
+    });
+    await waitFor(() => expect(screen.getByLabelText("Suggested follow-ups").textContent).toContain("Show my sales"));
+
+    await act(async () => {
+      stream.close();
+    });
+    await waitFor(() => expect(screen.getByLabelText("Suggested follow-ups").textContent).toContain("Show my sales"));
+    expect(showAlert).not.toHaveBeenCalled();
+    expect(screen.queryByText("Sorry, I ran into a problem. Please try again.")).toBeNull();
+  });
+
+  it("does not turn a completed answer into an error on late EOF after done", async () => {
+    const stream = openSseResponse();
+    request.mockResolvedValue(stream.response);
+
+    render(<AgentChat greeting="Hi" suggestions={[]} />);
+    await sendMessage("how are sales");
+
+    await act(async () => {
+      stream.push(doneFrame("You have one product."));
+    });
+    await waitFor(() => expect(screen.getByText("You have one product.")).toBeTruthy());
+    await waitFor(() => expect(composerLocked()).toBe(false));
+
+    await act(async () => {
+      stream.close();
+    });
+    await waitFor(() => expect(composerLocked()).toBe(false));
+    expect(screen.getByText("You have one product.")).toBeTruthy();
+    expect(screen.queryByText("Sorry, I ran into a problem. Please try again.")).toBeNull();
+    expect(showAlert).not.toHaveBeenCalled();
+  });
+
+  it("ignores the old stream's late chips and EOF after a new send", async () => {
+    const first = openSseResponse();
+    const second = openSseResponse();
+    request.mockResolvedValueOnce(first.response).mockResolvedValueOnce(second.response);
+
+    render(<AgentChat greeting="Hi" suggestions={[]} />);
+    await sendMessage("first");
+
+    await act(async () => {
+      first.push(doneFrame("First reply."));
+    });
+    await waitFor(() => expect(screen.getByText("First reply.")).toBeTruthy());
+    await waitFor(() => expect(composerLocked()).toBe(false));
+
+    await act(async () => {
+      first.push(frame("suggestions", { suggestions: ["Old chip"] }));
+    });
+    await waitFor(() => expect(screen.getByText("Old chip")).toBeTruthy());
+
+    await sendMessage("second");
+    expect(composerLocked()).toBe(true);
+
+    await act(async () => {
+      first.push(frame("suggestions", { suggestions: ["Stale chip"] }));
+      first.close();
+    });
+    expect(screen.queryByText("Stale chip")).toBeNull();
+    expect(screen.queryByText("Old chip")).toBeNull();
+
+    await act(async () => {
+      second.push(frame("token", { text: "Second reply." }));
+      second.push(doneFrame("Second reply."));
+    });
+    await waitFor(() => expect(screen.getByText("Second reply.")).toBeTruthy());
+    await waitFor(() => expect(composerLocked()).toBe(false));
+
+    await act(async () => {
+      second.push(frame("suggestions", { suggestions: ["New chip"] }));
+    });
+    await waitFor(() => expect(screen.getByLabelText("Suggested follow-ups").textContent).toContain("New chip"));
+    expect(screen.queryByText("Stale chip")).toBeNull();
+    expect(screen.queryByText("Sorry, I ran into a problem. Please try again.")).toBeNull();
+    expect(showAlert).not.toHaveBeenCalled();
+  });
+
+  it("drops late callbacks after unmount", async () => {
+    const stream = openSseResponse();
+    request.mockResolvedValue(stream.response);
+
+    const view = render(<AgentChat greeting="Hi" suggestions={[]} />);
+    await sendMessage("how are sales");
+    await act(async () => {
+      stream.push(doneFrame("You have one product."));
+    });
+    await waitFor(() => expect(screen.getByText("You have one product.")).toBeTruthy());
+
+    view.unmount();
+
+    expect(() => {
+      stream.push(frame("suggestions", { suggestions: ["After unmount"] }));
+      stream.close();
+    }).not.toThrow();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(showAlert).not.toHaveBeenCalled();
+  });
+});

--- a/app/javascript/components/Agent/AgentChat.streamSafety.test.tsx
+++ b/app/javascript/components/Agent/AgentChat.streamSafety.test.tsx
@@ -27,6 +27,7 @@ vi.stubGlobal("Routes", {
 });
 
 const { request } = vi.mocked(await import("$app/utils/request"));
+const { executeAgentAction } = vi.mocked(await import("$app/data/agent"), { partial: true });
 const { showAlert } = vi.mocked(await import("$app/components/server-components/Alert"));
 const { AgentChat } = await import("$app/components/Agent/AgentChat");
 
@@ -166,7 +167,42 @@ describe("AgentChat stream ownership after early done", () => {
     expect(showAlert).not.toHaveBeenCalled();
   });
 
-  it("drops late callbacks after unmount", async () => {
+  it("keeps a proposal confirmed during the chip wait when the stream later settles", async () => {
+    const stream = openSseResponse();
+    request.mockResolvedValue(stream.response);
+    executeAgentAction.mockResolvedValue({ message: "Created.", object: null });
+
+    render(<AgentChat greeting="Hi" suggestions={[]} />);
+    await sendMessage("make a 20% off code");
+
+    await act(async () => {
+      stream.push(
+        frame("done", {
+          reply: "Confirm the card below.",
+          proposed_action: { type: "api_write", params: { endpoint: "create_offer_code" }, summary: "Create LAUNCH." },
+          proposal_message_id: "msg1",
+          suggestions: [],
+          conversation_id: "conv1",
+        }),
+      );
+    });
+    await waitFor(() => expect(composerLocked()).toBe(false));
+    fireEvent.click(screen.getByText("Confirm"));
+    await waitFor(() => expect(screen.getByText("Applied")).toBeTruthy());
+
+    await act(async () => {
+      stream.push(frame("suggestions", { suggestions: ["Show my discount codes"] }));
+      stream.close();
+    });
+    await waitFor(() =>
+      expect(screen.getByLabelText("Suggested follow-ups").textContent).toContain("Show my discount codes"),
+    );
+    expect(screen.getByText("Applied")).toBeTruthy();
+    expect(screen.queryByText("Confirm")).toBeNull();
+    expect(executeAgentAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops late callbacks after unmount without aborting the server's turn", async () => {
     const stream = openSseResponse();
     request.mockResolvedValue(stream.response);
 
@@ -179,6 +215,8 @@ describe("AgentChat stream ownership after early done", () => {
 
     view.unmount();
 
+    // An abort would raise ClientDisconnected server-side and mark a still-generating turn failed.
+    expect(request.mock.calls[0]?.[0]?.abortSignal?.aborted).toBe(false);
     expect(() => {
       stream.push(frame("suggestions", { suggestions: ["After unmount"] }));
       stream.close();

--- a/app/javascript/components/Agent/AgentChat.test.tsx
+++ b/app/javascript/components/Agent/AgentChat.test.tsx
@@ -96,6 +96,30 @@ describe("AgentChat streamed reply reconciliation", () => {
     expect(fetchAgentTurnStatus).toHaveBeenCalledWith(sentClientTurnId());
   });
 
+  it("does not recover-wipe a completed answer if the stream promise rejects after onDone", async () => {
+    streamAgentMessage.mockImplementation(async (_messages, handlers = {}) => {
+      handlers.onDone?.({
+        reply: "You have one product.",
+        proposedAction: null,
+        proposalMessageId: null,
+        objects: [],
+        suggestions: ["Show my sales"],
+        conversationId: "conv1",
+      });
+      throw new AgentStreamInterruptedError();
+    });
+
+    render(<AgentChat greeting="Hi" suggestions={[]} />);
+    await sendMessage("how are sales");
+
+    await waitFor(() => expect(screen.getByText("You have one product.")).toBeTruthy());
+    expect(screen.getByLabelText("Suggested follow-ups").textContent).toContain("Show my sales");
+    expect(screen.queryByText("Sorry, I ran into a problem. Please try again.")).toBeNull();
+    expect(showAlert).not.toHaveBeenCalled();
+    expect(fetchAgentTurnStatus).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Message").hasAttribute("disabled")).toBe(false);
+  });
+
   it("adopts the recovered turn's conversation id for subsequent turns", async () => {
     interruptedStream();
     fetchAgentTurnStatus.mockResolvedValue({

--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -493,6 +493,8 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
   // Whether to follow new content to the bottom. Stays true while the seller is near the bottom and
   // flips off if they scroll up to read earlier messages, so streaming/suggestions don't yank them back.
   const stickToBottom = React.useRef(true);
+  const sendGenerationRef = React.useRef(0);
+  const activeStreamAbortRef = React.useRef<AbortController | null>(null);
 
   const handleScroll = () => {
     const el = scrollRef.current;
@@ -505,6 +507,9 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
+      sendGenerationRef.current += 1;
+      activeStreamAbortRef.current?.abort();
+      activeStreamAbortRef.current = null;
       for (const abortController of actionStatusAbortControllersRef.current.values()) abortController.abort();
       actionStatusAbortControllersRef.current.clear();
     };
@@ -716,6 +721,11 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
     const trimmed = text.trim();
     if (trimmed.length === 0 || isSending || locked) return;
 
+    sendGenerationRef.current += 1;
+    const generation = sendGenerationRef.current;
+    const belongsToThisTurn = () => mountedRef.current && sendGenerationRef.current === generation;
+    activeStreamAbortRef.current?.abort();
+
     // From here on the seller owns the chat: block the mount-time hydration from replacing it.
     hasSentMessageRef.current = true;
 
@@ -775,15 +785,18 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
     // or errored, or recovery reached a server verdict); after an inconclusive recovery the
     // connection is left alone, because the server may still be generating on it.
     const streamAbort = new AbortController();
+    activeStreamAbortRef.current = streamAbort;
     let turnSettled = false;
     const turnWasReset = { current: false };
 
     const handlers: AgentStreamHandlers = {
       onToken: (chunk) => {
+        if (!belongsToThisTurn()) return;
         setIsStreaming(true);
         appendToken(chunk);
       },
       onReset: () => {
+        if (!belongsToThisTurn()) return;
         turnWasReset.current = true;
         // An intermediate tool-use turn streamed preamble text; clear it so the real reply replaces
         // it instead of appending to it. Remove the empty turn entirely so a retry failure can insert
@@ -795,10 +808,20 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
           return next;
         });
       },
-      onObjects: (objects) => upsertAssistant({ objects }),
-      onProposedAction: (proposedAction) => upsertAssistant({ proposedAction }),
-      onSuggestions: (next) => setFollowUps(next),
+      onObjects: (objects) => {
+        if (!belongsToThisTurn()) return;
+        upsertAssistant({ objects });
+      },
+      onProposedAction: (proposedAction) => {
+        if (!belongsToThisTurn()) return;
+        upsertAssistant({ proposedAction });
+      },
+      onSuggestions: (next) => {
+        if (!belongsToThisTurn()) return;
+        setFollowUps(next);
+      },
       onDone: (result) => {
+        if (!belongsToThisTurn()) return;
         turnSettled = true;
         if (result.conversationId) setConversationId(result.conversationId);
         upsertAssistant({
@@ -808,6 +831,8 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
           ...(result.objects.length > 0 ? { objects: result.objects } : {}),
         });
         // Unlock as soon as the reply is persisted. Suggestion chips may still arrive.
+        // Empty done.suggestions must not wipe chips; a populated list can land immediately.
+        if (result.suggestions.length > 0) setFollowUps(result.suggestions);
         setIsSending(false);
         setIsStreaming(false);
       },
@@ -822,6 +847,7 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
         streamAbort.signal,
       );
       turnSettled = true;
+      if (!belongsToThisTurn()) return;
       if (result.conversationId) setConversationId(result.conversationId);
       // Reconcile with the final assembled turn. Upsert (not map) so a turn that produced no token —
       // e.g. the model staged a write and returned an empty reply — still lands its card/objects.
@@ -839,8 +865,13 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
         };
         return next;
       });
-      setFollowUps(result.suggestions);
+      // Empty done.suggestions must not wipe chips that already arrived on this turn.
+      if (result.suggestions.length > 0) setFollowUps(result.suggestions);
     } catch (e) {
+      if (!belongsToThisTurn()) return;
+      // onDone already assembled this turn. A late timeout/EOF while draining chips must not
+      // recover-wipe the completed answer or lock the composer again.
+      if (turnSettled) return;
       // A broken stream usually means the server finished (or is still finishing) the turn
       // without noticing the client stopped receiving — so the truncated text on screen
       // misrepresents a reply that exists (or will exist) in full server-side. Recover this exact
@@ -862,6 +893,7 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
           return next;
         });
         const outcome = await recoverInterruptedTurn(clientTurnId, assistantIndex);
+        if (!belongsToThisTurn()) return;
         recovered = outcome === "recovered";
         turnSettled = outcome !== "inconclusive";
         // Recovery couldn't tell what became of the turn, so the `finally` below leaves its
@@ -901,6 +933,8 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
       // an abort would raise ClientDisconnected there and kill a turn that could yet persist —
       // the background watch started above releases it later instead.
       if (turnSettled) streamAbort.abort();
+      if (activeStreamAbortRef.current === streamAbort) activeStreamAbortRef.current = null;
+      if (!belongsToThisTurn()) return;
       setIsSending(false);
       setIsStreaming(false);
     }

--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -798,6 +798,19 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
       onObjects: (objects) => upsertAssistant({ objects }),
       onProposedAction: (proposedAction) => upsertAssistant({ proposedAction }),
       onSuggestions: (next) => setFollowUps(next),
+      onDone: (result) => {
+        turnSettled = true;
+        if (result.conversationId) setConversationId(result.conversationId);
+        upsertAssistant({
+          content: result.reply,
+          ...(result.proposedAction ? { proposedAction: result.proposedAction } : {}),
+          ...(result.proposalMessageId ? { proposalMessageId: result.proposalMessageId } : {}),
+          ...(result.objects.length > 0 ? { objects: result.objects } : {}),
+        });
+        // Unlock as soon as the reply is persisted. Suggestion chips may still arrive.
+        setIsSending(false);
+        setIsStreaming(false);
+      },
     };
 
     try {

--- a/app/javascript/components/Agent/AgentChat.tsx
+++ b/app/javascript/components/Agent/AgentChat.tsx
@@ -507,9 +507,9 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
+      // Drop late callbacks, but leave the connection open: aborting mid-generation raises
+      // ClientDisconnected server-side and the turn is marked failed before it can persist.
       sendGenerationRef.current += 1;
-      activeStreamAbortRef.current?.abort();
-      activeStreamAbortRef.current = null;
       for (const abortController of actionStatusAbortControllersRef.current.values()) abortController.abort();
       actionStatusAbortControllersRef.current.clear();
     };
@@ -724,6 +724,8 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
     sendGenerationRef.current += 1;
     const generation = sendGenerationRef.current;
     const belongsToThisTurn = () => mountedRef.current && sendGenerationRef.current === generation;
+    // Only a post-`done` stream still draining suggestion chips can be open here (the composer
+    // stays locked until then), and that turn is already persisted, so aborting it is safe.
     activeStreamAbortRef.current?.abort();
 
     // From here on the seller owns the chat: block the mount-time hydration from replacing it.
@@ -846,25 +848,31 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
         clientTurnId,
         streamAbort.signal,
       );
+      // When onDone already assembled this turn, the composer has been unlocked since then and the
+      // seller may have confirmed the proposal card. Rebuilding the message here would drop that
+      // applied state, so only the chips can still be new.
+      const assembledByDone = turnSettled;
       turnSettled = true;
       if (!belongsToThisTurn()) return;
-      if (result.conversationId) setConversationId(result.conversationId);
-      // Reconcile with the final assembled turn. Upsert (not map) so a turn that produced no token —
-      // e.g. the model staged a write and returned an empty reply — still lands its card/objects.
-      setMessages((prev) => {
-        const next = [...prev];
-        const existing = next[assistantIndex];
-        const prior: DisplayMessage =
-          existing && existing.role === "assistant" ? existing : { role: "assistant", content: "" };
-        next[assistantIndex] = {
-          role: "assistant",
-          content: result.reply || prior.content || "",
-          ...(result.proposedAction ? { proposedAction: result.proposedAction } : {}),
-          ...(result.proposalMessageId ? { proposalMessageId: result.proposalMessageId } : {}),
-          ...(result.objects.length > 0 ? { objects: result.objects } : {}),
-        };
-        return next;
-      });
+      if (!assembledByDone) {
+        if (result.conversationId) setConversationId(result.conversationId);
+        // Reconcile with the final assembled turn. Upsert (not map) so a turn that produced no token —
+        // e.g. the model staged a write and returned an empty reply — still lands its card/objects.
+        setMessages((prev) => {
+          const next = [...prev];
+          const existing = next[assistantIndex];
+          const prior: DisplayMessage =
+            existing && existing.role === "assistant" ? existing : { role: "assistant", content: "" };
+          next[assistantIndex] = {
+            role: "assistant",
+            content: result.reply || prior.content || "",
+            ...(result.proposedAction ? { proposedAction: result.proposedAction } : {}),
+            ...(result.proposalMessageId ? { proposalMessageId: result.proposalMessageId } : {}),
+            ...(result.objects.length > 0 ? { objects: result.objects } : {}),
+          };
+          return next;
+        });
+      }
       // Empty done.suggestions must not wipe chips that already arrived on this turn.
       if (result.suggestions.length > 0) setFollowUps(result.suggestions);
     } catch (e) {
@@ -934,9 +942,10 @@ export const AgentChat = ({ greeting, suggestions, locked = null }: Props) => {
       // the background watch started above releases it later instead.
       if (turnSettled) streamAbort.abort();
       if (activeStreamAbortRef.current === streamAbort) activeStreamAbortRef.current = null;
-      if (!belongsToThisTurn()) return;
-      setIsSending(false);
-      setIsStreaming(false);
+      if (belongsToThisTurn()) {
+        setIsSending(false);
+        setIsStreaming(false);
+      }
     }
   };
 

--- a/app/javascript/data/agent.test.ts
+++ b/app/javascript/data/agent.test.ts
@@ -426,7 +426,9 @@ describe("streamAgentMessage", () => {
     await vi.advanceTimersByTimeAsync(0);
     await Promise.resolve();
     await Promise.resolve();
-    expect(onDone).toHaveBeenCalledWith(expect.objectContaining({ reply: "Want me to pull up?", conversationId: "conv1" }));
+    expect(onDone).toHaveBeenCalledWith(
+      expect.objectContaining({ reply: "Want me to pull up?", conversationId: "conv1" }),
+    );
 
     // The promise stays on the open socket so late suggestion chips can still arrive. Inactivity
     // after done still returns the assembled turn instead of treating it as an interruption.

--- a/app/javascript/data/agent.test.ts
+++ b/app/javascript/data/agent.test.ts
@@ -438,6 +438,29 @@ describe("streamAgentMessage", () => {
     expect(result.conversationId).toBe("conv1");
   });
 
+  it("keeps late suggestion chips when inactivity fires after a valid done frame", async () => {
+    vi.useFakeTimers();
+    const stream = openSseResponse();
+    request.mockResolvedValue(stream.response);
+    const onSuggestions = vi.fn();
+
+    const promise = streamAgentMessage(MESSAGES, { onSuggestions });
+    stream.push(frame("done", { reply: "You have one product.", proposed_action: null, suggestions: [] }));
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+    await Promise.resolve();
+    stream.push(frame("suggestions", { suggestions: ["Show my sales"] }));
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onSuggestions).toHaveBeenCalledWith(["Show my sales"]);
+
+    await vi.advanceTimersByTimeAsync(INACTIVITY_TIMEOUT_MS);
+    const result = await promise;
+    expect(result.reply).toBe("You have one product.");
+    expect(result.suggestions).toEqual(["Show my sales"]);
+  });
+
   it("throws AgentStreamInterruptedError when a frame arrives mangled", async () => {
     request.mockResolvedValue(sseResponse(["event: token\ndata: {not json\n\n"]));
 

--- a/app/javascript/data/agent.test.ts
+++ b/app/javascript/data/agent.test.ts
@@ -252,6 +252,31 @@ describe("streamAgentMessage", () => {
     expect(result.conversationId).toBe("conv1");
   });
 
+  it("unlocks on done then keeps late suggestion chips", async () => {
+    const order: string[] = [];
+    request.mockResolvedValue(
+      sseResponse([
+        frame("token", { text: "You have one product." }),
+        frame("done", {
+          reply: "You have one product.",
+          proposed_action: null,
+          conversation_id: "conv1",
+          suggestions: [],
+        }),
+        frame("suggestions", { suggestions: ["Show my sales"] }),
+      ]),
+    );
+
+    const result = await streamAgentMessage(MESSAGES, {
+      onDone: () => order.push("done"),
+      onSuggestions: () => order.push("suggestions"),
+    });
+
+    expect(order).toEqual(["done", "suggestions"]);
+    expect(result.suggestions).toEqual(["Show my sales"]);
+    expect(result.conversationId).toBe("conv1");
+  });
+
   it("returns the persisted proposal message id from the done frame", async () => {
     const action = { type: "api_write" as const, params: { endpoint: "create_offer_code" }, summary: "Create it." };
     request.mockResolvedValue(
@@ -390,13 +415,22 @@ describe("streamAgentMessage", () => {
     await vi.advanceTimersByTimeAsync(0);
   });
 
-  it("resolves the turn on the done frame even when the connection never closes", async () => {
+  it("calls onDone on the done frame even when the connection never closes", async () => {
+    vi.useFakeTimers();
     const stream = openSseResponse();
     request.mockResolvedValue(stream.response);
+    const onDone = vi.fn();
 
-    const promise = streamAgentMessage(MESSAGES);
+    const promise = streamAgentMessage(MESSAGES, { onDone });
     stream.push(frame("done", { reply: "Want me to pull up?", proposed_action: null, conversation_id: "conv1" }));
-    // No close(): the stream stays open, but `done` is terminal so the turn must resolve anyway.
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onDone).toHaveBeenCalledWith(expect.objectContaining({ reply: "Want me to pull up?", conversationId: "conv1" }));
+
+    // The promise stays on the open socket so late suggestion chips can still arrive. Inactivity
+    // after done still returns the assembled turn instead of treating it as an interruption.
+    await vi.advanceTimersByTimeAsync(INACTIVITY_TIMEOUT_MS);
     const result = await promise;
     expect(result.reply).toBe("Want me to pull up?");
     expect(result.conversationId).toBe("conv1");

--- a/app/javascript/data/agent.ts
+++ b/app/javascript/data/agent.ts
@@ -267,6 +267,9 @@ export type AgentStreamHandlers = {
   onObjects?: (objects: DisplayObject[]) => void;
   onProposedAction?: (action: ProposedAction) => void;
   onSuggestions?: (suggestions: string[]) => void;
+  // The reply is persisted and the terminal `done` frame arrived. Follow-up suggestion chips may
+  // still stream after this; unlock the composer here rather than waiting for them.
+  onDone?: (result: StreamResult) => void;
 };
 
 type StreamResult = {
@@ -437,11 +440,12 @@ export const streamAgentMessage = async (
       case "suggestions": {
         suggestions = typia.assert<SuggestionsData>(raw).suggestions;
         handlers.onSuggestions?.(suggestions);
+        if (done) done = { ...done, suggestions };
         return null;
       }
       case "done": {
         const data = typia.assert<DoneData>(raw);
-        return {
+        const assembled: StreamResult = {
           reply: data.reply,
           // Fall back to the proposed action accumulated mid-stream (the `proposed_action` event),
           // the same way objects/suggestions fall back to their accumulated state. A done frame that
@@ -452,6 +456,8 @@ export const streamAgentMessage = async (
           suggestions: data.suggestions ?? suggestions,
           conversationId: data.conversation_id ?? conversationId ?? null,
         };
+        handlers.onDone?.(assembled);
+        return assembled;
       }
       case "error": {
         throw new ResponseError(typia.assert<ErrorData>(raw).message);
@@ -474,10 +480,10 @@ export const streamAgentMessage = async (
         if (frame.trim().length > 0) done = handleFrame(frame) ?? done;
         separator = buffer.indexOf("\n\n");
       }
-      // `done` is the terminal frame — the server writes nothing meaningful after it. Return the
-      // assembled turn now rather than draining to EOF, so a connection whose close never reaches
-      // the client can't hold a finished turn hostage until the inactivity timeout.
-      if (done) return done;
+      // Keep reading after `done` so optional follow-up suggestion chips can still arrive. The
+      // composer unlocks from onDone when that frame lands; returning here would drop those chips.
+      // A connection that never closes is still bounded by the inactivity timeout, and the catch
+      // below returns an already-assembled `done` if the socket drops afterwards.
     }
     if (buffer.trim().length > 0) done = handleFrame(buffer) ?? done;
   } catch (e) {

--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -117,7 +117,10 @@ class Ai::AnthropicClient
     @fallback_model_override = fallback_model
     # Seconds already spent sleeping between retries; compared against RETRY_SLEEP_BUDGET_IN_SECONDS.
     @retry_sleep_spent = 0.0
+    @served_models = []
   end
+
+  attr_reader :served_models
 
   # Buffered request. `system` is Anthropic's top-level system prompt; `messages` is the Anthropic
   # message array (role + content); `tools` is the Anthropic tool-schema array (optional).
@@ -505,6 +508,8 @@ class Ai::AnthropicClient
     # version) — still the requested model, not a fallback. Only a genuinely different model warns.
     def log_served_model(served_model)
       return if served_model.blank?
+
+      @served_models << served_model
 
       requested = normalize_model_name(model)
       served = normalize_model_name(served_model)

--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -127,8 +127,8 @@ class Ai::AnthropicClient
   # Transient upstream failures (timeouts, 5xx/429/529) are retried a couple of times before
   # surfacing, because a buffered call has no partial output to worry about.
   # @return [Result]
-  def messages(system:, messages:, tools: nil, max_tokens: DEFAULT_MAX_TOKENS)
-    body = request_body(system:, messages:, tools:, max_tokens:, stream: false)
+  def messages(system:, messages:, tools: nil, max_tokens: DEFAULT_MAX_TOKENS, thinking: nil)
+    body = request_body(system:, messages:, tools:, max_tokens:, stream: false, thinking:)
     with_retries do
       response = http.post(api_url, json: body)
       raise_for_status!(response, kind: "request")
@@ -400,7 +400,7 @@ class Ai::AnthropicClient
       message.presence || body[0, 200]
     end
 
-    def request_body(system:, messages:, tools:, max_tokens:, stream:)
+    def request_body(system:, messages:, tools:, max_tokens:, stream:, thinking: nil)
       body = {
         model:,
         max_tokens:,
@@ -415,6 +415,7 @@ class Ai::AnthropicClient
       # the agent stays up on GPT when Anthropic is down. Sent only when routing through
       # OpenRouter; Anthropic's own API would reject the unknown parameter.
       body[:fallbacks] = [{ model: fallback_model }] if openrouter?
+      body[:thinking] = thinking if thinking.present?
       body
     end
 

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -749,6 +749,7 @@ class Ai::StoreAgentService
         retrying = turn_contract_retries < MAX_TURN_CONTRACT_RETRIES
         log_turn_contract_mismatch(reason: decision.fetch(:reason), retrying:)
         unless retrying
+          @turn_contract_failure = decision.fetch(:reason).to_s
           return turn_result(reply: fallback_reply_for(decision:, proposed_action:), proposed_action:)
         end
 
@@ -865,6 +866,7 @@ class Ai::StoreAgentService
         retrying = turn_contract_retries < MAX_TURN_CONTRACT_RETRIES
         log_turn_contract_mismatch(reason: decision.fetch(:reason), retrying:)
         unless retrying
+          @turn_contract_failure = decision.fetch(:reason).to_s
           reply = fallback_reply_for(decision:, proposed_action:)
           return finish_stream(reply:, proposed_action:, last_user_message:, emit:, on_reply_complete:) do |turn|
             emit.call(:reset, {}) if emitted_any
@@ -914,12 +916,15 @@ class Ai::StoreAgentService
         {
           event: "store_agent_turn",
           model: @_client_model,
+          requested_model: @_client_model,
+          served_models: (@_client.respond_to?(:served_models) ? Array(@_client.served_models).uniq : []),
           outcome:,
           stop_reason: @last_stop_reason,
           tool_iterations: @turn_iterations_used,
           contract_retries: @turn_contract_retries,
+          contract_failure: @turn_contract_failure,
           latency_ms:,
-        }.to_json,
+        }.compact.to_json,
       )
     end
 

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -417,10 +417,15 @@ class Ai::StoreAgentService
   # Reserve both even when the invalid final turn arrives at the normal iteration cap.
   TURN_CONTRACT_RECOVERY_ITERATIONS = 2
   TURN_CONTRACT_CORRECTION = <<~TEXT.strip
-    Your last response did not finish with a valid complete_turn call. Repeat the response, write the
-    creator-facing text before the tool call, then call complete_turn exactly once and as the only
-    tool in that response. Use outcome reply_only when this turn has no proposed change. Use outcome
-    proposal_ready only after api_write returned proposed: true in this same turn.
+    Your last response did not finish with a valid complete_turn call. Call complete_turn exactly
+    once as the only tool in that response, and put the creator-facing text in complete_turn.reply.
+    Use outcome reply_only when this turn has no proposed change. Use outcome proposal_ready only
+    after api_write returned proposed: true in this same turn. Do not send a text-only response.
+  TEXT
+  BLANK_REPLY_CORRECTION = <<~TEXT.strip
+    Your complete_turn had no creator-facing reply. Call complete_turn exactly once as the only tool,
+    with outcome reply_only and a nonblank reply string in the tool arguments. Do not send a
+    text-only response.
   TEXT
   PROPOSAL_OUTCOME_CORRECTION = <<~TEXT.strip
     This turn already has a proposed change from api_write, but your final outcome did not report it.
@@ -668,10 +673,12 @@ class Ai::StoreAgentService
       them you'll continue once they confirm.
     - Monetary amounts in the API are in CENTS (integer). $10 = 1000.
     - End EVERY final reply by calling complete_turn exactly once, as the only tool in that response.
-      Write the creator-facing text before the call; on a proposal turn that text is replaced with
+      Put the creator-facing text in complete_turn.reply so the outcome and the answer arrive
+      together. You may also write the same text before the call; on a proposal turn that text is replaced with
       fixed server copy and never shown, so keep it minimal there. Use reply_only when this turn has
       no proposed change. Use proposal_ready only after api_write returned proposed: true in this
-      same turn. Never mix complete_turn with api_read or api_write.
+      same turn. Never mix complete_turn with api_read or api_write. Never send a text-only final
+      response.
 
     How to write:
     - Write like a person: warm, plain, and direct. Short sentences. No corporate filler.
@@ -845,9 +852,14 @@ class Ai::StoreAgentService
       when :complete
         reply = decision.fetch(:reply)
         return finish_stream(reply:, proposed_action:, last_user_message:, emit:, on_reply_complete:) do |turn|
-          # Normal reply text was already streamed. Proposal copy was deliberately withheld, and a
-          # buffered client may also return final text without yielding a delta.
-          emit.call(:token, { text: turn[:reply] }) if suppress_model_text || !emitted_any
+          # Proposal copy was withheld until persist. A complete_turn.reply can also differ from
+          # whatever text deltas already streamed, so replace those with the accepted reply.
+          if suppress_model_text || result.text.to_s.strip != turn[:reply]
+            emit.call(:reset, {}) if emitted_any
+            emit.call(:token, { text: turn[:reply] })
+          elsif !emitted_any
+            emit.call(:token, { text: turn[:reply] })
+          end
         end
       when :invalid
         retrying = turn_contract_retries < MAX_TURN_CONTRACT_RETRIES
@@ -930,7 +942,8 @@ class Ai::StoreAgentService
       return { status: :invalid, reason: :mixed_or_duplicate_complete_turn } unless tool_uses.one? && complete_turn_calls.one?
       return { status: :invalid, reason: :invalid_complete_turn_stop_reason } unless result.stop_reason == "tool_use"
 
-      outcome = sanitize_param_hash(complete_turn_calls.first[:input])["outcome"]
+      input = sanitize_param_hash(complete_turn_calls.first[:input])
+      outcome = input["outcome"]
       return { status: :invalid, reason: :invalid_complete_turn_outcome } unless TURN_OUTCOMES.include?(outcome)
 
       if proposed_action.present?
@@ -941,12 +954,29 @@ class Ai::StoreAgentService
 
       return { status: :invalid, reason: :proposal_ready_without_proposal } unless outcome == TURN_OUTCOME_REPLY_ONLY
 
-      reply = result.text.to_s.strip
+      reply = complete_turn_reply(input:, result:)
+      return { status: :invalid, reason: :invalid_complete_turn_reply } if reply == :invalid_type
       return { status: :invalid, reason: :blank_reply } if reply.blank?
       return { status: :invalid, reason: :staging_claim_without_proposal } if reply == PROPOSAL_READY_REPLY
       return { status: :invalid, reason: :staging_claim_without_proposal } if phantom_staged_claim?(reply:, proposed_action:)
 
       { status: :complete, reply: }
+    end
+
+    # Prefer a typed complete_turn.reply so the outcome and the creator-facing text arrive together.
+    # Visible text without that field stays valid so current models keep working. A present reply
+    # field must be a real string; empty strings fall through to the text channel instead of
+    # succeeding as a blank answer.
+    def complete_turn_reply(input:, result:)
+      if input.key?("reply")
+        payload = input["reply"]
+        return :invalid_type unless payload.is_a?(String)
+
+        stripped = payload.strip
+        return stripped if stripped.present?
+      end
+
+      result.text.to_s.strip
     end
 
     def fallback_reply_for(decision:, proposed_action:)
@@ -959,6 +989,7 @@ class Ai::StoreAgentService
     def turn_contract_correction(decision:, proposed_action:)
       return PROPOSAL_OUTCOME_CORRECTION if proposed_action.present?
       return STAGED_CLAIM_CORRECTION if [:staging_claim_without_proposal, :proposal_ready_without_proposal].include?(decision.fetch(:reason))
+      return BLANK_REPLY_CORRECTION if [:blank_reply, :invalid_complete_turn_reply].include?(decision.fetch(:reason))
 
       TURN_CONTRACT_CORRECTION
     end
@@ -1595,12 +1626,16 @@ class Ai::StoreAgentService
         ),
         tool_schema(
           COMPLETE_TURN_TOOL,
-          "Finish the creator-facing reply after every API tool result is back. Call exactly once and as the only tool in the final response. Write the reply text before this call; on a proposal turn that text is replaced with fixed server copy and never shown. Use proposal_ready only when api_write returned proposed: true in this same turn; otherwise use reply_only.",
+          "Finish the creator-facing reply after every API tool result is back. Call exactly once and as the only tool in the final response. Put the creator-facing text in reply; on a proposal turn that text is replaced with fixed server copy and never shown. Use proposal_ready only when api_write returned proposed: true in this same turn; otherwise use reply_only.",
           {
             outcome: {
               type: "string",
               enum: TURN_OUTCOMES,
               description: "Whether this turn has a real proposed change waiting for confirmation.",
+            },
+            reply: {
+              type: "string",
+              description: "Creator-facing reply for reply_only turns. Must be nonblank when present. Prefer this over a separate text channel so the outcome and the answer arrive together.",
             },
           },
           required: ["outcome"],

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -1144,16 +1144,9 @@ class Ai::StoreAgentService
       end
     end
 
-    # Emit the trailing events for a completed streaming turn (objects, any staged change, a
-    # turn_ready marker, and the follow-up suggestions) and return the full result hash. The
-    # on_reply_complete hook fires first — before any further socket write — so the caller can
-    # persist the finished turn even when the client's connection is already dead (the next emit
-    # would raise ClientDisconnected and abandon the turn).
-    #
-    # turn_ready fires after the reply/objects/proposal are on the socket and BEFORE the extra
-    # suggestions LLM call. The web stream controller writes `done` from that event so the
-    # creator is not held on a spinner while optional follow-up chips generate. Mobile ignores
-    # the marker and still writes terminal `done` after suggestions. Suggestions are not dropped.
+    # Persist via on_reply_complete before any further emit so a dead socket still stores the turn.
+    # turn_ready is before the suggestions LLM call; web writes `done` from it, mobile ignores it
+    # and stays terminal after chips.
     def finish_stream(reply:, proposed_action:, last_user_message:, emit:, on_reply_complete: nil, &before_trailing_events)
       objects = deduped_objects
       result = turn_result(reply:, proposed_action:)

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -1149,9 +1149,9 @@ class Ai::StoreAgentService
     # would raise ClientDisconnected and abandon the turn).
     #
     # turn_ready fires after the reply/objects/proposal are on the socket and BEFORE the extra
-    # suggestions LLM call. Controllers write the terminal `done` frame from that event so the
-    # creator is not held on a spinner while optional follow-up chips generate. Suggestions still
-    # emit afterwards; they are not dropped.
+    # suggestions LLM call. The web stream controller writes `done` from that event so the
+    # creator is not held on a spinner while optional follow-up chips generate. Mobile ignores
+    # the marker and still writes terminal `done` after suggestions. Suggestions are not dropped.
     def finish_stream(reply:, proposed_action:, last_user_message:, emit:, on_reply_complete: nil, &before_trailing_events)
       objects = deduped_objects
       result = turn_result(reply:, proposed_action:)

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -4,7 +4,7 @@
 # assistant that can answer questions about their store and *propose* changes to it.
 #
 # The agent runs on Grok 4.5 via OpenRouter's Anthropic-compatible endpoint (see MODEL below), with
-# Claude Opus 5 as the request-level fallback when Grok errors. DeepSeek V4.1 Flash is ramped
+# Claude Opus 5 as the request-level fallback when Grok errors. DeepSeek V4 Flash is ramped
 # independently as a third option (see DEEPSEEK_MODEL below), also falling back to Opus.
 #
 # Safety model:
@@ -32,11 +32,11 @@ class Ai::StoreAgentService
   OPENROUTER_FALLBACK_MODEL = "anthropic/claude-opus-5"
   # Below 100%, gates Grok vs Opus per seller in addition to OPENROUTER_API_KEY being configured.
   GROK_RAMP_FEATURE = :store_agent_grok
-  # DeepSeek V4.1 Flash: cheap, fast MoE model worth ramping as a third option alongside Claude and
+  # DeepSeek V4 Flash: cheap, fast MoE model worth ramping as a third option alongside Claude and
   # Grok — same OpenRouter routing and Anthropic-compatible endpoint, so no client changes needed
   # beyond the model id. Falls back to Opus rather than Grok so a DeepSeek outage doesn't cascade
   # into a second experimental model.
-  DEEPSEEK_MODEL = "deepseek/deepseek-v4.1-flash"
+  DEEPSEEK_MODEL = "deepseek/deepseek-v4-flash-0731"
   DEEPSEEK_FALLBACK_MODEL = "anthropic/claude-opus-5"
   # Below 100%, gates DeepSeek vs Opus per seller in addition to OPENROUTER_API_KEY being
   # configured. Independent of GROK_RAMP_FEATURE — see #client for precedence when both are active

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -1142,11 +1142,16 @@ class Ai::StoreAgentService
       end
     end
 
-    # Emit the trailing events for a completed streaming turn (objects, any staged change, and the
-    # follow-up suggestions) and return the full result hash. The on_reply_complete hook fires
-    # first — before any further socket write — so the caller can persist the finished turn even
-    # when the client's connection is already dead (the next emit would raise ClientDisconnected
-    # and abandon the turn) and before the seller waits out the extra suggestions LLM call.
+    # Emit the trailing events for a completed streaming turn (objects, any staged change, a
+    # turn_ready marker, and the follow-up suggestions) and return the full result hash. The
+    # on_reply_complete hook fires first — before any further socket write — so the caller can
+    # persist the finished turn even when the client's connection is already dead (the next emit
+    # would raise ClientDisconnected and abandon the turn).
+    #
+    # turn_ready fires after the reply/objects/proposal are on the socket and BEFORE the extra
+    # suggestions LLM call. Controllers write the terminal `done` frame from that event so the
+    # creator is not held on a spinner while optional follow-up chips generate. Suggestions still
+    # emit afterwards; they are not dropped.
     def finish_stream(reply:, proposed_action:, last_user_message:, emit:, on_reply_complete: nil, &before_trailing_events)
       objects = deduped_objects
       result = turn_result(reply:, proposed_action:)
@@ -1154,6 +1159,7 @@ class Ai::StoreAgentService
       before_trailing_events&.call(result)
       emit.call(:objects, { objects: }) if objects.any?
       emit.call(:proposed_action, { proposed_action: proposed_action.as_json }) if proposed_action
+      emit.call(:turn_ready, result)
       suggestions = follow_up_suggestions(reply: result[:reply], last_user_message:)
       emit.call(:suggestions, { suggestions: }) if suggestions.any?
       result.merge(suggestions:)

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -1166,17 +1166,25 @@ class Ai::StoreAgentService
     def follow_up_suggestions(reply:, last_user_message:)
       return [] if reply.blank?
 
+      # DeepSeek otherwise spends this 200-token budget on hidden reasoning and returns no chips.
       result = client.messages(
         system: FOLLOW_UP_PROMPT,
         messages: [
           { role: "user", content: "The creator said: #{last_user_message}\n\nYou answered: #{reply}\n\nSuggest up to three follow-up prompts." },
         ],
         max_tokens: MAX_SUGGESTION_TOKENS,
+        **follow_up_thinking,
       )
       parse_suggestions(result.text)
     rescue => e
       Rails.logger.warn("Store agent follow-up suggestions failed: #{e.message}")
       []
+    end
+
+    def follow_up_thinking
+      return {} unless @_client_model.to_s.start_with?("deepseek/")
+
+      { thinking: { type: "disabled" } }
     end
 
     # Coerce the model's reply into a clean list of suggestion strings. Prefers a JSON array but

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -718,6 +718,7 @@ class Ai::StoreAgentService
     @completed_read_targets = {}
     @reads_completed_in_tool_batch = nil
     turn_contract_retries = 0
+    @turn_contract_failure = nil
     @turn_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
     remaining_iterations = MAX_TOOL_ITERATIONS
@@ -790,6 +791,7 @@ class Ai::StoreAgentService
     @completed_read_targets = {}
     @reads_completed_in_tool_batch = nil
     turn_contract_retries = 0
+    @turn_contract_failure = nil
     @turn_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
     remaining_iterations = MAX_TOOL_ITERATIONS

--- a/app/services/ai/store_agent_service.rb
+++ b/app/services/ai/store_agent_service.rb
@@ -4,7 +4,7 @@
 # assistant that can answer questions about their store and *propose* changes to it.
 #
 # The agent runs on Grok 4.5 via OpenRouter's Anthropic-compatible endpoint (see MODEL below), with
-# Claude Opus 5 as the request-level fallback when Grok errors. DeepSeek V4 Flash is ramped
+# Claude Opus 5 as the request-level fallback when Grok errors. DeepSeek V4.1 Flash is ramped
 # independently as a third option (see DEEPSEEK_MODEL below), also falling back to Opus.
 #
 # Safety model:
@@ -32,11 +32,11 @@ class Ai::StoreAgentService
   OPENROUTER_FALLBACK_MODEL = "anthropic/claude-opus-5"
   # Below 100%, gates Grok vs Opus per seller in addition to OPENROUTER_API_KEY being configured.
   GROK_RAMP_FEATURE = :store_agent_grok
-  # DeepSeek V4 Flash: cheap, fast MoE model worth ramping as a third option alongside Claude and
+  # DeepSeek V4.1 Flash: cheap, fast MoE model worth ramping as a third option alongside Claude and
   # Grok — same OpenRouter routing and Anthropic-compatible endpoint, so no client changes needed
   # beyond the model id. Falls back to Opus rather than Grok so a DeepSeek outage doesn't cascade
   # into a second experimental model.
-  DEEPSEEK_MODEL = "deepseek/deepseek-v4-flash-0731"
+  DEEPSEEK_MODEL = "deepseek/deepseek-v4.1-flash"
   DEEPSEEK_FALLBACK_MODEL = "anthropic/claude-opus-5"
   # Below 100%, gates DeepSeek vs Opus per seller in addition to OPENROUTER_API_KEY being
   # configured. Independent of GROK_RAMP_FEATURE — see #client for precedence when both are active

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -50,7 +50,8 @@ services:
       - elasticsearch7data:/data
 
   minio:
-    image: minio/minio
+    # MinIO images come from quay.io; the Docker Hub repositories were removed.
+    image: quay.io/minio/minio
     ports:
       - "9000:9000" # API port
       - "9001:9001" # Console port
@@ -68,7 +69,7 @@ services:
       start_period: 30s
 
   createbuckets:
-    image: minio/mc
+    image: quay.io/minio/mc
     depends_on:
       minio:
         condition: service_healthy
@@ -88,7 +89,7 @@ services:
       done; exit 0; "
 
   copyfixturefiles:
-    image: minio/mc
+    image: quay.io/minio/mc
     depends_on:
       createbuckets:
         condition: service_completed_successfully

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -50,7 +50,6 @@ services:
       - elasticsearch7data:/data
 
   minio:
-    # MinIO images come from quay.io; the Docker Hub repositories were removed.
     image: quay.io/minio/minio
     ports:
       - "9000:9000" # API port

--- a/docker/docker-compose-test-and-ci.yml
+++ b/docker/docker-compose-test-and-ci.yml
@@ -48,7 +48,8 @@ services:
       - "11211"
 
   minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    # MinIO images come from quay.io; the Docker Hub repositories were removed.
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       - "9000"
       - "9001"
@@ -66,7 +67,7 @@ services:
       start_period: 30s
 
   createbuckets:
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       minio:
         condition: service_healthy
@@ -86,7 +87,7 @@ services:
       done; exit 0; "
 
   copyfixturefiles:
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       createbuckets:
         condition: service_completed_successfully

--- a/docker/docker-compose-test-and-ci.yml
+++ b/docker/docker-compose-test-and-ci.yml
@@ -48,7 +48,6 @@ services:
       - "11211"
 
   minio:
-    # MinIO images come from quay.io; the Docker Hub repositories were removed.
     image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       - "9000"

--- a/spec/controllers/api/internal/agent_message_streams_controller_spec.rb
+++ b/spec/controllers/api/internal/agent_message_streams_controller_spec.rb
@@ -241,6 +241,29 @@ describe Api::Internal::AgentMessageStreamsController do
         $redis.del(turn_status_key) if turn_status_key
       end
 
+      it "writes done on turn_ready before follow-up suggestions" do
+        service_double = instance_double(Ai::StoreAgentService)
+        allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+        allow(service_double).to receive(:respond_streaming) do |on_reply_complete: nil, **_kwargs, &emit|
+          turn = store_agent_turn(reply: "You have one product.", proposed_action: nil)
+          on_reply_complete&.call(turn)
+          emit.call(:token, { text: turn[:reply] })
+          emit.call(:turn_ready, turn)
+          emit.call(:suggestions, { suggestions: ["Show my sales"] })
+          turn.merge(suggestions: ["Show my sales"])
+        end
+
+        post :create, params: valid_params, format: :json
+
+        expect(response.body.scan(/^event: (.+)$/).flatten).to eq(
+          %w[token done suggestions],
+        )
+        done_data = JSON.parse(response.body[/event: done\ndata: (.*)\n/, 1])
+        expect(done_data["reply"]).to eq("You have one product.")
+        expect(done_data["suggestions"]).to eq([])
+        expect(response.body).to include("Show my sales")
+      end
+
       it "rejects and replaces server-owned confirmation copy without a proposal" do
         service_double = instance_double(Ai::StoreAgentService)
         allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)

--- a/spec/controllers/api/mobile/agent_streams_controller_spec.rb
+++ b/spec/controllers/api/mobile/agent_streams_controller_spec.rb
@@ -80,6 +80,32 @@ describe Api::Mobile::AgentStreamsController do
       expect(response.body).to include(conversation.external_id)
     end
 
+    # Mobile's shipped reader returns on the first `done` frame and never consumes a later
+    # `suggestions` event (antiwork/gumroad-mobile lib/agent.ts). Keep `done` terminal and
+    # populated; do not forward the web-only internal `turn_ready` marker.
+    it "writes terminal done after suggestions and ignores internal turn_ready" do
+      service_double = instance_double(Ai::StoreAgentService)
+      allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)
+      allow(service_double).to receive(:respond_streaming) do |on_reply_complete: nil, **_kwargs, &emit|
+        turn = store_agent_turn(reply: "You have one product.")
+        on_reply_complete&.call(turn)
+        emit.call(:token, { text: turn[:reply] })
+        emit.call(:turn_ready, turn)
+        emit.call(:suggestions, { suggestions: ["Show my sales"] })
+        turn.merge(suggestions: ["Show my sales"])
+      end
+
+      post :create, params: valid_params
+
+      expect(response.body.scan(/^event: (.+)$/).flatten).to eq(
+        %w[token suggestions done],
+      )
+      expect(response.body).not_to include("event: turn_ready")
+      done_data = JSON.parse(response.body[/event: done\ndata: (.*)/, 1])
+      expect(done_data["reply"]).to eq("You have one product.")
+      expect(done_data["suggestions"]).to eq(["Show my sales"])
+    end
+
     it "commits the stream with a keepalive comment before any event" do
       service_double = instance_double(Ai::StoreAgentService)
       allow(Ai::StoreAgentService).to receive(:new).and_return(service_double)

--- a/spec/requests/agent_spec.rb
+++ b/spec/requests/agent_spec.rb
@@ -47,6 +47,7 @@ describe "Agent tab", type: :system, js: true do
       kwargs[:on_reply_complete]&.call(turn)
       emit.call(:objects, { objects: }) if objects.any?
       emit.call(:proposed_action, { proposed_action: }) if proposed_action
+      emit.call(:turn_ready, turn)
       emit.call(:suggestions, { suggestions: }) if suggestions.any?
       turn
     end

--- a/spec/services/ai/anthropic_client_spec.rb
+++ b/spec/services/ai/anthropic_client_spec.rb
@@ -50,6 +50,20 @@ describe Ai::AnthropicClient do
       expect(captured["tools"][1]["cache_control"]).to eq("type" => "ephemeral")
     end
 
+    it "includes thinking in the request body when given and omits it otherwise" do
+      captured = nil
+      stub_request(:post, url)
+        .with { |request| captured = JSON.parse(request.body); true }
+        .to_return(status: 200, body: { "content" => [], "stop_reason" => "end_turn" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      client.messages(system: "s", messages: [{ role: "user", content: "x" }], thinking: { type: "disabled" })
+      expect(captured["thinking"]).to eq("type" => "disabled")
+
+      captured = nil
+      client.messages(system: "s", messages: [{ role: "user", content: "x" }])
+      expect(captured).not_to have_key("thinking")
+    end
+
     it "parses tool_use blocks with their input" do
       body = {
         "content" => [

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -2224,15 +2224,17 @@ describe Ai::StoreAgentService do
       expect(captured[:fallback_model]).to be_nil
     end
 
-    it "requests DeepSeek with an Opus fallback once OpenRouter and the DeepSeek ramp flag are both on" do
+    it "requests DeepSeek V4.1 Flash with an Opus fallback once OpenRouter and the DeepSeek ramp flag are both on" do
       allow(Ai::AnthropicClient).to receive(:openrouter_configured?).and_return(true)
       Feature.activate_user(described_class::DEEPSEEK_RAMP_FEATURE, seller)
       allow(client).to receive(:messages).and_return(text_result("hi"))
 
       service.respond(messages: [{ role: "user", content: "hello" }])
 
-      expect(captured[:model]).to eq("deepseek/deepseek-v4-flash-0731")
+      expect(captured[:model]).to eq("deepseek/deepseek-v4.1-flash")
+      expect(captured[:model]).to eq(described_class::DEEPSEEK_MODEL)
       expect(captured[:fallback_model]).to eq("anthropic/claude-opus-5")
+      expect(captured[:fallback_model]).to eq(described_class::DEEPSEEK_FALLBACK_MODEL)
     end
 
     it "keeps requesting Opus when OpenRouter is configured but the seller is in neither ramp" do
@@ -2242,10 +2244,23 @@ describe Ai::StoreAgentService do
       service.respond(messages: [{ role: "user", content: "hello" }])
 
       expect(captured[:model]).to eq(Ai::AnthropicClient::DEFAULT_MODEL)
+      expect(captured[:model]).not_to eq("deepseek/deepseek-v4.1-flash")
       expect(captured[:fallback_model]).to be_nil
     end
 
-    it "prefers DeepSeek over Grok when a seller is in both ramps" do
+    it "does not request DeepSeek when OpenRouter is on but the DeepSeek ramp flag is off" do
+      allow(Ai::AnthropicClient).to receive(:openrouter_configured?).and_return(true)
+      Feature.activate_user(described_class::GROK_RAMP_FEATURE, seller)
+      allow(client).to receive(:messages).and_return(text_result("hi"))
+
+      service.respond(messages: [{ role: "user", content: "hello" }])
+
+      expect(captured[:model]).to eq("x-ai/grok-4.5")
+      expect(captured[:model]).not_to eq("deepseek/deepseek-v4.1-flash")
+      expect(captured[:fallback_model]).to eq("anthropic/claude-opus-5")
+    end
+
+    it "prefers DeepSeek V4.1 Flash over Grok when a seller is in both ramps" do
       allow(Ai::AnthropicClient).to receive(:openrouter_configured?).and_return(true)
       Feature.activate_user(described_class::GROK_RAMP_FEATURE, seller)
       Feature.activate_user(described_class::DEEPSEEK_RAMP_FEATURE, seller)
@@ -2253,7 +2268,7 @@ describe Ai::StoreAgentService do
 
       service.respond(messages: [{ role: "user", content: "hello" }])
 
-      expect(captured[:model]).to eq("deepseek/deepseek-v4-flash-0731")
+      expect(captured[:model]).to eq("deepseek/deepseek-v4.1-flash")
       expect(captured[:fallback_model]).to eq("anthropic/claude-opus-5")
     end
   end

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -2156,6 +2156,36 @@ describe Ai::StoreAgentService do
       expect(result[:suggestions]).to eq(["Show my best sellers", "Email my customers", "Create a discount"])
     end
 
+    it "disables thinking on the suggestions call when DeepSeek is selected" do
+      allow(Ai::AnthropicClient).to receive(:openrouter_configured?).and_return(true)
+      Feature.activate_user(described_class::DEEPSEEK_RAMP_FEATURE, seller)
+      stub_stream_turns(stream: ["You have 3 products."], result: text_result("You have 3 products."))
+      captured = nil
+      allow(client).to receive(:messages) do |**kwargs|
+        captured = kwargs
+        text_result('["List my products"]')
+      end
+
+      _events, result = collect_events([{ role: "user", content: "How many products?" }])
+
+      expect(captured[:thinking]).to eq({ type: "disabled" })
+      expect(captured[:max_tokens]).to eq(described_class::MAX_SUGGESTION_TOKENS)
+      expect(result[:suggestions]).to eq(["List my products"])
+    end
+
+    it "does not disable thinking on the suggestions call for Opus" do
+      stub_stream_turns(stream: ["You have 3 products."], result: text_result("You have 3 products."))
+      captured = nil
+      allow(client).to receive(:messages) do |**kwargs|
+        captured = kwargs
+        text_result('["List my products"]')
+      end
+
+      collect_events([{ role: "user", content: "How many products?" }])
+
+      expect(captured).not_to have_key(:thinking)
+    end
+
     it "emits a reset when an intermediate tool-use turn streams preamble text, then streams the real reply" do
       # First turn: the model streams a preamble ("Let me check...") AND asks to call a read tool.
       # That preamble is not the answer, so the service must emit :reset before the final turn.

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -2461,17 +2461,15 @@ describe Ai::StoreAgentService do
       expect(captured[:fallback_model]).to be_nil
     end
 
-    it "requests DeepSeek V4.1 Flash with an Opus fallback once OpenRouter and the DeepSeek ramp flag are both on" do
+    it "requests DeepSeek with an Opus fallback once OpenRouter and the DeepSeek ramp flag are both on" do
       allow(Ai::AnthropicClient).to receive(:openrouter_configured?).and_return(true)
       Feature.activate_user(described_class::DEEPSEEK_RAMP_FEATURE, seller)
       allow(client).to receive(:messages).and_return(text_result("hi"))
 
       service.respond(messages: [{ role: "user", content: "hello" }])
 
-      expect(captured[:model]).to eq("deepseek/deepseek-v4.1-flash")
-      expect(captured[:model]).to eq(described_class::DEEPSEEK_MODEL)
+      expect(captured[:model]).to eq("deepseek/deepseek-v4-flash-0731")
       expect(captured[:fallback_model]).to eq("anthropic/claude-opus-5")
-      expect(captured[:fallback_model]).to eq(described_class::DEEPSEEK_FALLBACK_MODEL)
     end
 
     it "keeps requesting Opus when OpenRouter is configured but the seller is in neither ramp" do
@@ -2481,23 +2479,10 @@ describe Ai::StoreAgentService do
       service.respond(messages: [{ role: "user", content: "hello" }])
 
       expect(captured[:model]).to eq(Ai::AnthropicClient::DEFAULT_MODEL)
-      expect(captured[:model]).not_to eq("deepseek/deepseek-v4.1-flash")
       expect(captured[:fallback_model]).to be_nil
     end
 
-    it "does not request DeepSeek when OpenRouter is on but the DeepSeek ramp flag is off" do
-      allow(Ai::AnthropicClient).to receive(:openrouter_configured?).and_return(true)
-      Feature.activate_user(described_class::GROK_RAMP_FEATURE, seller)
-      allow(client).to receive(:messages).and_return(text_result("hi"))
-
-      service.respond(messages: [{ role: "user", content: "hello" }])
-
-      expect(captured[:model]).to eq("x-ai/grok-4.5")
-      expect(captured[:model]).not_to eq("deepseek/deepseek-v4.1-flash")
-      expect(captured[:fallback_model]).to eq("anthropic/claude-opus-5")
-    end
-
-    it "prefers DeepSeek V4.1 Flash over Grok when a seller is in both ramps" do
+    it "prefers DeepSeek over Grok when a seller is in both ramps" do
       allow(Ai::AnthropicClient).to receive(:openrouter_configured?).and_return(true)
       Feature.activate_user(described_class::GROK_RAMP_FEATURE, seller)
       Feature.activate_user(described_class::DEEPSEEK_RAMP_FEATURE, seller)
@@ -2505,7 +2490,7 @@ describe Ai::StoreAgentService do
 
       service.respond(messages: [{ role: "user", content: "hello" }])
 
-      expect(captured[:model]).to eq("deepseek/deepseek-v4.1-flash")
+      expect(captured[:model]).to eq("deepseek/deepseek-v4-flash-0731")
       expect(captured[:fallback_model]).to eq("anthropic/claude-opus-5")
     end
   end

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -2020,7 +2020,7 @@ describe Ai::StoreAgentService do
       # The finished turn reaches the hook before anything else happens — before the extra
       # suggestions LLM call and before any trailing event is written to the (possibly already
       # dead) client socket — so callers can persist it no matter what happens afterwards.
-      expect(order).to eq([:reply_complete, :suggestions_call, :suggestions])
+      expect(order).to eq([:reply_complete, :turn_ready, :suggestions_call, :suggestions])
       expect(completed_turn).to eq(
         outcome: "reply_only",
         reply: "Here are your numbers.",

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -28,10 +28,12 @@ describe Ai::StoreAgentService do
     Ai::AnthropicClient::Result.new(text:, tool_uses: [], stop_reason: "end_turn")
   end
 
-  def complete_turn_result(text, outcome:)
+  def complete_turn_result(text, outcome:, reply: :omit)
+    input = { "outcome" => outcome }
+    input["reply"] = reply unless reply == :omit
     Ai::AnthropicClient::Result.new(
       text:,
-      tool_uses: [{ id: "toolu_complete", name: "complete_turn", input: { "outcome" => outcome } }],
+      tool_uses: [{ id: "toolu_complete", name: "complete_turn", input: }],
       stop_reason: "tool_use",
     )
   end
@@ -346,6 +348,169 @@ describe Ai::StoreAgentService do
 
         expect(client).to have_received(:messages).twice
         expect(result[:reply]).to eq("Here you go.")
+      end
+
+      it "accepts a nonblank complete_turn reply when visible text is blank" do
+        allow(client).to receive(:messages).and_return(
+          complete_turn_result("", outcome: "reply_only", reply: "You have 3 products."),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "How many products do I have?" }])
+
+        expect(client).to have_received(:messages).once
+        expect(result).to include(
+          outcome: "reply_only",
+          reply: "You have 3 products.",
+          proposed_action: nil,
+        )
+      end
+
+      it "still uses visible text when complete_turn omits reply" do
+        allow(client).to receive(:messages).and_return(
+          complete_turn_result("You have 3 products.", outcome: "reply_only"),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "How many products do I have?" }])
+
+        expect(result[:reply]).to eq("You have 3 products.")
+      end
+
+      it "rejects a non-string complete_turn reply" do
+        allow(client).to receive(:messages).and_return(
+          complete_turn_result("You have 3 products.", outcome: "reply_only", reply: ["You have 3 products."]),
+          complete_turn_result("You have 3 products.", outcome: "reply_only"),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "How many products do I have?" }])
+
+        expect(client).to have_received(:messages).twice
+        expect(result[:reply]).to eq("You have 3 products.")
+      end
+
+      it "rejects a blank complete_turn with no reply payload" do
+        allow(client).to receive(:messages).and_return(
+          complete_turn_result("", outcome: "reply_only"),
+          complete_turn_result("You have 3 products.", outcome: "reply_only"),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "How many products do I have?" }])
+
+        expect(client).to have_received(:messages).twice
+        expect(result[:reply]).to eq("You have 3 products.")
+      end
+
+      it "does not accept rejected prose when a blank complete_turn is followed by text without complete_turn" do
+        recovered_prose = "You have one published product named Cedar Ledger."
+        allow(client).to receive(:messages).and_return(
+          complete_turn_result("", outcome: "reply_only"),
+          untyped_text_result(recovered_prose),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "How many products do I have?" }])
+
+        expect(client).to have_received(:messages).twice
+        expect(result[:reply]).to eq(described_class::TURN_CONTRACT_FAILURE_REPLY)
+        expect(result[:reply]).not_to eq(recovered_prose)
+        expect(result[:proposed_action]).to be_nil
+      end
+
+      it "recovers a blank complete_turn when the retry puts the answer in the tool payload" do
+        allow(client).to receive(:messages).and_return(
+          complete_turn_result("", outcome: "reply_only"),
+          complete_turn_result("", outcome: "reply_only", reply: "You have 3 products."),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "How many products do I have?" }])
+
+        expect(client).to have_received(:messages).twice
+        expect(result[:reply]).to eq("You have 3 products.")
+      end
+
+      it "rejects a forged proposal_ready payload without a real proposal" do
+        allow(client).to receive(:messages).and_return(
+          complete_turn_result("", outcome: "proposal_ready", reply: "Confirm the card below."),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "unpublish Cedar Ledger" }])
+
+        expect(result[:reply]).to eq(described_class::NOTHING_STAGED_REPLY)
+        expect(result[:proposed_action]).to be_nil
+      end
+
+      it "keeps server-owned confirmation copy when complete_turn carries its own reply" do
+        allow(client).to receive(:messages).and_return(
+          tool_result("api_write", {
+                        "endpoint" => "create_offer_code",
+                        "path_params" => { "link_id" => "prod_1" },
+                        "params" => { "name" => "LAUNCH", "amount_off" => 20, "offer_type" => "percent" },
+                      }),
+          complete_turn_result("", outcome: "proposal_ready", reply: "I already applied that change."),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "Make a 20% off code" }])
+
+        expect(result[:reply]).to eq(described_class::PROPOSAL_READY_REPLY)
+        expect(result[:outcome]).to eq("proposal_ready")
+        expect(result[:proposed_action]).to include(type: "api_write")
+      end
+
+      it "rejects phantom staging text inside complete_turn.reply" do
+        allow(client).to receive(:messages).and_return(
+          complete_turn_result("", outcome: "reply_only", reply: "Staged. Confirm that card."),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "Make a 20% off code" }])
+
+        expect(result[:reply]).to eq(described_class::NOTHING_STAGED_REPLY)
+        expect(result[:proposed_action]).to be_nil
+      end
+
+      it "does not mutate when a mixed complete_turn payload claims a write" do
+        mixed_turn = Ai::AnthropicClient::Result.new(
+          text: "",
+          tool_uses: [
+            {
+              id: "toolu_write",
+              name: "api_write",
+              input: {
+                "endpoint" => "create_offer_code",
+                "path_params" => { "link_id" => "prod_1" },
+                "params" => { "name" => "LAUNCH", "amount_off" => 20, "offer_type" => "percent" },
+              },
+            },
+            { id: "toolu_complete", name: "complete_turn", input: { "outcome" => "proposal_ready", "reply" => "Ready." } },
+          ],
+          stop_reason: "tool_use",
+        )
+        allow(client).to receive(:messages).and_return(
+          mixed_turn,
+          complete_turn_result("I did not prepare that change.", outcome: "reply_only"),
+        )
+
+        expect do
+          result = service.respond(messages: [{ role: "user", content: "Make a 20% off code" }])
+          expect(result[:proposed_action]).to be_nil
+        end.not_to change { seller.offer_codes.count }
+      end
+
+      it "rejects duplicate complete_turn calls" do
+        duplicate = Ai::AnthropicClient::Result.new(
+          text: "You have 3 products.",
+          tool_uses: [
+            { id: "toolu_complete_1", name: "complete_turn", input: { "outcome" => "reply_only", "reply" => "You have 3 products." } },
+            { id: "toolu_complete_2", name: "complete_turn", input: { "outcome" => "reply_only", "reply" => "You have 3 products." } },
+          ],
+          stop_reason: "tool_use",
+        )
+        allow(client).to receive(:messages).and_return(
+          duplicate,
+          complete_turn_result("You have 3 products.", outcome: "reply_only"),
+        )
+
+        result = service.respond(messages: [{ role: "user", content: "How many products do I have?" }])
+
+        expect(client).to have_received(:messages).twice
+        expect(result[:reply]).to eq("You have 3 products.")
       end
     end
 
@@ -2152,6 +2317,65 @@ describe Ai::StoreAgentService do
       expect(result[:reply]).to eq(described_class::PROPOSAL_READY_REPLY)
       expect(result[:proposed_action]).to include(type: "api_write")
       expect(events.any? { |event, _| event == :proposed_action }).to be(true)
+    end
+
+    it "emits a complete_turn reply when the model streams no visible text" do
+      stub_stream_turns(
+        { stream: [], result: complete_turn_result("", outcome: "reply_only", reply: "You have 3 products.") },
+      )
+      allow(client).to receive(:messages).and_return(text_result("[]"))
+      persisted = nil
+
+      events = []
+      result = service.respond_streaming(
+        messages: [{ role: "user", content: "How many products?" }],
+        on_reply_complete: ->(turn) { persisted = turn },
+      ) { |event, payload| events << [event, payload] }
+
+      visible_reply = events.each_with_object(+"") do |(event, payload), text|
+        text.clear if event == :reset
+        text << payload[:text] if event == :token
+      end
+
+      expect(visible_reply).to eq("You have 3 products.")
+      expect(result[:reply]).to eq("You have 3 products.")
+      expect(persisted[:reply]).to eq("You have 3 products.")
+      expect(events.any? { |event, _| event == :reset }).to be(false)
+    end
+
+    it "does not accept streamed text-only after a blank complete_turn" do
+      stub_stream_turns(
+        { stream: [], result: complete_turn_result("", outcome: "reply_only") },
+        { stream: ["You have 3 products."], result: untyped_text_result("You have 3 products.") },
+      )
+      allow(client).to receive(:messages).and_return(text_result("[]"))
+
+      events, result = collect_events([{ role: "user", content: "How many products?" }])
+      visible_reply = events.each_with_object(+"") do |(event, payload), text|
+        text.clear if event == :reset
+        text << payload[:text] if event == :token
+      end
+
+      expect(result[:reply]).to eq(described_class::TURN_CONTRACT_FAILURE_REPLY)
+      expect(visible_reply).to eq(described_class::TURN_CONTRACT_FAILURE_REPLY)
+      expect(visible_reply).not_to eq("You have 3 products.")
+    end
+
+    it "replaces streamed channel text with the complete_turn reply when they disagree" do
+      stub_stream_turns(
+        { stream: ["partial channel text"], result: complete_turn_result("partial channel text", outcome: "reply_only", reply: "You have 3 products.") },
+      )
+      allow(client).to receive(:messages).and_return(text_result("[]"))
+
+      events, result = collect_events([{ role: "user", content: "How many products?" }])
+      visible_reply = events.each_with_object(+"") do |(event, payload), text|
+        text.clear if event == :reset
+        text << payload[:text] if event == :token
+      end
+
+      expect(events).to include([:reset, {}])
+      expect(visible_reply).to eq("You have 3 products.")
+      expect(result[:reply]).to eq("You have 3 products.")
     end
   end
 

--- a/spec/services/ai/store_agent_service_spec.rb
+++ b/spec/services/ai/store_agent_service_spec.rb
@@ -323,6 +323,8 @@ describe Ai::StoreAgentService do
           outcome: "gave up",
         )
         allow(Rails.logger).to receive(:warn)
+        logged = []
+        allow(Rails.logger).to receive(:info) { |message| logged << message }
         allow(client).to receive(:messages).and_return(untyped_text_result("Still no marker."))
 
         result = service.respond(messages: [{ role: "user", content: "what sells best?" }])
@@ -330,6 +332,17 @@ describe Ai::StoreAgentService do
         expect(Rails.logger).to have_received(:warn).with("Store agent final turn did not match proposal state (missing_complete_turn, gave up)")
         expect(client).to have_received(:messages).twice
         expect(result[:reply]).to eq(described_class::TURN_CONTRACT_FAILURE_REPLY)
+        turn_log = logged.filter_map do |message|
+          next unless message.is_a?(String) && message.include?("store_agent_turn")
+
+          JSON.parse(message)
+        end.last
+        expect(turn_log).to include(
+          "event" => "store_agent_turn",
+          "contract_failure" => "missing_complete_turn",
+          "requested_model" => turn_log["model"],
+        )
+        expect(turn_log["served_models"]).to eq([])
       end
 
       it "still reports a non-marker proposal-state mismatch on the retry" do


### PR DESCRIPTION
Premerge review: clean @ bf4629e4340698ed443738b5ea06617640696d4f

## What

Repair store-agent replies and stream reliability on the incumbent model.

`complete_turn.reply` can carry the answer together with the terminal outcome. The existing valid text-plus-tool format stays compatible. Blank or non-string replies, mixed or duplicate terminal tools, forged proposals, and phantom staging are still rejected. Streaming emits the validated reply; changes still require explicit confirmation.

Served-model and terminal-contract-failure telemetry is recorded without logging reply content.

On web, follow-up suggestion generation no longer holds the composer. Late callbacks from an older stream cannot mutate a newer turn, and an empty `done.suggestions` array does not wipe chips that already arrived on the same turn. Mobile keeps the shipped terminal contract: `done` is written after suggestions are populated, and the internal `turn_ready` marker is not forwarded.

This PR does not change the DeepSeek model version. The V4.1 trial is https://github.com/antiwork/gumroad/pull/7594.

**Draft. Not merge-ready. No production rollout. DeepSeek adoption is not a merge criterion.** Stream-safety screenshots name `92dd5ba77a`; `AgentChat.tsx` changed after that SHA.

Greptile P2 at `cd0a9144d` (overlong stream comments): trimmed at `903b78a1ae`. Comment-only.

## Stream-safety QA (head `92dd5ba77a8b0d4dc7b4ca0cb7a8ff63b2894f25`)

Controlled delayed-SSE harness of the real `AgentChat` component:

- Composer unlocks on `done` before chips.
- Same-turn late chips still appear.
- A second send drops the old chips; the old stream cannot paint a stale chip onto the new turn.
- Follow-ups stay enabled.

![Composer unlocked after done, chips not yet shown](https://github.com/user-attachments/assets/719b1e23-2b43-4810-ac0a-366c4a34c800)
![Same-turn late suggestion chips after done](https://github.com/user-attachments/assets/ca61a0b6-f794-4f84-841f-1a95549dd127)
![Second turn reply; old chips gone, new chip present](https://github.com/user-attachments/assets/9fe40679-881a-4b63-9a86-231ebea46458)

## Walkthrough

https://github.com/user-attachments/assets/1a67bac1-d079-405f-b135-b6bea8e95640

## Tests at this head

- Vitest: `AgentChat.streamSafety.test.tsx`, `AgentChat.test.tsx`, `agent.test.ts` — 77 passed.
- RSpec: mobile + internal stream controllers and `spec/requests/agent_spec.rb` — 50 examples, 0 failures.

## CI

GitHub Actions Fast/Slow, Minitest, lint/typecheck, Buildkite, and `ci/green` succeeded at `903b78a1ae`. This PR pins MinIO/mc to `quay.io` (same release tags) so CI is not blocked on Docker Hub `minio/minio` pulls.

## Historical evidence (old SHAs only)

These results certify the named SHA, not current head:

- At `0c210ead99fd9025a7c120ef7e1348a7ee2843ec` / `2b311c6eec9c1963b7067efdb20c76b8e109b5ec`: atomic `complete_turn.reply` plus telemetry. Targeted examples failed on old code and passed with the repair. Service + message/stream-controller specs: 202 examples, 0 failures. Real HTTP/SSE matched batch: 50 turns, 0 terminal-contract give-ups, 30 write confirmations applied only after confirmation, 30 repeats rejected.
- Astra + Fable was clean at `2b311c6eec9c1963b7067efdb20c76b8e109b5ec`. That marker does not apply after later commits or this split.
- Latency profiling at the later stream-unlock commits did not pass versus Opus. That bar is independent of this reliability PR.

## Checklist

- [x] Scope: reply contract, stream reliability, and telemetry on the incumbent. No DeepSeek version change.
- [x] Design: atomic answer-plus-outcome with legacy compatibility and unchanged confirmation safeguards.
- [x] Build: protocol, regression coverage, generation-scoped stream callbacks, mobile terminal `done`.
- [x] QA: delayed-SSE browser harness at `92dd5ba77a` plus unit/controller specs. `AgentChat.tsx` changed after that SHA; current-head GitHub CI is green.
- [ ] Shipped: not merged or enabled; no cron retiering.
- [x] Market: internal reliability; no announcement.
- [x] Sell: not applicable.

AI assistance: Grok 4.6 implementation. Task: repair dropped store-agent answers and stream reliability without weakening safeguards.

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: the ball is back with me (gianfrancopiana commented after my last word (2026-09-11T23:04) — unanswered), so I'm taking the assignee back and labelling `working`. I'll re-assign a human and flip to `awaiting-human` once it's genuinely ready again.
<!-- gumclaw-ownership-sweep -->

