### PR TITLE
Split the $0 PWYW step in help article 133 into short paragraphs (tastelint follow-up to #7615)

### DIFF
--- a/app/views/help_center/articles/contents/_133-pay-what-you-want-pricing.html.erb
+++ b/app/views/help_center/articles/contents/_133-pay-what-you-want-pricing.html.erb
@@ -12,7 +12,8 @@
   <h3 id="Create-a-free-product-EV4ZH">Create a free product</h3>
   <p>There are two ways to make a product free on Gumroad: </p>
   <ol>
-    <li>You can use our PWYW feature: set the Amount to $0, which turns on pay what you want automatically, allowing customers to enter “0" for the price and access your product for free.
+    <li>
+      <p>You can use our PWYW feature: set the Amount to $0, which turns on pay what you want automatically, allowing customers to enter “0" for the price and access your product for free.</p>
       <p>Pay what you want is not available on a $0 product that has versions with a price: the toggle is disabled and the editor shows <i>Pay what you want isn't available on products with paid pricing options</i>.</p>
       <p>To offer a free option and a paid option on one product, keep the Amount at $0, give the free version an Additional amount of $0, and give each paid version an Additional amount equal to its price.</p>
       <p>Memberships are priced per tier rather than with a single Amount, so set a tier's price to $0 and that tier's own pay-what-you-want toggle turns on automatically.</p>

--- a/app/views/help_center/articles/contents/_133-pay-what-you-want-pricing.html.erb
+++ b/app/views/help_center/articles/contents/_133-pay-what-you-want-pricing.html.erb
@@ -12,7 +12,11 @@
   <h3 id="Create-a-free-product-EV4ZH">Create a free product</h3>
   <p>There are two ways to make a product free on Gumroad: </p>
   <ol>
-    <li>You can use our PWYW feature: set the Amount to $0, which turns on pay what you want automatically, allowing customers to enter “0" for the price and access your product for free. Pay what you want is not available on a $0 product that has versions with a price: the toggle is disabled and the editor shows <i>Pay what you want isn't available on products with paid pricing options</i>. To offer a free option and a paid option on one product, keep the Amount at $0, give the free version an Additional amount of $0, and give each paid version an Additional amount equal to its price. Memberships are priced per tier rather than with a single Amount, so set a tier's price to $0 and that tier's own pay-what-you-want toggle turns on automatically. </li>
+    <li>You can use our PWYW feature: set the Amount to $0, which turns on pay what you want automatically, allowing customers to enter “0" for the price and access your product for free.
+      <p>Pay what you want is not available on a $0 product that has versions with a price: the toggle is disabled and the editor shows <i>Pay what you want isn't available on products with paid pricing options</i>.</p>
+      <p>To offer a free option and a paid option on one product, keep the Amount at $0, give the free version an Additional amount of $0, and give each paid version an Additional amount equal to its price.</p>
+      <p>Memberships are priced per tier rather than with a single Amount, so set a tier's price to $0 and that tier's own pay-what-you-want toggle turns on automatically.</p>
+    </li>
     <li>You can send customers a 100% off <a href="128-discount-codes">discount code</a>. </li>
   </ol>
   <p><b>Note</b>: You cannot price a product at $0 without the PWYW feature, and they have a lower <a href="289-file-size-limits-on-gumroad">file-size limit</a>. We also don't take any <a href="66-gumroads-fees">fee</a> on free product sales.</p>


### PR DESCRIPTION
Premerge review: exempt (docs-only help-center copy edit; no code, spec, or yml change)

Follow-up to antiwork/gumroad#7615, which took tastelint's finding on that PR's after-shot unresolved at merge: the updated step 1 for a $0 product packed four ideas into one numbered step, so the workaround for a $0 product with priced versions sat in the middle of a block of text.

## What

Same words, split into paragraphs: the lead sentence keeps the "set the Amount to $0" instruction, and the disabled-toggle caveat, the free-version-plus-paid-version setup, and the memberships note each get their own short paragraph inside the same list item. No sentence is reworded, added, or dropped — `git diff -w --word-diff` over the branch shows `<li>`/`<p>` markup only.

Body-only edit: one `.html.erb` partial, no `articles.yml`, code, or ERB-logic change.

## Why

The step is the only place article 133 tells a seller what to do when the PWYW toggle is disabled, and it was buried third in a paragraph. Tastelint's suggestion on #7615 was to keep step 1 short and move the caveat, the setup, and the memberships note into their own paragraphs; this does exactly that.

`<li>` containing short `<p>` blocks is the house pattern already used in `_128-discount-codes.html.erb`; a nested list is the other (`_13-getting-paid.html.erb`).

## Review

Greptile's P2 on the first push: the lead sentence stayed bare text while the other three blocks were `<p>`, so the article's typography applied differently to it. Valid, and this list item was the only one in the help center doing it — across `app/views/help_center/articles/contents/`, all 16 of the multi-paragraph `<li>` blocks on `main` open with a `<p>` (`_128-discount-codes`, `_131`, `_153`, `_295`, `_331`) and none leaves a bare lead. Fixed in `769f6d7f2b` by wrapping the lead and putting `<li>` on its own line, matching those files.

## Before / after

Before (merged in #7615) — one `<li>`, four ideas, all bare text:
`You can use our PWYW feature: set the Amount to $0, ... access your product for free. Pay what you want is not available on a $0 product that has versions with a price: ... To offer a free option and a paid option on one product, ... Memberships are priced per tier ...`

At this head (`769f6d7f2b`, served by the branch preview at `https://gumclaw-7615-tastelint-split-pwy.apps.staging.gumroad.org`) — `<li>` on its own line, four `<p>` blocks:

![article 133, "Create a free product": the first step reads as four short paragraphs, list still two items](https://github.com/user-attachments/assets/c4f0cc2f-8aee-404d-97e4-911dd559aac3)

## Test Results

- Tag balance on the partial after the fix: `li 4/4 · p 10/10 · ol 1/1 · ul 1/1 · div 1/1 · h3 2/2`.
- `git diff -w --word-diff` over both commits vs `main`: `<li>`/`<p>` markup only, no word changes. Every sentence of the merged wording is present verbatim.
- House pattern, scripted scan of `app/views/help_center/articles/contents/` on `main`: 16 multi-paragraph `<li>` blocks, 16 open with `<p>`, 0 bare leads. The pre-fix head was the only exception.
- CI on `769f6d7f2b`: 33 checks, 0 failures; `ci/green` success. (Docs-only diff, so the suite runs the scoped subset — no checkout/payment path is touched.)
- Preview render at `769f6d7f2b` (`x-revision: 769f6d7f2bdb`): DOM assertion on the step returned `itemCount=2`, first item's child tags `[P, P, P, P]`, `leadIsP=true`, and all four sentences still present.

## QA steps

Docs-only change; no spec or behavior change.

1. Render `/help/article/133-pay-what-you-want-pricing` on the branch preview and confirm the "Create a free product" step reads as four short paragraphs with the lead on its own, and the numbered list still shows two items. Done at `769f6d7f2b` — still above; the second item is unchanged and still one line.
2. Confirm every sentence of the merged wording is still present verbatim — done, `git diff -w --word-diff` on the partial shows no word changes across both commits.
3. Post-merge spot-check: `https://gumroad.com/help/article/133-pay-what-you-want-pricing`.

## Related

- antiwork/gumroad#7615 (the copy fix this splits)
- antiwork/gumroad-private#2573 (documentation half done; the product decision stays open with @gianfrancopiana)
- antiwork/gumroad#6906 (the guard), gumroad-private#2342 (the editor half)

## Merge

Ready for @gianfrancopiana rather than auto-merged, matching #7615: this is public help-center wording.

## Checklist

- [x] Scope
- [x] Design
- [x] Build
- [x] QA
- [ ] Shipped
- [ ] Market
- [ ] Sell

AI disclosure: deepseek/deepseek-v4.1-flash (OpenRouter). Prompt: resolve the unresolved tastelint finding on gumroad#7615, then address Greptile's P2 on the resulting PR.
