### PR TITLE
Native EUR charging on the platform account (slice 1)

### DIFF
--- a/app/helpers/currency_helper.rb
+++ b/app/helpers/currency_helper.rb
@@ -250,7 +250,18 @@ module CurrencyHelper
 
     # Accounts that settle this currency in itself rather than USD reject the FX quote the
     # charge needs, so a local price shown for them always ends up charged in USD.
-    Checkout::BuyerCurrencyEligibility.usd_settling_merchant_account?(merchant_account, presentment_currency: buyer_currency, seller:)
+    return true if Checkout::BuyerCurrencyEligibility.usd_settling_merchant_account?(merchant_account, presentment_currency: buyer_currency, seller:)
+
+    # Native EUR charging (flag on, platform account, USD one-time product) skips the quote,
+    # so the mismatch marker must not hide EUR from the picker for that seller.
+    return false unless Checkout::BuyerCurrencyEligibility.eur_native_charging_shape?(
+      seller:,
+      merchant_account:,
+      buyer_currency:,
+      products: [product]
+    )
+
+    buyer_local_currency_rate(from_currency: buyer_currency, to_currency: Currency::USD).present?
   end
 
   # The product-shape half of the gate, kept in step with

--- a/app/models/charge_presentment.rb
+++ b/app/models/charge_presentment.rb
@@ -10,10 +10,10 @@ class ChargePresentment < ApplicationRecord
   # base_rate is deliberately not persisted, so the spread is not reconstructible from these
   # rows (see StripeFxQuote#parsed_rate and the note on Balance#holding_currency).
 
-  # Stripe rows come in two shapes. Quote-backed buyer presentment carries all three quote
-  # columns. Direct-listed presentment has no FX conversion, so all three stay null.
-  # Enforce all-or-none so a partially persisted quote can never slip through.
-  validate :stripe_fx_quote_fields_all_or_none, if: :stripe_processor?
+  # Stripe rows: quote-backed (all three quote columns), direct-listed (all three
+  # blank), or cached-rate native presentment (fx_rate only). A quote id without
+  # expiry and rate is never valid.
+  validate :stripe_fx_quote_fields_consistent, if: :stripe_processor?
   validates :presentment_total_cents, :presentment_gumroad_amount_cents, numericality: { greater_than_or_equal_to: 0, only_integer: true }
   # Signed on purpose: negative when mirroring the seller's price ending lowered the
   # buyer's total, positive when it raised it. Zero on every charge that was not rounded.
@@ -24,10 +24,12 @@ class ChargePresentment < ApplicationRecord
       processor == StripeChargeProcessor.charge_processor_id
     end
 
-    def stripe_fx_quote_fields_all_or_none
-      quote_fields = [stripe_fx_quote_id, stripe_fx_quote_expires_at, fx_rate]
-      return if quote_fields.all?(&:present?) || quote_fields.all?(&:blank?)
+    def stripe_fx_quote_fields_consistent
+      quoted = stripe_fx_quote_id.present? || stripe_fx_quote_expires_at.present?
+      if quoted
+        return if stripe_fx_quote_id.present? && stripe_fx_quote_expires_at.present? && fx_rate.present?
 
-      errors.add(:base, "Stripe FX quote fields must either all be present (quote-backed row) or all be blank (quote-less direct-listed row)")
+        errors.add(:base, "Stripe FX quote id, expiry, and rate must all be present together")
+      end
     end
 end

--- a/app/models/charge_presentment.rb
+++ b/app/models/charge_presentment.rb
@@ -11,7 +11,7 @@ class ChargePresentment < ApplicationRecord
   # rows (see StripeFxQuote#parsed_rate and the note on Balance#holding_currency).
 
   # Stripe rows: quote-backed (all three quote columns), direct-listed (all three
-  # blank), or cached-rate native presentment (fx_rate only). A quote id without
+  # blank), or cached-rate native EUR presentment (fx_rate only). A quote id without
   # expiry and rate is never valid.
   validate :stripe_fx_quote_fields_consistent, if: :stripe_processor?
   validates :presentment_total_cents, :presentment_gumroad_amount_cents, numericality: { greater_than_or_equal_to: 0, only_integer: true }
@@ -30,6 +30,8 @@ class ChargePresentment < ApplicationRecord
         return if stripe_fx_quote_id.present? && stripe_fx_quote_expires_at.present? && fx_rate.present?
 
         errors.add(:base, "Stripe FX quote id, expiry, and rate must all be present together")
+      elsif fx_rate.present? && presentment_currency.to_s.downcase != Currency::EUR
+        errors.add(:base, "Cached-rate presentment without a Stripe FX quote is only valid for EUR")
       end
     end
 end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -172,6 +172,7 @@ class Purchase < ApplicationRecord
   has_one :charge_purchase, dependent: :destroy
   has_one :charge, through: :charge_purchase, dependent: :destroy
   has_one :purchase_presentment, dependent: :destroy
+  has_one :charge_presentment, through: :purchase_presentment
   has_one :early_fraud_warning, dependent: :destroy
   has_one :tip, dependent: :destroy
 
@@ -664,6 +665,13 @@ class Purchase < ApplicationRecord
   scope :by_email, ->(email) { where(email:) }
   scope :with_stripe_fingerprint, -> { where.not(stripe_fingerprint: nil) }
   scope :successful, -> { where(purchase_state: "successful") }
