### PR TITLE
Exclude PayPal-processor disputes from seller and buyer risk signals

### DIFF
--- a/app/controllers/api/internal/admin/products_controller.rb
+++ b/app/controllers/api/internal/admin/products_controller.rb
@@ -191,6 +191,7 @@ class Api::Internal::Admin::ProductsController < Api::Internal::Admin::BaseContr
       window = RECENT_CHARGEBACK_WINDOW_DAYS.days.ago
       base = Purchase.not_is_bundle_product_purchase
         .not_fully_refunded
+        .excluding_paypal_processor
         .where(link_id: product.id)
         .where("purchases.created_at >= ?", window)
 

--- a/app/models/concerns/purchase/blockable.rb
+++ b/app/models/concerns/purchase/blockable.rb
@@ -501,12 +501,14 @@ module Purchase::Blockable
   end
 
   def block_buyer_based_on_chargeback_count!
-    email_cb_count = Purchase.where(email: email)
+    email_cb_count = Purchase.excluding_paypal_processor
+                             .where(email: email)
                              .where.not(chargeback_date: nil)
                              .count
 
     purchaser_cb_count = if purchaser_id.present?
-      Purchase.where(purchaser_id: purchaser_id)
+      Purchase.excluding_paypal_processor
+              .where(purchaser_id: purchaser_id)
               .where.not(chargeback_date: nil)
               .count
     else

--- a/app/models/dispute.rb
+++ b/app/models/dispute.rb
@@ -11,7 +11,7 @@ class Dispute < ApplicationRecord
   belongs_to :service_charge, optional: true
   has_many :credits
 
-  # Same PayPal-MoR exclusion as Purchase.excluding_paypal_processor, covering both
+  # Same processor exclusion as Purchase.excluding_paypal_processor, covering both
   # purchase-linked and charge-linked (multi-item cart) dispute rows.
   scope :excluding_paypal_processor, -> {
     left_joins(:purchase, :charge).where(*User::Risk.not_paypal_processor_sql(charge_table: "charges"))

--- a/app/models/dispute.rb
+++ b/app/models/dispute.rb
@@ -10,6 +10,12 @@ class Dispute < ApplicationRecord
   belongs_to :charge, optional: true
   belongs_to :service_charge, optional: true
   has_many :credits
+
+  # Same PayPal-MoR exclusion as Purchase.excluding_paypal_processor, covering both
+  # purchase-linked and charge-linked (multi-item cart) dispute rows.
+  scope :excluding_paypal_processor, -> {
+    left_joins(:purchase, :charge).where(*User::Risk.not_paypal_processor_sql(charge_table: "charges"))
+  }
   has_many :balance_transactions
   has_one :dispute_evidence
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -767,6 +767,9 @@ class Purchase < ApplicationRecord
   }
   scope :chargedback, -> { successful.where("purchases.chargeback_date IS NOT NULL") }
   scope :not_chargedback, -> { where("purchases.chargeback_date IS NULL") }
