### PR TITLE
Stub chargeback-rate payout pause in payout fixture specs

### DIFF
--- a/spec/controllers/api/v2/payouts_controller_spec.rb
+++ b/spec/controllers/api/v2/payouts_controller_spec.rb
@@ -544,6 +544,8 @@ describe Api::V2::PayoutsController do
         @another_seller = create :named_user
         @direct_affiliate = create :direct_affiliate, affiliate_user: @seller, seller: @another_seller
         base_past_date = 1.month.ago
+        # These payout fixtures are not representative of the seller's chargeback rate.
+        allow_any_instance_of(Purchase).to receive(:pause_payouts_for_seller_based_on_chargeback_rate!)
         allow_any_instance_of(Purchase).to receive(:create_dispute_evidence_if_needed!).and_return(nil)
 
         travel_to(base_past_date) do

--- a/spec/modules/payment/stats_spec.rb
+++ b/spec/modules/payment/stats_spec.rb
@@ -48,6 +48,11 @@ describe Payment::Stats, :vcr do
     end
 
     describe "chargeback", :vcr do
+      before do
+        # These payout fixtures are not representative of the seller's chargeback rate.
+        allow_any_instance_of(Purchase).to receive(:pause_payouts_for_seller_based_on_chargeback_rate!)
+      end
+
       it "deducts the chargeback and refund fees from the link's revenue if we didn't waive our fee" do
         travel_to(Date.today - 10) do
           p1 = create(:purchase_in_progress, link: @product_1, chargeable: create(:chargeable))

--- a/spec/requests/balance_pages_spec.rb
+++ b/spec/requests/balance_pages_spec.rb
@@ -1174,6 +1174,8 @@ describe "Balance Pages Scenario", js: true, type: :system do
       let(:payout_processor_type) { PayoutProcessorType::STRIPE }
 
       before do
+        # These payout fixtures are not representative of the seller's chargeback rate.
+        allow_any_instance_of(Purchase).to receive(:pause_payouts_for_seller_based_on_chargeback_rate!)
         create(:merchant_account, user: seller, charge_processor_merchant_id: create_verified_stripe_account(country: "US").id)
 
         affiliate_product = create :product, price_cents: 1500


### PR DESCRIPTION
Stub the chargeback-rate payout pause only in payout fixture setup, preserving all expected CSV, API, balance-page, and revenue values. #7601's Elasticsearch→SQL aggregation now sees tiny dispute-heavy fixture sellers where the unindexed Elasticsearch fixtures returned `NA`, so dispute formalization pauses payouts before accounting assertions run.

Production behavior is unchanged by this spec-only fix; the intended SQL calculation remains intact. The initial draft #7608 was merged while local verification was in progress, landing the CSV setup fix; this follow-up completes the remaining three files, including the payouts API case found by the related-spec sweep.

Failing runs:
- https://github.com/antiwork/gumroad/actions/runs/34688841453
- https://github.com/antiwork/gumroad/actions/runs/34688573333

Specs fixed:
- `spec/requests/balance_pages_spec.rb` — past-payout fixtures only.
- `spec/modules/payment/stats_spec.rb` — chargeback revenue context only.
- `spec/controllers/api/v2/payouts_controller_spec.rb` — include-transactions fixture setup.
- `spec/services/exports/payouts/csv_spec.rb` — already landed in #7608; verified together here.

Sweep: searched dispute formalization (including `charge_event_dispute_formalized`), `mark_chargeback`, and `chargeback_date:` alongside payout creation and revenue consumers. The API fixture had the same issue. Scheduled-payout chargeback fixtures set dates directly and do not invoke this pause hook; risk-enforcement tests were left intact.

Local verification on final head: all four complete spec files, using the real RSpec runner with a seeded private MySQL database, dedicated Redis, isolated Elasticsearch index names, and this worktree's rebuilt Vite assets. No accounting assertions or external-payment behavior were replaced by the harness.

```text
ruby /Users/gumclaw/.hermes/artifacts/gp2566-currencies/fixmain-run.rb spec/services/exports/payouts/csv_spec.rb spec/modules/payment/stats_spec.rb spec/controllers/api/v2/payouts_controller_spec.rb spec/requests/balance_pages_spec.rb
Finished in 12 minutes 33 seconds (files took 12.67 seconds to load)
112 examples, 0 failures
RSPEC_EXIT=0

bundle exec rubocop spec/services/exports/payouts/csv_spec.rb spec/modules/payment/stats_spec.rb spec/controllers/api/v2/payouts_controller_spec.rb spec/requests/balance_pages_spec.rb
Inspecting 4 files
....
4 files inspected, no offenses detected
```

QA: run those four files against a seeded test environment; existing payout amounts and transaction rows must remain unchanged. Earlier local attempts hit a stale browser build and runner timeouts; the complete run above supersedes them.

Media: docs/spec-only — diff is the reviewable artifact.
Premerge review: clean @ 434817c07fd680405ec31c356ec87da1371ebb7d

---
AI disclosure: GPT-6 Astra. Prompt: verify the SQL chargeback-rate fixture regression, isolate payout fixtures without changing app code or expected amounts, sweep related specs, run local tests and RuboCop, and complete the premerge panel. Review harness: GPT-6 Astra and Claude Fable 5.1; no accepted/actionable findings.