+  # Quote-less EUR presentment that still stored a conversion rate (native EUR charging).
+  # Distinct from iDEAL/Bancontact on EUR-priced products, which persist no fx_rate.
+  scope :with_eur_native_charging_rate, -> {
+    joins(purchase_presentment: :charge_presentment)
+      .where(charge_presentments: { presentment_currency: Currency::EUR, stripe_fx_quote_id: nil })
+      .where.not(charge_presentments: { fx_rate: nil })
+  }
   scope :test_successful, -> { where(purchase_state: "test_successful") }
   scope :in_progress, -> { where(purchase_state: "in_progress") }
   # In-flight payment: ACH clearing, or a Pix QR still payable. stripe_status is set only

--- a/app/services/charge/method_forced_presentment.rb
+++ b/app/services/charge/method_forced_presentment.rb
@@ -142,7 +142,7 @@ class Charge::MethodForcedPresentment
       # Registry methods still need their live launch flag — a tab opened while UPI
       # was on can keep a signed inr_types list after rollback.
       decision = if displayed_quote?
-        eligibility.decision
+        eligibility.decision(payment_method: payment_method_type)
       else
         eligibility.method_forced_decision(payment_method: payment_method_type, forced_currency:)
       end
@@ -211,6 +211,13 @@ class Charge::MethodForcedPresentment
 
       locked_quote = locked_or_minted_quote(currency, quote_merchant_account)
       return nil if locked_quote.blank?
+      # A card-minted native EUR token has a cached rate and no Stripe FX quote id.
+      # Forced-currency methods cannot charge through that shape.
+      if Checkout::BuyerCurrencyEligibility.forced_currency_for(payment_method_type).present? &&
+         locked_quote.stripe_fx_quote_id.blank?
+        reject_displayed_quote!
+        return nil
+      end
 
       orchestrator = Charge::PresentmentOrchestrator.new(
         charge:,

--- a/app/services/charge/presentment_orchestrator.rb
+++ b/app/services/charge/presentment_orchestrator.rb
@@ -140,8 +140,8 @@ class Charge::PresentmentOrchestrator
       presentment_total_cents:,
       presentment_gumroad_amount_cents:,
       allocations:,
-      stripe_fx_quote_id: locked_quote.id,
-      stripe_fx_quote_expires_at: locked_quote.expires_at,
+      stripe_fx_quote_id: locked_quote.stripe_fx_quote_id,
+      stripe_fx_quote_expires_at: locked_quote.stripe_fx_quote_id.present? ? locked_quote.expires_at : nil,
       fx_rate: locked_quote.fx_rate,
       rounding_delta_cents: rounding_delta_cents
     )

--- a/app/services/checkout/buyer_currency_eligibility.rb
+++ b/app/services/checkout/buyer_currency_eligibility.rb
@@ -137,6 +137,12 @@ class Checkout::BuyerCurrencyEligibility
     end
   end
 
+  # Native EUR is the card/Link quote lane. Forced-currency methods keep their own
+  # presentment path even when a card quote is already in params (buyer switched to iDEAL).
+  def self.eur_native_charging_payment_method?(payment_method)
+    forced_currency_for(payment_method).blank?
+  end
+
   # The cart-shaped half of #decision's listed lane, for the selector and the surcharge menu,
   # which have line items rather than purchases. Every gate #decision reaches before that lane
   # returns eligible is re-applied here when a line item can answer it, so this never advertises
@@ -389,7 +395,7 @@ class Checkout::BuyerCurrencyEligibility
     @client_confirm = client_confirm
   end
 
-  def decision
+  def decision(payment_method: nil)
     return fallback(:feature_disabled) unless self.class.seller_enabled?(seller)
     return fallback(:unsupported_processor) unless merchant_account&.stripe_charge_processor?
     return fallback(:unsupported_charge_model) unless supported_charge_model?
@@ -480,9 +486,11 @@ class Checkout::BuyerCurrencyEligibility
     # Checked here (not up top with the other account gates) because the settlement
     # mismatch marker is scoped to the presentment currency, which isn't known earlier.
     # Native EUR charging skips the Stripe FX quote, so a live EUR mismatch must not
-    # hide this lane when the flag is on for the seller.
+    # hide this lane when the flag is on for the seller. Forced-currency methods are
+    # excluded: a displayed card quote must not carry this lane onto iDEAL.
     unless usd_settling_merchant_account?(buyer_currency) ||
-           self.class.eur_native_charging_shape?(seller:, merchant_account:, buyer_currency:, purchases:)
+           (self.class.eur_native_charging_shape?(seller:, merchant_account:, buyer_currency:, purchases:) &&
+            self.class.eur_native_charging_payment_method?(payment_method))
       return fallback(:unsupported_settlement_currency)
     end
 

--- a/app/services/checkout/buyer_currency_eligibility.rb
+++ b/app/services/checkout/buyer_currency_eligibility.rb
@@ -24,6 +24,12 @@ class Checkout::BuyerCurrencyEligibility
   # with the purchase's stored rate.
   LISTED_CURRENCY_DIRECT_CHARGE_FEATURE_NAME = :checkout_listed_currency_direct_charge
 
+  # USD-priced one-time products on the shared platform account, card only. Mints a EUR
+  # PaymentIntent with no Stripe FX quote and converts at the cached product-page rate.
+  # Default off; actor-gated.
+  EUR_NATIVE_CHARGING_FEATURE_NAME = :eur_native_charging
+  EUR_NATIVE_QUOTE_TTL = 1.hour
+
   # Memberships get their own ramp because the buyer-currency amount outlives checkout.
   # Pulling it stops new memberships; renewals keep billing the stored fixed amount.
   SUBSCRIPTION_FEATURE_NAME = :buyer_currency_subscriptions
