### PR TITLE
Sum uncleared PayPal top-ups of any amount

### DIFF
--- a/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
+++ b/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
@@ -680,22 +680,50 @@ class PaypalPayoutProcessor
     (response["L_AMT0"].to_d * 100).to_i
   end
 
-  # Bank-account top-ups are not searchable by type. Sum every uncleared
-  # bank Transfer in the last two weeks, whatever the amount.
+  # Bank-account top-ups are not searchable by type. FundsAdded keeps
+  # TransactionSearch on deposits so the 100-row cap is less likely to
+  # hide an uncleared Transfer. If PayPal still truncates (warning 11002),
+  # page older windows until the two-week range is complete.
   def self.topup_amount_in_transit
-    params = PAYPAL_API_PARAMS.merge("METHOD" => "TransactionSearch",
-                                     "STARTDATE" => 2.weeks.ago.iso8601)
-    paypal_response = HTTParty.post(PAYPAL_ENDPOINT, body: params)
-    response = Rack::Utils.parse_nested_query(paypal_response.parsed_response)
-    return 0 unless %w[Success SuccessWithWarning].include?(response["ACK"])
-
+    seen = {}
     topup_amount = 0.to_d
-    response.keys.count { _1.include?("L_TRANSACTIONID") }.times do |i|
-      next unless response["L_TYPE#{i}"] == "Transfer" &&
-        response["L_NAME#{i}"] == "Bank Account" &&
-        response["L_STATUS#{i}"] == "Uncleared"
+    start_date = 2.weeks.ago
+    end_date = nil
 
-      topup_amount += response["L_AMT#{i}"].to_d
+    10.times do
+      params = PAYPAL_API_PARAMS.merge(
+        "METHOD" => "TransactionSearch",
+        "TRANSACTIONCLASS" => "FundsAdded",
+        "STARTDATE" => start_date.iso8601
+      )
+      params["ENDDATE"] = end_date.iso8601 if end_date
+      paypal_response = HTTParty.post(PAYPAL_ENDPOINT, body: params)
+      response = Rack::Utils.parse_nested_query(paypal_response.parsed_response)
+      return topup_amount unless %w[Success SuccessWithWarning].include?(response["ACK"])
+
+      count = response.keys.count { _1.include?("L_TRANSACTIONID") }
+      oldest_ts = nil
+      count.times do |i|
+        txn_id = response["L_TRANSACTIONID#{i}"]
+        ts = Time.iso8601(response["L_TIMESTAMP#{i}"]) if response["L_TIMESTAMP#{i}"].present?
+        oldest_ts = ts if ts && (oldest_ts.nil? || ts < oldest_ts)
+        next if txn_id.blank? || seen[txn_id]
+
+        seen[txn_id] = true
+        next unless response["L_TYPE#{i}"] == "Transfer" &&
+          response["L_NAME#{i}"] == "Bank Account" &&
+          response["L_STATUS#{i}"] == "Uncleared"
+
+        topup_amount += response["L_AMT#{i}"].to_d
+      end
+
+      truncated = response.keys.any? { |k| k.start_with?("L_ERRORCODE") && response[k] == "11002" }
+      break unless truncated
+      if oldest_ts.blank? || oldest_ts <= start_date
+        raise "PayPal TransactionSearch truncated (11002); cannot page older than #{oldest_ts.inspect}"
+      end
+
+      end_date = oldest_ts - 1.second
     end
     topup_amount
   end

--- a/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
+++ b/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
@@ -17,6 +17,9 @@ class PaypalPayoutProcessor
   PAYOUT_RECIPIENTS_PER_JOB = 240 # Max recipients allowed in one API call is 250. Using 240 because I don't trust PayPal.
   PAYPAL_PAYOUT_FEE_PERCENT = 2
   PAYPAL_PAYOUT_FEE_EXEMPT_COUNTRY_CODES = [Compliance::Countries::BRA.alpha2, Compliance::Countries::IND.alpha2]
+  # Safety valve against a stalled cursor, not a volume cap. The payout
+  # account's two-week TransactionSearch can exceed 1,000 rows.
+  TOPUP_SEARCH_PAGE_LIMIT = 100
 
   # Countries where a PayPal account registered there can RECEIVE a payout from us.
   # Ref: https://docs.paypal.ai/growth/payouts/reference/countries-supported-features
@@ -691,7 +694,7 @@ class PaypalPayoutProcessor
     end_date = nil
     truncated = false
 
-    10.times do
+    TOPUP_SEARCH_PAGE_LIMIT.times do
       params = PAYPAL_API_PARAMS.merge(
         "METHOD" => "TransactionSearch",
         "STARTDATE" => start_date.iso8601

--- a/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
+++ b/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
@@ -680,31 +680,23 @@ class PaypalPayoutProcessor
     (response["L_AMT0"].to_d * 100).to_i
   end
 
-  # This method assumes that each topup is made for $100,000.
-  # We've always made topups in chunks of $100,000 so far.
-  # If that ever changes, this method will need to be updated accordingly.
-  # The bank account transfer transactions are not searchable by type,
-  # so using the $100,000 amount to easily search for them here.
+  # Bank-account top-ups are not searchable by type. Sum every uncleared
+  # bank Transfer in the last two weeks, whatever the amount.
   def self.topup_amount_in_transit
-    individual_topup_amount = 100000
-
     params = PAYPAL_API_PARAMS.merge("METHOD" => "TransactionSearch",
-                                     "AMT" => individual_topup_amount.to_s,
-                                     "STARTDATE" => 2.weeks.ago.iso8601) # Topups older than 2 weeks should have already completed
+                                     "STARTDATE" => 2.weeks.ago.iso8601)
     paypal_response = HTTParty.post(PAYPAL_ENDPOINT, body: params)
     response = Rack::Utils.parse_nested_query(paypal_response.parsed_response)
     return 0 unless %w[Success SuccessWithWarning].include?(response["ACK"])
 
