### PR TITLE
Hide Mark as shipped on digital listings that collect shipping

### DIFF
--- a/app/javascript/components/Audience/CustomerDetailPage.tsx
+++ b/app/javascript/components/Audience/CustomerDetailPage.tsx
@@ -633,23 +633,25 @@ const CustomerDetailPage = ({
         ) : null}
         {shipping ? (
           <Card className="break-inside-avoid">
-            <CardContent>
-              <TrackingSection
-                tracking={shipping.tracking}
-                onMarkShipped={(url) =>
-                  markShipped(customer.id, url).then(
-                    () => {
-                      showAlert("Changes saved!", "success");
-                      updateCustomer({ shipping: { ...shipping, tracking: { url, shipped: true } } });
-                    },
-                    (e: unknown) => {
-                      assertResponseError(e);
-                      showAlert(e.message, "error");
-                    },
-                  )
-                }
-              />
-            </CardContent>
+            {shipping.tracking ? (
+              <CardContent>
+                <TrackingSection
+                  tracking={shipping.tracking}
+                  onMarkShipped={(url) =>
+                    markShipped(customer.id, url).then(
+                      () => {
+                        showAlert("Changes saved!", "success");
+                        updateCustomer({ shipping: { ...shipping, tracking: { url, shipped: true } } });
+                      },
+                      (e: unknown) => {
+                        assertResponseError(e);
+                        showAlert(e.message, "error");
+                      },
+                    )
+                  }
+                />
+              </CardContent>
+            ) : null}
             <CardContent>
               <AddressSection
                 address={shipping.address}

--- a/app/javascript/components/Audience/CustomersPage.tsx
+++ b/app/javascript/components/Audience/CustomersPage.tsx
@@ -484,7 +484,7 @@ const CustomersPage = ({
                       style={{ cursor: "pointer" }}
                     >
                       <TableCell>
-                        {customer.shipping && !customer.shipping.tracking.shipped ? (
+                        {customer.shipping?.tracking && !customer.shipping.tracking.shipped ? (
                           <WithTooltip tip="Not Shipped">
                             <Truck
                               style={{ marginRight: "var(--spacer-2)" }}

--- a/app/javascript/components/ProductEdit/ProductTab/index.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/index.tsx
@@ -456,11 +456,13 @@ export const ProductTab = () => {
                       setShowPreview={setShowRefundPolicyPreview}
                     />
                   ) : null}
-                  <Switch
-                    checked={product.require_shipping}
-                    onChange={(e) => updateProduct({ require_shipping: e.target.checked })}
-                    label="Require shipping information"
-                  />
+                  {isPhysical || product.require_shipping ? (
+                    <Switch
+                      checked={product.require_shipping}
+                      onChange={(e) => updateProduct({ require_shipping: e.target.checked })}
+                      label="Require shipping information"
+                    />
+                  ) : null}
                 </Fieldset>
                 {product.native_type === "membership" ? (
                   <Fieldset>

--- a/app/javascript/data/customers.ts
+++ b/app/javascript/data/customers.ts
@@ -70,7 +70,7 @@ export type Customer = {
     native_type: ProductNativeType;
   };
   physical: { sku: string; order_number: string } | null;
-  shipping: { address: Address; tracking: Tracking; price: string } | null;
+  shipping: { address: Address; tracking: Tracking | null; price: string } | null;
   created_at: string;
   price: {
     cents: number;

--- a/app/policies/audience/purchase_policy.rb
+++ b/app/policies/audience/purchase_policy.rb
@@ -30,7 +30,7 @@ class Audience::PurchasePolicy < ApplicationPolicy
   end
 
   def mark_as_shipped?
-    update?
+    update? && record.link.is_physical?
   end
 
   def manage_license?

--- a/app/presenters/customer_presenter.rb
+++ b/app/presenters/customer_presenter.rb
@@ -47,11 +47,13 @@ class CustomerPresenter
         {
           address: purchase.shipping_information,
           price: purchase.formatted_shipping_amount,
-          tracking: purchase.shipment.present? ?
-            {
-              shipped: purchase.shipment.shipped?,
-              url: purchase.shipment.calculated_tracking_url,
-            } : { shipped: false },
+          # Address collection can stay on; the clerk is physical-only.
+          tracking: purchase.link.is_physical? ?
+            purchase.shipment.present? ?
+              {
+                shipped: purchase.shipment.shipped?,
+                url: purchase.shipment.calculated_tracking_url,
+              } : { shipped: false } : nil,
         } : nil,
       is_bundle_purchase: purchase.is_bundle_purchase,
       is_existing_user: purchase.purchaser.present?,

--- a/spec/policies/audience/purchase_policy_spec.rb
+++ b/spec/policies/audience/purchase_policy_spec.rb
@@ -45,7 +45,7 @@ describe Audience::PurchasePolicy do
     end
   end
 
-  permissions :update?, :refund?, :change_can_contact?, :cancel_preorder_by_seller?, :mark_as_shipped?, :manage_license? do
+  permissions :update?, :refund?, :change_can_contact?, :cancel_preorder_by_seller?, :manage_license? do
     it "grants access to owner" do
       seller_context = SellerContext.new(user: seller, seller:)
       expect(subject).to permit(seller_context, Follower)
@@ -69,6 +69,27 @@ describe Audience::PurchasePolicy do
     it "grants access to support" do
       seller_context = SellerContext.new(user: support_for_seller, seller:)
       expect(subject).to permit(seller_context, Purchase)
+    end
+  end
+
+  permissions :mark_as_shipped? do
+    let(:physical_purchase) { create(:physical_purchase, seller:, link: create(:physical_product, user: seller)) }
+    let(:digital_purchase) { create(:purchase, seller:, link: create(:product, user: seller, require_shipping: true)) }
+
+    it "grants access to owner for a physical product" do
+      expect(subject).to permit(SellerContext.new(user: seller, seller:), physical_purchase)
+    end
+
+    it "denies access for a digital product even when require_shipping is on" do
+      expect(subject).not_to permit(SellerContext.new(user: seller, seller:), digital_purchase)
+    end
+
+    it "grants access to admin for a physical product" do
+      expect(subject).to permit(SellerContext.new(user: admin_for_seller, seller:), physical_purchase)
+    end
+
+    it "denies access to accountant" do
+      expect(subject).not_to permit(SellerContext.new(user: accountant_for_seller, seller:), physical_purchase)
     end
   end
 

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -224,6 +224,20 @@ describe CustomerPresenter do
       )
     end
 
+    context "when a digital product requires shipping" do
+      let(:digital_product) { create(:product, user: seller, require_shipping: true) }
+      let(:digital_purchase) do
+        create(:purchase, link: digital_product, seller:, street_address: "123 Main St", city: "San Francisco", state: "CA", zip_code: "94105", country: "United States")
+      end
+
+      it "exposes the address but not the mark-as-shipped clerk" do
+        props = described_class.new(purchase: digital_purchase).customer(pundit_user:)
+
+        expect(props[:shipping][:address]).to eq(digital_purchase.shipping_information)
+        expect(props[:shipping][:tracking]).to be_nil
+      end
+    end
+
     context "when a shipment has a legacy invalid tracking_url" do
       it "does not expose the raw tracking_url" do
         shipment = create(:shipment, purchase: purchase1, shipped_at: Time.current)

--- a/spec/requests/products/edit/purchase_flow_spec.rb
+++ b/spec/requests/products/edit/purchase_flow_spec.rb
@@ -11,7 +11,13 @@ describe("ProductPurchaseFlowScenario", type: :system, js: true) do
 
   include_context "with switching account to user as admin for seller"
 
-  it "always shows the Require shipping information toggle for all product types" do
+  it "does not show the Require shipping information toggle on a digital product" do
+    visit edit_link_path(product.unique_permalink)
+
+    expect(page).to_not have_field("Require shipping information")
+  end
+
+  it "lets a digital listing that already requires shipping turn the toggle off" do
     product.update!(require_shipping: true)
     visit edit_link_path(product.unique_permalink)
 
@@ -20,7 +26,7 @@ describe("ProductPurchaseFlowScenario", type: :system, js: true) do
 
     save_change
     visit current_path
-    expect(page).to have_field("Require shipping information")
+    expect(page).to_not have_field("Require shipping information")
 
     expect(product.reload.require_shipping).to be false
   end


### PR DESCRIPTION
# Hide Mark as shipped on digital listings that collect shipping

> Draft status: code is pushed; presenter/policy specs and preview screenshots are still owed before ready.

## What

A digital product with `require_shipping` still collects a shipping address, but the seller dashboard no longer shows Mark as shipped / Tracking URL / Not Shipped on those sales. That clerk stays on physical products. The product editor hides "Require shipping information" on digital products unless the flag is already on, so existing listings can turn it off and new ones cannot turn it on.

## Why

The dashboard treated `require_shipping` as parcel fulfillment. Sellers who followed that UI built a physical offer, then had the listing unpublished because physical products are not allowed. Addresses antiwork/gumroad-private#2557.

## Before / after

- Before: digital + `require_shipping` rendered Tracking information, Tracking URL, and Mark as shipped on the sale page, and a Not Shipped icon on the customers table.
- After: those controls render only when the product is physical. Digital sales that already collected an address still show the address. Screenshot evidence owed on the hosted preview.

## Checklist

- [x] Scope — dashboard clerk + editor toggle; checkout address collection and purchase `Shipment.create` are unchanged
- [x] Design — gate the clerk on `is_physical?`, not `require_shipping?`; keep the editor toggle for listings that already have the flag so they can turn it off
- [x] Build — `gp2557-hide-digital-shipping-clerk`
- [ ] QA — hosted preview screenshots of product editor (digital, no toggle) and a physical sale (clerk still present)
- [ ] Shipped — draft until CI, premerge panel, and QA media
- [ ] Market — n/a, seller-dashboard consistency
- [ ] Sell — n/a

## Tests

```text
owed at dcea1c2e16a
bundle exec rspec spec/presenters/customer_presenter_spec.rb spec/policies/audience/purchase_policy_spec.rb
system spec spec/requests/products/edit/purchase_flow_spec.rb inverted; local JS system specs are environmental
```

## QA

Owed on the hosted preview after deploy: product editor for a digital listing (no Require shipping information), sale page for a leftover digital+require_shipping purchase (address, no Mark as shipped), sale page for a physical purchase (clerk still there).

---

## AI disclosure

Generated with **grok-4.6** (xAI), running as gumclaw. Prompts/instructions: autonomous-product-dev webhook on antiwork/gumroad-private#2557; hide the physical-fulfillment clerk on digital listings.