@@ -78,6 +84,57 @@ class Checkout::BuyerCurrencyEligibility
 
   def self.listed_currency_direct_charge_enabled?(seller)
     seller.present? && Feature.active?(LISTED_CURRENCY_DIRECT_CHARGE_FEATURE_NAME, seller)
+  end
+
+  def self.eur_native_charging_enabled?(seller)
+    seller.present? && Feature.active?(EUR_NATIVE_CHARGING_FEATURE_NAME, seller)
+  end
+
+  # Shared platform account only (MerchantAccount.gumroad / user_id nil). Connect and
+  # Custom destination charges keep the FX-quote path.
+  def self.platform_charging_account?(merchant_account)
+    merchant_account.present? &&
+      merchant_account.stripe_charge_processor? &&
+      merchant_account.is_managed_by_gumroad?
+  end
+
+  def self.eur_native_charging_product?(product)
+    return false if product.blank?
+    return false unless product.price_currency_type.to_s.downcase == Currency::USD
+    return false if product.is_physical?
+    return false if product.is_recurring_billing?
+    return false if product.is_in_preorder_state?
+    return false if product.native_type == Link::NATIVE_TYPE_COMMISSION
+    return false if product.installment_plan.present?
+    return false if product.free_trial_enabled?
+
+    true
+  end
+
+  def self.eur_native_charging_purchase?(purchase)
+    return false unless eur_native_charging_product?(purchase&.link)
+    return false if purchase.shipping_cents.to_i.positive?
+    return false if purchase.is_installment_payment?
+    return false if purchase.is_preorder_authorization?
+    return false if purchase.is_commission_deposit_purchase?
+
+    true
+  end
+
+  # Shape-only: flag, EUR, platform account, one-time USD product. Callers that
+  # convert still need a positive cached USD-per-EUR rate.
+  def self.eur_native_charging_shape?(seller:, merchant_account:, buyer_currency:, products: [], purchases: [])
+    return false unless buyer_currency.to_s.downcase == Currency::EUR
+    return false unless eur_native_charging_enabled?(seller)
+    return false unless platform_charging_account?(merchant_account)
+
+    if purchases.present?
+      purchases.all? { eur_native_charging_purchase?(_1) }
+    elsif products.present?
+      products.all? { eur_native_charging_product?(_1) }
+    else
+      false
+    end
   end
 
   # The cart-shaped half of #decision's listed lane, for the selector and the surcharge menu,
@@ -422,7 +479,12 @@ class Checkout::BuyerCurrencyEligibility
 
     # Checked here (not up top with the other account gates) because the settlement
     # mismatch marker is scoped to the presentment currency, which isn't known earlier.
-    return fallback(:unsupported_settlement_currency) unless usd_settling_merchant_account?(buyer_currency)
+    # Native EUR charging skips the Stripe FX quote, so a live EUR mismatch must not
+    # hide this lane when the flag is on for the seller.
+    unless usd_settling_merchant_account?(buyer_currency) ||
+           self.class.eur_native_charging_shape?(seller:, merchant_account:, buyer_currency:, purchases:)
+      return fallback(:unsupported_settlement_currency)
+    end
 
     eligible(currency: buyer_currency)
   end

--- a/app/services/checkout/buyer_currency_quote.rb
+++ b/app/services/checkout/buyer_currency_quote.rb
@@ -695,7 +695,13 @@ class Checkout::BuyerCurrencyQuote
       # suppress quoting for its GBP, nor for a seller charging on a different account. Sellers
       # without their own Stripe Connect account share the Gumroad platform account, so they do
       # share a marker with each other (see the rescue in #create).
-      return unless Checkout::BuyerCurrencyEligibility.usd_settling_merchant_account?(merchant_account, presentment_currency: buyer_currency, seller:)
+      native_eur = Checkout::BuyerCurrencyEligibility.eur_native_charging_shape?(
+        seller:,
+        merchant_account:,
+        buyer_currency:,
+        products: charge_line_items.map(&:product)
+      )
+      return unless native_eur || Checkout::BuyerCurrencyEligibility.usd_settling_merchant_account?(merchant_account, presentment_currency: buyer_currency, seller:)
 
       # The quote must be minted on the account this seller's PaymentIntent will be created on,
       # which for a destination charge is the Gumroad platform account rather than the seller's
@@ -715,24 +721,29 @@ class Checkout::BuyerCurrencyQuote
       # the buyer's hands.
       return unless charge_canonical_total_cents.positive?
 
-      quote = begin
-        StripeFxQuote.create(
-          to_currency: Currency::USD,
-          from_currency: buyer_currency,
-          stripe_account_id: quote_merchant_account.charge_processor_merchant_id,
-          # Declared up front because Stripe matches the quote's destination against the
-          # intent's transfer_data[destination] exactly; see StripeFxQuote#create.
-          destination_account_id: Checkout::BuyerCurrencyEligibility.fx_quote_destination_account_id(merchant_account)
-        )
-      rescue StripeFxQuote::SettlementCurrencyMismatch
-        # Record which account rejected the currency so the next checkout on that account
-        # skips the doomed round trip, then re-raise: #create turns it into the quiet
-        # cart-wide canonical-USD fallback. The marker goes on the account the quote was
-        # MINTED on (the platform account for a destination charge), because that is the
-        # account whose settlement currency Stripe objected to.
-        record_settlement_currency_mismatch(quote_merchant_account, buyer_currency)
-        raise
+      quote = if native_eur
+        cached_rate_quote(buyer_currency)
+      else
+        begin
+          StripeFxQuote.create(
+            to_currency: Currency::USD,
+            from_currency: buyer_currency,
+            stripe_account_id: quote_merchant_account.charge_processor_merchant_id,
+            # Declared up front because Stripe matches the quote's destination against the
+            # intent's transfer_data[destination] exactly; see StripeFxQuote#create.
+            destination_account_id: Checkout::BuyerCurrencyEligibility.fx_quote_destination_account_id(merchant_account)
+          )
+        rescue StripeFxQuote::SettlementCurrencyMismatch
+          # Record which account rejected the currency so the next checkout on that account
+          # skips the doomed round trip, then re-raise: #create turns it into the quiet
+          # cart-wide canonical-USD fallback. The marker goes on the account the quote was
+          # MINTED on (the platform account for a destination charge), because that is the
+          # account whose settlement currency Stripe objected to.
+          record_settlement_currency_mismatch(quote_merchant_account, buyer_currency)
+          raise
+        end
       end