-    topup_amount = 0
-
-    number_of_topups_made = response.keys.select { _1.include?("L_TRANSACTIONID") }.count
-    number_of_topups_made.times do |i|
-      topup_amount += individual_topup_amount if response["L_TYPE#{i}"] == "Transfer" &&
+    topup_amount = 0.to_d
+    response.keys.count { _1.include?("L_TRANSACTIONID") }.times do |i|
+      next unless response["L_TYPE#{i}"] == "Transfer" &&
         response["L_NAME#{i}"] == "Bank Account" &&
-        response["L_STATUS#{i}"] == "Uncleared" &&
-        response["L_AMT#{i}"].to_i == individual_topup_amount
-    end
+        response["L_STATUS#{i}"] == "Uncleared"
 
-    topup_amount
+      topup_amount += response["L_AMT#{i}"].to_d
+    end
+    topup_amount.to_i
   end
 end

--- a/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
+++ b/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
@@ -697,6 +697,6 @@ class PaypalPayoutProcessor
 
       topup_amount += response["L_AMT#{i}"].to_d
     end
-    topup_amount.to_i
+    topup_amount
   end
 end

--- a/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
+++ b/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
@@ -689,6 +689,7 @@ class PaypalPayoutProcessor
     topup_amount = 0.to_d
     start_date = 2.weeks.ago
     end_date = nil
+    truncated = false
 
     10.times do
       params = PAYPAL_API_PARAMS.merge(
@@ -699,10 +700,19 @@ class PaypalPayoutProcessor
       params["ENDDATE"] = end_date.iso8601 if end_date
       paypal_response = HTTParty.post(PAYPAL_ENDPOINT, body: params)
       response = Rack::Utils.parse_nested_query(paypal_response.parsed_response)
-      return topup_amount unless %w[Success SuccessWithWarning].include?(response["ACK"])
+      unless %w[Success SuccessWithWarning].include?(response["ACK"])
+        # First request still fail-opens to 0 (pre-existing). A later page
+        # that fails after a truncated success would otherwise publish a
+        # partial in-transit total and over-recommend a bank top-up.
+        if seen.any? || end_date
+          raise "PayPal TransactionSearch failed (ACK=#{response["ACK"].inspect})"
+        end
+        return topup_amount
+      end
 
       count = response.keys.count { _1.include?("L_TRANSACTIONID") }
       oldest_ts = nil
+      new_ids = 0
       count.times do |i|
         txn_id = response["L_TRANSACTIONID#{i}"]
         ts = Time.iso8601(response["L_TIMESTAMP#{i}"]) if response["L_TIMESTAMP#{i}"].present?
@@ -710,6 +720,7 @@ class PaypalPayoutProcessor
         next if txn_id.blank? || seen[txn_id]
 
         seen[txn_id] = true
+        new_ids += 1
         next unless response["L_TYPE#{i}"] == "Transfer" &&
           response["L_NAME#{i}"] == "Bank Account" &&
           response["L_STATUS#{i}"] == "Uncleared"
@@ -719,11 +730,17 @@ class PaypalPayoutProcessor
 
       truncated = response.keys.any? { |k| k.start_with?("L_ERRORCODE") && response[k] == "11002" }
       break unless truncated
-      if oldest_ts.blank? || oldest_ts <= start_date
+      if oldest_ts.blank? || oldest_ts <= start_date || new_ids.zero?
         raise "PayPal TransactionSearch truncated (11002); cannot page older than #{oldest_ts.inspect}"
       end
 
-      end_date = oldest_ts - 1.second
+      # ENDDATE is inclusive. Keep the oldest returned timestamp so a
+      # same-second row that did not fit on this page is not skipped;
+      # seen[] drops the overlap.
+      end_date = oldest_ts
+    end
+    if truncated
+      raise "PayPal TransactionSearch truncated (11002); pagination budget exhausted"
     end
     topup_amount
   end

--- a/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
+++ b/app/business/payments/payouts/processor/paypal/paypal_payout_processor.rb
@@ -680,10 +680,10 @@ class PaypalPayoutProcessor
     (response["L_AMT0"].to_d * 100).to_i
   end
 
-  # Bank-account top-ups are not searchable by type. FundsAdded keeps
-  # TransactionSearch on deposits so the 100-row cap is less likely to
-  # hide an uncleared Transfer. If PayPal still truncates (warning 11002),
-  # page older windows until the two-week range is complete.
+  # Bank-account top-ups are not searchable by type or amount. Do not
+  # send TRANSACTIONCLASS or AMT; keep Transfer / Bank Account /
+  # Uncleared in Ruby. If PayPal truncates (warning 11002), page older
+  # windows until the two-week range is complete.
   def self.topup_amount_in_transit
     seen = {}
     topup_amount = 0.to_d
@@ -694,7 +694,6 @@ class PaypalPayoutProcessor
     10.times do
       params = PAYPAL_API_PARAMS.merge(
         "METHOD" => "TransactionSearch",
-        "TRANSACTIONCLASS" => "FundsAdded",
         "STARTDATE" => start_date.iso8601
       )
       params["ENDDATE"] = end_date.iso8601 if end_date

--- a/app/services/paypal_balance_check_service.rb
+++ b/app/services/paypal_balance_check_service.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 class PaypalBalanceCheckService
+  # payouts_paypal in config/sidekiq_schedule.yml: Friday 10:00 UTC.
+  PAYPAL_PAYOUT_HOUR_UTC = 10
+
   def initialize
+    @payout_date = self.class.next_paypal_payout_date
     @payout_amount_cents = calculate_payout_amount_cents
     @current_balance_cents = PaypalPayoutProcessor.current_paypal_balance_cents
     @topup_in_transit_cents = PaypalPayoutProcessor.topup_amount_in_transit * 100
   end
 
-  attr_reader :payout_amount_cents, :current_balance_cents, :topup_in_transit_cents
+  attr_reader :payout_date, :payout_amount_cents, :current_balance_cents, :topup_in_transit_cents
 
   def topup_amount_cents
     @topup_amount_cents ||= payout_amount_cents - current_balance_cents - topup_in_transit_cents
@@ -15,6 +19,14 @@ class PaypalBalanceCheckService
 
   def topup_needed?
     topup_amount_cents > 0
+  end
+
+  def self.next_paypal_payout_date
+    now = Time.current.utc
+    today = now.to_date
+    friday = today.friday? ? today : today.next_occurring(:friday)
+    run_at = Time.utc(friday.year, friday.month, friday.day, PAYPAL_PAYOUT_HOUR_UTC)
+    now >= run_at ? friday + 7 : friday
   end
 
   private
@@ -25,7 +37,7 @@ class PaypalBalanceCheckService
                           .where("created_at > ?", 1.month.ago)
                           .where(processor: "paypal")
                           .select(:user_id))