+  # PayPal checkout is seller-liability (not Gumroad MoR). Risk signals use this so a
+  # PayPal dispute cannot move a chargeback rate, payout pause, or buyer-block metric.
+  scope :excluding_paypal_processor, -> { where(*User::Risk.not_paypal_processor_sql) }
   scope :not_chargedback_or_chargedback_reversed, lambda {
     where("purchases.chargeback_date IS NULL OR " \
  "(purchases.chargeback_date IS NOT NULL AND purchases.flags & ? != 0)", Purchase.flag_mapping["flags"][:chargeback_reversed])

--- a/app/modules/purchase/risk.rb
+++ b/app/modules/purchase/risk.rb
@@ -36,8 +36,8 @@ module Purchase::Risk
 
   def find_past_chargebacked_purchases
     @_find_past_chargebacked_purchases_for_purchases ||= begin
-      past_email_purchases = Purchase.where(email:).chargedback.not_chargeback_reversed.order(chargeback_date: :desc)
-      past_guid_purchases = Purchase.where("browser_guid is not null").where(browser_guid:).chargedback.not_chargeback_reversed.order(chargeback_date: :desc)
+      past_email_purchases = Purchase.excluding_paypal_processor.where(email:).chargedback.not_chargeback_reversed.order(chargeback_date: :desc)
+      past_guid_purchases = Purchase.excluding_paypal_processor.where("browser_guid is not null").where(browser_guid:).chargedback.not_chargeback_reversed.order(chargeback_date: :desc)
 
       past_email_purchases + past_guid_purchases
     end

--- a/app/modules/user/risk.rb
+++ b/app/modules/user/risk.rb
@@ -55,9 +55,8 @@ module User::Risk
 
   REFUND_POLICY_ENFORCEMENT_COMMENT_AUTHOR = "enforce_refund_policy_for_seller_based_on_dispute_rate"
 
-  # PayPal checkout is the seller's own PayPal account — Gumroad is not merchant of record,
-  # the money never hits our books, so those disputes are not our risk. One SQL predicate;
-  # Purchase.excluding_paypal_processor / Dispute.excluding_paypal_processor wrap it.
+  # Excludes seller-liability transactions from risk signals. Purchase.excluding_paypal_processor
+  # and Dispute.excluding_paypal_processor wrap this shared SQL predicate.
   PAYPAL_CHARGE_PROCESSOR_ID = PaypalChargeProcessor.charge_processor_id
 
   def self.not_paypal_processor_sql(purchase_table: "purchases", charge_table: nil)

--- a/app/modules/user/risk.rb
+++ b/app/modules/user/risk.rb
@@ -55,6 +55,20 @@ module User::Risk
 
   REFUND_POLICY_ENFORCEMENT_COMMENT_AUTHOR = "enforce_refund_policy_for_seller_based_on_dispute_rate"
 
+  # PayPal checkout is the seller's own PayPal account — Gumroad is not merchant of record,
+  # the money never hits our books, so those disputes are not our risk. One SQL predicate;
+  # Purchase.excluding_paypal_processor / Dispute.excluding_paypal_processor wrap it.
+  PAYPAL_CHARGE_PROCESSOR_ID = PaypalChargeProcessor.charge_processor_id
+
+  def self.not_paypal_processor_sql(purchase_table: "purchases", charge_table: nil)
+    column = if charge_table
+      "COALESCE(#{purchase_table}.charge_processor_id, #{charge_table}.processor, '')"
+    else
+      "COALESCE(#{purchase_table}.charge_processor_id, '')"
+    end
+    ["#{column} != ?", PAYPAL_CHARGE_PROCESSOR_ID]
+  end
+
   # Lifetime dispute stats by UNIQUE BUYER (not raw purchases, not dollar volume). Used to
   # decide whether to auto-enforce a buyer-friendly refund policy on the seller — see
   # Purchase::Blockable#enforce_refund_policy_for_seller_based_on_dispute_rate!.
@@ -75,9 +89,10 @@ module User::Risk
     # as its own buyer (keyed by the purchase id).
     buyer_key = Arel.sql("COALESCE(purchases.email, CONCAT('missing-email-', purchases.id))")
 
-    settled_count = sales.successful.count
-    settled_buyers_count = sales.successful.distinct.count(buyer_key)
-    disputing_buyers_count = sales.successful
+    settled = sales.successful.excluding_paypal_processor
+    settled_count = settled.count
+    settled_buyers_count = settled.distinct.count(buyer_key)
+    disputing_buyers_count = settled
                                   .where.not(chargeback_date: nil)
                                   .where("purchases.flags & ? = 0", Purchase.flag_mapping["flags"][:chargeback_reversed])
                                   .distinct

--- a/app/modules/user/stats.rb
+++ b/app/modules/user/stats.rb
@@ -254,33 +254,17 @@ module User::Stats
   end
 
   def chargeback_rates(created_on_or_after: nil) # returns `{ volume: String, count: String }`
-    search_params = {
-      seller: self,
-      state: "successful",
-      exclude_refunded: true,
-      exclude_bundle_product_purchases: true,
-      track_total_hits: true,
-      aggs: {
-        price_cents_total: { sum: { field: "price_cents" } },
-        unreversed_chargebacks: {
-          filter: {
-            bool: {
-              must: [{ exists: { field: "chargeback_date" } }],
-              must_not: [{ term: { "selected_flags" => "chargeback_reversed" } }]
-            }
-          },
-          aggs: {
-            price_cents_total: { sum: { field: "price_cents" } }
-          }
-        }
-      }
-    }
-    search_params[:created_on_or_after] = created_on_or_after if created_on_or_after
-    search_result = PurchaseSearchService.search(search_params)
-    count_denominator = search_result.response.hits.total.value.to_f
-    volume_denominator = search_result.aggregations["price_cents_total"]["value"]
-    count_numerator = search_result.aggregations["unreversed_chargebacks"]["doc_count"].to_f
-    volume_numerator = search_result.aggregations["unreversed_chargebacks"]["price_cents_total"]["value"]
+    # SQL rather than PurchaseSearchService: ES does not index charge_processor_id, and
+    # PayPal-processor sales must be out of both numerator and denominator (not our MoR).
+    scope = sales.successful.not_fully_refunded.not_is_bundle_product_purchase.excluding_paypal_processor
+    scope = scope.where("purchases.created_at >= ?", created_on_or_after) if created_on_or_after
+
+    count_denominator = scope.count.to_f
+    volume_denominator = scope.sum(:price_cents).to_f
+    chargedback = scope.where.not(chargeback_date: nil)
+                       .where("purchases.flags & ? = 0", Purchase.flag_mapping["flags"][:chargeback_reversed])
+    count_numerator = chargedback.count.to_f
+    volume_numerator = chargedback.sum(:price_cents).to_f
     volume = volume_denominator > 0 ? format("%.1f%%", volume_numerator / volume_denominator * 100) : "NA"
     count = count_denominator > 0 ? format("%.1f%%", count_numerator / count_denominator * 100) : "NA"
     { volume:, count: }

--- a/app/modules/user/stats.rb
+++ b/app/modules/user/stats.rb
@@ -255,7 +255,7 @@ module User::Stats
 
   def chargeback_rates(created_on_or_after: nil) # returns `{ volume: String, count: String }`
     # SQL rather than PurchaseSearchService: ES does not index charge_processor_id, and
-    # PayPal-processor sales must be out of both numerator and denominator (not our MoR).
+    # PayPal-processor sales must be out of both numerator and denominator.
     scope = sales.successful.not_fully_refunded.not_is_bundle_product_purchase.excluding_paypal_processor
     scope = scope.where("purchases.created_at >= ?", created_on_or_after) if created_on_or_after
 

--- a/app/modules/user/stats.rb
+++ b/app/modules/user/stats.rb
@@ -259,12 +259,14 @@ module User::Stats
     scope = sales.successful.not_fully_refunded.not_is_bundle_product_purchase.excluding_paypal_processor
     scope = scope.where("purchases.created_at >= ?", created_on_or_after) if created_on_or_after
 
-    count_denominator = scope.count.to_f
-    volume_denominator = scope.sum(:price_cents).to_f
-    chargedback = scope.where.not(chargeback_date: nil)
-                       .where("purchases.flags & ? = 0", Purchase.flag_mapping["flags"][:chargeback_reversed])
-    count_numerator = chargedback.count.to_f
-    volume_numerator = chargedback.sum(:price_cents).to_f
+    reversed_bit = Purchase.flag_mapping["flags"][:chargeback_reversed]
+    lost = "purchases.chargeback_date IS NOT NULL AND purchases.flags & #{reversed_bit} = 0"
+    count_denominator, volume_denominator, count_numerator, volume_numerator = scope.reorder(nil).pick(
+      Arel.sql("COUNT(*)"),
+      Arel.sql("COALESCE(SUM(purchases.price_cents), 0)"),
+      Arel.sql("COUNT(CASE WHEN #{lost} THEN 1 END)"),
+      Arel.sql("COALESCE(SUM(CASE WHEN #{lost} THEN purchases.price_cents ELSE 0 END), 0)")
+    ).map(&:to_f)
     volume = volume_denominator > 0 ? format("%.1f%%", volume_numerator / volume_denominator * 100) : "NA"
     count = count_denominator > 0 ? format("%.1f%%", count_numerator / count_denominator * 100) : "NA"
     { volume:, count: }

--- a/app/services/radar/seller_risk_stats_service.rb
+++ b/app/services/radar/seller_risk_stats_service.rb
@@ -48,7 +48,10 @@ module Radar
       end
 
       def successful_purchases_count
-        @successful_purchases_count ||= user.sales.successful.where("purchases.created_at >= ?", cutoff_date).count
+        @successful_purchases_count ||= user.sales.successful
+          .excluding_paypal_processor
+          .where("purchases.created_at >= ?", cutoff_date)
+          .count
       end
 
       def efws
@@ -68,6 +71,7 @@ module Radar
 
       def dispute_count
         @dispute_count ||= Dispute
+          .excluding_paypal_processor
           .where(seller_id: user.id)
           .where.not(state: "won")
           .where("disputes.created_at >= ?", cutoff_date)

--- a/app/services/risk/stranded_buyer_recovery_service.rb
+++ b/app/services/risk/stranded_buyer_recovery_service.rb
@@ -270,7 +270,8 @@ class Risk::StrandedBuyerRecoveryService
     # person veto (or fail to veto) recovery for the resolved buyer (same identity-isolation class
     # as candidate_purchases/identifier_emails above).
     def unreversed_chargeback?
-      scope = Purchase.where.not(chargeback_date: nil)
+      scope = Purchase.excluding_paypal_processor
+                      .where.not(chargeback_date: nil)
                       .where("purchases.flags & :bit = 0", bit: Purchase.flag_mapping["flags"][:chargeback_reversed])
       scope = if user.present?
         scope.where("purchaser_id = ? OR email = ?", user.id, user.email)

--- a/app/services/risk/stranded_buyer_scan_service.rb
+++ b/app/services/risk/stranded_buyer_scan_service.rb
@@ -155,7 +155,8 @@ class Risk::StrandedBuyerScanService
     def reject_disputed(settled)
       # The exact complement of the not_chargedback_or_chargedback_reversed scope the counts above
       # use, so the numerator and the veto cannot disagree about what a live dispute is.
-      disputed = Purchase.where(email: settled.keys)
+      disputed = Purchase.excluding_paypal_processor
+                         .where(email: settled.keys)
                          .where.not(chargeback_date: nil)
                          .where("purchases.flags & :bit = 0", bit: Purchase.flag_mapping["flags"][:chargeback_reversed])
                          .distinct

--- a/spec/controllers/api/internal/admin/products_controller_spec.rb
+++ b/spec/controllers/api/internal/admin/products_controller_spec.rb
@@ -533,6 +533,26 @@ describe Api::Internal::Admin::ProductsController do
       )
     end
 
