### PR TITLE
Pull MinIO images from quay.io

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -509,8 +509,9 @@ jobs:
         ports:
           - 9200:9200
       # MinIO (S3-compatible object storage) is started as a step below rather than
-      # a service: the official minio/minio image needs a `server /data` command
-      # that GitHub Actions service containers can't supply.
+      # a service: the official quay.io/minio/minio image needs a `server /data` command
+      # that GitHub Actions service containers can't supply. MinIO images are pulled from
+      # quay.io because the Docker Hub repositories were removed (pulls fail with access denied).
 
     env:
       RAILS_ENV: test
@@ -547,7 +548,7 @@ jobs:
         run: |
           docker run -d --name minio -p 9000:9000 -p 9001:9001 \
             -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data --console-address ":9001"
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data --console-address ":9001"
           for i in $(seq 1 30); do curl -fsS http://localhost:9000/minio/health/ready >/dev/null 2>&1 && break; sleep 2; done
           curl -fsS http://localhost:9000/minio/health/ready || { echo "MinIO did not become ready"; exit 1; }
           # Provision the buckets the app's :test storage service expects (see
@@ -562,7 +563,7 @@ jobs:
           # `mc anonymous set` and `mc version enable` each take exactly ONE bucket — passing
           # two makes mc print its usage text and exit 1 — so they run per bucket in a loop.
           # (`mc mb` does accept several.)
-          docker run --rm --network host --entrypoint /bin/sh minio/mc:RELEASE.2025-08-13T08-35-41Z -c "
+          docker run --rm --network host --entrypoint /bin/sh quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z -c "
             set -e
             mc alias set local http://localhost:9000 minioadmin minioadmin
             mc mb --ignore-existing local/gumroad-specs local/gumroad-invoices

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -510,8 +510,7 @@ jobs:
           - 9200:9200
       # MinIO (S3-compatible object storage) is started as a step below rather than
       # a service: the official quay.io/minio/minio image needs a `server /data` command
-      # that GitHub Actions service containers can't supply. MinIO images are pulled from
-      # quay.io because the Docker Hub repositories were removed (pulls fail with access denied).
+      # that GitHub Actions service containers can't supply.
 
     env:
       RAILS_ENV: test

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -50,7 +50,8 @@ services:
       - elasticsearch7data:/data
 
   minio:
-    image: minio/minio
+    # MinIO images come from quay.io; the Docker Hub repositories were removed.
+    image: quay.io/minio/minio
     ports:
       - "9000:9000" # API port
       - "9001:9001" # Console port
@@ -68,7 +69,7 @@ services:
       start_period: 30s
 
   createbuckets:
-    image: minio/mc
+    image: quay.io/minio/mc
     depends_on:
       minio:
         condition: service_healthy
@@ -88,7 +89,7 @@ services:
       done; exit 0; "
 
   copyfixturefiles:
-    image: minio/mc
+    image: quay.io/minio/mc
     depends_on:
       createbuckets:
         condition: service_completed_successfully

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -50,7 +50,6 @@ services:
       - elasticsearch7data:/data
 
   minio:
-    # MinIO images come from quay.io; the Docker Hub repositories were removed.
     image: quay.io/minio/minio
     ports:
       - "9000:9000" # API port

--- a/docker/docker-compose-test-and-ci.yml
+++ b/docker/docker-compose-test-and-ci.yml
@@ -48,7 +48,8 @@ services:
       - "11211"
 
   minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    # MinIO images come from quay.io; the Docker Hub repositories were removed.
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       - "9000"
       - "9001"
@@ -66,7 +67,7 @@ services:
       start_period: 30s
 
   createbuckets:
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       minio:
         condition: service_healthy
@@ -86,7 +87,7 @@ services:
       done; exit 0; "
 
   copyfixturefiles:
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       createbuckets:
         condition: service_completed_successfully

--- a/docker/docker-compose-test-and-ci.yml
+++ b/docker/docker-compose-test-and-ci.yml
@@ -48,7 +48,6 @@ services:
       - "11211"
 
   minio:
-    # MinIO images come from quay.io; the Docker Hub repositories were removed.
     image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       - "9000"


### PR DESCRIPTION
## What

Point every MinIO image reference at quay.io: the `Start MinIO` step in `.github/workflows/tests.yml`, and the `minio`, `createbuckets`, and `copyfixturefiles` services in `docker/docker-compose-test-and-ci.yml` and `docker/docker-compose-local.yml`. The pinned release tags do not change.

## Why

Docker Hub no longer serves the `minio/minio` and `minio/mc` repositories. `hub.docker.com/v2/repositories/minio/minio/` returns 404. Every `tests.yml` run since 2026-09-11 19:06 UTC fails in setup with `pull access denied for minio/minio`, on `main` as well as on every PR branch. MinIO publishes the same releases on quay.io, and both pinned tags (`RELEASE.2025-09-07T16-13-09Z` for the server, `RELEASE.2025-08-13T08-35-41Z` for `mc`) resolve there.

## Before/After

Documentation and CI configuration only. No user-facing change. No video.

## Test Results

- `docker compose -f docker/docker-compose-test-and-ci.yml config -q` and the local compose file: valid.
- `docker manifest inspect` for both pinned quay.io tags and both `latest` tags: found.
- CI on #7592 at `6b868396e`, which carries this commit.

## QA steps

1. Open the `Test Minitest 0` job on the CI run for this PR.
2. Confirm the `Start MinIO` step pulls `quay.io/minio/minio` and the health check passes.
3. Confirm `Test Relevant` jobs start the compose stack without a pull error.

---

AI disclosure: Claude Fable 5.1.