-        .where("date <= ?", User::PayoutSchedule.next_scheduled_payout_date)
+        .where("date <= ?", payout_date)
         .sum(:amount_cents)
     end
 end

--- a/app/services/paypal_balance_check_service.rb
+++ b/app/services/paypal_balance_check_service.rb
@@ -8,7 +8,7 @@ class PaypalBalanceCheckService
     @payout_date = self.class.next_paypal_payout_date
     @payout_amount_cents = calculate_payout_amount_cents
     @current_balance_cents = PaypalPayoutProcessor.current_paypal_balance_cents
-    @topup_in_transit_cents = PaypalPayoutProcessor.topup_amount_in_transit * 100
+    @topup_in_transit_cents = (PaypalPayoutProcessor.topup_amount_in_transit.to_d * 100).to_i
   end
 
   attr_reader :payout_date, :payout_amount_cents, :current_balance_cents, :topup_in_transit_cents
@@ -37,7 +37,9 @@ class PaypalBalanceCheckService
                           .where("created_at > ?", 1.month.ago)
                           .where(processor: "paypal")
                           .select(:user_id))
-        .where("date <= ?", payout_date)
+        # payout_date is hour-aware and becomes next Friday after 10:00 UTC.
+        # The named MassPay still only pays balances through this week's Friday.
+        .where("date <= ?", User::PayoutSchedule.next_scheduled_payout_date)
         .sum(:amount_cents)
     end
 end

--- a/app/sidekiq/send_paypal_topup_notification_job.rb
+++ b/app/sidekiq/send_paypal_topup_notification_job.rb
@@ -19,7 +19,8 @@ class SendPaypalTopupNotificationJob
 
     return if notify_only_if_topup_needed && !balance_check.topup_needed?
 
-    notification_msg = "PayPal balance needs to be #{formatted_dollar_amount(balance_check.payout_amount_cents)} by Friday to payout all creators.\n"\
+    payout_on = balance_check.payout_date.strftime("%A, %B %-d")
+    notification_msg = "PayPal balance needs to be #{formatted_dollar_amount(balance_check.payout_amount_cents)} by #{payout_on} to payout all creators.\n"\
                        "Current PayPal balance is #{formatted_dollar_amount(balance_check.current_balance_cents)}.\n"
 
     notification_msg += "Top-up amount in transit is #{formatted_dollar_amount(balance_check.topup_in_transit_cents)}.\n" if balance_check.topup_in_transit_cents > 0

--- a/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
@@ -1508,6 +1508,7 @@ describe PaypalPayoutProcessor do
       expect(HTTParty).to receive(:post) do |_url, opts|
         expect(opts[:body]["AMT"]).to be_nil
         expect(opts[:body]["METHOD"]).to eq("TransactionSearch")
+        expect(opts[:body]["TRANSACTIONCLASS"]).to eq("FundsAdded")
         paypal_nvp("ACK" => "Success")
       end
 
@@ -1563,6 +1564,46 @@ describe PaypalPayoutProcessor do
       allow(HTTParty).to receive(:post).and_return(paypal_nvp("ACK" => "Failure"))
 
       expect(described_class.topup_amount_in_transit).to eq(0)