+    it "ignores PayPal-processor chargebacks in recent_chargeback_rate and still counts Stripe ones" do
+      create(:merchant_account, user: nil)
+      product = create(:product, user: seller)
+      4.times { create(:purchase, link: product, seller:, created_at: 10.days.ago) }
+      stripe_cb = create(:purchase, link: product, seller:, created_at: 5.days.ago)
+      stripe_cb.update_column(:chargeback_date, 4.days.ago)
+      paypal_cb = create(:purchase, link: product, seller:, created_at: 5.days.ago)
+      paypal_cb.update_columns(
+        chargeback_date: 4.days.ago,
+        charge_processor_id: PaypalChargeProcessor.charge_processor_id
+      )
+
+      get :show, params: { id: product.external_id }
+
+      payload = response.parsed_body["product"]["recent_chargeback_rate"]
+      expect(payload["successful_count"]).to eq(5)
+      expect(payload["chargedback_count"]).to eq(1)
+      expect(payload["rate"]).to eq(0.2)
+    end
+
     it "omits recent_chargeback_rate from index rows to keep the listing cheap" do
       create(:merchant_account, user: nil)
       product = create(:product, user: seller)

--- a/spec/models/concerns/purchase/blockable_spec.rb
+++ b/spec/models/concerns/purchase/blockable_spec.rb
@@ -1889,6 +1889,23 @@ describe Purchase::Blockable do
       end
     end
 
