### PR TITLE
Reload checkout return page while payment is still processing

### DIFF
--- a/app/javascript/pages/Checkout/Returns/Pending.test.tsx
+++ b/app/javascript/pages/Checkout/Returns/Pending.test.tsx
@@ -7,12 +7,16 @@ import Pending, {
   PENDING_RELOAD_GIVE_UP_MS,
   PENDING_RELOAD_MS,
   PENDING_RELOAD_STARTED_AT_KEY,
+  PENDING_STARTED_AT_PARAM,
 } from "$app/pages/Checkout/Returns/Pending";
 
 vi.mock("$app/components/ui/Card", () => ({
   Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
+
+const PATH = "/checkout/returns/order-token";
+const HREF = `https://gumroad.test${PATH}?payment_intent=pi_123`;
 
 afterEach(() => {
   cleanup();
@@ -23,12 +27,17 @@ afterEach(() => {
 
 describe("Checkout/Returns/Pending", () => {
   const reload = vi.fn();
+  const replace = vi.fn();
 
   beforeEach(() => {
     reload.mockReset();
+    replace.mockReset();
     vi.stubGlobal("location", {
-      pathname: "/checkout/returns/order-token",
+      pathname: PATH,
+      search: "?payment_intent=pi_123",
+      href: HREF,
       reload,
+      replace,
     });
   });
 
@@ -45,15 +54,13 @@ describe("Checkout/Returns/Pending", () => {
 
   it("does not reload after the give-up window for this return URL", () => {
     vi.useFakeTimers();
-    sessionStorage.setItem(
-      `${PENDING_RELOAD_STARTED_AT_KEY}:/checkout/returns/order-token`,
-      String(Date.now() - PENDING_RELOAD_GIVE_UP_MS),
-    );
+    sessionStorage.setItem(`${PENDING_RELOAD_STARTED_AT_KEY}:${PATH}`, String(Date.now() - PENDING_RELOAD_GIVE_UP_MS));
 
     render(<Pending />);
     vi.advanceTimersByTime(PENDING_RELOAD_MS);
 
     expect(reload).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
   });
 
   it("clears the reload timeout on unmount", () => {
@@ -63,5 +70,48 @@ describe("Checkout/Returns/Pending", () => {
     vi.advanceTimersByTime(PENDING_RELOAD_MS);
 
     expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("still reloads when sessionStorage throws", () => {
+    vi.useFakeTimers();
+    vi.spyOn(sessionStorage, "getItem").mockImplementation(() => {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    });
+    vi.spyOn(sessionStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    });
+
+    render(<Pending />);
+    vi.advanceTimersByTime(PENDING_RELOAD_MS);
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(replace).toHaveBeenCalledTimes(1);
+    const nextUrl = new URL(String(replace.mock.calls[0]?.[0]));
+    expect(nextUrl.searchParams.get("payment_intent")).toBe("pi_123");
+    expect(nextUrl.searchParams.get(PENDING_STARTED_AT_PARAM)).toMatch(/^\d+$/);
+  });
+
+  it("stops polling from the URL clock when sessionStorage is unavailable", () => {
+    vi.useFakeTimers();
+    const started = Date.now() - PENDING_RELOAD_GIVE_UP_MS;
+    vi.stubGlobal("location", {
+      pathname: PATH,
+      search: `?payment_intent=pi_123&${PENDING_STARTED_AT_PARAM}=${started}`,
+      href: `${HREF}&${PENDING_STARTED_AT_PARAM}=${started}`,
+      reload,
+      replace,
+    });
+    vi.spyOn(sessionStorage, "getItem").mockImplementation(() => {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    });
+    vi.spyOn(sessionStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    });
+
+    render(<Pending />);
+    vi.advanceTimersByTime(PENDING_RELOAD_MS);
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
   });
 });

--- a/app/javascript/pages/Checkout/Returns/Pending.test.tsx
+++ b/app/javascript/pages/Checkout/Returns/Pending.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import Pending, {
+  PENDING_RELOAD_GIVE_UP_MS,
+  PENDING_RELOAD_MS,
+  PENDING_RELOAD_STARTED_AT_KEY,
+} from "$app/pages/Checkout/Returns/Pending";
+
+vi.mock("$app/components/ui/Card", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  sessionStorage.clear();
+});
+
+describe("Checkout/Returns/Pending", () => {
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    reload.mockReset();
+    vi.stubGlobal("location", {
+      pathname: "/checkout/returns/order-token",
+      reload,
+    });
+  });
+
+  it("reloads so a later successful finalize can redirect off this page", () => {
+    vi.useFakeTimers();
+    render(<Pending />);
+
+    expect(screen.getByRole("heading", { name: "Your payment is being processed" })).toBeTruthy();
+    expect(reload).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(PENDING_RELOAD_MS);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload after the give-up window for this return URL", () => {
+    vi.useFakeTimers();
+    sessionStorage.setItem(
+      `${PENDING_RELOAD_STARTED_AT_KEY}:/checkout/returns/order-token`,
+      String(Date.now() - PENDING_RELOAD_GIVE_UP_MS),
+    );
+
+    render(<Pending />);
+    vi.advanceTimersByTime(PENDING_RELOAD_MS);
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("clears the reload timeout on unmount", () => {
+    vi.useFakeTimers();
+    const { unmount } = render(<Pending />);
+    unmount();
+    vi.advanceTimersByTime(PENDING_RELOAD_MS);
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/app/javascript/pages/Checkout/Returns/Pending.test.tsx
+++ b/app/javascript/pages/Checkout/Returns/Pending.test.tsx
@@ -88,7 +88,7 @@ describe("Checkout/Returns/Pending", () => {
     expect(replace).toHaveBeenCalledTimes(1);
     const nextUrl = new URL(String(replace.mock.calls[0]?.[0]));
     expect(nextUrl.searchParams.get("payment_intent")).toBe("pi_123");
-    expect(nextUrl.searchParams.get(PENDING_STARTED_AT_PARAM)).toMatch(/^\d+$/);
+    expect(nextUrl.searchParams.get(PENDING_STARTED_AT_PARAM)).toMatch(/^\d+$/u);
   });
 
   it("stops polling from the URL clock when sessionStorage is unavailable", () => {

--- a/app/javascript/pages/Checkout/Returns/Pending.tsx
+++ b/app/javascript/pages/Checkout/Returns/Pending.tsx
@@ -5,21 +5,52 @@ import { Card, CardContent } from "$app/components/ui/Card";
 export const PENDING_RELOAD_MS = 3_000;
 export const PENDING_RELOAD_GIVE_UP_MS = 5 * 60 * 1_000;
 export const PENDING_RELOAD_STARTED_AT_KEY = "checkout-return-pending-started-at";
+export const PENDING_STARTED_AT_PARAM = "pending_started_at";
 
 function pendingReloadStorageKey() {
   return `${PENDING_RELOAD_STARTED_AT_KEY}:${window.location.pathname}`;
 }
 
+function readStartedAt(storageKey: string): number {
+  try {
+    const stored = Number(sessionStorage.getItem(storageKey));
+    if (Number.isFinite(stored) && stored > 0) return stored;
+  } catch {
+    // sessionStorage throws in some privacy modes; fall through.
+  }
+
+  const fromUrl = Number(new URLSearchParams(window.location.search).get(PENDING_STARTED_AT_PARAM));
+  if (Number.isFinite(fromUrl) && fromUrl > 0) return fromUrl;
+
+  return Date.now();
+}
+
+function persistStartedAt(storageKey: string, started: number): boolean {
+  try {
+    sessionStorage.setItem(storageKey, String(started));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export default function Pending() {
   React.useEffect(() => {
     const storageKey = pendingReloadStorageKey();
-    const stored = Number(sessionStorage.getItem(storageKey));
-    const started = Number.isFinite(stored) && stored > 0 ? stored : Date.now();
-    sessionStorage.setItem(storageKey, String(started));
-
+    const started = readStartedAt(storageKey);
     if (Date.now() - started >= PENDING_RELOAD_GIVE_UP_MS) return;
 
+    const stored = persistStartedAt(storageKey, started);
+
     const timeout = window.setTimeout(() => {
+      if (!stored) {
+        const url = new URL(window.location.href);
+        if (url.searchParams.get(PENDING_STARTED_AT_PARAM) !== String(started)) {
+          url.searchParams.set(PENDING_STARTED_AT_PARAM, String(started));
+          window.location.replace(url.toString());
+          return;
+        }
+      }
       window.location.reload();
     }, PENDING_RELOAD_MS);
 

--- a/app/javascript/pages/Checkout/Returns/Pending.tsx
+++ b/app/javascript/pages/Checkout/Returns/Pending.tsx
@@ -2,7 +2,30 @@ import * as React from "react";
 
 import { Card, CardContent } from "$app/components/ui/Card";
 
+export const PENDING_RELOAD_MS = 3_000;
+export const PENDING_RELOAD_GIVE_UP_MS = 5 * 60 * 1_000;
+export const PENDING_RELOAD_STARTED_AT_KEY = "checkout-return-pending-started-at";
+
+function pendingReloadStorageKey() {
+  return `${PENDING_RELOAD_STARTED_AT_KEY}:${window.location.pathname}`;
+}
+
 export default function Pending() {
+  React.useEffect(() => {
+    const storageKey = pendingReloadStorageKey();
+    const stored = Number(sessionStorage.getItem(storageKey));
+    const started = Number.isFinite(stored) && stored > 0 ? stored : Date.now();
+    sessionStorage.setItem(storageKey, String(started));
+
+    if (Date.now() - started >= PENDING_RELOAD_GIVE_UP_MS) return;
+
+    const timeout = window.setTimeout(() => {
+      window.location.reload();
+    }, PENDING_RELOAD_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, []);
+
   return (
     <Card className="mx-auto my-8 max-w-2xl">
       <CardContent asChild>
@@ -11,7 +34,8 @@ export default function Pending() {
         </header>
       </CardContent>
       <CardContent>
-        Check your email for your receipt — it will arrive once the payment completes. Please do not pay again.
+        Check your email for your receipt — it will arrive once the payment completes. Please do not pay again. This
+        page updates automatically.
       </CardContent>
     </Card>
   );

--- a/spec/requests/checkout/returns_spec.rb
+++ b/spec/requests/checkout/returns_spec.rb
@@ -168,6 +168,27 @@ describe "Checkout return page", :vcr, type: :request do
       expect(purchase.reload).to be_in_progress
       expect(purchase.stripe_status).to eq(StripeIntentStatus::PROCESSING)
     end
+
+    it "redirects to the content page on a later visit once the intent has succeeded" do
+      order, charge = build_client_confirmed_order
+      purchase = order.purchases.first
+      charge_intent = instance_double(StripeChargeIntent, succeeded?: false, processing?: true)
+      allow(ChargeProcessor).to receive(:get_charge_intent)
+        .with(charge.merchant_account, charge.stripe_payment_intent_id)
+        .and_return(charge_intent)
+
+      visit_return_page(order, payment_intent: charge.stripe_payment_intent_id)
+      expect(response.body).to include("Checkout/Returns/Pending")
+      expect(purchase.reload).to be_in_progress
+
+      allow(ChargeProcessor).to receive(:get_charge_intent).and_call_original
+      Stripe::PaymentIntent.confirm(charge.stripe_payment_intent_id, { payment_method: "pm_card_visa" })
+
+      visit_return_page(order, payment_intent: charge.stripe_payment_intent_id)
+
+      expect(purchase.reload).to be_successful
+      expect(response).to redirect_to("#{purchase.url_redirect.download_page_url}?receipt=true")
+    end
   end
 
   context "when the intent succeeded but no purchase could be finalized" do

--- a/spec/support/fixtures/vcr_cassettes/Checkout_return_page/when_the_payment_intent_is_still_processing/redirects_to_the_content_page_on_a_later_visit_once_the_intent_has_succeeded.yml
+++ b/spec/support/fixtures/vcr_cassettes/Checkout_return_page/when_the_payment_intent_is_still_processing/redirects_to_the_content_page_on_a_later_visit_once_the_intent_has_succeeded.yml
@@ -1,0 +1,674 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents
+    body:
+      encoding: UTF-8
+      string: amount=1000&currency=usd&description=Gumroad+Charge+1UokxkyxJ__gd-gssE0g7w%3D%3D&metadata[purchase]=CH-1UokxkyxJ__gd-gssE0g7w%3D%3D&payment_method_types[0]=card&transfer_group=CH-1&statement_descriptor_suffix=edgar248959d41
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Idempotency-Key:
+      - deferred_intent_test_eeef0447af02b7f29c5173e70b543396
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 01 Jul 2026 20:31:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1583'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Y5y11UP1UnSONf6tycnfUMKzKZuXWRn2GdvsGpzC6LQtbjRS8LIXbKsBRC9Owk5MyE9xAnfSQRoxxpD8;
+        report-to csp
+      Idempotency-Key:
+      - deferred_intent_test_eeef0447af02b7f29c5173e70b543396
+      Original-Request:
+      - req_uy4lATxP14Jd5O
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Y5y11UP1UnSONf6tycnfUMKzKZuXWRn2GdvsGpzC6LQtbjRS8LIXbKsBRC9Owk5MyE9xAnfSQRoxxpD8&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=Y5y11UP1UnSONf6tycnfUMKzKZuXWRn2GdvsGpzC6LQtbjRS8LIXbKsBRC9Owk5MyE9xAnfSQRoxxpD8&t=1"
+      Request-Id:
+      - req_uy4lATxP14Jd5O
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3ToUmgIBOqvOFDrf0ToU3Iea",
+          "object": "payment_intent",
+          "amount": 1000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3ToUmgIBOqvOFDrf0ToU3Iea_secret_9HEvTocibzY1iZC8scY7vkRmX",
+          "confirmation_method": "automatic",
+          "created": 1782937862,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "Gumroad Charge 1UokxkyxJ__gd-gssE0g7w==",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": null,
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "CH-1UokxkyxJ__gd-gssE0g7w=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": null,
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar248959d41",
+          "status": "requires_payment_method",
+          "transfer_data": null,
+          "transfer_group": "CH-1"
+        }
+  recorded_at: Wed, 01 Jul 2026 20:31:02 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/payment_intents/pi_3ToUmgIBOqvOFDrf0ToU3Iea/confirm
+    body:
+      encoding: UTF-8
+      string: payment_method=pm_card_visa
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_uy4lATxP14Jd5O","request_duration_ms":386}}'
+      Idempotency-Key:
+      - acab19a6-b1f8-4310-b236-c1bd317bfe8f
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 01 Jul 2026 20:31:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1622'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=BkyzSpLEzuu5FYhf8y_w27gs5NkRcwH_ilrL5wvz4toiPUJonUOtIcBElfD4AItOVArotY0TtwNUjhGk;
+        report-to csp
+      Idempotency-Key:
+      - acab19a6-b1f8-4310-b236-c1bd317bfe8f
+      Original-Request:
+      - req_CKgwb3QgfqbvFD
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=BkyzSpLEzuu5FYhf8y_w27gs5NkRcwH_ilrL5wvz4toiPUJonUOtIcBElfD4AItOVArotY0TtwNUjhGk&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=BkyzSpLEzuu5FYhf8y_w27gs5NkRcwH_ilrL5wvz4toiPUJonUOtIcBElfD4AItOVArotY0TtwNUjhGk&t=1"
+      Request-Id:
+      - req_CKgwb3QgfqbvFD
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3ToUmgIBOqvOFDrf0ToU3Iea",
+          "object": "payment_intent",
+          "amount": 1000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 1000,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3ToUmgIBOqvOFDrf0ToU3Iea_secret_9HEvTocibzY1iZC8scY7vkRmX",
+          "confirmation_method": "automatic",
+          "created": 1782937862,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "Gumroad Charge 1UokxkyxJ__gd-gssE0g7w==",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3ToUmgIBOqvOFDrf09HiyIy9",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "CH-1UokxkyxJ__gd-gssE0g7w=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1ToUmgIBOqvOFDrf6RXdFYkY",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar248959d41",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "CH-1"
+        }
+  recorded_at: Wed, 01 Jul 2026 20:31:03 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/payment_intents/pi_3ToUmgIBOqvOFDrf0ToU3Iea
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_CKgwb3QgfqbvFD","request_duration_ms":1080}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 01 Jul 2026 20:31:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1622'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=BkyzSpLEzuu5FYhf8y_w27gs5NkRcwH_ilrL5wvz4toiPUJonUOtIcBElfD4AItOVArotY0TtwNUjhGk;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=BkyzSpLEzuu5FYhf8y_w27gs5NkRcwH_ilrL5wvz4toiPUJonUOtIcBElfD4AItOVArotY0TtwNUjhGk&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=BkyzSpLEzuu5FYhf8y_w27gs5NkRcwH_ilrL5wvz4toiPUJonUOtIcBElfD4AItOVArotY0TtwNUjhGk&t=1"
+      Request-Id:
+      - req_5etFZ3SFAHSm74
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "pi_3ToUmgIBOqvOFDrf0ToU3Iea",
+          "object": "payment_intent",
+          "amount": 1000,
+          "amount_capturable": 0,
+          "amount_details": {
+            "tip": {}
+          },
+          "amount_received": 1000,
+          "application": null,
+          "application_fee_amount": null,
+          "automatic_payment_methods": null,
+          "canceled_at": null,
+          "cancellation_reason": null,
+          "capture_method": "automatic",
+          "client_secret": "pi_3ToUmgIBOqvOFDrf0ToU3Iea_secret_9HEvTocibzY1iZC8scY7vkRmX",
+          "confirmation_method": "automatic",
+          "created": 1782937862,
+          "currency": "usd",
+          "customer": null,
+          "customer_account": null,
+          "description": "Gumroad Charge 1UokxkyxJ__gd-gssE0g7w==",
+          "excluded_payment_method_types": null,
+          "invoice": null,
+          "last_payment_error": null,
+          "latest_charge": "ch_3ToUmgIBOqvOFDrf09HiyIy9",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "purchase": "CH-1UokxkyxJ__gd-gssE0g7w=="
+          },
+          "next_action": null,
+          "on_behalf_of": null,
+          "payment_method": "pm_1ToUmgIBOqvOFDrf6RXdFYkY",
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "installments": null,
+              "mandate_options": null,
+              "network": null,
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "processing": null,
+          "receipt_email": null,
+          "review": null,
+          "setup_future_usage": null,
+          "shared_payment_granted_token": null,
+          "shipping": null,
+          "source": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar248959d41",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "CH-1"
+        }
+  recorded_at: Wed, 01 Jul 2026 20:31:03 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/ch_3ToUmgIBOqvOFDrf09HiyIy9?expand%5B%5D=application_fee.balance_transaction&expand%5B%5D=balance_transaction
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/12.5.0
+      Authorization:
+      - Bearer <STRIPE_API_KEY>
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_5etFZ3SFAHSm74","request_duration_ms":265}}'
+      Stripe-Version:
+      - '2023-10-16'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"12.5.0","lang":"ruby","lang_version":"3.4.3 p32 (2025-04-14)","platform":"arm64-darwin24","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Is-MacBook-Air.local 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:32:56
+        PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8132 arm64","hostname":"Is-MacBook-Air.local"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 01 Jul 2026 20:31:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3758'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=BkyzSpLEzuu5FYhf8y_w27gs5NkRcwH_ilrL5wvz4toiPUJonUOtIcBElfD4AItOVArotY0TtwNUjhGk;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=BkyzSpLEzuu5FYhf8y_w27gs5NkRcwH_ilrL5wvz4toiPUJonUOtIcBElfD4AItOVArotY0TtwNUjhGk&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=BkyzSpLEzuu5FYhf8y_w27gs5NkRcwH_ilrL5wvz4toiPUJonUOtIcBElfD4AItOVArotY0TtwNUjhGk&t=1"
+      Request-Id:
+      - req_2Mo2SqURtJRyMs
+      Stripe-Notice:
+      - You are using an outdated API version (2023-10-16). We recommend upgrading
+        to the latest API version, 2026-06-24.dahlia. See https://docs.stripe.com/upgrades
+      Stripe-Version:
+      - '2023-10-16'
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "ch_3ToUmgIBOqvOFDrf09HiyIy9",
+          "object": "charge",
+          "amount": 1000,
+          "amount_captured": 1000,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3ToUmgIBOqvOFDrf0GTSW5t0",
+            "object": "balance_transaction",
+            "amount": 1000,
+            "available_on": 1783468800,
+            "balance_type": "payments",
+            "created": 1782937863,
+            "currency": "usd",
+            "description": "Gumroad Charge 1UokxkyxJ__gd-gssE0g7w==",
+            "exchange_rate": null,
+            "fee": 59,
+            "fee_details": [
+              {
+                "amount": 59,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 941,
+            "reporting_category": "charge",
+            "source": "ch_3ToUmgIBOqvOFDrf09HiyIy9",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "calculated_statement_descriptor": "STRIPE* EDGAR248959D41",
+          "captured": true,
+          "created": 1782937863,
+          "currency": "usd",
+          "customer": null,
+          "description": "Gumroad Charge 1UokxkyxJ__gd-gssE0g7w==",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_balance_transaction": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {},
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "purchase": "CH-1UokxkyxJ__gd-gssE0g7w=="
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "advice_code": null,
+            "network_advice_code": null,
+            "network_decline_code": null,
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 27,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": "pi_3ToUmgIBOqvOFDrf0ToU3Iea",
+          "payment_method": "pm_1ToUmgIBOqvOFDrf6RXdFYkY",
+          "payment_method_details": {
+            "card": {
+              "amount_authorized": 1000,
+              "authorization_code": "286079",
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 7,
+              "exp_year": 2027,
+              "extended_authorization": {
+                "status": "disabled"
+              },
+              "fingerprint": "hsksJCaNjbEGzjqP",
+              "funding": "credit",
+              "incremental_authorization": {
+                "status": "unavailable"
+              },
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "multicapture": {
+                "status": "unavailable"
+              },
+              "network": "visa",
+              "network_token": {
+                "used": false
+              },
+              "network_transaction_id": "104115107115746",
+              "overcapture": {
+                "maximum_amount_capturable": 1000,
+                "status": "unavailable"
+              },
+              "regulated_status": "unregulated",
+              "three_d_secure": null,
+              "transaction_link_id": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {},
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xU05FZ3NJQk9xdk9GRHJmKIjyldIGMga6i-Af1346LBYPtr1yxi50YuKNMJ2FfCHC3PzlbJLO533xdjitb72EXWg6x4HxChW_tCPc",
+          "refunded": false,
+          "review": null,
+          "shipping": null,
+          "source": null,
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "edgar248959d41",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": "CH-1"
+        }
+  recorded_at: Wed, 01 Jul 2026 20:31:04 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
Re-homed from fork #7604 so Tests is not stuck on ci-protected.

Reload the checkout return page while payment is still processing

> Draft status: Greptile P1 (sessionStorage throw aborts polling) fixed at `078dcee4fd`. Request spec + preview evidence still owed.

## What

After a card is captured, Stripe (or a post-capture finalize that is still `processing`) sends the buyer to `/checkout/returns/:id`. That page used to render a static "Your payment is being processed" card and never request the return URL again. A later successful finalize — including the one that already sent the receipt — therefore never redirected to the download or product page.

The pending page now reloads the same return URL every 3 seconds (capped at 5 minutes per return path). If `sessionStorage` throws (privacy-restricted browsers), polling still runs and the give-up clock rides on `pending_started_at` without dropping the existing `payment_intent` query. The existing controller already redirects on a later GET once every line is successful and not processing.

## Why

Buyers who completed a real charge (receipt already in their inbox) were left on a dead-end processing screen. Same class as the client-confirm return path, not the older Payment Element confirm crash (that family is closed).

Fixes antiwork/gumroad-private#2565.

## Before / after

- Before: return page stays on "Your payment is being processed" forever, even after the receipt email. A `sessionStorage` throw also left the page with no reload at all.
- After: the page reloads until the controller redirects to the content/product URL, or stops after 5 minutes and keeps the "check your email / do not pay again" copy.

## Checklist

- [x] Scope — pending-page reload + request spec that a later successful visit redirects. No change to charge/finalize logic.
- [x] Design — client reload of the existing return GET (which already 302s on success). Rejected: webhook-pushed redirect (no channel to this public page) and dropping the pending page (async methods still need it). Storage-unavailable path keeps polling via a URL clock.
- [x] Build — `078dcee4fd` on `gumclaw/gp2565-checkout-return-pending-reload`
- [ ] QA — vitest 5/5 locally; request spec + preview screenshot still owed
- [ ] Shipped — money-path return page; stays draft until panel + QA
- [ ] Market — n/a (checkout bugfix)
- [ ] Sell — n/a

## Tests

```text
npx vitest run app/javascript/pages/Checkout/Returns/Pending.test.tsx
Test Files  1 passed (1)
Tests  5 passed (5)

Mutants:
- persistStartedAt without catch → "still reloads when sessionStorage throws" red
- drop URL started-at read → "stops polling from the URL clock..." red

bundle exec rspec spec/requests/checkout/returns_spec.rb -e "later visit"
(still owed)
```

## QA

Not preview-exercised yet. Watch: after a 3DS/async card charge, the processing page must leave for the receipt/content URL once the purchase is successful.

---

## AI disclosure

Generated with **grok-4.6** (xAI), running as gumclaw.
Prompts/instructions given: GitHub webhook on gumroad-private#2565 (post-payment processing page never advances after a successful charge and receipt); Greptile P1 on sessionStorage throw; autonomous-product-dev build loop.


## Premerge

Astra+Fable panel at `f65000badcae110154afdb5a6d0379ec399a7b22`: not clean. Both engines accepted one process P1 (missing current-head preview of the processing page then the post-success redirect). No code P1s. Preview returned HTTP 500 with no x-revision during capture; Consul had no key for the branch slug. Not stamping a clean marker. Money-path; no automerge.
