### PR TITLE
Reload checkout return page while payment is still processing

### DIFF
--- a/app/javascript/pages/Checkout/Returns/Pending.test.tsx
+++ b/app/javascript/pages/Checkout/Returns/Pending.test.tsx
@@ -7,12 +7,16 @@ import Pending, {
   PENDING_RELOAD_GIVE_UP_MS,
   PENDING_RELOAD_MS,
   PENDING_RELOAD_STARTED_AT_KEY,
+  PENDING_STARTED_AT_PARAM,
 } from "$app/pages/Checkout/Returns/Pending";
 
 vi.mock("$app/components/ui/Card", () => ({
   Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
+
+const PATH = "/checkout/returns/order-token";
+const HREF = `https://gumroad.test${PATH}?payment_intent=pi_123`;
 
 afterEach(() => {
   cleanup();
@@ -23,12 +27,17 @@ afterEach(() => {
 
 describe("Checkout/Returns/Pending", () => {
   const reload = vi.fn();
+  const replace = vi.fn();
 
   beforeEach(() => {
     reload.mockReset();
+    replace.mockReset();
     vi.stubGlobal("location", {
-      pathname: "/checkout/returns/order-token",
+      pathname: PATH,
+      search: "?payment_intent=pi_123",
+      href: HREF,
       reload,
+      replace,
     });
   });
 
@@ -45,15 +54,13 @@ describe("Checkout/Returns/Pending", () => {
 
   it("does not reload after the give-up window for this return URL", () => {
     vi.useFakeTimers();
-    sessionStorage.setItem(
-      `${PENDING_RELOAD_STARTED_AT_KEY}:/checkout/returns/order-token`,
-      String(Date.now() - PENDING_RELOAD_GIVE_UP_MS),
-    );
+    sessionStorage.setItem(`${PENDING_RELOAD_STARTED_AT_KEY}:${PATH}`, String(Date.now() - PENDING_RELOAD_GIVE_UP_MS));
 
     render(<Pending />);
     vi.advanceTimersByTime(PENDING_RELOAD_MS);
 
     expect(reload).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
   });
 
   it("clears the reload timeout on unmount", () => {
@@ -63,5 +70,48 @@ describe("Checkout/Returns/Pending", () => {
     vi.advanceTimersByTime(PENDING_RELOAD_MS);
 
     expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("still reloads when sessionStorage throws", () => {
+    vi.useFakeTimers();
+    vi.spyOn(sessionStorage, "getItem").mockImplementation(() => {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    });
+    vi.spyOn(sessionStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    });
+
+    render(<Pending />);
+    vi.advanceTimersByTime(PENDING_RELOAD_MS);
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(replace).toHaveBeenCalledTimes(1);
+    const nextUrl = new URL(String(replace.mock.calls[0]?.[0]));
+    expect(nextUrl.searchParams.get("payment_intent")).toBe("pi_123");
+    expect(nextUrl.searchParams.get(PENDING_STARTED_AT_PARAM)).toMatch(/^\d+$/);
+  });
+
+  it("stops polling from the URL clock when sessionStorage is unavailable", () => {
+    vi.useFakeTimers();
+    const started = Date.now() - PENDING_RELOAD_GIVE_UP_MS;
+    vi.stubGlobal("location", {
+      pathname: PATH,
+      search: `?payment_intent=pi_123&${PENDING_STARTED_AT_PARAM}=${started}`,
+      href: `${HREF}&${PENDING_STARTED_AT_PARAM}=${started}`,
+      reload,
+      replace,
+    });
+    vi.spyOn(sessionStorage, "getItem").mockImplementation(() => {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    });
+    vi.spyOn(sessionStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    });
+
+    render(<Pending />);
+    vi.advanceTimersByTime(PENDING_RELOAD_MS);
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
   });
 });

--- a/app/javascript/pages/Checkout/Returns/Pending.test.tsx
+++ b/app/javascript/pages/Checkout/Returns/Pending.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import Pending, {
+  PENDING_RELOAD_GIVE_UP_MS,
+  PENDING_RELOAD_MS,
+  PENDING_RELOAD_STARTED_AT_KEY,
+} from "$app/pages/Checkout/Returns/Pending";
+
+vi.mock("$app/components/ui/Card", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  sessionStorage.clear();
+});
+
+describe("Checkout/Returns/Pending", () => {
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    reload.mockReset();
+    vi.stubGlobal("location", {
+      pathname: "/checkout/returns/order-token",
+      reload,
+    });
+  });
+
+  it("reloads so a later successful finalize can redirect off this page", () => {
+    vi.useFakeTimers();
+    render(<Pending />);
+
+    expect(screen.getByRole("heading", { name: "Your payment is being processed" })).toBeTruthy();
+    expect(reload).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(PENDING_RELOAD_MS);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload after the give-up window for this return URL", () => {
+    vi.useFakeTimers();
+    sessionStorage.setItem(
+      `${PENDING_RELOAD_STARTED_AT_KEY}:/checkout/returns/order-token`,
+      String(Date.now() - PENDING_RELOAD_GIVE_UP_MS),
+    );
+
+    render(<Pending />);
+    vi.advanceTimersByTime(PENDING_RELOAD_MS);
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("clears the reload timeout on unmount", () => {
+    vi.useFakeTimers();
+    const { unmount } = render(<Pending />);
+    unmount();
+    vi.advanceTimersByTime(PENDING_RELOAD_MS);
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/app/javascript/pages/Checkout/Returns/Pending.tsx
+++ b/app/javascript/pages/Checkout/Returns/Pending.tsx
@@ -5,21 +5,52 @@ import { Card, CardContent } from "$app/components/ui/Card";
 export const PENDING_RELOAD_MS = 3_000;
 export const PENDING_RELOAD_GIVE_UP_MS = 5 * 60 * 1_000;
 export const PENDING_RELOAD_STARTED_AT_KEY = "checkout-return-pending-started-at";
+export const PENDING_STARTED_AT_PARAM = "pending_started_at";
 
 function pendingReloadStorageKey() {
   return `${PENDING_RELOAD_STARTED_AT_KEY}:${window.location.pathname}`;
 }
 
+function readStartedAt(storageKey: string): number {
+  try {
+    const stored = Number(sessionStorage.getItem(storageKey));
+    if (Number.isFinite(stored) && stored > 0) return stored;
+  } catch {
+    // sessionStorage throws in some privacy modes; fall through.
+  }
+
+  const fromUrl = Number(new URLSearchParams(window.location.search).get(PENDING_STARTED_AT_PARAM));
+  if (Number.isFinite(fromUrl) && fromUrl > 0) return fromUrl;
+
+  return Date.now();
+}
+
+function persistStartedAt(storageKey: string, started: number): boolean {
+  try {
+    sessionStorage.setItem(storageKey, String(started));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export default function Pending() {
   React.useEffect(() => {
     const storageKey = pendingReloadStorageKey();
-    const stored = Number(sessionStorage.getItem(storageKey));
-    const started = Number.isFinite(stored) && stored > 0 ? stored : Date.now();
-    sessionStorage.setItem(storageKey, String(started));
-
+    const started = readStartedAt(storageKey);
     if (Date.now() - started >= PENDING_RELOAD_GIVE_UP_MS) return;
 
+    const stored = persistStartedAt(storageKey, started);
+
     const timeout = window.setTimeout(() => {
+      if (!stored) {
+        const url = new URL(window.location.href);
+        if (url.searchParams.get(PENDING_STARTED_AT_PARAM) !== String(started)) {
+          url.searchParams.set(PENDING_STARTED_AT_PARAM, String(started));
+          window.location.replace(url.toString());
+          return;
+        }
+      }
       window.location.reload();
     }, PENDING_RELOAD_MS);
 

--- a/app/javascript/pages/Checkout/Returns/Pending.tsx
+++ b/app/javascript/pages/Checkout/Returns/Pending.tsx
@@ -2,7 +2,30 @@ import * as React from "react";
 
 import { Card, CardContent } from "$app/components/ui/Card";
 
+export const PENDING_RELOAD_MS = 3_000;
+export const PENDING_RELOAD_GIVE_UP_MS = 5 * 60 * 1_000;
+export const PENDING_RELOAD_STARTED_AT_KEY = "checkout-return-pending-started-at";
+
+function pendingReloadStorageKey() {
+  return `${PENDING_RELOAD_STARTED_AT_KEY}:${window.location.pathname}`;
+}
+
 export default function Pending() {
+  React.useEffect(() => {
+    const storageKey = pendingReloadStorageKey();
+    const stored = Number(sessionStorage.getItem(storageKey));
+    const started = Number.isFinite(stored) && stored > 0 ? stored : Date.now();
+    sessionStorage.setItem(storageKey, String(started));
+
+    if (Date.now() - started >= PENDING_RELOAD_GIVE_UP_MS) return;
+
+    const timeout = window.setTimeout(() => {
+      window.location.reload();
+    }, PENDING_RELOAD_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, []);
+
   return (
     <Card className="mx-auto my-8 max-w-2xl">
       <CardContent asChild>
@@ -11,7 +34,8 @@ export default function Pending() {
         </header>
       </CardContent>
       <CardContent>
-        Check your email for your receipt — it will arrive once the payment completes. Please do not pay again.
+        Check your email for your receipt — it will arrive once the payment completes. Please do not pay again. This
+        page updates automatically.
       </CardContent>
     </Card>
   );

--- a/spec/requests/checkout/returns_spec.rb
+++ b/spec/requests/checkout/returns_spec.rb
@@ -168,6 +168,27 @@ describe "Checkout return page", :vcr, type: :request do
       expect(purchase.reload).to be_in_progress
       expect(purchase.stripe_status).to eq(StripeIntentStatus::PROCESSING)
     end
+
+    it "redirects to the content page on a later visit once the intent has succeeded" do
+      order, charge = build_client_confirmed_order
+      purchase = order.purchases.first
+      charge_intent = instance_double(StripeChargeIntent, succeeded?: false, processing?: true)
+      allow(ChargeProcessor).to receive(:get_charge_intent)
+        .with(charge.merchant_account, charge.stripe_payment_intent_id)
+        .and_return(charge_intent)
+
+      visit_return_page(order, payment_intent: charge.stripe_payment_intent_id)
+      expect(response.body).to include("Checkout/Returns/Pending")
+      expect(purchase.reload).to be_in_progress
+
+      allow(ChargeProcessor).to receive(:get_charge_intent).and_call_original
+      Stripe::PaymentIntent.confirm(charge.stripe_payment_intent_id, { payment_method: "pm_card_visa" })
+
+      visit_return_page(order, payment_intent: charge.stripe_payment_intent_id)
+
+      expect(purchase.reload).to be_successful
+      expect(response).to redirect_to("#{purchase.url_redirect.download_page_url}?receipt=true")
+    end
   end
 
   context "when the intent succeeded but no purchase could be finalized" do


### PR DESCRIPTION
Reload the checkout return page while payment is still processing

> Draft status: Greptile P1 (sessionStorage throw aborts polling) fixed at `078dcee4fd`. Request spec + preview evidence still owed.

## What

After a card is captured, Stripe (or a post-capture finalize that is still `processing`) sends the buyer to `/checkout/returns/:id`. That page used to render a static "Your payment is being processed" card and never request the return URL again. A later successful finalize — including the one that already sent the receipt — therefore never redirected to the download or product page.

The pending page now reloads the same return URL every 3 seconds (capped at 5 minutes per return path). If `sessionStorage` throws (privacy-restricted browsers), polling still runs and the give-up clock rides on `pending_started_at` without dropping the existing `payment_intent` query. The existing controller already redirects on a later GET once every line is successful and not processing.

## Why

Buyers who completed a real charge (receipt already in their inbox) were left on a dead-end processing screen. Same class as the client-confirm return path, not the older Payment Element confirm crash (that family is closed).

Fixes antiwork/gumroad-private#2565.

## Before / after

- Before: return page stays on "Your payment is being processed" forever, even after the receipt email. A `sessionStorage` throw also left the page with no reload at all.
- After: the page reloads until the controller redirects to the content/product URL, or stops after 5 minutes and keeps the "check your email / do not pay again" copy.

## Checklist

- [x] Scope — pending-page reload + request spec that a later successful visit redirects. No change to charge/finalize logic.
- [x] Design — client reload of the existing return GET (which already 302s on success). Rejected: webhook-pushed redirect (no channel to this public page) and dropping the pending page (async methods still need it). Storage-unavailable path keeps polling via a URL clock.
- [x] Build — `078dcee4fd` on `gumclaw/gp2565-checkout-return-pending-reload`
- [ ] QA — vitest 5/5 locally; request spec + preview screenshot still owed
- [ ] Shipped — money-path return page; stays draft until panel + QA
- [ ] Market — n/a (checkout bugfix)
- [ ] Sell — n/a

## Tests

```text
npx vitest run app/javascript/pages/Checkout/Returns/Pending.test.tsx
Test Files  1 passed (1)
Tests  5 passed (5)

Mutants:
- persistStartedAt without catch → "still reloads when sessionStorage throws" red
- drop URL started-at read → "stops polling from the URL clock..." red

bundle exec rspec spec/requests/checkout/returns_spec.rb -e "later visit"
(still owed)
```

## QA

Not preview-exercised yet. Watch: after a 3DS/async card charge, the processing page must leave for the receipt/content URL once the purchase is successful.

---

## AI disclosure

Generated with **grok-4.6** (xAI), running as gumclaw.
Prompts/instructions given: GitHub webhook on gumroad-private#2565 (post-payment processing page never advances after a successful charge and receipt); Greptile P1 on sessionStorage throw; autonomous-product-dev build loop.