+    context "when buyer has 5 PayPal-processor chargebacks by email" do
+      before do
+        5.times do
+          p = create(:purchase)
+          p.update_columns(
+            chargeback_date: Time.current,
+            email: "repeat-offender@example.com",
+            charge_processor_id: PaypalChargeProcessor.charge_processor_id
+          )
+        end
+      end
+
+      it "does not block the buyer" do
+        expect { purchase.block_buyer_based_on_chargeback_count! }.not_to change { PlatformBlock.count }
+      end
+    end
+
     context "when buyer has 5 chargebacks by purchaser_id with different email" do
       before do
         create_chargebacked_purchases_by_purchaser(5, buyer)

--- a/spec/modules/purchase/risk_spec.rb
+++ b/spec/modules/purchase/risk_spec.rb
@@ -205,6 +205,18 @@ describe Purchase::Risk do
       end
     end
 
+    context "when the only past chargeback is PayPal-processor" do
+      before do
+        paypal = create(:purchase, link: product, email: "test@example.com", chargeback_date: Time.current)
+        paypal.update_column(:charge_processor_id, PaypalChargeProcessor.charge_processor_id)
+      end
+
+      it "does not add errors" do
+        expect { new_purchase.send(:check_for_past_chargebacks) }.not_to change { new_purchase.errors.count }
+        expect(new_purchase.error_code).to be_nil
+      end
+    end
+
     context "when purchase has neither email nor browser_guid" do
       let(:new_purchase) { build(:purchase, link: product, email: nil, browser_guid: nil) }
 

