### PR TITLE
Map recurring branch-specs gaps so fewer PRs need run-all-specs

### DIFF
--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -82,15 +82,6 @@ DISCOVER_FLOW_SPECS = %w[spec/requests/discover].freeze
 WISHLIST_FLOW_SPECS = %w[spec/requests/wishlists].freeze
 DOWNLOAD_PAGE_SPECS = %w[spec/requests/download_page].freeze
 WORKFLOW_FLOW_SPECS = %w[spec/requests/workflows_spec.rb].freeze
-# Shared editor mounts on product, email, download, profile, and workflow
-# surfaces. Product-only fanout would let a change merge without those
-# consumers' request specs.
-EDITOR_FLOW_SPECS = (
-  PRODUCT_FLOW_SPECS + EMAIL_FLOW_SPECS + DOWNLOAD_PAGE_SPECS +
-  PROFILE_FLOW_SPECS + WORKFLOW_FLOW_SPECS +
-  %w[spec/controllers/pages_controller_spec.rb]
-).freeze
-MAILER_FLOW_SPECS = %w[spec/mailers].freeze
 HELP_CENTER_SPECS = %w[
   spec/requests/help_center_spec.rb
   spec/requests/help_center
@@ -151,32 +142,39 @@ FANOUT = {
   # authorize screens live in oauth_authorizations*_spec.rb.
   %r{\Aapp/views/doorkeeper/} => %w[spec/requests/oauth_authorizations_spec.rb spec/requests/oauth_authorize_scope_list_spec.rb],
   %r{\Aspec/support/dynamodb\.rb\z} => %w[spec/services/email_engagement_dynamo_store_spec.rb],
-  # Harvest 2026-09-12. A mapping is only safe when the spec set covers
-  # every flow that imports/renders/reads the source — not the PR that
-  # happened to share the path. Unions that exceed MAX_SELECTED_FILES
-  # escalate (the safe direction).
-  %r{\Aapp/javascript/components/Settings/} => SETTINGS_FLOW_SPECS + %w[spec/requests/oauth_applications_pages_spec.rb], # ApplicationForm also mounts on Oauth/Applications/Edit
-  %r{\Aapp/javascript/(components|pages)/Payouts/} => PAYOUT_PAGE_SPECS, # #7438 #7495
-  %r{\Aapp/javascript/pages/Emails/} => EMAIL_FLOW_SPECS, # #7578 #7580
-  %r{\Aapp/javascript/components/EmailsPage/} => EMAIL_FLOW_SPECS + %w[spec/requests/followers], # Layout also mounts on Followers/Index
-  %r{\Aapp/javascript/data/installments} => EMAIL_FLOW_SPECS, # #7578
-  %r{\Aapp/models/help_center/articles\.yml\z} => HELP_CENTER_SPECS, # YAML also feeds ArticleText + the v2 help API
-  %r{\Aapp/javascript/components/TiptapExtensions/} => EDITOR_FLOW_SPECS,
-  %r{\Aapp/javascript/components/RichTextEditor} => EDITOR_FLOW_SPECS,
-  %r{\Aapp/javascript/components/ImageUploader} => PRODUCT_FLOW_SPECS + PROFILE_FLOW_SPECS, # LogoInput avatar upload
-  %r{\Aapp/javascript/components/ReviewForm} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS + %w[spec/requests/library_spec.rb spec/requests/customers/customers_spec.rb],
-  %r{\Aapp/javascript/components/Review\.tsx\z} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS + %w[spec/requests/library_spec.rb spec/requests/customers/customers_spec.rb],
-  %r{\Aapp/javascript/components/ReviewVideoPlayer} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS + %w[spec/requests/library_spec.rb spec/requests/customers/customers_spec.rb],
-  %r{\Aapp/javascript/components/DiscordButton} => DOWNLOAD_PAGE_SPECS + CHECKOUT_FLOW_SPECS, # also Checkout/Receipt
-  %r{\Aapp/javascript/components/DownloadPage/} => DOWNLOAD_PAGE_SPECS, # #7529
+  # Harvest 2026-09-12, round 3. Shared components whose consumers span
+  # more than one flow ESCALATE. Do not raise MAX_SELECTED_FILES to keep
+  # an incomplete union (RichTextEditor importer-complete union is 157).
+  # Importer traces below are rg from "$app/<module>" (or the inertia render).
+  %r{\Aapp/javascript/components/Settings/} => SETTINGS_FLOW_SPECS + %w[spec/requests/oauth_applications_pages_spec.rb],
+  # Importers: pages/Settings/* Layout/Advanced/Payments; also
+  # Oauth/Applications/Edit.tsx:7 ApplicationForm and :8 Layout.
+  %r{\Aapp/javascript/(components|pages)/Payouts/} => PAYOUT_PAGE_SPECS,
+  # Renderer: balance_controller.rb:14 inertia "Payouts/Index".
+  %r{\Aapp/javascript/pages/Emails/} => EMAIL_FLOW_SPECS,
+  %r{\Aapp/javascript/components/EmailsPage/} => EMAIL_FLOW_SPECS + %w[spec/requests/followers],
+  # Importers: pages/Emails/{Edit,Scheduled,Published,Drafts,New}; also
+  # Followers/Index.tsx:9 EmailsLayout.
+  %r{\Aapp/javascript/data/installments} => EMAIL_FLOW_SPECS,
+  %r{\Aapp/models/help_center/articles.yml\z} => HELP_CENTER_SPECS,
+  # Consumers: article_text.rb:90/:122 HelpCenter::Article.all;
+  # api/v2/help_articles_controller.rb:25/:31/:36.
+  %r{\Aapp/javascript/components/DiscordButton} => DOWNLOAD_PAGE_SPECS + CHECKOUT_FLOW_SPECS,
+  # Importers: DownloadPage/WithContent.tsx:19, Checkout/Receipt.tsx:13.
+  %r{\Aapp/javascript/components/DownloadPage/} => DOWNLOAD_PAGE_SPECS,
   %r{\Aapp/javascript/data/discord_integration} => DOWNLOAD_PAGE_SPECS + CHECKOUT_FLOW_SPECS + %w[spec/requests/products/edit/integrations/discord_integrations_spec.rb],
-  %r{\Aapp/javascript/data/product_reviews} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS + %w[spec/requests/library_spec.rb spec/requests/customers/customers_spec.rb],
-  %r{\Aapp/javascript/components/DateRangePicker} => ANALYTICS_FLOW_SPECS, # #7259
-  %r{\Aapp/javascript/components/useRecaptcha} => CHECKOUT_FLOW_SPECS, # #7203
-  %r{\Aapp/javascript/parsers/profile} => PROFILE_FLOW_SPECS, # #7341
+  # Importers: DiscordButton.tsx:4 join/leave;
+  # ProductEdit/ProductTab/DiscordIntegrationEditor.tsx:4 fetchServerInfo.
+  %r{\Aapp/javascript/parsers/profile} => PROFILE_FLOW_SPECS,
   %r{\Aapp/javascript/pages/Users/Coffee} => PROFILE_FLOW_SPECS + %w[spec/requests/purchases/product/coffee_spec.rb],
-  %r{\Aapp/javascript/pages/Users/} => PROFILE_FLOW_SPECS,
+  # Renderer: users_controller.rb:115 Users/Coffee.
+  %r{\Aapp/javascript/pages/Users/Show} => PROFILE_FLOW_SPECS,
+  # Renderer: users_controller.rb:35 Users/Show storefront.
+  %r{\Aapp/javascript/pages/Users/Subscribe} => PROFILE_FLOW_SPECS,
+  # Renderer: users_controller.rb:125 Users/Subscribe, :133 SubscribePreview.
+  # Users/ReviewReminders is not storefront (review_reminders_controller) — escalate.
   %r{\Aapp/javascript/pages/User/Passwords/} => %w[spec/requests/password_reset_spec.rb spec/requests/login_spec.rb],
+  # Renderer: user/passwords_controller.rb:16 New, :39 Edit.
   %r{\Aapp/javascript/pages/UrlRedirects/} => DOWNLOAD_PAGE_SPECS,
   %r{\Aapp/javascript/pages/Pages/} => %w[
     spec/controllers/pages_controller_spec.rb
@@ -184,6 +182,7 @@ FANOUT = {
     spec/requests/pages_landing_embed_routing_spec.rb
     spec/requests/pages_landing_embed_storage_shim_spec.rb
   ],
+  # Renderer: pages_controller.rb:25 Index, :42/:77/:88 Edit.
   %r{\Aapp/javascript/pages/Dashboard/} => %w[spec/requests/dashboard_spec.rb],
   %r{\Aapp/javascript/pages/Customers/} => %w[spec/requests/customers],
   %r{\Aapp/javascript/pages/Library/} => %w[spec/requests/library_spec.rb],
@@ -191,20 +190,21 @@ FANOUT = {
   %r{\Aapp/javascript/pages/Followers/} => %w[spec/requests/followers],
   %r{\Aapp/javascript/pages/Reviews/} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS + %w[spec/requests/library_spec.rb],
   %r{\Aapp/javascript/pages/Workflows/} => WORKFLOW_FLOW_SPECS,
-  %r{\Aapp/javascript/data/paypal} => CHECKOUT_FLOW_SPECS, # Checkout/PaymentForm billing agreement, not Settings
-  %r{\Aapp/javascript/data/search} => DISCOVER_FLOW_SPECS + %w[spec/requests/user/product_panel], # CardGrid storefront filter
-  %r{\Aapp/javascript/pages/Discover/} => DISCOVER_FLOW_SPECS, # #7236
-  %r{\Aapp/javascript/pages/Wishlists/} => WISHLIST_FLOW_SPECS, # #7236
-  %r{\Aapp/javascript/components/WorkflowsPage/} => WORKFLOW_FLOW_SPECS, # #7474
+  %r{\Aapp/javascript/data/paypal} => CHECKOUT_FLOW_SPECS,
+  # Importers: Checkout/PaymentForm.tsx:33 createBillingAgreement (not Settings).
+  %r{\Aapp/javascript/pages/Discover/} => DISCOVER_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/Wishlists/} => WISHLIST_FLOW_SPECS,
+  %r{\Aapp/javascript/components/WorkflowsPage/} => WORKFLOW_FLOW_SPECS,
   %r{\Aapp/javascript/entrypoints/custom_html_analytics} => %w[
     spec/requests/products/show/custom_html_analytics_spec.rb
     spec/requests/profile_custom_html_spec.rb
+    spec/requests/profile_analytics_spec.rb
     spec/requests/custom_html_background_wiring_spec.rb
     spec/controllers/links_controller_custom_html_spec.rb
     spec/controllers/users_controller_custom_html_spec.rb
     spec/requests/products/show
   ],
-  %r{\Aapp/javascript/stylesheets/_email} => MAILER_FLOW_SPECS, # #7156 #7404
+  # Renderers: links_controller custom HTML + users_controller.rb:425 profile wrapper.
 }.freeze
 
 # Config files with dedicated, local coverage. Boot-global files (domain.rb,

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -77,6 +77,20 @@ AUDIENCE_FLOW_SPECS = %w[
   spec/requests/analytics/audience_spec.rb
   spec/requests/customers
 ].freeze
+EMAIL_FLOW_SPECS = %w[spec/requests/emails].freeze
+DISCOVER_FLOW_SPECS = %w[spec/requests/discover].freeze
+WISHLIST_FLOW_SPECS = %w[spec/requests/wishlists].freeze
+DOWNLOAD_PAGE_SPECS = %w[spec/requests/download_page].freeze
+WORKFLOW_FLOW_SPECS = %w[spec/requests/workflows_spec.rb].freeze
+MAILER_FLOW_SPECS = %w[spec/mailers].freeze
+HELP_CENTER_SPECS = %w[spec/requests/help_center_spec.rb spec/requests/help_center spec/presenters/help_center_presenter_spec.rb].freeze
+# Instant-payout / balance page (Inertia Payouts/Index), not the 45 backend payout specs.
+PAYOUT_PAGE_SPECS = %w[
+  spec/requests/balance_pages_spec.rb
+  spec/controllers/balance_controller_spec.rb
+  spec/controllers/instant_payouts_controller_spec.rb
+  spec/controllers/payouts
+].freeze
 
 FANOUT = {
   %r{\Aapp/presenters/checkout/} => CHECKOUT_FLOW_SPECS,
@@ -101,9 +115,9 @@ FANOUT = {
   %r{\Aapp/javascript/pages/Profile/} => PROFILE_FLOW_SPECS,
   # Help-center article partials render through the help_center request specs;
   # the per-article view glob finds nothing because specs aren't per-article.
-  %r{\Aapp/views/help_center/} => %w[spec/requests/help_center_spec.rb spec/requests/help_center],
-  %r{\Aapp/javascript/components/HelpCenterPage} => %w[spec/requests/help_center_spec.rb spec/requests/help_center],
-  %r{\Aapp/javascript/pages/HelpCenter/} => %w[spec/requests/help_center_spec.rb spec/requests/help_center],
+  %r{\Aapp/views/help_center/} => HELP_CENTER_SPECS,
+  %r{\Aapp/javascript/components/HelpCenterPage} => HELP_CENTER_SPECS,
+  %r{\Aapp/javascript/pages/HelpCenter/} => HELP_CENTER_SPECS,
   # Recurring run-all-specs gaps (ProductEdit, Settings, API docs, Analytics,
   # Audience, Bundles, Dashboard). These trees have no co-located rspec.
   %r{\Aapp/javascript/components/ProductEdit/} => PRODUCT_FLOW_SPECS,
@@ -123,23 +137,70 @@ FANOUT = {
   # authorize screens live in oauth_authorizations*_spec.rb.
   %r{\Aapp/views/doorkeeper/} => %w[spec/requests/oauth_authorizations_spec.rb spec/requests/oauth_authorize_scope_list_spec.rb],
   %r{\Aspec/support/dynamodb\.rb\z} => %w[spec/services/email_engagement_dynamo_store_spec.rb],
+  # Harvest 2026-09-12 (run-all-specs PRs since 2026-08-01). Each line names
+  # the PR(s) that escalated on this path.
+  %r{\Aapp/javascript/components/Settings/} => SETTINGS_FLOW_SPECS, # #7473 PayPalEmailSection
+  %r{\Aapp/javascript/(components|pages)/Payouts/} => PAYOUT_PAGE_SPECS, # #7438 #7495
+  %r{\Aapp/javascript/pages/Emails/} => EMAIL_FLOW_SPECS, # #7578 #7580
+  %r{\Aapp/javascript/components/EmailsPage/} => EMAIL_FLOW_SPECS, # #7581
+  %r{\Aapp/javascript/data/installments} => EMAIL_FLOW_SPECS, # #7578
+  %r{\Aapp/models/help_center/articles\.yml\z} => HELP_CENTER_SPECS, # #7375
+  %r{\Aapp/javascript/components/TiptapExtensions/} => PRODUCT_FLOW_SPECS, # #7404 #7535
+  %r{\Aapp/javascript/components/RichTextEditor} => PRODUCT_FLOW_SPECS, # #7207 #7403
+  %r{\Aapp/javascript/components/ImageUploader} => PRODUCT_FLOW_SPECS, # #7403
+  %r{\Aapp/javascript/components/ReviewForm} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS, # #7332
+  %r{\Aapp/javascript/components/Review\.tsx\z} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS, # #7529
+  %r{\Aapp/javascript/components/ReviewVideoPlayer} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS, # #7474
+  %r{\Aapp/javascript/components/DiscordButton} => DOWNLOAD_PAGE_SPECS, # #7529
+  %r{\Aapp/javascript/components/DownloadPage/} => DOWNLOAD_PAGE_SPECS, # #7529
+  %r{\Aapp/javascript/data/discord_integration} => DOWNLOAD_PAGE_SPECS, # #7529
+  %r{\Aapp/javascript/data/product_reviews} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS, # #7529
+  %r{\Aapp/javascript/components/DateRangePicker} => ANALYTICS_FLOW_SPECS, # #7259
+  %r{\Aapp/javascript/components/useRecaptcha} => CHECKOUT_FLOW_SPECS, # #7203
+  %r{\Aapp/javascript/parsers/profile} => PROFILE_FLOW_SPECS, # #7341
+  %r{\Aapp/javascript/pages/Users/} => PROFILE_FLOW_SPECS, # #7236 Coffee
+  %r{\Aapp/javascript/data/paypal} => SETTINGS_FLOW_SPECS, # #7355
+  %r{\Aapp/javascript/data/search} => DISCOVER_FLOW_SPECS, # #7267
+  %r{\Aapp/javascript/pages/Discover/} => DISCOVER_FLOW_SPECS, # #7236
+  %r{\Aapp/javascript/pages/Wishlists/} => WISHLIST_FLOW_SPECS, # #7236
+  %r{\Aapp/javascript/components/WorkflowsPage/} => WORKFLOW_FLOW_SPECS, # #7474
+  %r{\Aapp/javascript/entrypoints/custom_html_analytics} => ANALYTICS_FLOW_SPECS, # #7504
+  %r{\Aapp/javascript/stylesheets/_email} => MAILER_FLOW_SPECS, # #7156 #7404
 }.freeze
 
-# Config files with dedicated request coverage. Everything else under
-# config/ still escalates via ESCALATE_PATTERNS; entries here are reviewed
-# like FANOUT — a file belongs only when a spec exists whose entire purpose
-# is exercising it.
+# Config files with a dedicated spec. Boot-global files still escalate via
+# ESCALATE_PATTERNS. Other config/* is tried via spec_candidates (spec/config/...)
+# and mapping-gaps if nothing exists — harvested 2026-09-12.
 CONFIG_SPEC_MAP = {
   "config/initializers/rack_attack.rb" => %w[spec/requests/rack_attack_spec.rb],
+  "config/currencies.json" => %w[spec/config/currencies_spec.rb spec/requests/checkout/currencies_spec.rb], # #7229
+  "config/initializers/sentry.rb" => %w[spec/config/initializers/sentry_spec.rb],
+  "config/initializers/filter_parameter_logging.rb" => %w[spec/config/initializers/filter_parameter_logging_spec.rb],
+  "config/initializers/devise_pwned_password_safe_params.rb" => %w[spec/config/initializers/devise_pwned_password_safe_params_spec.rb],
+  "config/initializers/secure_headers.rb" => %w[spec/config/initializers/secure_headers_spec.rb], # #7432
+  "config/initializers/alterity.rb" => %w[spec/config/initializers/alterity_spec.rb],
+  "config/initializers/active_storage_jobs.rb" => %w[spec/config/initializers/active_storage_jobs_spec.rb],
+  "config/initializers/instant_ddl_first.rb" => %w[spec/config/initializers/instant_ddl_first_spec.rb],
+  "config/initializers/005_apple.rb" => %w[spec/config/initializers/apple_strategy_patch_spec.rb], # #7589
 }.freeze
 
 # Support files with mappings; any OTHER spec/support change escalates.
 MAPPED_SUPPORT = FANOUT.keys.select { |re| re.source.start_with?('\Aspec/support') }.freeze
 
 # Paths that cannot be attributed to specs by filename: run the full suite.
+# Blanket `config/` was replaced 2026-09-12: only boot-global files stay here.
+# Other config (currencies.json, domain.rb, initializers with a dedicated spec)
+# maps via CONFIG_SPEC_MAP / spec_candidates. Unknown config still mapping-gaps.
 ESCALATE_PATTERNS = [
   %r{\AGemfile},
-  %r{\Aconfig/},
+  %r{\Aconfig/application\.rb\z},
+  %r{\Aconfig/boot\.rb\z},
+  %r{\Aconfig/environment\.rb\z},
+  %r{\Aconfig/environments/},
+  %r{\Aconfig/database},
+  %r{\Aconfig/routes\.rb\z},
+  # Cron graph — 13 harvested PRs; no spec/config/sidekiq_schedule_spec.rb.
+  %r{\Aconfig/sidekiq_schedule\.yml\z},
   %r{\Adb/},
   %r{\Apackage\.json\z},
   %r{\A(pnpm-lock\.yaml|yarn\.lock|package-lock\.json)\z},
@@ -168,6 +229,8 @@ IGNORED_PATTERNS = [
   # Recorded HTTP, not helpers. A cassette-only diff must not force Slow;
   # the spec that plays the tape is already in the selection (or unchanged).
   %r{\Aspec/support/fixtures/vcr_cassettes/},
+  # Image/nginx/web scripts are not the rspec suite. Harvest: #7260 #7468 #7527.
+  %r{\Adocker/},
 ].freeze
 
 # Above this many selected files the full suite's parallelism wins anyway.
@@ -369,6 +432,13 @@ def spec_candidates(path)
     ["spec/#{$1}/#{$2}_spec.rb"]
   when %r{\Alib/(.*)\.rb\z}
     ["spec/lib/#{$1}_spec.rb"]
+  when %r{\Aconfig/(.*)\.(rb|yml|json)\z}
+    # Convention: config/foo.rb → spec/config/foo_spec.rb (and nested initializers).
+    ["spec/config/#{$1}_spec.rb"]
+  when %r{\Aapp/javascript/pages/([^/]+)/}
+    underscored = $1.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
+    Dir.glob("spec/requests/#{underscored}/**/*_spec.rb") +
+      Dir.glob("spec/requests/#{underscored}*_spec.rb")
   else
     []
   end

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -58,6 +58,7 @@ PROFILE_FLOW_SPECS = %w[
   spec/requests/user
   spec/requests/profile_analytics_spec.rb
   spec/requests/profile_custom_html_spec.rb
+  spec/requests/user_custom_domain_spec.rb
 ].freeze
 
 # Harvested from PRs that had to carry run-all-specs because these JS
@@ -165,17 +166,21 @@ FANOUT = {
   %r{\Aapp/javascript/data/discord_integration} => DOWNLOAD_PAGE_SPECS + CHECKOUT_FLOW_SPECS + %w[spec/requests/products/edit/integrations/discord_integrations_spec.rb],
   # Importers: DiscordButton.tsx:4 join/leave;
   # ProductEdit/ProductTab/DiscordIntegrationEditor.tsx:4 fetchServerInfo.
-  %r{\Aapp/javascript/parsers/profile} => PROFILE_FLOW_SPECS,
+  # parsers/profile is shared (Coffee, product profile, settings) — escalate.
   %r{\Aapp/javascript/pages/Users/Coffee} => PROFILE_FLOW_SPECS + %w[spec/requests/purchases/product/coffee_spec.rb],
   # Renderer: users_controller.rb:115 Users/Coffee.
   %r{\Aapp/javascript/pages/Users/Show} => PROFILE_FLOW_SPECS,
   # Renderer: users_controller.rb:35 Users/Show storefront.
-  %r{\Aapp/javascript/pages/Users/Subscribe} => PROFILE_FLOW_SPECS,
-  # Renderer: users_controller.rb:125 Users/Subscribe, :133 SubscribePreview.
-  # Users/ReviewReminders is not storefront (review_reminders_controller) — escalate.
+  %r{\Aapp/javascript/pages/Users/Subscribe\.tsx\z} => PROFILE_FLOW_SPECS,
+  # Renderer: users_controller.rb:125 Users/Subscribe.
+  # SubscribePreview and ReviewReminders are not storefront-list coverage — escalate.
   %r{\Aapp/javascript/pages/User/Passwords/} => %w[spec/requests/password_reset_spec.rb spec/requests/login_spec.rb],
   # Renderer: user/passwords_controller.rb:16 New, :39 Edit.
-  %r{\Aapp/javascript/pages/UrlRedirects/} => DOWNLOAD_PAGE_SPECS,
+  %r{\Aapp/javascript/pages/UrlRedirects/DownloadPage} => DOWNLOAD_PAGE_SPECS,
+  # Renderer: url_redirects_controller.rb:107 DownloadPage. Read.tsx has
+  # a co-located vitest (Read.test.tsx); a directory catch-all would
+  # override that skip with download_page request specs that never visit
+  # the EPUB reader. Confirm/Stream/Expired escalate.
   %r{\Aapp/javascript/pages/Pages/} => %w[
     spec/controllers/pages_controller_spec.rb
     spec/requests/pages_landing_embed_csp_spec.rb
@@ -187,7 +192,9 @@ FANOUT = {
   %r{\Aapp/javascript/pages/Customers/} => %w[spec/requests/customers],
   %r{\Aapp/javascript/pages/Library/} => %w[spec/requests/library_spec.rb],
   %r{\Aapp/javascript/pages/Oauth/} => %w[spec/requests/oauth_applications_pages_spec.rb],
-  %r{\Aapp/javascript/pages/Followers/} => %w[spec/requests/followers],
+  %r{\Aapp/javascript/pages/Followers/Index} => %w[spec/requests/followers],
+  # Renderer: followers_controller.rb:39 Index (seller list). Cancel and
+  # FromEmbedForm are buyer unsubscribe/embed flows — escalate.
   %r{\Aapp/javascript/pages/Reviews/} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS + %w[spec/requests/library_spec.rb],
   %r{\Aapp/javascript/pages/Workflows/} => WORKFLOW_FLOW_SPECS,
   %r{\Aapp/javascript/data/paypal} => CHECKOUT_FLOW_SPECS,

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -154,6 +154,8 @@ FANOUT = {
   %r{\Aapp/javascript/components/Settings/} => SETTINGS_FLOW_SPECS + %w[
     spec/requests/oauth_applications_pages_spec.rb
     spec/requests/login/passkeys_spec.rb
+    spec/requests/account_confirmation_spec.rb
+    spec/requests/user/disable_affiliate_requests_setting_spec.rb
   ],
   # Importers: pages/Settings/* Layout/Advanced/Payments; also
   # Oauth/Applications/Edit.tsx:7 ApplicationForm and :8 Layout.
@@ -181,8 +183,7 @@ FANOUT = {
   ],
   # Renderer: users_controller.rb:115 Users/Coffee. tipping_spec.rb visits
   # coffee.long_url then checkout (coffee-only carts cannot tip).
-  %r{\Aapp/javascript/pages/Users/Show} => PROFILE_FLOW_SPECS,
-  # Renderer: users_controller.rb:35 Users/Show storefront.
+  # Users/Show is also a Discover/UTM checkout surface — escalate.
   %r{\Aapp/javascript/pages/Users/Subscribe\.tsx\z} => PROFILE_FLOW_SPECS,
   # Renderer: users_controller.rb:125 Users/Subscribe.
   # SubscribePreview and ReviewReminders are not storefront-list coverage — escalate.
@@ -199,14 +200,6 @@ FANOUT = {
     spec/requests/pages_landing_embed_storage_shim_spec.rb
   ],
   # Renderer: pages_controller.rb:25 Index, :42/:77/:88 Edit.
-  %r{\Aapp/javascript/pages/Dashboard/} => %w[
-    spec/requests/dashboard_spec.rb
-    spec/requests/dashboard_mobile_table_spec.rb
-    spec/requests/dashboard_nav_mobile_spec.rb
-    spec/requests/dashboard_nav_progressive_disclosure_spec.rb
-    spec/requests/dashboard_nav_promotion_spec.rb
-    spec/requests/social_connect_return_spec.rb
-  ],
   %r{\Aapp/javascript/pages/Customers/} => %w[spec/requests/customers],
   %r{\Aapp/javascript/pages/Library/} => %w[spec/requests/library_spec.rb],
   %r{\Aapp/javascript/pages/Oauth/} => %w[spec/requests/oauth_applications_pages_spec.rb],

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -87,10 +87,17 @@ WORKFLOW_FLOW_SPECS = %w[spec/requests/workflows_spec.rb].freeze
 # consumers' request specs.
 EDITOR_FLOW_SPECS = (
   PRODUCT_FLOW_SPECS + EMAIL_FLOW_SPECS + DOWNLOAD_PAGE_SPECS +
-  PROFILE_FLOW_SPECS + WORKFLOW_FLOW_SPECS
+  PROFILE_FLOW_SPECS + WORKFLOW_FLOW_SPECS +
+  %w[spec/controllers/pages_controller_spec.rb]
 ).freeze
 MAILER_FLOW_SPECS = %w[spec/mailers].freeze
-HELP_CENTER_SPECS = %w[spec/requests/help_center_spec.rb spec/requests/help_center spec/presenters/help_center_presenter_spec.rb].freeze
+HELP_CENTER_SPECS = %w[
+  spec/requests/help_center_spec.rb
+  spec/requests/help_center
+  spec/presenters/help_center_presenter_spec.rb
+  spec/services/help_center/article_text_spec.rb
+  spec/controllers/api/v2/help_articles_controller_spec.rb
+].freeze
 # Instant-payout / balance page (Inertia Payouts/Index), not the 45 backend payout specs.
 PAYOUT_PAGE_SPECS = %w[
   spec/requests/balance_pages_spec.rb
@@ -144,69 +151,83 @@ FANOUT = {
   # authorize screens live in oauth_authorizations*_spec.rb.
   %r{\Aapp/views/doorkeeper/} => %w[spec/requests/oauth_authorizations_spec.rb spec/requests/oauth_authorize_scope_list_spec.rb],
   %r{\Aspec/support/dynamodb\.rb\z} => %w[spec/services/email_engagement_dynamo_store_spec.rb],
-  %r{\Aapp/javascript/components/Settings/} => SETTINGS_FLOW_SPECS,
-  %r{\Aapp/javascript/(components|pages)/Payouts/} => PAYOUT_PAGE_SPECS,
-  %r{\Aapp/javascript/pages/Emails/} => EMAIL_FLOW_SPECS,
-  %r{\Aapp/javascript/components/EmailsPage/} => EMAIL_FLOW_SPECS,
-  %r{\Aapp/javascript/data/installments} => EMAIL_FLOW_SPECS,
-  %r{\Aapp/models/help_center/articles\.yml\z} => HELP_CENTER_SPECS,
+  # Harvest 2026-09-12. A mapping is only safe when the spec set covers
+  # every flow that imports/renders/reads the source — not the PR that
+  # happened to share the path. Unions that exceed MAX_SELECTED_FILES
+  # escalate (the safe direction).
+  %r{\Aapp/javascript/components/Settings/} => SETTINGS_FLOW_SPECS + %w[spec/requests/oauth_applications_pages_spec.rb], # ApplicationForm also mounts on Oauth/Applications/Edit
+  %r{\Aapp/javascript/(components|pages)/Payouts/} => PAYOUT_PAGE_SPECS, # #7438 #7495
+  %r{\Aapp/javascript/pages/Emails/} => EMAIL_FLOW_SPECS, # #7578 #7580
+  %r{\Aapp/javascript/components/EmailsPage/} => EMAIL_FLOW_SPECS + %w[spec/requests/followers], # Layout also mounts on Followers/Index
+  %r{\Aapp/javascript/data/installments} => EMAIL_FLOW_SPECS, # #7578
+  %r{\Aapp/models/help_center/articles\.yml\z} => HELP_CENTER_SPECS, # YAML also feeds ArticleText + the v2 help API
   %r{\Aapp/javascript/components/TiptapExtensions/} => EDITOR_FLOW_SPECS,
   %r{\Aapp/javascript/components/RichTextEditor} => EDITOR_FLOW_SPECS,
-  %r{\Aapp/javascript/components/ImageUploader} => PRODUCT_FLOW_SPECS + PROFILE_FLOW_SPECS,
-  %r{\Aapp/javascript/components/ReviewForm} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS,
-  %r{\Aapp/javascript/components/Review\.tsx\z} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS,
-  %r{\Aapp/javascript/components/ReviewVideoPlayer} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS,
-  %r{\Aapp/javascript/components/DiscordButton} => DOWNLOAD_PAGE_SPECS,
-  %r{\Aapp/javascript/components/DownloadPage/} => DOWNLOAD_PAGE_SPECS,
-  %r{\Aapp/javascript/data/discord_integration} => DOWNLOAD_PAGE_SPECS,
-  %r{\Aapp/javascript/data/product_reviews} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS,
-  %r{\Aapp/javascript/components/DateRangePicker} => ANALYTICS_FLOW_SPECS,
-  %r{\Aapp/javascript/components/useRecaptcha} => CHECKOUT_FLOW_SPECS,
-  %r{\Aapp/javascript/parsers/profile} => PROFILE_FLOW_SPECS,
+  %r{\Aapp/javascript/components/ImageUploader} => PRODUCT_FLOW_SPECS + PROFILE_FLOW_SPECS, # LogoInput avatar upload
+  %r{\Aapp/javascript/components/ReviewForm} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS + %w[spec/requests/library_spec.rb spec/requests/customers/customers_spec.rb],
+  %r{\Aapp/javascript/components/Review\.tsx\z} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS + %w[spec/requests/library_spec.rb spec/requests/customers/customers_spec.rb],
+  %r{\Aapp/javascript/components/ReviewVideoPlayer} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS + %w[spec/requests/library_spec.rb spec/requests/customers/customers_spec.rb],
+  %r{\Aapp/javascript/components/DiscordButton} => DOWNLOAD_PAGE_SPECS + CHECKOUT_FLOW_SPECS, # also Checkout/Receipt
+  %r{\Aapp/javascript/components/DownloadPage/} => DOWNLOAD_PAGE_SPECS, # #7529
+  %r{\Aapp/javascript/data/discord_integration} => DOWNLOAD_PAGE_SPECS + CHECKOUT_FLOW_SPECS + %w[spec/requests/products/edit/integrations/discord_integrations_spec.rb],
+  %r{\Aapp/javascript/data/product_reviews} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS + %w[spec/requests/library_spec.rb spec/requests/customers/customers_spec.rb],
+  %r{\Aapp/javascript/components/DateRangePicker} => ANALYTICS_FLOW_SPECS, # #7259
+  %r{\Aapp/javascript/components/useRecaptcha} => CHECKOUT_FLOW_SPECS, # #7203
+  %r{\Aapp/javascript/parsers/profile} => PROFILE_FLOW_SPECS, # #7341
+  %r{\Aapp/javascript/pages/Users/Coffee} => PROFILE_FLOW_SPECS + %w[spec/requests/purchases/product/coffee_spec.rb],
   %r{\Aapp/javascript/pages/Users/} => PROFILE_FLOW_SPECS,
-  %r{\Aapp/javascript/data/paypal} => SETTINGS_FLOW_SPECS,
-  %r{\Aapp/javascript/data/search} => DISCOVER_FLOW_SPECS,
-  %r{\Aapp/javascript/pages/Discover/} => DISCOVER_FLOW_SPECS,
-  %r{\Aapp/javascript/pages/Wishlists/} => WISHLIST_FLOW_SPECS,
-  %r{\Aapp/javascript/components/WorkflowsPage/} => WORKFLOW_FLOW_SPECS,
-  %r{\Aapp/javascript/entrypoints/custom_html_analytics} => ANALYTICS_FLOW_SPECS,
-  %r{\Aapp/javascript/stylesheets/_email} => MAILER_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/User/Passwords/} => %w[spec/requests/password_reset_spec.rb spec/requests/login_spec.rb],
+  %r{\Aapp/javascript/pages/UrlRedirects/} => DOWNLOAD_PAGE_SPECS,
+  %r{\Aapp/javascript/pages/Pages/} => %w[
+    spec/controllers/pages_controller_spec.rb
+    spec/requests/pages_landing_embed_csp_spec.rb
+    spec/requests/pages_landing_embed_routing_spec.rb
+    spec/requests/pages_landing_embed_storage_shim_spec.rb
+  ],
+  %r{\Aapp/javascript/pages/Dashboard/} => %w[spec/requests/dashboard_spec.rb],
+  %r{\Aapp/javascript/pages/Customers/} => %w[spec/requests/customers],
+  %r{\Aapp/javascript/pages/Library/} => %w[spec/requests/library_spec.rb],
+  %r{\Aapp/javascript/pages/Oauth/} => %w[spec/requests/oauth_applications_pages_spec.rb],
+  %r{\Aapp/javascript/pages/Followers/} => %w[spec/requests/followers],
+  %r{\Aapp/javascript/pages/Reviews/} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS + %w[spec/requests/library_spec.rb],
+  %r{\Aapp/javascript/pages/Workflows/} => WORKFLOW_FLOW_SPECS,
+  %r{\Aapp/javascript/data/paypal} => CHECKOUT_FLOW_SPECS, # Checkout/PaymentForm billing agreement, not Settings
+  %r{\Aapp/javascript/data/search} => DISCOVER_FLOW_SPECS + %w[spec/requests/user/product_panel], # CardGrid storefront filter
+  %r{\Aapp/javascript/pages/Discover/} => DISCOVER_FLOW_SPECS, # #7236
+  %r{\Aapp/javascript/pages/Wishlists/} => WISHLIST_FLOW_SPECS, # #7236
+  %r{\Aapp/javascript/components/WorkflowsPage/} => WORKFLOW_FLOW_SPECS, # #7474
+  %r{\Aapp/javascript/entrypoints/custom_html_analytics} => %w[
+    spec/requests/products/show/custom_html_analytics_spec.rb
+    spec/requests/profile_custom_html_spec.rb
+    spec/requests/custom_html_background_wiring_spec.rb
+    spec/controllers/links_controller_custom_html_spec.rb
+    spec/controllers/users_controller_custom_html_spec.rb
+    spec/requests/products/show
+  ],
+  %r{\Aapp/javascript/stylesheets/_email} => MAILER_FLOW_SPECS, # #7156 #7404
 }.freeze
 
-# Config files with a dedicated spec. Boot-global files still escalate via
-# ESCALATE_PATTERNS. Unknown config mapping-gaps. A same-named spec is not
-# coverage unless it is listed here — domain.rb's spec only pins development
-# constants, not production hosts/CORS/mailer.
+# Config files with dedicated, local coverage. Boot-global files (domain.rb,
+# currencies.json, secure_headers, test_redis_isolation, devise/sentry/filter
+# hooks, OmniAuth Apple) stay in ESCALATE_PATTERNS — a matching
+# spec/config/*_spec.rb is not proof the initializer's effect is local.
 CONFIG_SPEC_MAP = {
   "config/initializers/rack_attack.rb" => %w[spec/requests/rack_attack_spec.rb],
-  "config/currencies.json" => %w[spec/config/currencies_spec.rb spec/requests/checkout/currencies_spec.rb],
-  "config/initializers/sentry.rb" => %w[spec/config/initializers/sentry_spec.rb],
-  "config/initializers/filter_parameter_logging.rb" => %w[spec/config/initializers/filter_parameter_logging_spec.rb],
-  "config/initializers/devise_pwned_password_safe_params.rb" => %w[spec/config/initializers/devise_pwned_password_safe_params_spec.rb],
-  "config/initializers/secure_headers.rb" => %w[spec/config/initializers/secure_headers_spec.rb],
   "config/initializers/alterity.rb" => %w[spec/config/initializers/alterity_spec.rb],
-  "config/initializers/active_storage_jobs.rb" => %w[spec/config/initializers/active_storage_jobs_spec.rb],
   "config/initializers/instant_ddl_first.rb" => %w[spec/config/initializers/instant_ddl_first_spec.rb],
-  "config/initializers/005_apple.rb" => %w[spec/config/initializers/apple_strategy_patch_spec.rb],
+  "config/initializers/active_storage_jobs.rb" => %w[spec/config/initializers/active_storage_jobs_spec.rb],
 }.freeze
 
 # Support files with mappings; any OTHER spec/support change escalates.
 MAPPED_SUPPORT = FANOUT.keys.select { |re| re.source.start_with?('\Aspec/support') }.freeze
 
 # Paths that cannot be attributed to specs by filename: run the full suite.
-# Boot-global config stays here. Allowlisted config maps via CONFIG_SPEC_MAP.
-# Unknown config mapping-gaps. domain.rb is boot-global (hosts/CORS/mailer).
+# Blanket config/ stays: a spec/config twin is not enough for boot-global
+# files (domain, CSP, currencies, test redis, Warden/Sentry hooks).
+# CONFIG_SPEC_MAP is the only reviewed exception.
 ESCALATE_PATTERNS = [
   %r{\AGemfile},
-  %r{\Aconfig/application\.rb\z},
-  %r{\Aconfig/boot\.rb\z},
-  %r{\Aconfig/environment\.rb\z},
-  %r{\Aconfig/environments/},
-  %r{\Aconfig/database},
-  %r{\Aconfig/routes\.rb\z},
-  %r{\Aconfig/domain\.rb\z},
-  # Cron graph; no spec/config/sidekiq_schedule_spec.rb.
-  %r{\Aconfig/sidekiq_schedule\.yml\z},
+  %r{\Aconfig/},
   %r{\Adb/},
   %r{\Apackage\.json\z},
   %r{\A(pnpm-lock\.yaml|yarn\.lock|package-lock\.json)\z},
@@ -235,11 +256,12 @@ IGNORED_PATTERNS = [
   # Recorded HTTP, not helpers. A cassette-only diff must not force Slow;
   # the spec that plays the tape is already in the selection (or unchanged).
   %r{\Aspec/support/fixtures/vcr_cassettes/},
-  # Production nginx and the web entrypoint are not the rspec suite.
-  # docker/ci, Dockerfile.test, and compose-test still mapping-gap.
-  %r{\Adocker/nginx/},
-  %r{\Adocker/branch_app_nginx/},
-  %r{\Adocker/web/server\.sh\z},
+  # Production nginx/startup/local-compose only. Test-image inputs
+  # (Dockerfile.test, compose-test-and-ci, docker/ci, rspec.sh, fixture
+  # manifests) are unattributed and escalate — they feed the rspec image.
+  %r{\Adocker/(nginx|branch_app_nginx)/},
+  %r{\Adocker/web/(server|sidekiq_worker|rpush|post_deployment|database_migration|compile_assets|push_assets_to_s3|setup_db)\.sh\z},
+  %r{\Adocker/docker-compose-local\.yml\z},
 ].freeze
 
 # Above this many selected files the full suite's parallelism wins anyway.

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -82,6 +82,13 @@ DISCOVER_FLOW_SPECS = %w[spec/requests/discover].freeze
 WISHLIST_FLOW_SPECS = %w[spec/requests/wishlists].freeze
 DOWNLOAD_PAGE_SPECS = %w[spec/requests/download_page].freeze
 WORKFLOW_FLOW_SPECS = %w[spec/requests/workflows_spec.rb].freeze
+# Shared editor mounts on product, email, download, profile, and workflow
+# surfaces. Product-only fanout would let a change merge without those
+# consumers' request specs.
+EDITOR_FLOW_SPECS = (
+  PRODUCT_FLOW_SPECS + EMAIL_FLOW_SPECS + DOWNLOAD_PAGE_SPECS +
+  PROFILE_FLOW_SPECS + WORKFLOW_FLOW_SPECS
+).freeze
 MAILER_FLOW_SPECS = %w[spec/mailers].freeze
 HELP_CENTER_SPECS = %w[spec/requests/help_center_spec.rb spec/requests/help_center spec/presenters/help_center_presenter_spec.rb].freeze
 # Instant-payout / balance page (Inertia Payouts/Index), not the 45 backend payout specs.
@@ -137,60 +144,58 @@ FANOUT = {
   # authorize screens live in oauth_authorizations*_spec.rb.
   %r{\Aapp/views/doorkeeper/} => %w[spec/requests/oauth_authorizations_spec.rb spec/requests/oauth_authorize_scope_list_spec.rb],
   %r{\Aspec/support/dynamodb\.rb\z} => %w[spec/services/email_engagement_dynamo_store_spec.rb],
-  # Harvest 2026-09-12 (run-all-specs PRs since 2026-08-01). Each line names
-  # the PR(s) that escalated on this path.
-  %r{\Aapp/javascript/components/Settings/} => SETTINGS_FLOW_SPECS, # #7473 PayPalEmailSection
-  %r{\Aapp/javascript/(components|pages)/Payouts/} => PAYOUT_PAGE_SPECS, # #7438 #7495
-  %r{\Aapp/javascript/pages/Emails/} => EMAIL_FLOW_SPECS, # #7578 #7580
-  %r{\Aapp/javascript/components/EmailsPage/} => EMAIL_FLOW_SPECS, # #7581
-  %r{\Aapp/javascript/data/installments} => EMAIL_FLOW_SPECS, # #7578
-  %r{\Aapp/models/help_center/articles\.yml\z} => HELP_CENTER_SPECS, # #7375
-  %r{\Aapp/javascript/components/TiptapExtensions/} => PRODUCT_FLOW_SPECS, # #7404 #7535
-  %r{\Aapp/javascript/components/RichTextEditor} => PRODUCT_FLOW_SPECS, # #7207 #7403
-  %r{\Aapp/javascript/components/ImageUploader} => PRODUCT_FLOW_SPECS, # #7403
-  %r{\Aapp/javascript/components/ReviewForm} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS, # #7332
-  %r{\Aapp/javascript/components/Review\.tsx\z} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS, # #7529
-  %r{\Aapp/javascript/components/ReviewVideoPlayer} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS, # #7474
-  %r{\Aapp/javascript/components/DiscordButton} => DOWNLOAD_PAGE_SPECS, # #7529
-  %r{\Aapp/javascript/components/DownloadPage/} => DOWNLOAD_PAGE_SPECS, # #7529
-  %r{\Aapp/javascript/data/discord_integration} => DOWNLOAD_PAGE_SPECS, # #7529
-  %r{\Aapp/javascript/data/product_reviews} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS, # #7529
-  %r{\Aapp/javascript/components/DateRangePicker} => ANALYTICS_FLOW_SPECS, # #7259
-  %r{\Aapp/javascript/components/useRecaptcha} => CHECKOUT_FLOW_SPECS, # #7203
-  %r{\Aapp/javascript/parsers/profile} => PROFILE_FLOW_SPECS, # #7341
-  %r{\Aapp/javascript/pages/Users/} => PROFILE_FLOW_SPECS, # #7236 Coffee
-  %r{\Aapp/javascript/data/paypal} => SETTINGS_FLOW_SPECS, # #7355
-  %r{\Aapp/javascript/data/search} => DISCOVER_FLOW_SPECS, # #7267
-  %r{\Aapp/javascript/pages/Discover/} => DISCOVER_FLOW_SPECS, # #7236
-  %r{\Aapp/javascript/pages/Wishlists/} => WISHLIST_FLOW_SPECS, # #7236
-  %r{\Aapp/javascript/components/WorkflowsPage/} => WORKFLOW_FLOW_SPECS, # #7474
-  %r{\Aapp/javascript/entrypoints/custom_html_analytics} => ANALYTICS_FLOW_SPECS, # #7504
-  %r{\Aapp/javascript/stylesheets/_email} => MAILER_FLOW_SPECS, # #7156 #7404
+  %r{\Aapp/javascript/components/Settings/} => SETTINGS_FLOW_SPECS,
+  %r{\Aapp/javascript/(components|pages)/Payouts/} => PAYOUT_PAGE_SPECS,
+  %r{\Aapp/javascript/pages/Emails/} => EMAIL_FLOW_SPECS,
+  %r{\Aapp/javascript/components/EmailsPage/} => EMAIL_FLOW_SPECS,
+  %r{\Aapp/javascript/data/installments} => EMAIL_FLOW_SPECS,
+  %r{\Aapp/models/help_center/articles\.yml\z} => HELP_CENTER_SPECS,
+  %r{\Aapp/javascript/components/TiptapExtensions/} => EDITOR_FLOW_SPECS,
+  %r{\Aapp/javascript/components/RichTextEditor} => EDITOR_FLOW_SPECS,
+  %r{\Aapp/javascript/components/ImageUploader} => PRODUCT_FLOW_SPECS + PROFILE_FLOW_SPECS,
+  %r{\Aapp/javascript/components/ReviewForm} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS,
+  %r{\Aapp/javascript/components/Review\.tsx\z} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS,
+  %r{\Aapp/javascript/components/ReviewVideoPlayer} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS,
+  %r{\Aapp/javascript/components/DiscordButton} => DOWNLOAD_PAGE_SPECS,
+  %r{\Aapp/javascript/components/DownloadPage/} => DOWNLOAD_PAGE_SPECS,
+  %r{\Aapp/javascript/data/discord_integration} => DOWNLOAD_PAGE_SPECS,
+  %r{\Aapp/javascript/data/product_reviews} => PRODUCT_FLOW_SPECS + DOWNLOAD_PAGE_SPECS,
+  %r{\Aapp/javascript/components/DateRangePicker} => ANALYTICS_FLOW_SPECS,
+  %r{\Aapp/javascript/components/useRecaptcha} => CHECKOUT_FLOW_SPECS,
+  %r{\Aapp/javascript/parsers/profile} => PROFILE_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/Users/} => PROFILE_FLOW_SPECS,
+  %r{\Aapp/javascript/data/paypal} => SETTINGS_FLOW_SPECS,
+  %r{\Aapp/javascript/data/search} => DISCOVER_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/Discover/} => DISCOVER_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/Wishlists/} => WISHLIST_FLOW_SPECS,
+  %r{\Aapp/javascript/components/WorkflowsPage/} => WORKFLOW_FLOW_SPECS,
+  %r{\Aapp/javascript/entrypoints/custom_html_analytics} => ANALYTICS_FLOW_SPECS,
+  %r{\Aapp/javascript/stylesheets/_email} => MAILER_FLOW_SPECS,
 }.freeze
 
 # Config files with a dedicated spec. Boot-global files still escalate via
-# ESCALATE_PATTERNS. Other config/* is tried via spec_candidates (spec/config/...)
-# and mapping-gaps if nothing exists — harvested 2026-09-12.
+# ESCALATE_PATTERNS. Unknown config mapping-gaps. A same-named spec is not
+# coverage unless it is listed here — domain.rb's spec only pins development
+# constants, not production hosts/CORS/mailer.
 CONFIG_SPEC_MAP = {
   "config/initializers/rack_attack.rb" => %w[spec/requests/rack_attack_spec.rb],
-  "config/currencies.json" => %w[spec/config/currencies_spec.rb spec/requests/checkout/currencies_spec.rb], # #7229
+  "config/currencies.json" => %w[spec/config/currencies_spec.rb spec/requests/checkout/currencies_spec.rb],
   "config/initializers/sentry.rb" => %w[spec/config/initializers/sentry_spec.rb],
   "config/initializers/filter_parameter_logging.rb" => %w[spec/config/initializers/filter_parameter_logging_spec.rb],
   "config/initializers/devise_pwned_password_safe_params.rb" => %w[spec/config/initializers/devise_pwned_password_safe_params_spec.rb],
-  "config/initializers/secure_headers.rb" => %w[spec/config/initializers/secure_headers_spec.rb], # #7432
+  "config/initializers/secure_headers.rb" => %w[spec/config/initializers/secure_headers_spec.rb],
   "config/initializers/alterity.rb" => %w[spec/config/initializers/alterity_spec.rb],
   "config/initializers/active_storage_jobs.rb" => %w[spec/config/initializers/active_storage_jobs_spec.rb],
   "config/initializers/instant_ddl_first.rb" => %w[spec/config/initializers/instant_ddl_first_spec.rb],
-  "config/initializers/005_apple.rb" => %w[spec/config/initializers/apple_strategy_patch_spec.rb], # #7589
+  "config/initializers/005_apple.rb" => %w[spec/config/initializers/apple_strategy_patch_spec.rb],
 }.freeze
 
 # Support files with mappings; any OTHER spec/support change escalates.
 MAPPED_SUPPORT = FANOUT.keys.select { |re| re.source.start_with?('\Aspec/support') }.freeze
 
 # Paths that cannot be attributed to specs by filename: run the full suite.
-# Blanket `config/` was replaced 2026-09-12: only boot-global files stay here.
-# Other config (currencies.json, domain.rb, initializers with a dedicated spec)
-# maps via CONFIG_SPEC_MAP / spec_candidates. Unknown config still mapping-gaps.
+# Boot-global config stays here. Allowlisted config maps via CONFIG_SPEC_MAP.
+# Unknown config mapping-gaps. domain.rb is boot-global (hosts/CORS/mailer).
 ESCALATE_PATTERNS = [
   %r{\AGemfile},
   %r{\Aconfig/application\.rb\z},
@@ -199,7 +204,8 @@ ESCALATE_PATTERNS = [
   %r{\Aconfig/environments/},
   %r{\Aconfig/database},
   %r{\Aconfig/routes\.rb\z},
-  # Cron graph — 13 harvested PRs; no spec/config/sidekiq_schedule_spec.rb.
+  %r{\Aconfig/domain\.rb\z},
+  # Cron graph; no spec/config/sidekiq_schedule_spec.rb.
   %r{\Aconfig/sidekiq_schedule\.yml\z},
   %r{\Adb/},
   %r{\Apackage\.json\z},
@@ -229,8 +235,11 @@ IGNORED_PATTERNS = [
   # Recorded HTTP, not helpers. A cassette-only diff must not force Slow;
   # the spec that plays the tape is already in the selection (or unchanged).
   %r{\Aspec/support/fixtures/vcr_cassettes/},
-  # Image/nginx/web scripts are not the rspec suite. Harvest: #7260 #7468 #7527.
-  %r{\Adocker/},
+  # Production nginx and the web entrypoint are not the rspec suite.
+  # docker/ci, Dockerfile.test, and compose-test still mapping-gap.
+  %r{\Adocker/nginx/},
+  %r{\Adocker/branch_app_nginx/},
+  %r{\Adocker/web/server\.sh\z},
 ].freeze
 
 # Above this many selected files the full suite's parallelism wins anyway.
@@ -432,13 +441,6 @@ def spec_candidates(path)
     ["spec/#{$1}/#{$2}_spec.rb"]
   when %r{\Alib/(.*)\.rb\z}
     ["spec/lib/#{$1}_spec.rb"]
-  when %r{\Aconfig/(.*)\.(rb|yml|json)\z}
-    # Convention: config/foo.rb → spec/config/foo_spec.rb (and nested initializers).
-    ["spec/config/#{$1}_spec.rb"]
-  when %r{\Aapp/javascript/pages/([^/]+)/}
-    underscored = $1.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
-    Dir.glob("spec/requests/#{underscored}/**/*_spec.rb") +
-      Dir.glob("spec/requests/#{underscored}*_spec.rb")
   else
     []
   end

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -151,9 +151,13 @@ FANOUT = {
   # more than one flow ESCALATE. Do not raise MAX_SELECTED_FILES to keep
   # an incomplete union (RichTextEditor importer-complete union is 157).
   # Importer traces below are rg from "$app/<module>" (or the inertia render).
-  %r{\Aapp/javascript/components/Settings/} => SETTINGS_FLOW_SPECS + %w[spec/requests/oauth_applications_pages_spec.rb],
+  %r{\Aapp/javascript/components/Settings/} => SETTINGS_FLOW_SPECS + %w[
+    spec/requests/oauth_applications_pages_spec.rb
+    spec/requests/login/passkeys_spec.rb
+  ],
   # Importers: pages/Settings/* Layout/Advanced/Payments; also
   # Oauth/Applications/Edit.tsx:7 ApplicationForm and :8 Layout.
+  # PasskeysSection registers then logs in (login/passkeys_spec.rb).
   %r{\Aapp/javascript/(components|pages)/Payouts/} => PAYOUT_PAGE_SPECS,
   # Renderer: balance_controller.rb:14 inertia "Payouts/Index".
   %r{\Aapp/javascript/pages/Emails/} => EMAIL_FLOW_SPECS,
@@ -195,7 +199,14 @@ FANOUT = {
     spec/requests/pages_landing_embed_storage_shim_spec.rb
   ],
   # Renderer: pages_controller.rb:25 Index, :42/:77/:88 Edit.
-  %r{\Aapp/javascript/pages/Dashboard/} => %w[spec/requests/dashboard_spec.rb],
+  %r{\Aapp/javascript/pages/Dashboard/} => %w[
+    spec/requests/dashboard_spec.rb
+    spec/requests/dashboard_mobile_table_spec.rb
+    spec/requests/dashboard_nav_mobile_spec.rb
+    spec/requests/dashboard_nav_progressive_disclosure_spec.rb
+    spec/requests/dashboard_nav_promotion_spec.rb
+    spec/requests/social_connect_return_spec.rb
+  ],
   %r{\Aapp/javascript/pages/Customers/} => %w[spec/requests/customers],
   %r{\Aapp/javascript/pages/Library/} => %w[spec/requests/library_spec.rb],
   %r{\Aapp/javascript/pages/Oauth/} => %w[spec/requests/oauth_applications_pages_spec.rb],
@@ -207,7 +218,9 @@ FANOUT = {
   %r{\Aapp/javascript/data/paypal} => CHECKOUT_FLOW_SPECS,
   # Importers: Checkout/PaymentForm.tsx:33 createBillingAgreement (not Settings).
   %r{\Aapp/javascript/pages/Discover/} => DISCOVER_FLOW_SPECS,
-  %r{\Aapp/javascript/pages/Wishlists/} => WISHLIST_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/Wishlists/Index} => WISHLIST_FLOW_SPECS,
+  %r{\Aapp/javascript/pages/Wishlists/Following} => WISHLIST_FLOW_SPECS,
+  # Wishlists/Show is also a Discover purchase/commission surface — escalate.
   %r{\Aapp/javascript/components/WorkflowsPage/} => WORKFLOW_FLOW_SPECS,
   %r{\Aapp/javascript/entrypoints/custom_html_analytics} => %w[
     spec/requests/products/show/custom_html_analytics_spec.rb

--- a/bin/branch-specs
+++ b/bin/branch-specs
@@ -81,7 +81,11 @@ AUDIENCE_FLOW_SPECS = %w[
 EMAIL_FLOW_SPECS = %w[spec/requests/emails].freeze
 DISCOVER_FLOW_SPECS = %w[spec/requests/discover].freeze
 WISHLIST_FLOW_SPECS = %w[spec/requests/wishlists].freeze
-DOWNLOAD_PAGE_SPECS = %w[spec/requests/download_page].freeze
+DOWNLOAD_PAGE_SPECS = %w[
+  spec/requests/download_page
+  spec/requests/reading_spec.rb
+  spec/requests/video_streaming_spec.rb
+].freeze
 WORKFLOW_FLOW_SPECS = %w[spec/requests/workflows_spec.rb].freeze
 HELP_CENTER_SPECS = %w[
   spec/requests/help_center_spec.rb
@@ -167,8 +171,12 @@ FANOUT = {
   # Importers: DiscordButton.tsx:4 join/leave;
   # ProductEdit/ProductTab/DiscordIntegrationEditor.tsx:4 fetchServerInfo.
   # parsers/profile is shared (Coffee, product profile, settings) — escalate.
-  %r{\Aapp/javascript/pages/Users/Coffee} => PROFILE_FLOW_SPECS + %w[spec/requests/purchases/product/coffee_spec.rb],
-  # Renderer: users_controller.rb:115 Users/Coffee.
+  %r{\Aapp/javascript/pages/Users/Coffee} => PROFILE_FLOW_SPECS + %w[
+    spec/requests/purchases/product/coffee_spec.rb
+    spec/requests/purchases/tipping_spec.rb
+  ],
+  # Renderer: users_controller.rb:115 Users/Coffee. tipping_spec.rb visits
+  # coffee.long_url then checkout (coffee-only carts cannot tip).
   %r{\Aapp/javascript/pages/Users/Show} => PROFILE_FLOW_SPECS,
   # Renderer: users_controller.rb:35 Users/Show storefront.
   %r{\Aapp/javascript/pages/Users/Subscribe\.tsx\z} => PROFILE_FLOW_SPECS,
@@ -177,10 +185,9 @@ FANOUT = {
   %r{\Aapp/javascript/pages/User/Passwords/} => %w[spec/requests/password_reset_spec.rb spec/requests/login_spec.rb],
   # Renderer: user/passwords_controller.rb:16 New, :39 Edit.
   %r{\Aapp/javascript/pages/UrlRedirects/DownloadPage} => DOWNLOAD_PAGE_SPECS,
-  # Renderer: url_redirects_controller.rb:107 DownloadPage. Read.tsx has
-  # a co-located vitest (Read.test.tsx); a directory catch-all would
-  # override that skip with download_page request specs that never visit
-  # the EPUB reader. Confirm/Stream/Expired escalate.
+  # Renderer: url_redirects_controller.rb:107 DownloadPage. reading_spec
+  # and video_streaming_spec visit /d/:token (Watch/Read controls).
+  # Read.tsx has co-located vitest; Confirm/Stream/Expired escalate.
   %r{\Aapp/javascript/pages/Pages/} => %w[
     spec/controllers/pages_controller_spec.rb
     spec/requests/pages_landing_embed_csp_spec.rb

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -738,53 +738,24 @@ check(
 )
 
 check(
-  "Tiptap extension fans out to every consuming flow, not just products",
-  base_files: {
-    "spec/requests/products/edit/covers_spec.rb" => SPEC_STUB,
-    "spec/requests/emails/list_spec.rb" => SPEC_STUB,
-    "spec/requests/download_page/show_spec.rb" => SPEC_STUB,
-    "spec/requests/user/profile_spec.rb" => SPEC_STUB,
-    "spec/requests/workflows_spec.rb" => SPEC_STUB,
-    "app/javascript/components/TiptapExtensions/FileUpload.tsx" => "old",
-  },
+  "Tiptap extension still escalates (shared editor, multi-flow consumers)",
+  base_files: { "app/javascript/components/TiptapExtensions/FileUpload.tsx" => "old" },
   head_files: { "app/javascript/components/TiptapExtensions/FileUpload.tsx" => "new" },
-  expect_specs: %w[
-    spec/requests/products/edit/covers_spec.rb
-    spec/requests/emails/list_spec.rb
-    spec/requests/download_page/show_spec.rb
-    spec/requests/user/profile_spec.rb
-    spec/requests/workflows_spec.rb
-  ],
+  expect_escalate: true,
 )
 
 check(
-  "RichTextEditor fans out to email and download consumers, not just products",
-  base_files: {
-    "spec/requests/products/edit/covers_spec.rb" => SPEC_STUB,
-    "spec/requests/emails/list_spec.rb" => SPEC_STUB,
-    "spec/requests/download_page/show_spec.rb" => SPEC_STUB,
-    "app/javascript/components/RichTextEditor.tsx" => "old",
-  },
+  "RichTextEditor still escalates (importer-complete union exceeds 120)",
+  base_files: { "app/javascript/components/RichTextEditor.tsx" => "old" },
   head_files: { "app/javascript/components/RichTextEditor.tsx" => "new" },
-  expect_specs: %w[
-    spec/requests/products/edit/covers_spec.rb
-    spec/requests/emails/list_spec.rb
-    spec/requests/download_page/show_spec.rb
-  ],
+  expect_escalate: true,
 )
 
 check(
-  "ImageUploader fans out to product and profile consumers",
-  base_files: {
-    "spec/requests/products/edit/covers_spec.rb" => SPEC_STUB,
-    "spec/requests/user/profile_spec.rb" => SPEC_STUB,
-    "app/javascript/components/ImageUploader.tsx" => "old",
-  },
+  "ImageUploader still escalates (product + profile + bundle consumers)",
+  base_files: { "app/javascript/components/ImageUploader.tsx" => "old" },
   head_files: { "app/javascript/components/ImageUploader.tsx" => "new" },
-  expect_specs: %w[
-    spec/requests/products/edit/covers_spec.rb
-    spec/requests/user/profile_spec.rb
-  ],
+  expect_escalate: true,
 )
 
 check(
@@ -854,13 +825,10 @@ check(
 )
 
 check(
-  "email stylesheet fans out to mailer specs (#7156)",
-  base_files: {
-    "spec/mailers/customer_mailer_spec.rb" => SPEC_STUB,
-    "app/javascript/stylesheets/_email.scss" => "old",
-  },
+  "email stylesheet still escalates (mailers plus receipt-preview renderer)",
+  base_files: { "app/javascript/stylesheets/_email.scss" => "old" },
   head_files: { "app/javascript/stylesheets/_email.scss" => "new" },
-  expect_specs: %w[spec/mailers/customer_mailer_spec.rb],
+  expect_escalate: true,
 )
 
 check(
@@ -938,6 +906,7 @@ check(
   base_files: {
     "spec/requests/products/show/custom_html_analytics_spec.rb" => SPEC_STUB,
     "spec/requests/profile_custom_html_spec.rb" => SPEC_STUB,
+    "spec/requests/profile_analytics_spec.rb" => SPEC_STUB,
     "spec/requests/analytics/sales_spec.rb" => SPEC_STUB,
     "app/javascript/entrypoints/custom_html_analytics.ts" => "old",
   },
@@ -945,6 +914,7 @@ check(
   expect_specs: %w[
     spec/requests/products/show/custom_html_analytics_spec.rb
     spec/requests/profile_custom_html_spec.rb
+    spec/requests/profile_analytics_spec.rb
   ],
 )
 
@@ -981,23 +951,10 @@ check(
 )
 
 check(
-  "RichTextEditor selects emails + download + profile, not products-only",
-  base_files: {
-    "spec/requests/products/edit/covers_spec.rb" => SPEC_STUB,
-    "spec/requests/emails/create_spec.rb" => SPEC_STUB,
-    "spec/requests/download_page/rich_text_editor_spec.rb" => SPEC_STUB,
-    "spec/requests/user/profile_spec.rb" => SPEC_STUB,
-    "spec/requests/workflows_spec.rb" => SPEC_STUB,
-    "app/javascript/components/RichTextEditor.tsx" => "old",
-  },
-  head_files: { "app/javascript/components/RichTextEditor.tsx" => "new" },
-  expect_specs: %w[
-    spec/requests/products/edit/covers_spec.rb
-    spec/requests/emails/create_spec.rb
-    spec/requests/download_page/rich_text_editor_spec.rb
-    spec/requests/user/profile_spec.rb
-    spec/requests/workflows_spec.rb
-  ],
+  "ReviewForm still escalates (editor + purchase + library consumers)",
+  base_files: { "app/javascript/components/ReviewForm.tsx" => "old" },
+  head_files: { "app/javascript/components/ReviewForm.tsx" => "new" },
+  expect_escalate: true,
 )
 
 check(
@@ -1026,53 +983,38 @@ check(
 )
 
 check(
-  "ImageUploader selects avatar upload settings spec",
-  base_files: {
-    "spec/requests/products/edit/covers_spec.rb" => SPEC_STUB,
-    "spec/requests/user/settings_spec.rb" => SPEC_STUB,
-    "app/javascript/components/ImageUploader.tsx" => "old",
-  },
-  head_files: { "app/javascript/components/ImageUploader.tsx" => "new" },
-  expect_specs: %w[
-    spec/requests/products/edit/covers_spec.rb
-    spec/requests/user/settings_spec.rb
-  ],
-)
-
-check(
-  "ReviewForm selects library spec",
-  base_files: {
-    "spec/requests/products/show/reviews_spec.rb" => SPEC_STUB,
-    "spec/requests/library_spec.rb" => SPEC_STUB,
-    "app/javascript/components/ReviewForm.tsx" => "old",
-  },
-  head_files: { "app/javascript/components/ReviewForm.tsx" => "new" },
-  expect_specs: %w[spec/requests/library_spec.rb],
-)
-
-check(
-  "ReviewVideoPlayer selects customers spec",
-  base_files: {
-    "spec/requests/products/show/reviews_spec.rb" => SPEC_STUB,
-    "spec/requests/customers/customers_spec.rb" => SPEC_STUB,
-    "app/javascript/components/ReviewVideoPlayer.tsx" => "old",
-  },
+  "ReviewVideoPlayer still escalates (editor + purchase + customers consumers)",
+  base_files: { "app/javascript/components/ReviewVideoPlayer.tsx" => "old" },
   head_files: { "app/javascript/components/ReviewVideoPlayer.tsx" => "new" },
-  expect_specs: %w[spec/requests/customers/customers_spec.rb],
+  expect_escalate: true,
 )
 
 check(
-  "data/search selects product_panel storefront specs",
-  base_files: {
-    "spec/requests/discover/index_spec.rb" => SPEC_STUB,
-    "spec/requests/user/product_panel/product_panel_sort_filter_spec.rb" => SPEC_STUB,
-    "app/javascript/data/search.ts" => "old",
-  },
+  "data/product_reviews still escalates (editor + purchase consumers)",
+  base_files: { "app/javascript/data/product_reviews.ts" => "old" },
+  head_files: { "app/javascript/data/product_reviews.ts" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "DateRangePicker still escalates (analytics + customers consumers)",
+  base_files: { "app/javascript/components/DateRangePicker.tsx" => "old" },
+  head_files: { "app/javascript/components/DateRangePicker.tsx" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "useRecaptcha still escalates (checkout + profile follow consumers)",
+  base_files: { "app/javascript/components/useRecaptcha.tsx" => "old" },
+  head_files: { "app/javascript/components/useRecaptcha.tsx" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "data/search still escalates (discover + storefront editor consumers)",
+  base_files: { "app/javascript/data/search.ts" => "old" },
   head_files: { "app/javascript/data/search.ts" => "new" },
-  expect_specs: %w[
-    spec/requests/discover/index_spec.rb
-    spec/requests/user/product_panel/product_panel_sort_filter_spec.rb
-  ],
+  expect_escalate: true,
 )
 
 check(
@@ -1109,6 +1051,24 @@ check(
   },
   head_files: { "app/javascript/pages/Users/Coffee.tsx" => "new" },
   expect_specs: %w[spec/requests/purchases/product/coffee_spec.rb],
+)
+
+check(
+  "Users/Show selects profile request specs (storefront-only)",
+  base_files: {
+    "spec/requests/user/profile_spec.rb" => SPEC_STUB,
+    "spec/controllers/users/review_reminders_controller_spec.rb" => SPEC_STUB,
+    "app/javascript/pages/Users/Show.tsx" => "old",
+  },
+  head_files: { "app/javascript/pages/Users/Show.tsx" => "new" },
+  expect_specs: %w[spec/requests/user/profile_spec.rb],
+)
+
+check(
+  "Users/ReviewReminders still escalates (not storefront)",
+  base_files: { "app/javascript/pages/Users/ReviewReminders/Unsubscribe.tsx" => "old" },
+  head_files: { "app/javascript/pages/Users/ReviewReminders/Unsubscribe.tsx" => "new" },
+  expect_escalate: true,
 )
 
 check(
@@ -1154,6 +1114,36 @@ check(
   },
   head_files: { "config/initializers/005_apple.rb" => "new" },
   expect_escalate: true,
+)
+
+check(
+  "alterity initializer maps to alterity_spec instead of escalating",
+  base_files: {
+    "spec/config/initializers/alterity_spec.rb" => SPEC_STUB,
+    "config/initializers/alterity.rb" => "old",
+  },
+  head_files: { "config/initializers/alterity.rb" => "new" },
+  expect_specs: %w[spec/config/initializers/alterity_spec.rb],
+)
+
+check(
+  "instant_ddl_first initializer maps to its dedicated spec",
+  base_files: {
+    "spec/config/initializers/instant_ddl_first_spec.rb" => SPEC_STUB,
+    "config/initializers/instant_ddl_first.rb" => "old",
+  },
+  head_files: { "config/initializers/instant_ddl_first.rb" => "new" },
+  expect_specs: %w[spec/config/initializers/instant_ddl_first_spec.rb],
+)
+
+check(
+  "active_storage_jobs initializer maps to its dedicated spec",
+  base_files: {
+    "spec/config/initializers/active_storage_jobs_spec.rb" => SPEC_STUB,
+    "config/initializers/active_storage_jobs.rb" => "old",
+  },
+  head_files: { "config/initializers/active_storage_jobs.rb" => "new" },
+  expect_specs: %w[spec/config/initializers/active_storage_jobs_spec.rb],
 )
 
 check(

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -702,33 +702,39 @@ check(
 )
 
 check(
-  "help_center articles.yml maps to help center specs (#7375)",
+  "help_center articles.yml maps to help center + API/search specs (#7375)",
   base_files: {
     "spec/requests/help_center_spec.rb" => SPEC_STUB,
+    "spec/services/help_center/article_text_spec.rb" => SPEC_STUB,
+    "spec/controllers/api/v2/help_articles_controller_spec.rb" => SPEC_STUB,
     "app/models/help_center/articles.yml" => "old",
   },
   head_files: { "app/models/help_center/articles.yml" => "new" },
-  expect_specs: %w[spec/requests/help_center_spec.rb],
+  expect_specs: %w[
+    spec/requests/help_center_spec.rb
+    spec/services/help_center/article_text_spec.rb
+    spec/controllers/api/v2/help_articles_controller_spec.rb
+  ],
 )
 
 check(
-  "currencies.json maps to currencies spec instead of escalating (#7229)",
+  "currencies.json still escalates (boot-global pricing registry)",
   base_files: {
     "spec/config/currencies_spec.rb" => SPEC_STUB,
     "config/currencies.json" => "{}",
   },
   head_files: { "config/currencies.json" => "{\"USD\":{}}" },
-  expect_specs: %w[spec/config/currencies_spec.rb],
+  expect_escalate: true,
 )
 
 check(
-  "initializer with a dedicated spec maps (#7432 family)",
+  "secure_headers initializer still escalates (global CSP)",
   base_files: {
     "spec/config/initializers/secure_headers_spec.rb" => SPEC_STUB,
     "config/initializers/secure_headers.rb" => "old",
   },
   head_files: { "config/initializers/secure_headers.rb" => "new" },
-  expect_specs: %w[spec/config/initializers/secure_headers_spec.rb],
+  expect_escalate: true,
 )
 
 check(
@@ -796,7 +802,7 @@ check(
 )
 
 check(
-  "docker-only change does not escalate (#7260)",
+  "docker production server.sh-only change does not escalate (#7260)",
   base_files: { "docker/web/server.sh" => "old" },
   head_files: { "docker/web/server.sh" => "new" },
   expect_specs: [],
@@ -817,7 +823,7 @@ check(
 )
 
 check(
-  "docker test Dockerfile change still escalates",
+  "docker test-image Dockerfile.test escalates (feeds CI rspec image)",
   base_files: { "docker/web/Dockerfile.test" => "old" },
   head_files: { "docker/web/Dockerfile.test" => "new" },
   expect_escalate: true,
@@ -831,12 +837,9 @@ check(
 )
 
 check(
-  "Pages JS does not treat pages_landing_embed specs as coverage",
-  base_files: {
-    "spec/requests/pages_landing_embed_routing_spec.rb" => SPEC_STUB,
-    "app/javascript/pages/Pages/Edit.tsx" => "old",
-  },
-  head_files: { "app/javascript/pages/Pages/Edit.tsx" => "new" },
+  "docker fixture manifest escalates (feeds stamp_spec MinIO copies)",
+  base_files: { "docker/fixture-files-private.txt" => "old" },
+  head_files: { "docker/fixture-files-private.txt" => "new" },
   expect_escalate: true,
 )
 
@@ -915,6 +918,252 @@ check(
   },
   head_files: { "app/presenters/checkout/stripe_payment_presenter.rb" => "new" },
   expect_specs: %w[spec/requests/checkout/payment_spec.rb],
+)
+
+# Importer-traced pins (round 2). Each asserts a consuming flow's spec,
+# not a coincidental sibling path from a harvested PR.
+check(
+  "data/paypal selects checkout payment spec, not settings",
+  base_files: {
+    "spec/requests/checkout/payment_spec.rb" => SPEC_STUB,
+    "spec/requests/settings/payments_spec.rb" => SPEC_STUB,
+    "app/javascript/data/paypal.ts" => "old",
+  },
+  head_files: { "app/javascript/data/paypal.ts" => "new" },
+  expect_specs: %w[spec/requests/checkout/payment_spec.rb],
+)
+
+check(
+  "custom_html_analytics selects buyer custom-HTML specs, not seller analytics",
+  base_files: {
+    "spec/requests/products/show/custom_html_analytics_spec.rb" => SPEC_STUB,
+    "spec/requests/profile_custom_html_spec.rb" => SPEC_STUB,
+    "spec/requests/analytics/sales_spec.rb" => SPEC_STUB,
+    "app/javascript/entrypoints/custom_html_analytics.ts" => "old",
+  },
+  head_files: { "app/javascript/entrypoints/custom_html_analytics.ts" => "new" },
+  expect_specs: %w[
+    spec/requests/products/show/custom_html_analytics_spec.rb
+    spec/requests/profile_custom_html_spec.rb
+  ],
+)
+
+check(
+  "pages/UrlRedirects selects download_page specs",
+  base_files: {
+    "spec/requests/download_page/download_page_spec.rb" => SPEC_STUB,
+    "spec/requests/url_redirects_epub_reader_system_spec.rb" => SPEC_STUB,
+    "app/javascript/pages/UrlRedirects/DownloadPage.tsx" => "old",
+  },
+  head_files: { "app/javascript/pages/UrlRedirects/DownloadPage.tsx" => "new" },
+  expect_specs: %w[spec/requests/download_page/download_page_spec.rb],
+)
+
+check(
+  "pages/Pages selects pages_controller and landing embed specs",
+  base_files: {
+    "spec/controllers/pages_controller_spec.rb" => SPEC_STUB,
+    "spec/requests/pages_landing_embed_csp_spec.rb" => SPEC_STUB,
+    "app/javascript/pages/Pages/Edit.tsx" => "old",
+  },
+  head_files: { "app/javascript/pages/Pages/Edit.tsx" => "new" },
+  expect_specs: %w[
+    spec/controllers/pages_controller_spec.rb
+    spec/requests/pages_landing_embed_csp_spec.rb
+  ],
+)
+
+check(
+  "unlisted pages dir still escalates (generic name-match dropped)",
+  base_files: { "app/javascript/pages/Signup/New.tsx" => "old" },
+  head_files: { "app/javascript/pages/Signup/New.tsx" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "RichTextEditor selects emails + download + profile, not products-only",
+  base_files: {
+    "spec/requests/products/edit/covers_spec.rb" => SPEC_STUB,
+    "spec/requests/emails/create_spec.rb" => SPEC_STUB,
+    "spec/requests/download_page/rich_text_editor_spec.rb" => SPEC_STUB,
+    "spec/requests/user/profile_spec.rb" => SPEC_STUB,
+    "spec/requests/workflows_spec.rb" => SPEC_STUB,
+    "app/javascript/components/RichTextEditor.tsx" => "old",
+  },
+  head_files: { "app/javascript/components/RichTextEditor.tsx" => "new" },
+  expect_specs: %w[
+    spec/requests/products/edit/covers_spec.rb
+    spec/requests/emails/create_spec.rb
+    spec/requests/download_page/rich_text_editor_spec.rb
+    spec/requests/user/profile_spec.rb
+    spec/requests/workflows_spec.rb
+  ],
+)
+
+check(
+  "DiscordButton selects checkout receipt coverage",
+  base_files: {
+    "spec/requests/download_page/download_page_spec.rb" => SPEC_STUB,
+    "spec/requests/checkout/payment_spec.rb" => SPEC_STUB,
+    "app/javascript/components/DiscordButton.tsx" => "old",
+  },
+  head_files: { "app/javascript/components/DiscordButton.tsx" => "new" },
+  expect_specs: %w[
+    spec/requests/download_page/download_page_spec.rb
+    spec/requests/checkout/payment_spec.rb
+  ],
+)
+
+check(
+  "discord_integration selects product edit integrations spec",
+  base_files: {
+    "spec/requests/download_page/download_page_spec.rb" => SPEC_STUB,
+    "spec/requests/products/edit/integrations/discord_integrations_spec.rb" => SPEC_STUB,
+    "app/javascript/data/discord_integration.ts" => "old",
+  },
+  head_files: { "app/javascript/data/discord_integration.ts" => "new" },
+  expect_specs: %w[spec/requests/products/edit/integrations/discord_integrations_spec.rb],
+)
+
+check(
+  "ImageUploader selects avatar upload settings spec",
+  base_files: {
+    "spec/requests/products/edit/covers_spec.rb" => SPEC_STUB,
+    "spec/requests/user/settings_spec.rb" => SPEC_STUB,
+    "app/javascript/components/ImageUploader.tsx" => "old",
+  },
+  head_files: { "app/javascript/components/ImageUploader.tsx" => "new" },
+  expect_specs: %w[
+    spec/requests/products/edit/covers_spec.rb
+    spec/requests/user/settings_spec.rb
+  ],
+)
+
+check(
+  "ReviewForm selects library spec",
+  base_files: {
+    "spec/requests/products/show/reviews_spec.rb" => SPEC_STUB,
+    "spec/requests/library_spec.rb" => SPEC_STUB,
+    "app/javascript/components/ReviewForm.tsx" => "old",
+  },
+  head_files: { "app/javascript/components/ReviewForm.tsx" => "new" },
+  expect_specs: %w[spec/requests/library_spec.rb],
+)
+
+check(
+  "ReviewVideoPlayer selects customers spec",
+  base_files: {
+    "spec/requests/products/show/reviews_spec.rb" => SPEC_STUB,
+    "spec/requests/customers/customers_spec.rb" => SPEC_STUB,
+    "app/javascript/components/ReviewVideoPlayer.tsx" => "old",
+  },
+  head_files: { "app/javascript/components/ReviewVideoPlayer.tsx" => "new" },
+  expect_specs: %w[spec/requests/customers/customers_spec.rb],
+)
+
+check(
+  "data/search selects product_panel storefront specs",
+  base_files: {
+    "spec/requests/discover/index_spec.rb" => SPEC_STUB,
+    "spec/requests/user/product_panel/product_panel_sort_filter_spec.rb" => SPEC_STUB,
+    "app/javascript/data/search.ts" => "old",
+  },
+  head_files: { "app/javascript/data/search.ts" => "new" },
+  expect_specs: %w[
+    spec/requests/discover/index_spec.rb
+    spec/requests/user/product_panel/product_panel_sort_filter_spec.rb
+  ],
+)
+
+check(
+  "Settings ApplicationForm also selects oauth applications pages spec",
+  base_files: {
+    "spec/requests/settings/payments_spec.rb" => SPEC_STUB,
+    "spec/requests/oauth_applications_pages_spec.rb" => SPEC_STUB,
+    "app/javascript/components/Settings/AdvancedPage/ApplicationForm.tsx" => "old",
+  },
+  head_files: { "app/javascript/components/Settings/AdvancedPage/ApplicationForm.tsx" => "new" },
+  expect_specs: %w[spec/requests/oauth_applications_pages_spec.rb],
+)
+
+check(
+  "EmailsPage Layout selects followers specs",
+  base_files: {
+    "spec/requests/emails/list_spec.rb" => SPEC_STUB,
+    "spec/requests/followers/followers_spec.rb" => SPEC_STUB,
+    "app/javascript/components/EmailsPage/Layout.tsx" => "old",
+  },
+  head_files: { "app/javascript/components/EmailsPage/Layout.tsx" => "new" },
+  expect_specs: %w[
+    spec/requests/emails/list_spec.rb
+    spec/requests/followers/followers_spec.rb
+  ],
+)
+
+check(
+  "Users/Coffee selects purchase coffee spec",
+  base_files: {
+    "spec/requests/user/profile_spec.rb" => SPEC_STUB,
+    "spec/requests/purchases/product/coffee_spec.rb" => SPEC_STUB,
+    "app/javascript/pages/Users/Coffee.tsx" => "old",
+  },
+  head_files: { "app/javascript/pages/Users/Coffee.tsx" => "new" },
+  expect_specs: %w[spec/requests/purchases/product/coffee_spec.rb],
+)
+
+check(
+  "User/Passwords selects password_reset spec, not generic user/",
+  base_files: {
+    "spec/requests/password_reset_spec.rb" => SPEC_STUB,
+    "spec/requests/login_spec.rb" => SPEC_STUB,
+    "spec/requests/user/profile_spec.rb" => SPEC_STUB,
+    "app/javascript/pages/User/Passwords/Edit.tsx" => "old",
+  },
+  head_files: { "app/javascript/pages/User/Passwords/Edit.tsx" => "new" },
+  expect_specs: %w[
+    spec/requests/password_reset_spec.rb
+    spec/requests/login_spec.rb
+  ],
+)
+
+check(
+  "config/domain.rb still escalates (boot-global hosts)",
+  base_files: {
+    "spec/config/domain_spec.rb" => SPEC_STUB,
+    "config/domain.rb" => "old",
+  },
+  head_files: { "config/domain.rb" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "config/test_redis_isolation.rb still escalates (required from application.rb)",
+  base_files: {
+    "spec/config/test_redis_isolation_spec.rb" => SPEC_STUB,
+    "config/test_redis_isolation.rb" => "old",
+  },
+  head_files: { "config/test_redis_isolation.rb" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "005_apple.rb still escalates (global OmniAuth strategy)",
+  base_files: {
+    "spec/config/initializers/apple_strategy_patch_spec.rb" => SPEC_STUB,
+    "config/initializers/005_apple.rb" => "old",
+  },
+  head_files: { "config/initializers/005_apple.rb" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "devise_pwned_password_safe_params still escalates (Warden after_set_user)",
+  base_files: {
+    "spec/config/initializers/devise_pwned_password_safe_params_spec.rb" => SPEC_STUB,
+    "config/initializers/devise_pwned_password_safe_params.rb" => "old",
+  },
+  head_files: { "config/initializers/devise_pwned_password_safe_params.rb" => "new" },
+  expect_escalate: true,
 )
 
 WORKFLOW = File.expand_path("../../.github/workflows/tests.yml", __dir__)

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -732,13 +732,53 @@ check(
 )
 
 check(
-  "Tiptap extension fans out to product request specs (#7535)",
+  "Tiptap extension fans out to every consuming flow, not just products",
   base_files: {
     "spec/requests/products/edit/covers_spec.rb" => SPEC_STUB,
+    "spec/requests/emails/list_spec.rb" => SPEC_STUB,
+    "spec/requests/download_page/show_spec.rb" => SPEC_STUB,
+    "spec/requests/user/profile_spec.rb" => SPEC_STUB,
+    "spec/requests/workflows_spec.rb" => SPEC_STUB,
     "app/javascript/components/TiptapExtensions/FileUpload.tsx" => "old",
   },
   head_files: { "app/javascript/components/TiptapExtensions/FileUpload.tsx" => "new" },
-  expect_specs: %w[spec/requests/products/edit/covers_spec.rb],
+  expect_specs: %w[
+    spec/requests/products/edit/covers_spec.rb
+    spec/requests/emails/list_spec.rb
+    spec/requests/download_page/show_spec.rb
+    spec/requests/user/profile_spec.rb
+    spec/requests/workflows_spec.rb
+  ],
+)
+
+check(
+  "RichTextEditor fans out to email and download consumers, not just products",
+  base_files: {
+    "spec/requests/products/edit/covers_spec.rb" => SPEC_STUB,
+    "spec/requests/emails/list_spec.rb" => SPEC_STUB,
+    "spec/requests/download_page/show_spec.rb" => SPEC_STUB,
+    "app/javascript/components/RichTextEditor.tsx" => "old",
+  },
+  head_files: { "app/javascript/components/RichTextEditor.tsx" => "new" },
+  expect_specs: %w[
+    spec/requests/products/edit/covers_spec.rb
+    spec/requests/emails/list_spec.rb
+    spec/requests/download_page/show_spec.rb
+  ],
+)
+
+check(
+  "ImageUploader fans out to product and profile consumers",
+  base_files: {
+    "spec/requests/products/edit/covers_spec.rb" => SPEC_STUB,
+    "spec/requests/user/profile_spec.rb" => SPEC_STUB,
+    "app/javascript/components/ImageUploader.tsx" => "old",
+  },
+  head_files: { "app/javascript/components/ImageUploader.tsx" => "new" },
+  expect_specs: %w[
+    spec/requests/products/edit/covers_spec.rb
+    spec/requests/user/profile_spec.rb
+  ],
 )
 
 check(
@@ -760,6 +800,54 @@ check(
   base_files: { "docker/web/server.sh" => "old" },
   head_files: { "docker/web/server.sh" => "new" },
   expect_specs: [],
+)
+
+check(
+  "docker nginx-only change does not escalate",
+  base_files: { "docker/nginx/nginx.conf" => "old" },
+  head_files: { "docker/nginx/nginx.conf" => "new" },
+  expect_specs: [],
+)
+
+check(
+  "docker compose-test change still escalates",
+  base_files: { "docker/docker-compose-test-and-ci.yml" => "old" },
+  head_files: { "docker/docker-compose-test-and-ci.yml" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "docker test Dockerfile change still escalates",
+  base_files: { "docker/web/Dockerfile.test" => "old" },
+  head_files: { "docker/web/Dockerfile.test" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "docker ci restore_test_db change still escalates",
+  base_files: { "docker/ci/restore_test_db.sh" => "old" },
+  head_files: { "docker/ci/restore_test_db.sh" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "Pages JS does not treat pages_landing_embed specs as coverage",
+  base_files: {
+    "spec/requests/pages_landing_embed_routing_spec.rb" => SPEC_STUB,
+    "app/javascript/pages/Pages/Edit.tsx" => "old",
+  },
+  head_files: { "app/javascript/pages/Pages/Edit.tsx" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "domain.rb still escalates even when domain_spec exists",
+  base_files: {
+    "spec/config/domain_spec.rb" => SPEC_STUB,
+    "config/domain.rb" => "old",
+  },
+  head_files: { "config/domain.rb" => "new" },
+  expect_escalate: true,
 )
 
 check(

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -664,6 +664,171 @@ check(
   expect_specs: [],
 )
 
+# Harvest 2026-09-12: recurring run-all-specs gaps.
+check(
+  "Payouts page fans out to balance request specs (#7438)",
+  base_files: {
+    "spec/requests/balance_pages_spec.rb" => SPEC_STUB,
+    "app/javascript/pages/Payouts/Index.tsx" => "old",
+    "app/javascript/components/Payouts/index.tsx" => "old",
+  },
+  head_files: {
+    "app/javascript/pages/Payouts/Index.tsx" => "new",
+    "app/javascript/components/Payouts/index.tsx" => "new",
+  },
+  expect_specs: %w[spec/requests/balance_pages_spec.rb],
+)
+
+check(
+  "Settings PaymentsPage component fans out to settings request specs (#7473)",
+  base_files: {
+    "spec/requests/settings/payments_spec.rb" => SPEC_STUB,
+    "app/javascript/components/Settings/PaymentsPage/PayPalEmailSection.tsx" => "old",
+  },
+  head_files: {
+    "app/javascript/components/Settings/PaymentsPage/PayPalEmailSection.tsx" => "new",
+  },
+  expect_specs: %w[spec/requests/settings/payments_spec.rb],
+)
+
+check(
+  "Emails page fans out to emails request specs (#7578)",
+  base_files: {
+    "spec/requests/emails/list_spec.rb" => SPEC_STUB,
+    "app/javascript/pages/Emails/Published.tsx" => "old",
+  },
+  head_files: { "app/javascript/pages/Emails/Published.tsx" => "new" },
+  expect_specs: %w[spec/requests/emails/list_spec.rb],
+)
+
+check(
+  "help_center articles.yml maps to help center specs (#7375)",
+  base_files: {
+    "spec/requests/help_center_spec.rb" => SPEC_STUB,
+    "app/models/help_center/articles.yml" => "old",
+  },
+  head_files: { "app/models/help_center/articles.yml" => "new" },
+  expect_specs: %w[spec/requests/help_center_spec.rb],
+)
+
+check(
+  "currencies.json maps to currencies spec instead of escalating (#7229)",
+  base_files: {
+    "spec/config/currencies_spec.rb" => SPEC_STUB,
+    "config/currencies.json" => "{}",
+  },
+  head_files: { "config/currencies.json" => "{\"USD\":{}}" },
+  expect_specs: %w[spec/config/currencies_spec.rb],
+)
+
+check(
+  "initializer with a dedicated spec maps (#7432 family)",
+  base_files: {
+    "spec/config/initializers/secure_headers_spec.rb" => SPEC_STUB,
+    "config/initializers/secure_headers.rb" => "old",
+  },
+  head_files: { "config/initializers/secure_headers.rb" => "new" },
+  expect_specs: %w[spec/config/initializers/secure_headers_spec.rb],
+)
+
+check(
+  "Tiptap extension fans out to product request specs (#7535)",
+  base_files: {
+    "spec/requests/products/edit/covers_spec.rb" => SPEC_STUB,
+    "app/javascript/components/TiptapExtensions/FileUpload.tsx" => "old",
+  },
+  head_files: { "app/javascript/components/TiptapExtensions/FileUpload.tsx" => "new" },
+  expect_specs: %w[spec/requests/products/edit/covers_spec.rb],
+)
+
+check(
+  "docker nginx with a mapped spec does not escalate (#7468)",
+  base_files: {
+    "app/models/widget.rb" => "old",
+    "spec/models/widget_spec.rb" => SPEC_STUB,
+    "docker/nginx/nginx.conf" => "old",
+  },
+  head_files: {
+    "app/models/widget.rb" => "new",
+    "docker/nginx/nginx.conf" => "new",
+  },
+  expect_specs: %w[spec/models/widget_spec.rb],
+)
+
+check(
+  "docker-only change does not escalate (#7260)",
+  base_files: { "docker/web/server.sh" => "old" },
+  head_files: { "docker/web/server.sh" => "new" },
+  expect_specs: [],
+)
+
+check(
+  "email stylesheet fans out to mailer specs (#7156)",
+  base_files: {
+    "spec/mailers/customer_mailer_spec.rb" => SPEC_STUB,
+    "app/javascript/stylesheets/_email.scss" => "old",
+  },
+  head_files: { "app/javascript/stylesheets/_email.scss" => "new" },
+  expect_specs: %w[spec/mailers/customer_mailer_spec.rb],
+)
+
+check(
+  "profile parser fans out to profile request specs (#7341)",
+  base_files: {
+    "spec/requests/user/profile_spec.rb" => SPEC_STUB,
+    "app/javascript/parsers/profile.ts" => "old",
+  },
+  head_files: { "app/javascript/parsers/profile.ts" => "new" },
+  expect_specs: %w[spec/requests/user/profile_spec.rb],
+)
+
+# Negatives harvested as unsafe to map.
+check(
+  "shared Select.tsx still escalates (#7437)",
+  base_files: { "app/javascript/components/Select.tsx" => "old" },
+  head_files: { "app/javascript/components/Select.tsx" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "ui/Select.tsx still escalates (imported from checkout+payouts+settings)",
+  base_files: { "app/javascript/components/ui/Select.tsx" => "old" },
+  head_files: { "app/javascript/components/ui/Select.tsx" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "routes.rb still escalates",
+  base_files: { "config/routes.rb" => "old" },
+  head_files: { "config/routes.rb" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "sidekiq_schedule.yml still escalates",
+  base_files: { "config/sidekiq_schedule.yml" => "old" },
+  head_files: { "config/sidekiq_schedule.yml" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "application.rb still escalates",
+  base_files: { "config/application.rb" => "old" },
+  head_files: { "config/application.rb" => "new" },
+  expect_escalate: true,
+)
+
+# #7070 post-merge miss: checkout presenter must still pull checkout flow specs.
+check(
+  "checkout presenter still fans out to checkout request specs (#7070)",
+  base_files: {
+    "spec/requests/checkout/payment_spec.rb" => SPEC_STUB,
+    "app/presenters/checkout/stripe_payment_presenter.rb" => "old",
+  },
+  head_files: { "app/presenters/checkout/stripe_payment_presenter.rb" => "new" },
+  expect_specs: %w[spec/requests/checkout/payment_spec.rb],
+)
+
 WORKFLOW = File.expand_path("../../.github/workflows/tests.yml", __dir__)
 workflow = YAML.load_file(WORKFLOW)
 migration_versions = workflow.fetch("jobs").fetch("migration_versions")

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -879,10 +879,16 @@ check(
   "checkout presenter still fans out to checkout request specs (#7070)",
   base_files: {
     "spec/requests/checkout/payment_spec.rb" => SPEC_STUB,
+    "spec/requests/purchases/product_spec.rb" => SPEC_STUB,
+    "spec/requests/subscription/non_tiered_membership_spec.rb" => SPEC_STUB,
     "app/presenters/checkout/stripe_payment_presenter.rb" => "old",
   },
   head_files: { "app/presenters/checkout/stripe_payment_presenter.rb" => "new" },
-  expect_specs: %w[spec/requests/checkout/payment_spec.rb],
+  expect_specs: %w[
+    spec/requests/checkout/payment_spec.rb
+    spec/requests/purchases/product_spec.rb
+    spec/requests/subscription/non_tiered_membership_spec.rb
+  ],
 )
 
 # Importer-traced pins (round 2). Each asserts a consuming flow's spec,
@@ -916,14 +922,20 @@ check(
 )
 
 check(
-  "pages/UrlRedirects/DownloadPage selects download_page specs",
+  "pages/UrlRedirects/DownloadPage selects download_page plus reading/video specs",
   base_files: {
     "spec/requests/download_page/download_page_spec.rb" => SPEC_STUB,
+    "spec/requests/reading_spec.rb" => SPEC_STUB,
+    "spec/requests/video_streaming_spec.rb" => SPEC_STUB,
     "spec/requests/url_redirects_epub_reader_system_spec.rb" => SPEC_STUB,
     "app/javascript/pages/UrlRedirects/DownloadPage.tsx" => "old",
   },
   head_files: { "app/javascript/pages/UrlRedirects/DownloadPage.tsx" => "new" },
-  expect_specs: %w[spec/requests/download_page/download_page_spec.rb],
+  expect_specs: %w[
+    spec/requests/download_page/download_page_spec.rb
+    spec/requests/reading_spec.rb
+    spec/requests/video_streaming_spec.rb
+  ],
 )
 
 check(
@@ -1047,14 +1059,18 @@ check(
 )
 
 check(
-  "Users/Coffee selects purchase coffee spec",
+  "Users/Coffee selects purchase coffee spec and tipping spec",
   base_files: {
     "spec/requests/user/profile_spec.rb" => SPEC_STUB,
     "spec/requests/purchases/product/coffee_spec.rb" => SPEC_STUB,
+    "spec/requests/purchases/tipping_spec.rb" => SPEC_STUB,
     "app/javascript/pages/Users/Coffee.tsx" => "old",
   },
   head_files: { "app/javascript/pages/Users/Coffee.tsx" => "new" },
-  expect_specs: %w[spec/requests/purchases/product/coffee_spec.rb],
+  expect_specs: %w[
+    spec/requests/purchases/product/coffee_spec.rb
+    spec/requests/purchases/tipping_spec.rb
+  ],
 )
 
 check(

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -832,13 +832,10 @@ check(
 )
 
 check(
-  "profile parser fans out to profile request specs (#7341)",
-  base_files: {
-    "spec/requests/user/profile_spec.rb" => SPEC_STUB,
-    "app/javascript/parsers/profile.ts" => "old",
-  },
+  "profile parser still escalates (Coffee + product profile + settings consumers)",
+  base_files: { "app/javascript/parsers/profile.ts" => "old" },
   head_files: { "app/javascript/parsers/profile.ts" => "new" },
-  expect_specs: %w[spec/requests/user/profile_spec.rb],
+  expect_escalate: true,
 )
 
 # Negatives harvested as unsafe to map.
@@ -919,7 +916,7 @@ check(
 )
 
 check(
-  "pages/UrlRedirects selects download_page specs",
+  "pages/UrlRedirects/DownloadPage selects download_page specs",
   base_files: {
     "spec/requests/download_page/download_page_spec.rb" => SPEC_STUB,
     "spec/requests/url_redirects_epub_reader_system_spec.rb" => SPEC_STUB,
@@ -927,6 +924,13 @@ check(
   },
   head_files: { "app/javascript/pages/UrlRedirects/DownloadPage.tsx" => "new" },
   expect_specs: %w[spec/requests/download_page/download_page_spec.rb],
+)
+
+check(
+  "pages/UrlRedirects/Read still escalates (EPUB reader is not download_page)",
+  base_files: { "app/javascript/pages/UrlRedirects/Read.tsx" => "old" },
+  head_files: { "app/javascript/pages/UrlRedirects/Read.tsx" => "new" },
+  expect_escalate: true,
 )
 
 check(
@@ -1054,20 +1058,38 @@ check(
 )
 
 check(
-  "Users/Show selects profile request specs (storefront-only)",
+  "Users/Show selects profile request specs including custom-domain storefront",
   base_files: {
     "spec/requests/user/profile_spec.rb" => SPEC_STUB,
+    "spec/requests/user_custom_domain_spec.rb" => SPEC_STUB,
     "spec/controllers/users/review_reminders_controller_spec.rb" => SPEC_STUB,
     "app/javascript/pages/Users/Show.tsx" => "old",
   },
   head_files: { "app/javascript/pages/Users/Show.tsx" => "new" },
-  expect_specs: %w[spec/requests/user/profile_spec.rb],
+  expect_specs: %w[
+    spec/requests/user/profile_spec.rb
+    spec/requests/user_custom_domain_spec.rb
+  ],
 )
 
 check(
   "Users/ReviewReminders still escalates (not storefront)",
   base_files: { "app/javascript/pages/Users/ReviewReminders/Unsubscribe.tsx" => "old" },
   head_files: { "app/javascript/pages/Users/ReviewReminders/Unsubscribe.tsx" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "Users/SubscribePreview still escalates (preview generator, not storefront list)",
+  base_files: { "app/javascript/pages/Users/SubscribePreview.tsx" => "old" },
+  head_files: { "app/javascript/pages/Users/SubscribePreview.tsx" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "Followers/Cancel still escalates (buyer unsubscribe, not seller list)",
+  base_files: { "app/javascript/pages/Followers/Cancel.tsx" => "old" },
+  head_files: { "app/javascript/pages/Followers/Cancel.tsx" => "new" },
   expect_escalate: true,
 )
 

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -1045,6 +1045,17 @@ check(
 )
 
 check(
+  "Settings PasskeysSection selects passkey login spec",
+  base_files: {
+    "spec/requests/settings/payments_spec.rb" => SPEC_STUB,
+    "spec/requests/login/passkeys_spec.rb" => SPEC_STUB,
+    "app/javascript/components/Settings/PasswordPage/PasskeysSection.tsx" => "old",
+  },
+  head_files: { "app/javascript/components/Settings/PasswordPage/PasskeysSection.tsx" => "new" },
+  expect_specs: %w[spec/requests/login/passkeys_spec.rb],
+)
+
+check(
   "EmailsPage Layout selects followers specs",
   base_files: {
     "spec/requests/emails/list_spec.rb" => SPEC_STUB,
@@ -1106,6 +1117,27 @@ check(
   "Followers/Cancel still escalates (buyer unsubscribe, not seller list)",
   base_files: { "app/javascript/pages/Followers/Cancel.tsx" => "old" },
   head_files: { "app/javascript/pages/Followers/Cancel.tsx" => "new" },
+  expect_escalate: true,
+)
+
+check(
+  "Dashboard page selects mobile table spec, not only dashboard_spec",
+  base_files: {
+    "spec/requests/dashboard_spec.rb" => SPEC_STUB,
+    "spec/requests/dashboard_mobile_table_spec.rb" => SPEC_STUB,
+    "app/javascript/pages/Dashboard/Index.tsx" => "old",
+  },
+  head_files: { "app/javascript/pages/Dashboard/Index.tsx" => "new" },
+  expect_specs: %w[
+    spec/requests/dashboard_spec.rb
+    spec/requests/dashboard_mobile_table_spec.rb
+  ],
+)
+
+check(
+  "Wishlists/Show still escalates (Discover purchase/commission consumer)",
+  base_files: { "app/javascript/pages/Wishlists/Show.tsx" => "old" },
+  head_files: { "app/javascript/pages/Wishlists/Show.tsx" => "new" },
   expect_escalate: true,
 )
 

--- a/spec/bin/branch_specs_test.rb
+++ b/spec/bin/branch_specs_test.rb
@@ -1045,6 +1045,17 @@ check(
 )
 
 check(
+  "Settings Layout selects account confirmation spec",
+  base_files: {
+    "spec/requests/settings/payments_spec.rb" => SPEC_STUB,
+    "spec/requests/account_confirmation_spec.rb" => SPEC_STUB,
+    "app/javascript/components/Settings/Layout.tsx" => "old",
+  },
+  head_files: { "app/javascript/components/Settings/Layout.tsx" => "new" },
+  expect_specs: %w[spec/requests/account_confirmation_spec.rb],
+)
+
+check(
   "Settings PasskeysSection selects passkey login spec",
   base_files: {
     "spec/requests/settings/payments_spec.rb" => SPEC_STUB,
@@ -1085,18 +1096,10 @@ check(
 )
 
 check(
-  "Users/Show selects profile request specs including custom-domain storefront",
-  base_files: {
-    "spec/requests/user/profile_spec.rb" => SPEC_STUB,
-    "spec/requests/user_custom_domain_spec.rb" => SPEC_STUB,
-    "spec/controllers/users/review_reminders_controller_spec.rb" => SPEC_STUB,
-    "app/javascript/pages/Users/Show.tsx" => "old",
-  },
+  "Users/Show still escalates (UTM checkout consumer)",
+  base_files: { "app/javascript/pages/Users/Show.tsx" => "old" },
   head_files: { "app/javascript/pages/Users/Show.tsx" => "new" },
-  expect_specs: %w[
-    spec/requests/user/profile_spec.rb
-    spec/requests/user_custom_domain_spec.rb
-  ],
+  expect_escalate: true,
 )
 
 check(
@@ -1121,17 +1124,10 @@ check(
 )
 
 check(
-  "Dashboard page selects mobile table spec, not only dashboard_spec",
-  base_files: {
-    "spec/requests/dashboard_spec.rb" => SPEC_STUB,
-    "spec/requests/dashboard_mobile_table_spec.rb" => SPEC_STUB,
-    "app/javascript/pages/Dashboard/Index.tsx" => "old",
-  },
+  "Dashboard page still escalates (auth and Agent visitors)",
+  base_files: { "app/javascript/pages/Dashboard/Index.tsx" => "old" },
   head_files: { "app/javascript/pages/Dashboard/Index.tsx" => "new" },
-  expect_specs: %w[
-    spec/requests/dashboard_spec.rb
-    spec/requests/dashboard_mobile_table_spec.rb
-  ],
+  expect_escalate: true,
 )
 
 check(


### PR DESCRIPTION
Round 3: shared components whose consumers span more than one flow escalate.

## Checklist

- [x] Scope — mapper-only: FANOUT/config/ignore in `bin/branch-specs`. Unknown still escalates. Not raising MAX_SELECTED_FILES.
- [x] Design — importer-complete unions only. Shared multi-flow components escalate. Harvest coincidence is not coverage.
- [x] Build — harvest maps, then three adversarial rounds. Round 3 removes incomplete shared-component fanouts.
- [x] QA — `ruby spec/bin/branch_specs_test.rb` → 99 checks passed. Replay: paypal maps to checkout; RichTextEditor exits 3.
- [ ] Shipped — ready for human review. Do not automerge.
- [ ] Market — n/a, CI selector.
- [ ] Sell — n/a.

What

`bin/branch-specs` maps a branch diff to the specs CI should run. Exit 3 means the PR must carry `run-all-specs`. This change teaches it recurring, importer-traced gaps — and refuses to certify a shared component whose consumers span more than one flow.

Why

Sahil, 2026-09-12: "Update run-all-specs based on prior runs to improve it and need it less."

## Review rounds

Round 1 claimed 22 of 118 no longer escalate. Astra and Fable BLOCKed: harvest counts were coincidental, not importer-complete.

Round 2 traced importers and reverted boot-global config. Astra still BLOCKed: RichTextEditor's complete union is 157 files (>120), so it must escalate. Same for every shared component whose consumers span more than one flow.

Round 3 principle: stop approximating those fanouts. Do not raise MAX_SELECTED_FILES. Removed: RichTextEditor, TiptapExtensions, ImageUploader, ReviewForm / Review.tsx / ReviewVideoPlayer / data/product_reviews, DateRangePicker, useRecaptcha, data/search.ts, `_email.scss`. Users/ catch-all replaced with Coffee + Subscribe only (Show and ReviewReminders escalate). Wishlists/Show and Dashboard pages escalate. parsers/profile escalates.

Kept (importer-traced): data/paypal → checkout; Discord button + data; Settings including OAuth, passkeys, and settings_main visitors; EmailsPage + followers; Payouts; Coffee + tipping; articles.yml; Pages and Passwords; DownloadPage including reading/video specs that visit `/d/:token`; custom_html_analytics including profile_analytics_spec.rb; CONFIG_SPEC_MAP = rack_attack, alterity, instant_ddl_first, active_storage_jobs; docker production nginx/startup/local-compose ignored, test-image inputs escalate.

Honest harvest against origin/main labeled PRs: **12 of 116** no longer escalate (r1 claimed 22 of 118). Three of those 12 are ignored-only docker production files (exit 0, zero specs).

Before → after (origin/main ESCALATE → this head)

| PR | After |
|---|---|
| #7207 RichTextEditor | ESCALATE |
| #7229 currencies.json | ESCALATE |
| #7259 DateRangePicker | ESCALATE |
| #7260 docker/web/server.sh | ignored (0 specs) |
| #7267 data/search.ts | ESCALATE |
| #7332 ReviewForm | ESCALATE |
| #7341 parsers/profile.ts | ESCALATE |
| #7355 data/paypal.ts | 77 checkout specs |
| #7375 articles.yml | 5 specs |
| #7404 Tiptap + _email.scss | ESCALATE |
| #7422 config/domain.rb | ESCALATE |
| #7438 Payouts | 16 specs |
| #7468 docker/nginx | ignored |
| #7473 Settings PayPalEmailSection | 19 specs |
| #7495 Payouts | 36 specs |
| #7504 custom_html_analytics.ts | 46 specs |
| #7527 docker/nginx | ignored |
| #7535 TiptapExtensions | ESCALATE |
| #7578 Emails/Published | 6 specs |
| #7580 Emails/Published | 4 specs |
| #7581 EmailsPage/shared | 5 specs |
| #7589 005_apple.rb | ESCALATE |

Post-merge miss #7070 (checkout presenter → checkout/purchases/subscription) is unchanged and pinned.

This PR only touches `bin/branch-specs` and `spec/bin/branch_specs_test.rb`, which the selector skips.

Premerge review: clean @ 1856a091de694490796d9a0f9d262abcb7d49b8f

## Walkthrough

Terminal recording of `ruby spec/bin/branch_specs_test.rb` (99 checks) plus selector replay: `data/paypal.ts` maps to checkout (includes payment_spec, not settings); `RichTextEditor.tsx` exits 3.

https://github.com/user-attachments/assets/ecb7928f-f98d-4924-a11a-8eed2f1ea0b7

## QA

```
cd <worktree>
ruby spec/bin/branch_specs_test.rb
# 99 checks passed
ruby /tmp/astra-replay.rb paths app/javascript/data/paypal.ts
# status 0, includes spec/requests/checkout/payment_spec.rb
ruby /tmp/astra-replay.rb paths app/javascript/components/RichTextEditor.tsx
# status 3
```

No user-facing surface.

---

AI disclosure: Grok 4.6. Prompt: harvest run-all-specs PRs, map importer-traced FANOUT gaps, escalate shared multi-flow components, keep MAX_SELECTED_FILES at 120. Round 3: Astra+Fable adversarial passes until SHIP-WITH-FIXES with no P0/P1.
