### PR TITLE
Stub chargeback-rate payout pause in payout fixture specs

### DIFF
--- a/spec/services/exports/payouts/csv_spec.rb
+++ b/spec/services/exports/payouts/csv_spec.rb
@@ -13,6 +13,8 @@ describe Exports::Payouts::Csv, :vcr do
       @another_seller = create :named_user
       @direct_affiliate = create :direct_affiliate, affiliate_user: @seller, seller: @another_seller
       base_past_date = 1.month.ago
+      # These payout fixtures are not representative of the seller's chargeback rate.
+      allow_any_instance_of(Purchase).to receive(:pause_payouts_for_seller_based_on_chargeback_rate!)
       allow_any_instance_of(Purchase).to receive(:create_dispute_evidence_if_needed!).and_return(nil)
 
       travel_to(base_past_date) do


### PR DESCRIPTION
Stub the chargeback-rate payout pause in payout fixture specs without changing expected CSV or revenue values. The Elasticsearch→SQL change in #7601 makes the gate see tiny, dispute-heavy fixture sellers that previously had no indexed sales.

Production payout-pause behavior is unchanged by this spec-only fix; the intended SQL calculation stays intact. Draft: completing the related-spec sweep, local verification, and premerge panel.

Failing runs:
- https://github.com/antiwork/gumroad/actions/runs/34688841453
- https://github.com/antiwork/gumroad/actions/runs/34688573333

Specs being fixed: spec/services/exports/payouts/csv_spec.rb, spec/requests/balance_pages_spec.rb, spec/modules/payment/stats_spec.rb.
Local test output: pending.
Media: docs/spec-only — diff is the reviewable artifact.

---
AI disclosure: GPT-6 Astra. Prompt: verify the SQL chargeback-rate fixture regression, isolate payout fixtures without changing app code or expected amounts, sweep related specs, run local tests and RuboCop, and complete the premerge panel.