--- a/spec/modules/user/risk_spec.rb
+++ b/spec/modules/user/risk_spec.rb
@@ -329,6 +329,21 @@ describe User::Risk do
       expect(stats[:disputing_buyers_count]).to eq(1)
       expect(stats[:rate]).to eq(1 * 100.0 / 3)
     end
+
+    it "ignores PayPal-processor sales and chargebacks, and still counts Stripe ones" do
+      create(:purchase, link: product, email: "stripe-clean@example.com")
+      create(:purchase, link: product, email: "stripe-disputed@example.com", chargeback_date: Time.current)
+      paypal_clean = create(:purchase, link: product, email: "paypal-clean@example.com")
+      paypal_clean.update_column(:charge_processor_id, PaypalChargeProcessor.charge_processor_id)
+      paypal_disputed = create(:purchase, link: product, email: "paypal-disputed@example.com", chargeback_date: Time.current)
+      paypal_disputed.update_column(:charge_processor_id, PaypalChargeProcessor.charge_processor_id)
+
+      stats = seller.dispute_rate_stats
+      expect(stats[:settled_count]).to eq(2)
+      expect(stats[:settled_buyers_count]).to eq(2)
+      expect(stats[:disputing_buyers_count]).to eq(1)
+      expect(stats[:rate]).to eq(50.0)
+    end
   end
 
   describe "#clear_refund_policy_enforcement!" do

--- a/spec/modules/user/stats_spec.rb
+++ b/spec/modules/user/stats_spec.rb
@@ -1627,6 +1627,15 @@ describe User::Stats, :vcr do
         expect(result[:volume]).to eq("16.7%") # (disputed_volume / all_volume) == (10 / (50 + 10))
         expect(result[:count]).to eq("50.0%") # (disputed_count / all_count) == (1 / (1 + 1))
       end
+
+      it "ignores PayPal-processor chargebacks and still counts Stripe ones" do
+        paypal_disputed = create(:disputed_purchase, link: create(:product, price_cents: 4000, user: @user))
+        paypal_disputed.update_column(:charge_processor_id, PaypalChargeProcessor.charge_processor_id)
+
+        result = @user.lost_chargebacks
+        expect(result[:volume]).to eq("16.7%")
+        expect(result[:count]).to eq("50.0%")
+      end
     end
 
     context "when the user has no sales" do