+      return if quote.blank?
       converted_total_cents = presentment_cents_for(charge_canonical_total_cents, quote.fx_rate, buyer_currency)
       # Give the converted total the same price ending the seller chose in USD ($9.99 →
       # €8,99, $10 → €9), HERE, before the token is signed, so the rounded amount is the one
@@ -1039,5 +1050,18 @@ class Checkout::BuyerCurrencyQuote
       raise ArgumentError, "FX rate must be positive" unless fx_rate.positive?
 
       ((BigDecimal(canonical_usd_cents.to_s) / subunit_to_unit(Currency::USD)) / fx_rate * subunit_to_unit(currency)).round
+    end
+
+    # Same Stripe-shaped rate the product page shows inverted (USD per EUR), locked for
+    # an hour so verify! still has an expiry. No Stripe FX quote id.
+    def cached_rate_quote(buyer_currency)
+      rate = buyer_local_currency_rate(from_currency: buyer_currency, to_currency: Currency::USD)
+      return if rate.blank?
+
+      StripeFxQuote::Quote.new(
+        id: nil,
+        expires_at: Checkout::BuyerCurrencyEligibility::EUR_NATIVE_QUOTE_TTL.from_now,
+        fx_rate: rate
+      )
     end
 end

--- a/app/services/order/prepare_payment_intent_service.rb
+++ b/app/services/order/prepare_payment_intent_service.rb
@@ -643,7 +643,7 @@ class Order::PreparePaymentIntentService
         setup_future_charges: false,
         off_session: false,
         client_confirm: true
-      ).decision
+      ).decision(payment_method: @previewed_payment_method_type)
     end
 
     def buyer_currency_quote_presentment_for(charge)

--- a/spec/controllers/customer_surcharge_controller_spec.rb
+++ b/spec/controllers/customer_surcharge_controller_spec.rb
@@ -135,6 +135,7 @@ describe CustomerSurchargeController, :vcr do
       Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, @user)
       Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::SUBSCRIPTION_FEATURE_NAME, @user)
       Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::LISTED_CURRENCY_DIRECT_CHARGE_FEATURE_NAME, @user)
+      Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::EUR_NATIVE_CHARGING_FEATURE_NAME, @user)
     end
 
 
@@ -165,6 +166,26 @@ describe CustomerSurchargeController, :vcr do
       }, as: :json
 
       expect(response.parsed_body.fetch("buyer_currency_quote")).to be_nil
+    end
+
+    it "offers EUR and quotes it without Stripe when native EUR charging is on" do
+      Feature.activate_user(Checkout::BuyerCurrencyEligibility::EUR_NATIVE_CHARGING_FEATURE_NAME, @user)
+      MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id).record_settlement_currency_mismatch!(Currency::EUR)
+      allow_any_instance_of(Checkout::BuyerCurrencyQuote).to receive(:buyer_local_currency_rate).and_return(BigDecimal("1.1"))
+      allow_any_instance_of(CustomerSurchargeController).to receive(:buyer_local_currency_rate).and_return(BigDecimal("1.1"))
+      expect(StripeFxQuote).not_to receive(:create)
+
+      post "calculate_all", params: {
+        products: [{ permalink: @product.unique_permalink, price: 100, quantity: 1 }],
+        buyer_currency: Currency::EUR,
+      }, as: :json
+
+      codes = response.parsed_body.fetch("available_buyer_currencies").map { |currency| currency["code"] }
+      expect(codes).to include(Currency::EUR)
+      quote = response.parsed_body.fetch("buyer_currency_quote")
+      expect(quote).to include("currency" => Currency::EUR)
+      payload = Rails.application.message_verifier(:buyer_currency_quote).verify(quote.fetch("token"))
+      expect(payload["stripe_fx_quote_id"]).to be_nil
     end
 
     it "keeps the quoted buyer currency available for a mixed listed-currency cart" do

--- a/spec/helpers/buyer_local_currency_helper_spec.rb
+++ b/spec/helpers/buyer_local_currency_helper_spec.rb
@@ -270,6 +270,25 @@ describe CurrencyHelper do
       expect(props).to include(display_mode: "default", buyer_currency_shown: "usd", rate: nil)
     end
 