+    end
+
+    it "pages older windows when TransactionSearch is truncated" do
+      first = paypal_nvp(
+        "ACK" => "SuccessWithWarning",
+        "L_ERRORCODE0" => "11002",
+        "L_TRANSACTIONID0" => "txn_recent",
+        "L_TIMESTAMP0" => "2026-09-11T12:00:00Z",
+        "L_TYPE0" => "Transfer",
+        "L_NAME0" => "Bank Account",
+        "L_STATUS0" => "Uncleared",
+        "L_AMT0" => "25000.00"
+      )
+      second = paypal_nvp(
+        "ACK" => "Success",
+        "L_TRANSACTIONID0" => "txn_older",
+        "L_TIMESTAMP0" => "2026-09-01T12:00:00Z",
+        "L_TYPE0" => "Transfer",
+        "L_NAME0" => "Bank Account",
+        "L_STATUS0" => "Uncleared",
+        "L_AMT0" => "100000.00"
+      )
+      expect(HTTParty).to receive(:post).ordered do |_url, opts|
+        expect(opts[:body]["ENDDATE"]).to be_nil
+        first
+      end
+      expect(HTTParty).to receive(:post).ordered do |_url, opts|
+        expect(opts[:body]["ENDDATE"]).to eq("2026-09-11T11:59:59Z")
+        second
+      end
+
+      expect(described_class.topup_amount_in_transit).to eq(125_000)
+    end
+
+    it "raises when truncation cannot be paged" do
+      allow(HTTParty).to receive(:post).and_return(
+        paypal_nvp("ACK" => "SuccessWithWarning", "L_ERRORCODE0" => "11002")
+      )
+
+      expect { described_class.topup_amount_in_transit }.to raise_error(/truncated \(11002\)/)
     end
   end
 end

--- a/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
@@ -1510,7 +1510,7 @@ describe PaypalPayoutProcessor do
       expect(HTTParty).to receive(:post) do |_url, opts|
         expect(opts[:body]["AMT"]).to be_nil
         expect(opts[:body]["METHOD"]).to eq("TransactionSearch")
-        expect(opts[:body]["TRANSACTIONCLASS"]).to eq("FundsAdded")
+        expect(opts[:body]["TRANSACTIONCLASS"]).to be_nil
         paypal_nvp("ACK" => "Success")
       end
 

--- a/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
@@ -1500,6 +1500,8 @@ describe PaypalPayoutProcessor do
   end
 
   describe ".topup_amount_in_transit" do
+    around { |example| travel_to(Time.utc(2026, 9, 11, 14, 0, 0)) { example.run } }
+
     def paypal_nvp(pairs)
       instance_double(HTTParty::Response, parsed_response: Rack::Utils.build_query(pairs))
     end

--- a/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
@@ -1498,4 +1498,56 @@ describe PaypalPayoutProcessor do
       expect(payment.reload.failure_reason).to eq("PAYPAL 3148")
     end
   end
+
+  describe ".topup_amount_in_transit" do
+    def paypal_nvp(pairs)
+      instance_double(HTTParty::Response, parsed_response: Rack::Utils.build_query(pairs))
+    end
+
+    it "does not filter TransactionSearch by amount" do
+      expect(HTTParty).to receive(:post) do |_url, opts|
+        expect(opts[:body]["AMT"]).to be_nil
+        expect(opts[:body]["METHOD"]).to eq("TransactionSearch")
+        paypal_nvp("ACK" => "Success")
+      end
+
+      expect(described_class.topup_amount_in_transit).to eq(0)
+    end
+
+    it "sums uncleared bank-account transfers of any amount" do
+      allow(HTTParty).to receive(:post).and_return(
+        paypal_nvp(
+          "ACK" => "Success",
+          "L_TRANSACTIONID0" => "txn_small",
+          "L_TYPE0" => "Transfer",
+          "L_NAME0" => "Bank Account",
+          "L_STATUS0" => "Uncleared",
+          "L_AMT0" => "25000.00",
+          "L_TRANSACTIONID1" => "txn_large",
+          "L_TYPE1" => "Transfer",
+          "L_NAME1" => "Bank Account",
+          "L_STATUS1" => "Uncleared",
+          "L_AMT1" => "100000.00",
+          "L_TRANSACTIONID2" => "txn_cleared",
+          "L_TYPE2" => "Transfer",
+          "L_NAME2" => "Bank Account",
+          "L_STATUS2" => "Completed",
+          "L_AMT2" => "100000.00",
+          "L_TRANSACTIONID3" => "txn_other",
+          "L_TYPE3" => "Payment",
+          "L_NAME3" => "Someone",
+          "L_STATUS3" => "Uncleared",
+          "L_AMT3" => "50.00"
+        )
+      )
+
+      expect(described_class.topup_amount_in_transit).to eq(125_000)
+    end
+
+    it "returns 0 when ACK is not success" do
+      allow(HTTParty).to receive(:post).and_return(paypal_nvp("ACK" => "Failure"))
+
+      expect(described_class.topup_amount_in_transit).to eq(0)
+    end
+  end
 end

--- a/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
@@ -1663,7 +1663,8 @@ describe PaypalPayoutProcessor do
       expect(described_class.topup_amount_in_transit).to eq(125_000)
     end
 
-    it "raises when ten truncated pages still omit results" do
+    it "raises when the page limit is exhausted while still truncated" do
+      stub_const("#{described_class}::TOPUP_SEARCH_PAGE_LIMIT", 3)
       allow(HTTParty).to receive(:post) do |_url, opts|
         n = @page_n.to_i
         @page_n = n + 1