--- a/spec/services/radar/seller_risk_stats_service_spec.rb
+++ b/spec/services/radar/seller_risk_stats_service_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Radar::SellerRiskStatsService do
+  let(:seller) { create(:user) }
+  let(:product) { create(:product, user: seller) }
+
+  it "counts a Stripe dispute in dispute_count/rate and ignores a PayPal-processor one" do
+    stripe_purchase = create(:purchase, link: product)
+    paypal_purchase = create(:purchase, link: product)
+    paypal_purchase.update_column(:charge_processor_id, PaypalChargeProcessor.charge_processor_id)
+
+    create(:dispute, purchase: stripe_purchase, seller:, state: :formalized, event_created_at: Time.current)
+    create(:dispute, purchase: paypal_purchase, seller:, state: :formalized, event_created_at: Time.current)
+
+    stats = described_class.new(seller).stats
+    expect(stats[:successful_purchases]).to eq(1)
+    expect(stats[:dispute_count]).to eq(1)
+    expect(stats[:dispute_rate]).to eq(100.0)
+  end
+end

--- a/spec/services/risk/stranded_buyer_recovery_service_spec.rb
+++ b/spec/services/risk/stranded_buyer_recovery_service_spec.rb
@@ -235,6 +235,15 @@ describe Risk::StrandedBuyerRecoveryService do
       expect(result.reason).to eq(:unreversed_chargeback)
     end
 
+    it "does not veto on a PayPal-processor chargeback" do
+      paypal = create(:purchase, email: buyer_email, purchase_state: "successful",
+                                 stripe_fingerprint: "paypal-other-card", chargeback_date: 1.month.ago,
+                                 created_at: 7.months.ago)
+      paypal.update_column(:charge_processor_id, PaypalChargeProcessor.charge_processor_id)
+
+      expect(call.verdict).to eq(:cleared)
+    end
+
     it "does not veto on a chargeback that was reversed" do
       create(:purchase, email: buyer_email, purchase_state: "successful",
                         stripe_fingerprint: "reversed-other-card", chargeback_date: 1.month.ago,

--- a/spec/services/risk/stranded_buyer_scan_service_spec.rb
+++ b/spec/services/risk/stranded_buyer_scan_service_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Risk::StrandedBuyerScanService do
+  describe "#reject_disputed" do
+    it "does not drop a buyer whose only chargeback is PayPal-processor" do
+      email = "paypal-buyer@example.com"
+      paypal = create(:purchase, email:, chargeback_date: Time.current)
+      paypal.update_column(:charge_processor_id, PaypalChargeProcessor.charge_processor_id)
+
+      settled = { email => 3 }
+      expect(described_class.new.send(:reject_disputed, settled)).to eq(settled)
+    end
+
+    it "still drops a buyer with a Stripe chargeback" do
+      email = "stripe-buyer@example.com"
+      create(:purchase, email:, chargeback_date: Time.current)
+
+      expect(described_class.new.send(:reject_disputed, { email => 3 })).to eq({})
+    end
+  end
+end

--- a/spec/support/fixtures/vcr_cassettes/User_Stats/_lost_chargebacks/when_the_user_has_sales/ignores_PayPal-processor_chargebacks_and_still_counts_Stripe_ones.yml
+++ b/spec/support/fixtures/vcr_cassettes/User_Stats/_lost_chargebacks/when_the_user_has_sales/ignores_PayPal-processor_chargebacks_and_still_counts_Stripe_ones.yml
@@ -1,0 +1,287 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_UDAH0KszdJfZo2","request_duration_ms":7}}'
+      Idempotency-Key:
+      - 1d9a9906-0028-4cc3-950e-f916e724040b
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 12 Sep 2026 04:39:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=FO1aYgUC991ZhUw_b4IklIoHoLvLfa4KxewVDz-KcyihSnwFJeYHGitSBqUJG9uexvXAf2i6QyJx_dIX;
+        report-to csp
+      Idempotency-Key:
+      - 1d9a9906-0028-4cc3-950e-f916e724040b
+      Original-Request:
+      - req_k3sPOmrYN62EXx
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=FO1aYgUC991ZhUw_b4IklIoHoLvLfa4KxewVDz-KcyihSnwFJeYHGitSBqUJG9uexvXAf2i6QyJx_dIX&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=FO1aYgUC991ZhUw_b4IklIoHoLvLfa4KxewVDz-KcyihSnwFJeYHGitSBqUJG9uexvXAf2i6QyJx_dIX&t=1"
+      Request-Id:
+      - req_k3sPOmrYN62EXx
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-08-26.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1UEij9IBOqvOFDrfsyDyXLlg",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 9,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1789187987,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 12 Sep 2026 04:39:47 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_methods
+    body:
+      encoding: UTF-8
+      string: type=card&card[token]=tok_createDispute
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_k3sPOmrYN62EXx","request_duration_ms":275}}'
+      Idempotency-Key:
+      - b176e450-a138-4102-9517-59957779baa9
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - "<STRIPE_CLIENT_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 12 Sep 2026 04:39:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1122'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=FO1aYgUC991ZhUw_b4IklIoHoLvLfa4KxewVDz-KcyihSnwFJeYHGitSBqUJG9uexvXAf2i6QyJx_dIX;
+        report-to csp
+      Idempotency-Key:
+      - b176e450-a138-4102-9517-59957779baa9
+      Original-Request:
+      - req_8FpByU7jjg9IrV
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=FO1aYgUC991ZhUw_b4IklIoHoLvLfa4KxewVDz-KcyihSnwFJeYHGitSBqUJG9uexvXAf2i6QyJx_dIX&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=FO1aYgUC991ZhUw_b4IklIoHoLvLfa4KxewVDz-KcyihSnwFJeYHGitSBqUJG9uexvXAf2i6QyJx_dIX&t=1"
+      Request-Id:
+      - req_8FpByU7jjg9IrV
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-08-26.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pm_1UEijAIBOqvOFDrfy4z2qBdW",
+          "object": "payment_method",
+          "allow_redisplay": "unspecified",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "unchecked"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 9,
+            "exp_year": 2027,
+            "fingerprint": "xhj6XkBnqmm1SCzj",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0259",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1789187988,
+          "customer": null,
+          "customer_account": null,
+          "livemode": false,
+          "metadata": {},
+          "shared_payment_granted_token": null,
+          "type": "card"
+        }
+  recorded_at: Sat, 12 Sep 2026 04:39:48 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
PayPal checkout charges the seller's own PayPal account. Gumroad is not merchant of record and the money never hits our books, so those disputes are the seller's PayPal problem — they should not count as a Gumroad risk signal about a seller or a buyer.