+    it "shows EUR on the platform account when native EUR charging is on for the seller" do
+      platform = MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id) ||
+        create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_gumroad", currency: Currency::USD)
+      platform.record_settlement_currency_mismatch!("eur")
+      platform_seller = create(:user, disable_buyer_local_currency: false)
+      platform_product = create(:product, user: platform_seller, price_cents: 1000, price_currency_type: "usd")
+      Feature.activate_user(:buyer_local_currency, platform_seller)
+      Feature.activate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, platform_seller)
+      Feature.activate_user(Checkout::BuyerCurrencyEligibility::EUR_NATIVE_CHARGING_FEATURE_NAME, platform_seller)
+
+      props = helper.buyer_currency_display_props(product: platform_product, price_cents: 1000, ip: "1.2.3.4")
+
+      expect(props).to include(display_mode: "buyer_local", buyer_currency_shown: "eur")
+    ensure
+      Feature.deactivate_user(:buyer_local_currency, platform_seller) if platform_seller
+      Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, platform_seller) if platform_seller
+      Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::EUR_NATIVE_CHARGING_FEATURE_NAME, platform_seller) if platform_seller
+    end
+
     it "keeps showing another currency the same account can still settle" do
       merchant_account.record_settlement_currency_mismatch!("eur")
       allow(helper).to receive(:buyer_currency_for_ip).and_return("gbp")

--- a/spec/models/charge_presentment_spec.rb
+++ b/spec/models/charge_presentment_spec.rb
@@ -31,6 +31,17 @@ describe ChargePresentment do
     expect(presentment).to be_valid
   end
 
