### PR TITLE
Fill shipping fields on digital require_shipping spec purchases

### DIFF
--- a/spec/policies/audience/purchase_policy_spec.rb
+++ b/spec/policies/audience/purchase_policy_spec.rb
@@ -74,7 +74,19 @@ describe Audience::PurchasePolicy do
 
   permissions :mark_as_shipped? do
     let(:physical_purchase) { create(:physical_purchase, seller:, link: create(:physical_product, user: seller)) }
-    let(:digital_purchase) { create(:purchase, seller:, link: create(:product, user: seller, require_shipping: true)) }
+    let(:digital_purchase) do
+      create(
+        :purchase,
+        seller:,
+        link: create(:product, user: seller, require_shipping: true),
+        full_name: "Jane Buyer",
+        street_address: "123 Main St",
+        city: "San Francisco",
+        state: "CA",
+        zip_code: "94105",
+        country: "United States",
+      )
+    end
 
     it "grants access to owner for a physical product" do
       expect(subject).to permit(SellerContext.new(user: seller, seller:), physical_purchase)

--- a/spec/presenters/customer_presenter_spec.rb
+++ b/spec/presenters/customer_presenter_spec.rb
@@ -227,7 +227,7 @@ describe CustomerPresenter do
     context "when a digital product requires shipping" do
       let(:digital_product) { create(:product, user: seller, require_shipping: true) }
       let(:digital_purchase) do
-        create(:purchase, link: digital_product, seller:, street_address: "123 Main St", city: "San Francisco", state: "CA", zip_code: "94105", country: "United States")
+        create(:purchase, link: digital_product, seller:, full_name: "Jane Buyer", street_address: "123 Main St", city: "San Francisco", state: "CA", zip_code: "94105", country: "United States")
       end
 
       it "exposes the address but not the mark-as-shipped clerk" do


### PR DESCRIPTION
## What / why
#7596 hid Mark as shipped on digital listings that collect shipping, but its new examples create a `require_shipping` purchase without the address attributes `Purchase` validates on create. Main Fast 16/17 fail with `Full name can't be blank` (and the rest of the shipping presence set). Fill those fields so the examples can actually assert clerk hiding.

Does not change product or checkout behavior.

## Test results
Not run locally in this sweep (no clean app checkout). CI on this branch is the gate.

---
AI assistance: Grok 4.6. Prompt: diagnose red main Fast 16/17 after #7596 and fill the missing shipping factory fields.