This matches the existing risk-dashboard split of seller Stripe Connect disputes (dashboards#105): if it is not our liability, it does not belong in our rate, pause, or fraud gates. Stripe (Gumroad MoR) disputes still count.

Signals changed (PayPal-processor purchases excluded via one predicate, `User::Risk.not_paypal_processor_sql` / `Purchase.excluding_paypal_processor` / `Dispute.excluding_paypal_processor`):

- Seller dispute-rate stats (refund-policy enforcement)
- Seller lost-chargeback volume/count (payout pause + release)
- Radar seller dispute count/rate
- Admin product `recent_chargeback_rate`
- Buyer auto-block on chargeback count
- Checkout `check_for_past_chargebacks`
- Stranded-buyer scan `reject_disputed` and recovery dispute veto

Left alone: refunds, balances, dispute evidence, buyer-facing dispute handling, tax/finance reports, PayPal webhook processing.

Production 28-day disputes (replica, 2026-09-12): 736 total, 180 PayPal ($4,094), 556 not-PayPal ($39,349). After this change the risk dashboard chargeback tiles drop the 180 PayPal rows.

Does not merge autonomously — it changes payout-pause and refund-policy gates.

Premerge review: clean @ 7083dcba608cf4bc462830a07f1bbdbcf22117c4

<!-- gumclaw-ownership-sweep -->
_Ownership sweep:_ Ownership sweep: assigning **@gianfrancopiana** as the human owner of this (PR) — derived from who owns the linked PR / filed it / reviews this surface. Labelled `awaiting-human`: it's with you now.

Automated ownership fix — while an item is being worked, assignee=gumclaw; at hand-off, assignee swaps to a human. If more visibility is needed, add another human assignee rather than replacing.
<!-- gumclaw-ownership-sweep -->