+  it "rejects cached-rate rows without a quote id for currencies other than EUR" do
+    presentment = build(:charge_presentment,
+                        stripe_fx_quote_id: nil,
+                        stripe_fx_quote_expires_at: nil,
+                        fx_rate: BigDecimal("1.1"),
+                        presentment_currency: Currency::GBP)
+
+    expect(presentment).not_to be_valid
+    expect(presentment.errors).to include(:base)
+  end
+
   it "rejects Stripe rows with a partially persisted quote" do
     presentment = build(:charge_presentment,
                         stripe_fx_quote_id: "fxq_partial",

--- a/spec/models/charge_presentment_spec.rb
+++ b/spec/models/charge_presentment_spec.rb
@@ -21,6 +21,16 @@ describe ChargePresentment do
     expect(presentment).to be_valid
   end
 
+  it "allows Stripe rows with a cached rate and no quote id" do
+    presentment = build(:charge_presentment,
+                        stripe_fx_quote_id: nil,
+                        stripe_fx_quote_expires_at: nil,
+                        fx_rate: BigDecimal("1.1"),
+                        presentment_currency: Currency::EUR)
+
+    expect(presentment).to be_valid
+  end
+
   it "rejects Stripe rows with a partially persisted quote" do
     presentment = build(:charge_presentment,
                         stripe_fx_quote_id: "fxq_partial",

--- a/spec/services/checkout/eur_native_charging_spec.rb
+++ b/spec/services/checkout/eur_native_charging_spec.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "native EUR charging" do
+  def platform_account
+    MerchantAccount.gumroad(StripeChargeProcessor.charge_processor_id)&.tap do |account|
+      account.update!(charge_processor_merchant_id: "acct_gumroad", currency: Currency::USD)
+    end || create(:merchant_account, user: nil, charge_processor_merchant_id: "acct_gumroad", currency: Currency::USD)
+  end
+
+  let(:seller) { create(:user, disable_buyer_local_currency: false, disable_buyer_currency_rounding: true) }
+  let(:product) { create(:product, user: seller, price_cents: 10_00, price_currency_type: Currency::USD) }
+  let(:merchant_account) { platform_account }
+  let(:fx_rate) { BigDecimal("1.1") }
+
+  before do
+    merchant_account
+    Feature.activate_user(:buyer_local_currency, seller)
+    Feature.activate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller)
+    Feature.activate_user(Checkout::BuyerCurrencyEligibility::EUR_NATIVE_CHARGING_FEATURE_NAME, seller)
+    allow(Stripe).to receive(:api_key).and_return("sk_test_eur_native")
+  end
+
+  after do
+    Feature.deactivate_user(:buyer_local_currency, seller)
+    Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::FEATURE_NAME, seller)
+    Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::EUR_NATIVE_CHARGING_FEATURE_NAME, seller)
+  end
+
+  describe Checkout::BuyerCurrencyEligibility do
+    let(:purchase) do
+      create(:purchase,
+             link: product,
+             seller:,
+             merchant_account:,
+             purchase_state: "in_progress",
+             ip_address: "203.0.113.1")
+    end
+    let(:chargeable) { instance_double(Chargeable, get_chargeable_for: instance_double(StripeChargeablePaymentMethod)) }
+
+    def eligibility_decision(currency: Currency::EUR)
+      token = Rails.application.message_verifier(:buyer_currency_quote).generate({ currency: })
+      described_class.new(
+        order: create(:order),
+        seller:,
+        merchant_account:,
+        chargeable:,
+        purchases: [purchase],
+        params: { buyer_currency_quote: token },
+        setup_future_charges: false,
+        off_session: false
+      ).decision
+    end
+
+    it "stays eligible for EUR on the platform account when the mismatch marker is set" do
+      merchant_account.record_settlement_currency_mismatch!(Currency::EUR)
+
+      decision = eligibility_decision
+      expect(decision).to be_eligible
+      expect(decision.currency).to eq(Currency::EUR)
+      expect(decision.direct_listed_amount?).to eq(false)
+    end
+
+    it "falls back when the flag is off" do
+      Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::EUR_NATIVE_CHARGING_FEATURE_NAME, seller)
+      merchant_account.record_settlement_currency_mismatch!(Currency::EUR)
+
+      decision = eligibility_decision
+      expect(decision).not_to be_eligible
+      expect(decision.fallback_reason).to eq(:unsupported_settlement_currency)
+    end
+
+    it "does not apply to Stripe Connect sellers" do
+      connect_account = create(:merchant_account_stripe_connect, user: seller)
+      seller.update!(check_merchant_account_is_linked: true)
+      connect_account.record_settlement_currency_mismatch!(Currency::EUR)
+      purchase.update!(merchant_account: connect_account)
+
+      decision = described_class.new(
+        order: create(:order),
+        seller:,
+        merchant_account: connect_account,
+        chargeable:,
+        purchases: [purchase],
+        params: { buyer_currency_quote: Rails.application.message_verifier(:buyer_currency_quote).generate({ currency: Currency::EUR }) },
+        setup_future_charges: false,
+        off_session: false
+      ).decision
+
+      expect(decision).not_to be_eligible
+      expect(decision.fallback_reason).to eq(:unsupported_settlement_currency)
+    end
+
+    it "excludes memberships, preorders, and shipping" do
+      merchant_account.record_settlement_currency_mismatch!(Currency::EUR)
+
+      purchase.update!(link: create(:membership_product, user: seller, price_currency_type: Currency::USD))
+      expect(eligibility_decision).not_to be_eligible
+
+      purchase.update!(link: create(:product, user: seller, price_currency_type: Currency::USD, is_in_preorder_state: true), is_preorder_authorization: true)
+      expect(eligibility_decision).not_to be_eligible
+
+      purchase.update!(link: create(:physical_product, user: seller, price_currency_type: Currency::USD), shipping_cents: 500, is_preorder_authorization: false)
+      expect(eligibility_decision).not_to be_eligible
+    end
+  end
+
+  describe Checkout::BuyerCurrencyQuote do
+    def line_items
+      [described_class::LineItem.new(
+        permalink: product.unique_permalink,
+        product:,
+        price_cents: 10_00,
+        tip_cents: 0,
+        seller_tax_cents: 0,
+        gumroad_tax_cents: 0,
+        shipping_cents: 0
+      )]
+    end
+
+    before do
+      allow_any_instance_of(described_class).to receive(:buyer_local_currency_rate).and_return(fx_rate)
+    end
+
+    it "mints a quote-less EUR lock from the cached rate and does not call Stripe" do
+      merchant_account.record_settlement_currency_mismatch!(Currency::EUR)
+      expect(StripeFxQuote).not_to receive(:create)
+
+      result = described_class.create(
+        line_items:,
+        canonical_total_cents: 10_00,
+        ip: "203.0.113.1",
+        currency: Currency::EUR
+      )
+
+      expect(result).to have_attributes(
+        currency: Currency::EUR,
+        canonical_total_cents: 10_00,
+        presentment_total_cents: 909
+      )
+      payload = Rails.application.message_verifier(:buyer_currency_quote).verify(result.token)
+      expect(payload["stripe_fx_quote_id"]).to be_nil
+      expect(BigDecimal(payload["fx_rate"])).to eq(fx_rate)
+    end
+
+    it "does not mint when the flag is off" do
+      Feature.deactivate_user(Checkout::BuyerCurrencyEligibility::EUR_NATIVE_CHARGING_FEATURE_NAME, seller)
+      merchant_account.record_settlement_currency_mismatch!(Currency::EUR)
+      allow(StripeFxQuote).to receive(:create).and_raise(StripeFxQuote::SettlementCurrencyMismatch, "eur")
+
+      result = described_class.create(
+        line_items:,
+        canonical_total_cents: 10_00,
+        ip: "203.0.113.1",
+        currency: Currency::EUR
+      )
+
+      expect(result).to be_nil
+    end
+  end
+
+  describe Charge::CreateService do
+    it "creates a EUR PaymentIntent with no Stripe FX quote and keeps seller USD" do
+      allow_any_instance_of(Checkout::BuyerCurrencyQuote).to receive(:buyer_local_currency_rate).and_return(fx_rate)
+      merchant_account.record_settlement_currency_mismatch!(Currency::EUR)
+
+      quote = Checkout::BuyerCurrencyQuote.create(
+        line_items: [Checkout::BuyerCurrencyQuote::LineItem.new(
+          permalink: product.unique_permalink,
+          product:,
+          price_cents: 10_00,
+          tip_cents: 0,
+          seller_tax_cents: 0,
+          gumroad_tax_cents: 0,
+          shipping_cents: 0
+        )],
+        canonical_total_cents: 10_00,
+        ip: "203.0.113.1",
+        currency: Currency::EUR
+      )
+
+      order = create(:order)
+      purchase = create(:purchase,
+                        link: product,
+                        seller:,
+                        merchant_account:,
+                        purchase_state: "in_progress",
+                        ip_address: "203.0.113.1",
+                        price_cents: 10_00,
+                        total_transaction_cents: 10_00)
+      order.purchases << purchase
+      stripe_chargeable = instance_double(StripeChargeablePaymentMethod)
+      chargeable = instance_double(Chargeable, fingerprint: "card_fp", get_chargeable_for: stripe_chargeable)
+      captured = nil
+
+      allow(ChargeProcessor).to receive(:create_payment_intent_or_charge!) do |*args, **kwargs|
+        captured = { positional: args, keyword: kwargs }
+        expect(ChargePresentment.sole).to have_attributes(
+          presentment_currency: Currency::EUR,
+          presentment_total_cents: 909,
+          stripe_fx_quote_id: nil,
+          fx_rate:
+        )
+        nil
+      end
+
+      Charge::CreateService.new(
+        order:,
+        seller:,
+        merchant_account:,
+        chargeable:,
+        purchases: [purchase],
+        amount_cents: 10_00,
+        gumroad_amount_cents: 1_50,
+        setup_future_charges: false,
+        off_session: false,
+        statement_description: seller.name_or_username,
+        params: { buyer_currency_quote: quote.token }
+      ).perform
+
+      expect(captured).to be_present
+      expect(captured[:keyword][:processor_currency]).to eq(Currency::EUR)
+      expect(captured[:keyword][:processor_amount_cents]).to eq(909)
+      expect(captured[:keyword][:stripe_fx_quote_id]).to be_nil
+      expect(purchase.reload.total_transaction_cents).to eq(10_00)
+    end
+  end
+
+  describe "refunds" do
+    it "reverses seller USD from the purchase, not a fresh FX rate" do
+      purchase = create(:purchase, link: product, seller:, merchant_account:, purchase_state: "successful", price_cents: 10_00, total_transaction_cents: 10_00)
+      create(:purchase_presentment,
+             purchase:,
+             presentment_currency: Currency::EUR,
+             presentment_price_cents: 909,
+             presentment_gumroad_tax_cents: 0,
+             presentment_total_cents: 909,
+             presentment_gumroad_amount_cents: 136)
+      purchase.association(:purchase_presentment).reset
+      allow_any_instance_of(CurrencyHelper).to receive(:buyer_local_currency_rate).and_return(BigDecimal("2"))
+
+      refund = purchase.refunds.build(total_transaction_cents: 10_00)
+      amount = purchase.send(:presentment_canonical_refund_issued_amount, refund)
+
+      expect(amount.currency).to eq(Currency::USD)
+      expect(amount.cents).to eq(-10_00)
+    end
+  end
+end