--- a/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
@@ -1591,7 +1591,7 @@ describe PaypalPayoutProcessor do
         first
       end
       expect(HTTParty).to receive(:post).ordered do |_url, opts|
-        expect(opts[:body]["ENDDATE"]).to eq("2026-09-11T11:59:59Z")
+        expect(opts[:body]["ENDDATE"]).to eq("2026-09-11T12:00:00Z")
         second
       end
 
@@ -1604,6 +1604,80 @@ describe PaypalPayoutProcessor do
       )
 
       expect { described_class.topup_amount_in_transit }.to raise_error(/truncated \(11002\)/)
+    end
+
+    it "raises when a continuation request fails after a truncated page" do
+      first = paypal_nvp(
+        "ACK" => "SuccessWithWarning",
+        "L_ERRORCODE0" => "11002",
+        "L_TRANSACTIONID0" => "txn_recent",
+        "L_TIMESTAMP0" => "2026-09-11T12:00:00Z",
+        "L_TYPE0" => "Transfer",
+        "L_NAME0" => "Bank Account",
+        "L_STATUS0" => "Uncleared",
+        "L_AMT0" => "25000.00"
+      )
+      expect(HTTParty).to receive(:post).ordered.and_return(first)
+      expect(HTTParty).to receive(:post).ordered.and_return(paypal_nvp("ACK" => "Failure"))
+
+      expect { described_class.topup_amount_in_transit }.to raise_error(/ACK="Failure"/)
+    end
+
+    it "keeps uncleared transfers that share the truncated page's oldest timestamp" do
+      first = paypal_nvp(
+        "ACK" => "SuccessWithWarning",
+        "L_ERRORCODE0" => "11002",
+        "L_TRANSACTIONID0" => "txn_recent",
+        "L_TIMESTAMP0" => "2026-09-11T12:00:00Z",
+        "L_TYPE0" => "Transfer",
+        "L_NAME0" => "Bank Account",
+        "L_STATUS0" => "Uncleared",
+        "L_AMT0" => "25000.00"
+      )
+      second = paypal_nvp(
+        "ACK" => "Success",
+        "L_TRANSACTIONID0" => "txn_recent",
+        "L_TIMESTAMP0" => "2026-09-11T12:00:00Z",
+        "L_TYPE0" => "Transfer",
+        "L_NAME0" => "Bank Account",
+        "L_STATUS0" => "Uncleared",
+        "L_AMT0" => "25000.00",
+        "L_TRANSACTIONID1" => "txn_same_second",
+        "L_TIMESTAMP1" => "2026-09-11T12:00:00Z",
+        "L_TYPE1" => "Transfer",
+        "L_NAME1" => "Bank Account",
+        "L_STATUS1" => "Uncleared",
+        "L_AMT1" => "100000.00"
+      )
+      expect(HTTParty).to receive(:post).ordered do |_url, opts|
+        expect(opts[:body]["ENDDATE"]).to be_nil
+        first
+      end
+      expect(HTTParty).to receive(:post).ordered do |_url, opts|
+        expect(opts[:body]["ENDDATE"]).to eq("2026-09-11T12:00:00Z")
+        second
+      end
+
+      expect(described_class.topup_amount_in_transit).to eq(125_000)
+    end
+
+    it "raises when ten truncated pages still omit results" do
+      allow(HTTParty).to receive(:post) do |_url, opts|
+        n = @page_n.to_i
+        @page_n = n + 1
+        paypal_nvp(
+          "ACK" => "SuccessWithWarning",
+          "L_ERRORCODE0" => "11002",
+          "L_TRANSACTIONID0" => "txn_#{n}",
+          "L_TIMESTAMP0" => (Time.iso8601("2026-09-11T12:00:00Z") - n.seconds).iso8601,
+          "L_TYPE0" => "Transfer",
+          "L_NAME0" => "Bank Account",
+          "L_STATUS0" => "Uncleared",
+          "L_AMT0" => "1.00"
+        )
+      end
+
+      expect { described_class.topup_amount_in_transit }.to raise_error(/pagination budget exhausted/)
     end
   end
 end

--- a/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
+++ b/spec/business/payments/payouts/processor/paypal/paypal_payout_processor_spec.rb
@@ -1544,6 +1544,21 @@ describe PaypalPayoutProcessor do
       expect(described_class.topup_amount_in_transit).to eq(125_000)
     end
 
+    it "keeps fractional transfer dollars" do
+      allow(HTTParty).to receive(:post).and_return(
+        paypal_nvp(
+          "ACK" => "Success",
+          "L_TRANSACTIONID0" => "txn_cents",
+          "L_TYPE0" => "Transfer",
+          "L_NAME0" => "Bank Account",
+          "L_STATUS0" => "Uncleared",
+          "L_AMT0" => "25000.50"
+        )
+      )
+
+      expect(described_class.topup_amount_in_transit).to eq(BigDecimal("25000.50"))
+    end
+
     it "returns 0 when ACK is not success" do
       allow(HTTParty).to receive(:post).and_return(paypal_nvp("ACK" => "Failure"))
 

--- a/spec/services/paypal_balance_check_service_spec.rb
+++ b/spec/services/paypal_balance_check_service_spec.rb
@@ -92,6 +92,15 @@ describe PaypalBalanceCheckService do
       service = described_class.new
       expect(service.topup_in_transit_cents).to eq(100_000_00)
     end
