### PR TITLE
Tighten AnthropicClient comments to three lines

### DIFF
--- a/app/services/ai/anthropic_client.rb
+++ b/app/services/ai/anthropic_client.rb
@@ -94,10 +94,8 @@ class Ai::AnthropicClient
   end
 
   # Retry only before the first yield — a later retry would replay on the seller's screen.
-  # Corrupted tool-call JSON after all streamed attempts: one buffered replay (#buffered_fallback).
-  # That regenerates the turn, so already-yielded text must be erased via on_discard_streamed_text
-  # or the error surfaces. Tool-use turns usually stream preamble first, so production almost
-  # always needs the discard callback for the fallback to run.
+  # Corrupted tool-call JSON: one buffered replay. Already-yielded text (usual tool-use preamble)
+  # must be erased via on_discard_streamed_text or the fallback cannot run.
   def stream_messages(system:, messages:, tools: nil, max_tokens: DEFAULT_MAX_TOKENS, on_discard_streamed_text: nil, &on_text)
     yielded_any = false
 
@@ -473,12 +471,9 @@ class Ai::AnthropicClient
       Result.new(text:, tool_uses:, stop_reason: body["stop_reason"])
     end
 
-    # Empty tool-use JSON is a no-arg call. Malformed non-empty JSON must fail the turn, except:
-    # max_tokens — drop the block and let the caller see the stop_reason.
-    # stop_reason nil — connection dropped mid-stream (complete Anthropic streams always send one).
-    # stop_reason present but JSON still unreadable — OpenRouter can lose input_json_delta fragments
-    # while still closing the stream; raise UnreadableToolCallError so #stream_messages can replay
-    # once without streaming. Do not coerce to {} (that would dispatch a lossy tool call).
+    # Empty JSON is a no-arg call. Do not coerce unreadable JSON to {} (lossy dispatch).
+    # max_tokens: drop the block. nil stop_reason: mid-stream drop. Otherwise UnreadableToolCallError
+    # so #stream_messages can replay once without streaming (OpenRouter can lose input_json_delta).
     def assemble_tool_uses(blocks, stop_reason: nil)
       truncated = stop_reason == "max_tokens"
       blocks.keys.sort.filter_map do |index|


### PR DESCRIPTION
## Status

- [x] Scope — n/a, comments-only trim
- [x] Design — n/a, comments-only trim
- [x] Build
- [x] QA — docs-only — diff is the reviewable artifact
- [ ] Shipped
- [x] Market — n/a, internal-only
- [x] Sell — n/a, internal-only

## What

Tighten the two leftover `Ai::AnthropicClient` comments from #7612 to three lines each. Comments only, no behaviour change.

## Why

Greptile P2 on #7612 after merge: the stream-retry comment and the `assemble_tool_uses` comment still exceeded the repo's ~three-line guide. Traps stay (retry-before-yield, discard callback, empty JSON vs unreadable JSON vs max_tokens vs nil stop_reason).

## Before / after

- Before: 5-line `stream_messages` comment; 6-line `assemble_tool_uses` comment
- After: both three lines, same traps

## Tests

```text
ruby -c app/services/ai/anthropic_client.rb
Syntax OK
```

## QA

docs-only — diff is the reviewable artifact

## Risk

LOW RISK, comments only. gumclaw + `working`. No `awaiting-human`.

Premerge review: exempt (comments only, no behaviour change)

---

AI disclosure: Grok 4.6 via xai, running as github-event webhook on #7612. Prompt: Greptile P2 asked to tighten two leftover comments after #7612 merged.