--- a/spec/services/checkout/eur_native_charging_spec.rb
+++ b/spec/services/checkout/eur_native_charging_spec.rb
@@ -39,7 +39,7 @@ describe "native EUR charging" do
     end
     let(:chargeable) { instance_double(Chargeable, get_chargeable_for: instance_double(StripeChargeablePaymentMethod)) }
 
-    def eligibility_decision(currency: Currency::EUR)
+    def eligibility_decision(currency: Currency::EUR, payment_method: nil)
       token = Rails.application.message_verifier(:buyer_currency_quote).generate({ currency: })
       described_class.new(
         order: create(:order),
@@ -50,7 +50,7 @@ describe "native EUR charging" do
         params: { buyer_currency_quote: token },
         setup_future_charges: false,
         off_session: false
-      ).decision
+      ).decision(payment_method:)
     end
 
     it "stays eligible for EUR on the platform account when the mismatch marker is set" do
@@ -60,6 +60,23 @@ describe "native EUR charging" do
       expect(decision).to be_eligible
       expect(decision.currency).to eq(Currency::EUR)
       expect(decision.direct_listed_amount?).to eq(false)
+    end
+
+    it "does not keep native EUR eligibility when the buyer pays with iDEAL" do
+      merchant_account.record_settlement_currency_mismatch!(Currency::EUR)
+
+      decision = eligibility_decision(payment_method: "ideal")
+      expect(decision).not_to be_eligible
+      expect(decision.fallback_reason).to eq(:unsupported_settlement_currency)
+    end
+
+    it "treats card as native-EUR-eligible and iDEAL/Bancontact/UPI/Pix as not" do
+      expect(described_class.eur_native_charging_payment_method?(nil)).to eq(true)
+      expect(described_class.eur_native_charging_payment_method?("card")).to eq(true)
+      expect(described_class.eur_native_charging_payment_method?("link")).to eq(true)
+      %w[ideal bancontact upi pix].each do |method|
+        expect(described_class.eur_native_charging_payment_method?(method)).to eq(false)
+      end
     end
 
     it "falls back when the flag is off" do
@@ -224,6 +241,68 @@ describe "native EUR charging" do
       expect(captured[:keyword][:processor_amount_cents]).to eq(909)
       expect(captured[:keyword][:stripe_fx_quote_id]).to be_nil
       expect(purchase.reload.total_transaction_cents).to eq(10_00)
+    end
+  end
+
+  describe Charge::MethodForcedPresentment do
+    def perform_ideal_with_native_quote
+      quote = Checkout::BuyerCurrencyQuote.create(
+        line_items: [Checkout::BuyerCurrencyQuote::LineItem.new(
+          permalink: product.unique_permalink,
+          product:,
+          price_cents: 10_00,
+          tip_cents: 0,
+          seller_tax_cents: 0,
+          gumroad_tax_cents: 0,
+          shipping_cents: 0
+        )],
+        canonical_total_cents: 10_00,
+        ip: "203.0.113.1",
+        currency: Currency::EUR
+      )
+      order = create(:order)
+      purchase = create(:purchase,
+                        link: product,
+                        seller:,
+                        merchant_account:,
+                        purchase_state: "in_progress",
+                        ip_address: "203.0.113.1",
+                        price_cents: 10_00,
+                        total_transaction_cents: 10_00)
+      order.purchases << purchase
+      charge = create(:charge, order:, seller:, merchant_account:, amount_cents: 10_00, gumroad_amount_cents: 1_50)
+
+      result = described_class.new(
+        charge:,
+        order:,
+        seller:,
+        merchant_account:,
+        purchases: [purchase],
+        amount_cents: 10_00,
+        gumroad_amount_cents: 1_50,
+        payment_method_type: "ideal",
+        params: { buyer_currency_quote: quote.token }
+      ).perform
+
+      [result, charge]
+    end
+
+    before do
+      allow_any_instance_of(Checkout::BuyerCurrencyQuote).to receive(:buyer_local_currency_rate).and_return(fx_rate)
+    end
+
+    it "does not persist native EUR presentment when the buyer switches to iDEAL" do
+      merchant_account.record_settlement_currency_mismatch!(Currency::EUR)
+
+      result, charge = perform_ideal_with_native_quote
+      expect(result).to be_nil
+      expect(charge.reload.charge_presentment).to be_nil
+    end
+
+    it "does not persist native EUR presentment for iDEAL when the mismatch marker is absent" do
+      result, charge = perform_ideal_with_native_quote
+      expect(result).to be_nil
+      expect(charge.reload.charge_presentment).to be_nil
     end
   end
 