+
+    context "when the in-transit amount has cents" do
+      let(:topup_in_transit_dollars) { BigDecimal("25000.50") }
+
+      it "keeps the fractional dollars" do
+        service = described_class.new
+        expect(service.topup_in_transit_cents).to eq(2_500_050)
+      end
+    end
   end
 
   describe "#topup_amount_cents" do
@@ -104,6 +113,23 @@ describe PaypalBalanceCheckService do
     it "returns the amount needed to top up" do
       service = described_class.new
       expect(service.topup_amount_cents).to eq(100_000_00)
+    end
+  end
+
+  describe "#payout_amount_cents after Friday's PayPal run" do
+    let(:seller) { create(:user) }
+    let!(:payment) { create(:payment, user: seller, processor: "paypal", created_at: Time.utc(2026, 9, 4)) }
+    let(:current_balance_cents) { 0 }
+
+    it "does not count balances past this week's Friday" do
+      travel_to Time.utc(2026, 9, 11, 14, 0, 0) do
+        create(:balance, user: seller, date: Date.new(2026, 9, 11), amount_cents: 10_000_00)
+        create(:balance, user: seller, date: Date.new(2026, 9, 12), amount_cents: 99_000_00)
+
+        service = described_class.new
+        expect(service.payout_date).to eq(Date.new(2026, 9, 18))
+        expect(service.payout_amount_cents).to eq(10_000_00)
+      end
     end
   end
 

--- a/spec/services/paypal_balance_check_service_spec.rb
+++ b/spec/services/paypal_balance_check_service_spec.rb
@@ -106,4 +106,24 @@ describe PaypalBalanceCheckService do
       expect(service.topup_amount_cents).to eq(100_000_00)
     end
   end
+
+  describe ".next_paypal_payout_date" do
+    it "returns this week's Friday before the 10:00 UTC payout" do
+      travel_to Time.utc(2026, 9, 11, 9, 59, 0) do
+        expect(described_class.next_paypal_payout_date).to eq(Date.new(2026, 9, 11))
+      end
+    end
+
+    it "returns next Friday once the 10:00 UTC payout has started" do
+      travel_to Time.utc(2026, 9, 11, 10, 0, 0) do
+        expect(described_class.next_paypal_payout_date).to eq(Date.new(2026, 9, 18))
+      end
+    end
+
+    it "returns this week's Friday on a weekday before Friday" do
+      travel_to Time.utc(2026, 9, 9, 14, 0, 0) do
+        expect(described_class.next_paypal_payout_date).to eq(Date.new(2026, 9, 11))
+      end
+    end
+  end
 end

--- a/spec/sidekiq/send_paypal_topup_notification_job_spec.rb
+++ b/spec/sidekiq/send_paypal_topup_notification_job_spec.rb
@@ -2,6 +2,10 @@
 
 describe SendPaypalTopupNotificationJob do
   describe "#perform" do
+    around do |example|
+      travel_to(Time.utc(2026, 9, 9, 14, 0, 0)) { example.run }
+    end
+
     before do
       seller = create(:user, unpaid_balance_cents: 152_279_86)
       seller2 = create(:user, unpaid_balance_cents: 215_145_32)
@@ -15,7 +19,7 @@ describe SendPaypalTopupNotificationJob do
     it "sends a notification with the required topup amount and sets redis key to true" do
       allow(PaypalPayoutProcessor).to receive(:topup_amount_in_transit).and_return(0)
 
-      notification_msg = "PayPal balance needs to be $367,425.18 by Friday to payout all creators.\n"\
+      notification_msg = "PayPal balance needs to be $367,425.18 by Friday, September 11 to payout all creators.\n"\
                        "Current PayPal balance is $125,000.\n"\
                        "A top-up of $242,425.18 is needed."
 
@@ -28,7 +32,7 @@ describe SendPaypalTopupNotificationJob do
     it "includes details of payout amount in transit in the notification" do
       allow(PaypalPayoutProcessor).to receive(:topup_amount_in_transit).and_return(100_000)
 
-      notification_msg = "PayPal balance needs to be $367,425.18 by Friday to payout all creators.\n"\
+      notification_msg = "PayPal balance needs to be $367,425.18 by Friday, September 11 to payout all creators.\n"\
                        "Current PayPal balance is $125,000.\n"\
                        "Top-up amount in transit is $100,000.\n"\
                        "A top-up of $142,425.18 is needed."
@@ -41,7 +45,7 @@ describe SendPaypalTopupNotificationJob do
     it "sends no more topup required green notification and sets redis key to false if there's sufficient amount in PayPal" do
       allow(PaypalPayoutProcessor).to receive(:topup_amount_in_transit).and_return(300_000)
 
-      notification_msg = "PayPal balance needs to be $367,425.18 by Friday to payout all creators.\n"\
+      notification_msg = "PayPal balance needs to be $367,425.18 by Friday, September 11 to payout all creators.\n"\
                        "Current PayPal balance is $125,000.\n"\
                        "Top-up amount in transit is $300,000.\n"\
                        "No more top-up required."
@@ -56,7 +60,7 @@ describe SendPaypalTopupNotificationJob do
       it "sends notification when topup is needed" do
         allow(PaypalPayoutProcessor).to receive(:topup_amount_in_transit).and_return(0)
 
