### PR TITLE
Make receipt download CTA tappable on Gmail iOS

### DIFF
--- a/app/javascript/stylesheets/_email.scss
+++ b/app/javascript/stylesheets/_email.scss
@@ -394,10 +394,11 @@ $accent-color: map-get($colors, "pink"); // [1]
         font-family: inherit;
         cursor: pointer;
         text-decoration: none;
-        /* Needed to expand button full width in emails */
-        display: block;
+        /* Gmail iOS: padding on display:block <a> paints but is not tappable. */
+        display: inline-block;
+        box-sizing: border-box;
         text-align: center;
-        width: unset;
+        width: 100%;
 
         /* Some email clients don't support CSS variables: https://www.caniemail.com/search/?s=var */
         background-color: transparent;

--- a/app/javascript/stylesheets/_email.scss
+++ b/app/javascript/stylesheets/_email.scss
@@ -50,13 +50,19 @@ $accent-color: map-get($colors, "pink"); // [1]
 
       &.reset {
         display: revert;
+        width: 100%;
         border-collapse: separate;
         border-spacing: 0;
 
         & > tbody,
         & > tfoot {
+          // Without this, tbody stays display:block and a width:100% CTA shrink-wraps.
+          display: revert;
+          width: 100%;
+
           & > * {
             display: revert;
+            width: 100%;
             border: none;
 
             & > * {

--- a/app/views/shared/_download_button.html.erb
+++ b/app/views/shared/_download_button.html.erb
@@ -17,9 +17,20 @@ is true then the url_redirect is nil. If the url_redirect is not nil then is_pre
 question the use of try in this template. %>
 
 <% preview = !!(defined?(is_preview) && is_preview) %>
-
-<% if !url_redirect&.is_rental? %>
-  <%= link_to view_content_button_text(link), preview ? "#" : url_redirect_download_page_url(url_redirect.token), class: "button primary" %>
-<% elsif link.streamable? %>
-  <%= link_to "Watch", preview ? "#" : url_redirect_stream_page_url(url_redirect.token), class: "button primary" %>
+<%
+  cta =
+    if !url_redirect&.is_rental?
+      [view_content_button_text(link), preview ? "#" : url_redirect_download_page_url(url_redirect.token)]
+    elsif link.streamable?
+      ["Watch", preview ? "#" : url_redirect_stream_page_url(url_redirect.token)]
+    end
+%>
+<% if cta %>
+  <table class="reset" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
+    <tr>
+      <td align="center">
+        <%= link_to cta[0], cta[1], class: "button primary", style: "display:inline-block;box-sizing:border-box;width:100%;" %>
+      </td>
+    </tr>
+  </table>
 <% end %>

--- a/app/views/shared/_download_button.html.erb
+++ b/app/views/shared/_download_button.html.erb
@@ -26,10 +26,10 @@ question the use of try in this template. %>
     end
 %>
 <% if cta %>
-  <table class="reset" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
-    <tbody>
-      <tr>
-        <td align="center">
+  <table class="reset" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="width:100%;display:table;">
+    <tbody style="width:100%;display:table-row-group;">
+      <tr style="width:100%;display:table-row;">
+        <td align="center" width="100%" style="width:100%;display:table-cell;">
           <%= link_to cta[0], cta[1], class: "button primary", style: "display:inline-block;box-sizing:border-box;width:100%;" %>
         </td>
       </tr>

--- a/app/views/shared/_download_button.html.erb
+++ b/app/views/shared/_download_button.html.erb
@@ -27,10 +27,12 @@ question the use of try in this template. %>
 %>
 <% if cta %>
   <table class="reset" role="presentation" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
-    <tr>
-      <td align="center">
-        <%= link_to cta[0], cta[1], class: "button primary", style: "display:inline-block;box-sizing:border-box;width:100%;" %>
-      </td>
-    </tr>
+    <tbody>
+      <tr>
+        <td align="center">
+          <%= link_to cta[0], cta[1], class: "button primary", style: "display:inline-block;box-sizing:border-box;width:100%;" %>
+        </td>
+      </tr>
+    </tbody>
   </table>
 <% end %>

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -684,6 +684,23 @@ describe CustomerMailer do
       wrapper = link.ancestors("table").find { |table| table["role"] == "presentation" }
       expect(wrapper).to be_present
       expect(wrapper["class"].to_s.split).to include("reset")
+      # Email CSS only resets `table.reset > tbody > *`. Nokogiri HTML4 does not
+      # invent an implicit tbody, so Premailer would leave the generic row
+      # border and cell padding on this wrapper without an explicit one.
+      expect(body).to match(/<table class="reset"[^>]*>\s*<tbody>\s*<tr>/)
+      row = wrapper.at_css("> tbody > tr")
+      cell = row&.at_css("> td")
+      expect(row).to be_present
+      expect(cell).to be_present
+
+      inlined = Premailer::Rails::CustomizedPremailer.new(body).to_inline_css
+      inlined_doc = Nokogiri::HTML(inlined)
+      inlined_link = inlined_doc.at_css("a.button.primary")
+      inlined_wrapper = inlined_link.ancestors("table").find { |table| table["role"] == "presentation" }
+      inlined_row = inlined_wrapper.at_css("> tbody > tr")
+      inlined_cell = inlined_row.at_css("> td")
+      expect(inlined_cell["style"].to_s).to match(/padding:\s*0/)
+      expect(inlined_row["style"].to_s).to match(/border-style:\s*none/)
     end
 
     it "discloses sales tax when it was taxed" do

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -687,7 +687,7 @@ describe CustomerMailer do
       # Email CSS only resets `table.reset > tbody > *`. Nokogiri HTML4 does not
       # invent an implicit tbody, so Premailer would leave the generic row
       # border and cell padding on this wrapper without an explicit one.
-      expect(body).to match(/<table class="reset"[^>]*>\s*<tbody>\s*<tr>/)
+      expect(body).to match(/<table class="reset"[^>]*>\s*<tbody[^>]*>\s*<tr[^>]*>/)
       row = wrapper.at_css("> tbody > tr")
       cell = row&.at_css("> td")
       expect(row).to be_present
@@ -697,10 +697,17 @@ describe CustomerMailer do
       inlined_doc = Nokogiri::HTML(inlined)
       inlined_link = inlined_doc.at_css("a.button.primary")
       inlined_wrapper = inlined_link.ancestors("table").find { |table| table["role"] == "presentation" }
+      inlined_tbody = inlined_wrapper.at_css("> tbody")
       inlined_row = inlined_wrapper.at_css("> tbody > tr")
       inlined_cell = inlined_row.at_css("> td")
       expect(inlined_cell["style"].to_s).to match(/padding:\s*0/)
       expect(inlined_row["style"].to_s).to match(/border-style:\s*none/)
+      tbody_displays = inlined_tbody["style"].to_s.scan(/display:\s*([^;]+)/).flatten.map(&:strip)
+      expect(tbody_displays.last).to match(/\A(table-row-group|revert)\z/)
+      expect(inlined_wrapper["style"].to_s).to match(/width:\s*100%/)
+      expect(inlined_cell["style"].to_s).to match(/width:\s*100%/)
+      cell_displays = inlined_cell["style"].to_s.scan(/display:\s*([^;]+)/).flatten.map(&:strip)
+      expect(cell_displays.last).to match(/\A(table-cell|revert)\z/)
     end
 
     it "discloses sales tax when it was taxed" do

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -667,6 +667,25 @@ describe CustomerMailer do
       expect(mail.body.sanitized).to include("View content")
     end
 
+    it "puts padding/hit-area on the download CTA anchor itself" do
+      product = create(:product)
+      purchase = create(:purchase, link: product)
+      create(:url_redirect, purchase:)
+      mail = CustomerMailer.receipt(purchase.id)
+      body = mail.html_part&.decoded || mail.body.decoded
+      html = Nokogiri::HTML(body)
+      link = html.at_css("a.button.primary")
+
+      expect(link).to be_present
+      expect(link.text).to include("View content")
+      expect(link["href"]).to eq(purchase.url_redirect.download_page_url)
+      expect(link["style"]).to match(/display:\s*inline-block/)
+      expect(link["style"]).to match(/box-sizing:\s*border-box/)
+      wrapper = link.ancestors("table").find { |table| table["role"] == "presentation" }
+      expect(wrapper).to be_present
+      expect(wrapper["class"].to_s.split).to include("reset")
+    end
+
     it "discloses sales tax when it was taxed" do
       user = create(:user)
       link = create(:product, user:)


### PR DESCRIPTION
# Make receipt download CTA tappable on Gmail iOS

## What

Receipt download buttons wrap `a.button.primary` in a `table.reset` with an explicit `tbody`, and the anchor is `display:inline-block; box-sizing:border-box; width:100%`. Email `.button` CSS uses the same display so other `a.button` mailer CTAs get the Gmail iOS hit-target fix without rewriting every template.

QA of the first render found the wrapper `tbody` still inlined as `display:block`, so `width:100%` shrink-wrapped the button to the label (119px vs 306px). This head forces table layout on the wrapper (`display:table` / `table-row-group` / `table-cell` plus `width:100%`) and reverts `table.reset > tbody` in the stylesheet.

Ref antiwork/gumroad-private#2570.

## Why

Gmail iOS paints padding on `display:block` `<a>` tags but only taps the text. The receipt download control looks like a full-width button and does nothing unless the buyer hits the label. Desktop and browser Gmail are fine.

Approach: padding stays on the `<a>` (the whole painted box is the hit target). `table.reset` is required because the email stylesheet otherwise restyles every `table` as a stacked card. `tbody` must not stay `display:block` or the CTA collapses.

Rejected:

- CSS-only (`inline-block` on `.button`) with no table — Outlook still ignores padding on anchors. The table wrapper is only on the shared download partial (the ticket).
- A new helper used by every mailer CTA — 40+ templates, including mustache `post_email.html.erb`. Out of scope.
- Changing `posts/post_email.html.erb` — different pipeline, left alone.

## Before / After

Rendered `CustomerMailer.receipt` through Premailer on `public/main` vs this branch, iPhone 14 viewport (390px).

**Before** (main, `display:block`, no table): painted box 306×48, text box 85×18. Chromium taps the padding; Gmail iOS does not.

![Receipt before, mobile](https://github.com/user-attachments/assets/1c5f6838-69f7-4f80-9fb5-179c5bae2fa4)

![CTA crop before](https://github.com/user-attachments/assets/4bf8d327-d1b6-40c3-b0f1-0d1b4b51ef5b)

**After** (this head): same 306×48 painted box, `display:inline-block; width:100%` inside `table.reset` with `tbody` as `table-row-group`, cell padding 0.

![Receipt after, mobile](https://github.com/user-attachments/assets/d21ff52e-6416-431e-a4d9-6c00dfe4bb31)

![CTA crop after](https://github.com/user-attachments/assets/d8b1c19c-aec5-4e15-afb0-a3810de55c57)

Walkthrough of those frames:

https://github.com/user-attachments/assets/5c895066-e4a6-4110-a8db-45754bb32d0e

Gmail iOS app is not installed on the simulator, so the Gmail-specific tap is inferred from the HTML/CSS mechanism (block + padding vs inline-block filling the same 306px box), not from a tap in the Gmail app.

## Checklist

- [x] Scope — shared download partial + email `.button` CSS. Not marketing post emails.
- [x] Design — table wrapper on the ticket CTA; CSS hardening for the rest of the class.
- [x] Build — `17601d374` on `gp2570-gmail-ios-cta-v2`.
- [x] QA — receipt HTML render + geometry (below). Gmail iOS app tap not run here.
- [ ] Shipped
- [ ] Market — n/a (bugfix, no launch).
- [ ] Sell — n/a.

## Tests

- `bundle exec rspec spec/mailers/customer_mailer_spec.rb -e "puts padding/hit-area on the download CTA anchor itself"` — 1 example, 0 failures.
- Playwright geometry on the Premailer HTML: before `display:block` 306×48 / text 85×18 / no table; after `display:inline-block` 306×48 / `table.reset` / `tbody` present / td padding 0. An earlier after render at 119px wide is what the tbody display fix closed.

## QA

1. Render `CustomerMailer.receipt` for a product with a `url_redirect` on main and on this branch; inline with Premailer.
2. Confirm the View content control is `a.button.primary` with `display:inline-block; box-sizing:border-box; width:100%` inside `table.reset[role=presentation]` with an explicit tbody whose last `display` is not `block`.
3. Measure the painted box vs the text box at 390px width. After should match main's 306px width, not shrink to the label.
4. Gmail iOS app: open the same receipt and tap the padding around "View content" (not run in this session; simulator has no Gmail app).

---

## AI disclosure

Generated with **grok-4.6** (xAI), running as gumclaw autonomous product-dev.

Premerge review: clean @ 17601d3743c652027ffbb67cb67f5dcc2ced8292