### PR DESCRIPTION
Premerge review: clean @ 30578b0aaacb854ed4d514773315f1efdf848aef

- [x] Scope
- [x] Design
- [x] Build
- [x] Ship
- [ ] Market
- [ ] Sell

Charge EUR cards on USD-priced one-time products through Gumroad's shared payment account, without a Stripe FX quote.

## What

When a buyer picks EUR and pays by card on a USD-priced, one-time, no-shipping product charged on the platform account (MerchantAccount.gumroad, not Stripe Connect), checkout creates a EUR PaymentIntent with no Stripe FX quote. The EUR amount uses the cached rate already shown on the product page. That rate and both amounts are stored on the presentment row. Seller earnings stay what a USD charge would have paid. Gumroad eats the spread. Refunds stay in EUR; the seller's USD reversal uses the persisted presentment amounts, not a fresh rate.

The picker shows EUR for a flagged seller on the platform account even while the EUR settlement-mismatch marker is still active. The marker itself is not cleared.

Greptile was right on both findings against `4ee4a70`. `65002b78128` gates native EUR on a non-forced payment method, rejects quote-less tokens in `Charge::MethodForcedPresentment#quoted_result`, and allows rate-only Stripe presentment only for EUR. `30578b0a` (Gianfranco) closes the same hole on the quote-token route: `buyer_currency_quote_presentment_for` returns before `MethodForcedPresentment` is ever built, and eligibility's USD-settling branch passes a forced-currency method whenever the mismatch marker is absent, so a quote-less native EUR token on iDEAL/Bancontact/UPI/Pix is now rejected in `PreparePaymentIntentService` before any processor call.

## Why

Sahil's goal is to maximize conversions and creator earnings. Multi and local currency do that. Quote-backed EUR on the platform account has been 0 for 45 days because the account settles EUR in EUR, so Stripe refuses EUR-to-USD quotes. This lane skips the quote.

## What this does not do

- Does not lift the EUR hide for everyone
- Does not change Connect sellers, memberships, preorders, shipping, installment plans, or iDEAL on USD-priced products
- Does not open EUR Gumroad-held balance rows (`Balance.holding_currency` stays USD)
- Does not change KRW/TWD
- Does not change platform EUR settlement (option 2)

## Flag

`eur_native_charging` (Flipper, default off, actor-gated on the seller). Enable for one test seller to try it.

## Finance visibility

`Purchase.with_eur_native_charging_rate` is purchases whose presentment is EUR, has no Stripe FX quote id, and has a persisted rate. That is the spend/spread set.

## How to verify in production

1. Enable `eur_native_charging` for one test seller who charges on the platform account.
2. Open a USD-priced one-time product, pick EUR, pay by card.
3. Confirm the Stripe PaymentIntent currency is eur and there is no FX quote on it.
4. Confirm the seller balance credit is in USD at the same amount a USD charge would have paid.
5. Refund the purchase and confirm the seller USD debit matches the original credit, not a newly fetched rate.

## QA

Preview QA at `8b76e0a5dc70` (screenshots in the thread): flag-off hides EUR while the mismatch marker is on, flag-on charged a quote-less EUR PaymentIntent and refunded from the persisted presentment, marker unchanged, cleanup verified. `30578b0a` only adds a rejection for forced-currency methods on the quote-token route — it does not touch the card path those stills exercise.

## Tests

```
DISABLE_SPRING=1 TEST_DATABASE_NAME=gumroad_test_7602 bundle exec rspec \
  spec/models/charge_presentment_spec.rb \
  spec/services/checkout/eur_native_charging_spec.rb
19 examples, 0 failures
DISABLE_SPRING=1 TEST_DATABASE_NAME=gumroad_test_7602 bundle exec rspec \
  spec/services/order/prepare_payment_intent_service_spec.rb:2401 \
  spec/services/order/prepare_payment_intent_service_spec.rb:2425 \
  spec/services/order/prepare_payment_intent_service_spec.rb:2450
3 examples, 0 failures
bundle exec rubocop app/models/charge_presentment.rb app/services/charge/method_forced_presentment.rb app/services/checkout/buyer_currency_eligibility.rb app/services/order/prepare_payment_intent_service.rb spec/models/charge_presentment_spec.rb spec/services/checkout/eur_native_charging_spec.rb
6 files inspected, no offenses detected
```

Mutation (each mutant reddened only its named example): drop the payment-method gate -> iDEAL eligibility; accept rate-only for any currency -> GBP presentment; allow quote-less tokens on forced methods -> iDEAL without mismatch; drop the token-route guard -> iDEAL token accepted; let the token-route guard ignore the Stripe FX quote id -> legacy quoted iDEAL rejected.

Tracked in antiwork/gumroad-private#2541. Money path: do not merge without a human.

---

AI disclosure: grok-4.6 built slice 1 (commits `4ee4a70` … `8b76e0a`) and the Greptile fixes in `65002b78128`. The re-review cycle at `30578b0a` — panel run, focused spec run, mutation proof and this body refresh — ran on DeepSeek V4.1 Flash as the gumclaw autonomous agent; `30578b0a` itself is Gianfranco's commit.