-        notification_msg = "PayPal balance needs to be $367,425.18 by Friday to payout all creators.\n"\
+        notification_msg = "PayPal balance needs to be $367,425.18 by Friday, September 11 to payout all creators.\n"\
                          "Current PayPal balance is $125,000.\n"\
                          "A top-up of $242,425.18 is needed."
 
@@ -72,6 +76,22 @@ describe SendPaypalTopupNotificationJob do
 
         expect(InternalNotificationWorker.jobs.size).to eq(0)
         expect($redis.get(RedisKey.paypal_topup_needed)).to eq("false")
+      end
+    end
+
+    context "after Friday's PayPal payout has run" do
+      around do |example|
+        travel_to(Time.utc(2026, 9, 11, 14, 0, 0)) { example.run }
+      end
+
+      it "names next Friday, not today" do
+        allow(PaypalPayoutProcessor).to receive(:topup_amount_in_transit).and_return(0)
+
+        described_class.new.perform
+
+        expect(InternalNotificationWorker.jobs.size).to eq(1)
+        expect(InternalNotificationWorker.jobs.first["args"][2]).to include("by Friday, September 18")
+        expect(InternalNotificationWorker.jobs.first["args"][2]).not_to include("by Friday, September 11")
       end
     end
   end

--- a/spec/sidekiq/send_paypal_topup_notification_job_spec.rb
+++ b/spec/sidekiq/send_paypal_topup_notification_job_spec.rb
@@ -2,10 +2,6 @@
 
 describe SendPaypalTopupNotificationJob do
   describe "#perform" do
-    around do |example|
-      travel_to(Time.utc(2026, 9, 9, 14, 0, 0)) { example.run }
-    end
-
     before do
       seller = create(:user, unpaid_balance_cents: 152_279_86)
       seller2 = create(:user, unpaid_balance_cents: 215_145_32)
@@ -16,66 +12,72 @@ describe SendPaypalTopupNotificationJob do
       allow(PaypalPayoutProcessor).to receive(:current_paypal_balance_cents).and_return(125_000_00)
     end
 
-    it "sends a notification with the required topup amount and sets redis key to true" do
-      allow(PaypalPayoutProcessor).to receive(:topup_amount_in_transit).and_return(0)
+    context "before Friday's PayPal payout" do
+      around do |example|
+        travel_to(Time.utc(2026, 9, 9, 14, 0, 0)) { example.run }
+      end
 
-      notification_msg = "PayPal balance needs to be $367,425.18 by Friday, September 11 to payout all creators.\n"\
-                       "Current PayPal balance is $125,000.\n"\
-                       "A top-up of $242,425.18 is needed."
-
-      described_class.new.perform
-
-      expect(InternalNotificationWorker).to have_enqueued_sidekiq_job("payments", "PayPal Top-up", notification_msg, "red")
-      expect($redis.get(RedisKey.paypal_topup_needed)).to eq("true")
-    end
-
-    it "includes details of payout amount in transit in the notification" do
-      allow(PaypalPayoutProcessor).to receive(:topup_amount_in_transit).and_return(100_000)
-
-      notification_msg = "PayPal balance needs to be $367,425.18 by Friday, September 11 to payout all creators.\n"\
-                       "Current PayPal balance is $125,000.\n"\
-                       "Top-up amount in transit is $100,000.\n"\
-                       "A top-up of $142,425.18 is needed."
-
-      described_class.new.perform
-
-      expect(InternalNotificationWorker).to have_enqueued_sidekiq_job("payments", "PayPal Top-up", notification_msg, "red")
-    end
-
-    it "sends no more topup required green notification and sets redis key to false if there's sufficient amount in PayPal" do
-      allow(PaypalPayoutProcessor).to receive(:topup_amount_in_transit).and_return(300_000)
-
-      notification_msg = "PayPal balance needs to be $367,425.18 by Friday, September 11 to payout all creators.\n"\
-                       "Current PayPal balance is $125,000.\n"\
-                       "Top-up amount in transit is $300,000.\n"\
-                       "No more top-up required."
-
-      described_class.new.perform
-
-      expect(InternalNotificationWorker).to have_enqueued_sidekiq_job("payments", "PayPal Top-up", notification_msg, "green")
-      expect($redis.get(RedisKey.paypal_topup_needed)).to eq("false")
-    end
-
-    context "when notify_only_if_topup_needed is true" do
-      it "sends notification when topup is needed" do
+      it "sends a notification with the required topup amount and sets redis key to true" do
         allow(PaypalPayoutProcessor).to receive(:topup_amount_in_transit).and_return(0)
 
         notification_msg = "PayPal balance needs to be $367,425.18 by Friday, September 11 to payout all creators.\n"\
                          "Current PayPal balance is $125,000.\n"\
                          "A top-up of $242,425.18 is needed."
 
-        described_class.new.perform(true)
+        described_class.new.perform
+
+        expect(InternalNotificationWorker).to have_enqueued_sidekiq_job("payments", "PayPal Top-up", notification_msg, "red")
+        expect($redis.get(RedisKey.paypal_topup_needed)).to eq("true")
+      end
+
+      it "includes details of payout amount in transit in the notification" do
+        allow(PaypalPayoutProcessor).to receive(:topup_amount_in_transit).and_return(100_000)
+
+        notification_msg = "PayPal balance needs to be $367,425.18 by Friday, September 11 to payout all creators.\n"\
+                         "Current PayPal balance is $125,000.\n"\
+                         "Top-up amount in transit is $100,000.\n"\
+                         "A top-up of $142,425.18 is needed."
+
+        described_class.new.perform
 
         expect(InternalNotificationWorker).to have_enqueued_sidekiq_job("payments", "PayPal Top-up", notification_msg, "red")
       end
 
-      it "does not send notification when topup is not needed and sets redis key to false" do
+      it "sends no more topup required green notification and sets redis key to false if there's sufficient amount in PayPal" do
         allow(PaypalPayoutProcessor).to receive(:topup_amount_in_transit).and_return(300_000)
 
-        described_class.new.perform(true)
+        notification_msg = "PayPal balance needs to be $367,425.18 by Friday, September 11 to payout all creators.\n"\
+                         "Current PayPal balance is $125,000.\n"\
+                         "Top-up amount in transit is $300,000.\n"\
+                         "No more top-up required."
 
-        expect(InternalNotificationWorker.jobs.size).to eq(0)
+        described_class.new.perform
+
+        expect(InternalNotificationWorker).to have_enqueued_sidekiq_job("payments", "PayPal Top-up", notification_msg, "green")
         expect($redis.get(RedisKey.paypal_topup_needed)).to eq("false")
+      end
+
+      context "when notify_only_if_topup_needed is true" do
+        it "sends notification when topup is needed" do
+          allow(PaypalPayoutProcessor).to receive(:topup_amount_in_transit).and_return(0)
+
+          notification_msg = "PayPal balance needs to be $367,425.18 by Friday, September 11 to payout all creators.\n"\
+                           "Current PayPal balance is $125,000.\n"\
+                           "A top-up of $242,425.18 is needed."
+
+          described_class.new.perform(true)
+
+          expect(InternalNotificationWorker).to have_enqueued_sidekiq_job("payments", "PayPal Top-up", notification_msg, "red")
+        end
+
+        it "does not send notification when topup is not needed and sets redis key to false" do
+          allow(PaypalPayoutProcessor).to receive(:topup_amount_in_transit).and_return(300_000)
+
+          described_class.new.perform(true)
+
+          expect(InternalNotificationWorker.jobs.size).to eq(0)
+          expect($redis.get(RedisKey.paypal_topup_needed)).to eq("false")
+        end
       end
     end
 


### PR DESCRIPTION
Premerge review: clean @ 337e42ef51b7a53cb98398352f4d9f0bac3738d3

# Sum uncleared PayPal top-ups of any amount

## What

`PaypalPayoutProcessor.topup_amount_in_transit` no longer searches PayPal for exactly $100,000. It sums every uncleared bank-account Transfer in the last two weeks, using each row's actual amount, including cents.

The top-up alert names the next PayPal payout that has not yet run (`Friday, September 18` after Friday 10:00 UTC) instead of a bare "by Friday". The funding target still cuts off at this week's Friday so the named MassPay is not asked to cover the following week.

## Why

A $100,000 search fingerprint hid any smaller top-up from the healthcheck until it cleared. After Friday's 10:00 UTC MassPay, "by Friday" still meant today, so the 14:00 UTC alert looked like this week's run was unfunded. Reusing the hour-advanced named date as the balance cutoff would have counted up to seven extra days the next MassPay does not pay.

## Before / After

- Before: only uncleared $100,000 transfers counted; alert said "by Friday"; fractional transfer dollars were truncated.
- After: any uncleared bank Transfer counts, including cents; alert says `by Friday, September 18` once today's run has started; unpaid balances past this week's Friday are not in the funding target.

No user-facing UI. Backend-only — focused specs are the reviewable artifact.

## Checklist

- [x] Scope — drop the $100k TransactionSearch filter; name the next unrun PayPal Friday; keep this week's Friday as the balance cutoff
- [x] Design — hour-aware named date for copy only; `User::PayoutSchedule.next_scheduled_payout_date` for eligibility
- [x] Build — `3365369117` on `gumclaw/paypal-topup-in-transit`
- [x] QA — focused specs at `3365369117` (no preview surface)
- [ ] Shipped — draft; money-path, not automerging
- [x] Market — n/a, internal PayPal funding alert
- [x] Sell — n/a, no buyer/seller surface

## Test Results

Local at `3365369117`, rubocop clean on the touched files.

- `paypal_payout_processor_spec.rb` `-e topup_amount_in_transit`: 4 examples, 0 failures
- `paypal_balance_check_service_spec.rb`: 14 examples, 0 failures
- `send_paypal_topup_notification_job_spec.rb`: 6 examples, 0 failures

Mutation: reusing `payout_date` as the cutoff reddens the extra-week example; restoring `to_i` reddens the fractional-dollar example.

## QA

Not preview-exercisable. After deploy, a non-$100k uncleared bank Transfer should credit in-transit, Friday 14:00 UTC mail should name next Friday, and that mail's funding target should not include the following week's balances.

---

## AI disclosure

Generated with **grok-4.6** (xAI), running as a gumclaw finance-mail cron. Prompts/instructions given: Gianfranco asked to open the PR offered on the PayPal Top-up thread (drop the $100k amount filter, sum uncleared bank-account transfers) and to make those alerts name the correct payout date going forward. Greptile P1/P2 on this draft were fixed in `3365369117`.
