### PR TITLE
Match decimals across the order summary and skeleton its re-quote

### DIFF
--- a/app/javascript/components/Checkout/buyerCurrencyDisplay.ts
+++ b/app/javascript/components/Checkout/buyerCurrencyDisplay.ts
@@ -279,7 +279,19 @@ export const getMatchingDirectListedAllocations = (
 export const formatPresentmentCents = (
   cents: number,
   buyerCurrencyDisplay: Pick<CheckoutBuyerCurrencyDisplay, "currencyCode" | "subunitToUnit">,
-) => formatMinorUnitPriceWithIntl(buyerCurrencyDisplay.currencyCode, cents, buyerCurrencyDisplay.subunitToUnit);
+  { noCentsIfWhole = true }: { noCentsIfWhole?: boolean } = {},
+) =>
+  formatMinorUnitPriceWithIntl(buyerCurrencyDisplay.currencyCode, cents, buyerCurrencyDisplay.subunitToUnit, {
+    noCentsIfWhole,
+  });
+
+// The order summary is one column of amounts, so a single line holding cents makes every whole line
+// above and below it look truncated (US$10 next to US$2.10). Every amount the card renders is
+// passed in here in the displayed currency's minor units; if any one of them is fractional the
+// whole column shows cents. Zero-decimal currencies have no fractional unit to show, so their
+// whole-unit look is unaffected either way.
+export const summaryAmountsAreAllWhole = (amountsInMinorUnits: readonly number[], subunitToUnit: number) =>
+  amountsInMinorUnits.every((amount) => amount % subunitToUnit === 0);
 
 // All the listed-currency amounts the checkout table displays on the direct-listed lane. Two
 // different kinds of input meet here, and keeping them straight is the whole point of this
@@ -368,7 +380,7 @@ export const formatCheckoutPrice = (
   const canonicalCents = Math.floor(price);
   if (!buyerCurrencyDisplay) {
     return usdSymbolFormat === "expanded"
-      ? formatUSDCentsWithExpandedCurrencySymbol(canonicalCents)
+      ? formatUSDCentsWithExpandedCurrencySymbol(canonicalCents, { noCentsIfWhole })
       : formatPriceCentsWithCurrencySymbol("usd", canonicalCents, {
           symbolFormat: "short",
           noCentsIfWhole,
@@ -379,5 +391,6 @@ export const formatCheckoutPrice = (
     buyerCurrencyDisplay.currencyCode,
     toBuyerCurrencyCents(canonicalCents, buyerCurrencyDisplay),
     buyerCurrencyDisplay.subunitToUnit,
+    { noCentsIfWhole },
   );
 };

--- a/app/javascript/components/Checkout/index.test.tsx
+++ b/app/javascript/components/Checkout/index.test.tsx
@@ -1017,7 +1017,7 @@ describe("Checkout order summary decimals", () => {
   it("leaves a zero-decimal currency whole even when another amount is fractional", () => {
     // KRW is stored in 100 subunits but has no fractional unit to show, so the column's cents
     // decision cannot put decimals on it.
-    const krwQuote = {
+    const krwQuote: NonNullable<SurchargesResponse["buyer_currency_quote"]> = {
       token: "quote-token",
       currency: "krw",
       canonical_total_cents: 100_000,

--- a/app/javascript/components/Checkout/index.test.tsx
+++ b/app/javascript/components/Checkout/index.test.tsx
@@ -1008,7 +1008,7 @@ describe("Checkout order summary decimals", () => {
     );
 
     // The item price and Subtotal are whole dollars and the tax line is not, so the column shows
-    // cents throughout instead of US$10 beside US$2.10 (tastelint on #7602).
+    // cents throughout instead of US$10 beside US$2.10.
     expect(getAllByText("US$10.00")).toHaveLength(2);
     expect(getAllByText("US$2.10").length).toBeGreaterThan(0);
     expect(getAllByText("US$12.10").length).toBeGreaterThan(0);
@@ -1056,6 +1056,25 @@ describe("Checkout order summary decimals", () => {
     // Item price, Subtotal and Total.
     expect(getAllByText("₩10,000").length).toBeGreaterThanOrEqual(3);
     expect(queryByText(/₩10,000\./u)).toBeNull();
+  });
+
+  it("shows cents on the whole rows when a free trial's renewal price has them", () => {
+    const trialCart: CartState = {
+      items: [
+        cartItem({
+          price: 999,
+          recurrence: "monthly",
+          product: cartProduct({ price_cents: 999, free_trial: { duration: { amount: 1, unit: "week" } } }),
+        }),
+      ],
+      discountCodes: [],
+    };
+    const { getAllByLabelText, getAllByText } = renderCheckout(buildState(), trialCart);
+
+    // Nothing is charged today, so the line price and the summary are whole. The renewal price the
+    // trial prints under the line price is in the same column and is not, so the column shows cents.
+    expect(getAllByLabelText("Price").map((node) => node.textContent)).toEqual(["US$0.00"]);
+    expect(getAllByText(/US\$9\.99/u).length).toBeGreaterThan(0);
   });
 });
 
@@ -1212,7 +1231,7 @@ describe("Checkout currency picker", () => {
     expect(busy).toHaveLength(2);
     for (const block of busy) {
       // Those amounts belong to the currency the buyer just left, and a dimmed wrong-currency
-      // number reads as the new price — so the amount is replaced, not faded (tastelint on #7600).
+      // number reads as the new price — so the amount is replaced, not faded.
       expect(block.textContent).not.toContain("CA$12.50");
       expect(block.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
       expect(block.className).not.toContain("opacity-50");

--- a/app/javascript/components/Checkout/index.test.tsx
+++ b/app/javascript/components/Checkout/index.test.tsx
@@ -504,7 +504,9 @@ describe("Checkout method-forced listed-currency amounts", () => {
       cart,
     );
 
-    expect(getAllByLabelText("Price").map((node) => node.textContent)).toEqual(["US$9.15", "US$10"]);
+    // The first line is not a whole dollar, so the second one shows its cents too rather than
+    // sitting next to it as US$10.
+    expect(getAllByLabelText("Price").map((node) => node.textContent)).toEqual(["US$9.15", "US$10.00"]);
   });
 
   // The tip is canonical USD cents in state on every lane (`computeTip` takes its percentage of
@@ -573,7 +575,7 @@ describe("Checkout method-forced listed-currency amounts", () => {
     );
 
     expect(getByLabelText("Tip").getAttribute("value")).toBe("10");
-    expect(getAllByText("R$10").length).toBeGreaterThan(0);
+    expect(getAllByText("R$10.00").length).toBeGreaterThan(0);
     expect(queryByText("R$9.97")).toBeNull();
     expect(queryByText("R$9.96")).toBeNull();
   });
@@ -924,7 +926,7 @@ describe("Checkout direct-listed currency picker", () => {
       "usd",
       "cad",
     ]);
-    expect(getAllByLabelText("Price").map((node) => node.textContent)).toEqual(["US$10"]);
+    expect(getAllByLabelText("Price").map((node) => node.textContent)).toEqual(["US$10.00"]);
     expect(getByLabelText("Tip").getAttribute("value")).toBe("3.50");
   });
 
@@ -974,7 +976,86 @@ describe("Checkout direct-listed currency picker", () => {
       "cad",
     ]);
     expect(picker).toHaveProperty("value", "cad");
-    expect(getAllByLabelText("Price").map((node) => node.textContent)).toEqual(["CA$15"]);
+    expect(getAllByLabelText("Price").map((node) => node.textContent)).toEqual(["CA$15.00"]);
+  });
+});
+
+describe("Checkout order summary decimals", () => {
+  const cart: CartState = { items: [cartItem()], discountCodes: [] };
+  const surchargesWithTax = (taxCents: number): SurchargesResponse => ({
+    vat_id_valid: false,
+    has_vat_id_input: false,
+    shipping_rate_cents: 0,
+    tax_cents: taxCents,
+    tax_included_cents: 0,
+    subtotal: 1_000,
+    buyer_currency_quote: null,
+  });
+
+  it("keeps the whole-unit look when every amount in the summary is whole", () => {
+    const { getAllByLabelText, getAllByText, queryByText } = renderCheckout(buildState(), cart);
+
+    expect(getAllByLabelText("Price").map((node) => node.textContent)).toEqual(["US$10"]);
+    // The item price, Subtotal and Total.
+    expect(getAllByText("US$10")).toHaveLength(3);
+    expect(queryByText("US$10.00")).toBeNull();
+  });
+
+  it("shows cents on every amount once one of them has them", () => {
+    const { getAllByText } = renderCheckout(
+      buildState({ surcharges: { type: "loaded", result: surchargesWithTax(210) } }),
+      cart,
+    );
+
+    // The item price and Subtotal are whole dollars and the tax line is not, so the column shows
+    // cents throughout instead of US$10 beside US$2.10 (tastelint on #7602).
+    expect(getAllByText("US$10.00")).toHaveLength(2);
+    expect(getAllByText("US$2.10").length).toBeGreaterThan(0);
+    expect(getAllByText("US$12.10").length).toBeGreaterThan(0);
+  });
+
+  it("leaves a zero-decimal currency whole even when another amount is fractional", () => {
+    // KRW is stored in 100 subunits but has no fractional unit to show, so the column's cents
+    // decision cannot put decimals on it.
+    const krwQuote = {
+      token: "quote-token",
+      currency: "krw",
+      canonical_total_cents: 100_000,
+      presentment_total_cents: 1_000_005,
+      rate: 10,
+      subunit_to_unit: 100,
+      expires_at: "2999-01-01T00:00:00Z",
+      line_allocations: [
+        {
+          permalink: "prod",
+          price_cents: 1_000_000,
+          tip_cents: 5,
+          tax_cents: 0,
+          shipping_cents: 0,
+          total_cents: 1_000_005,
+        },
+      ],
+    };
+    const { getAllByText, queryByText } = renderCheckout(
+      buildState({
+        products: [stateProduct({ hasTippingEnabled: true })],
+        tip: { type: "fixed", amount: 1 },
+        surcharges: {
+          type: "loaded",
+          result: {
+            ...surchargesWithTax(0),
+            subtotal: 100_000,
+            detected_buyer_currency: "krw",
+            buyer_currency_quote: krwQuote,
+          },
+        },
+      }),
+      cart,
+    );
+
+    // Item price, Subtotal and Total.
+    expect(getAllByText("₩10,000").length).toBeGreaterThanOrEqual(3);
+    expect(queryByText(/₩10,000\./u)).toBeNull();
   });
 });
 
@@ -1114,6 +1195,28 @@ describe("Checkout currency picker", () => {
     expect(getByText("Total")).toBeTruthy();
     expect(getByText("Subtotal")).toBeTruthy();
     expect(getByText("Updating total…")).toBeTruthy();
+  });
+
+  it("holds skeletons over the held quote's amounts while the new currency is quoted", () => {
+    renderCheckout(
+      buildState({
+        buyerCurrency: "usd",
+        surcharges: { type: "pending" },
+        buyerCurrencyRemint: { surcharges: quotedSurcharges, previousCurrency: "cad" },
+      }),
+      cart,
+    );
+
+    // The price rows and the Total footer, the two blocks that carry the amounts still on screen.
+    const busy = Array.from(document.querySelectorAll('[aria-busy="true"]'));
+    expect(busy).toHaveLength(2);
+    for (const block of busy) {
+      // Those amounts belong to the currency the buyer just left, and a dimmed wrong-currency
+      // number reads as the new price — so the amount is replaced, not faded (tastelint on #7600).
+      expect(block.textContent).not.toContain("CA$12.50");
+      expect(block.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+      expect(block.className).not.toContain("opacity-50");
+    }
   });
 
   it("leaves the focused select in the document across the re-quote", () => {

--- a/app/javascript/components/Checkout/index.tsx
+++ b/app/javascript/components/Checkout/index.tsx
@@ -43,6 +43,7 @@ import {
 } from "$app/components/Product/ConfigurationSelector";
 import { Thumbnail } from "$app/components/Product/Thumbnail";
 import { showAlert } from "$app/components/server-components/Alert";
+import { Skeleton } from "$app/components/Skeleton";
 import { Alert } from "$app/components/ui/Alert";
 import { Fieldset, FieldsetTitle } from "$app/components/ui/Fieldset";
 import { Input } from "$app/components/ui/Input";
@@ -67,6 +68,7 @@ import {
   getCheckoutPresentmentAmounts,
   getMatchingDirectListedAllocations,
   isRecurringUpiPaymentConfig,
+  summaryAmountsAreAllWhole,
   toBuyerCurrencyCents,
   toCanonicalCents,
 } from "./buyerCurrencyDisplay";
@@ -493,6 +495,43 @@ export const Checkout = ({
     totalCents: number;
   } | null = presentmentAmounts ?? listedAmounts;
 
+  // The amounts the summary card displays, in the currency it displays them in. Rows backed by a
+  // server allocation render that allocation; every other row is converted from canonical USD the
+  // same way the formatters below convert it, so the column's one cents decision matches what it
+  // prints. Rows that are not rendered are left out, since an off-screen amount must not be able to
+  // change what the visible ones look like.
+  const toDisplayedCents = (canonicalCents: number) =>
+    localCurrency ? toBuyerCurrencyCents(Math.floor(canonicalCents), localCurrency) : Math.floor(canonicalCents);
+  const summaryDisplayedCents = [
+    ...cart.items.map((item, index) => {
+      const allocated = localAmounts?.linePriceCents[index];
+      if (allocated != null) return allocated;
+      return toDisplayedCents(convertToUSD(item, hasFreeTrial(item, isGift) ? 0 : item.price * item.quantity));
+    }),
+    localAmounts?.subtotalCents ?? toDisplayedCents(subtotal),
+    listedAmounts?.taxIncludedCents ?? toDisplayedCents(summarySurcharges?.tax_included_cents ?? 0),
+    localAmounts?.taxCents ?? toDisplayedCents(summarySurcharges?.tax_cents ?? 0),
+    localAmounts?.shippingCents ?? toDisplayedCents(summarySurcharges?.shipping_rate_cents ?? 0),
+    localAmounts?.discountCents ?? toDisplayedCents(discount),
+    localAmounts?.tipCents ?? toDisplayedCents(computeTip(state)),
+    localAmounts?.totalCents ?? toDisplayedCents(total ?? 0),
+    ...(commissionCompletionTotal > 0 || futureInstallmentsWithoutTipsTotal > 0
+      ? [
+          buyerCurrencyDisplay?.chargePresentmentTotalCents ??
+            toDisplayedCents(
+              total == null ? 0 : total - commissionCompletionTotal - futureInstallmentsWithoutTipsTotal,
+            ),
+          buyerCurrencyDisplay?.futureInstallmentsPresentmentTotalCents ??
+            toDisplayedCents(futureInstallmentsWithoutTipsTotal),
+          toDisplayedCents(commissionCompletionTotal),
+        ]
+      : []),
+  ];
+  // The summary is one column of amounts, so a single line holding cents makes every whole line in
+  // it look truncated (US$10 next to US$2.10 — tastelint on #7602). One fractional line switches the
+  // whole column to cents; an all-whole cart keeps the compact US$10 look.
+  const noCentsIfWhole = summaryAmountsAreAllWhole(summaryDisplayedCents, localCurrency?.subunitToUnit ?? 100);
+
   return (
     // data-checkout-scope bounds PaymentForm's scroll-to-first-error scan: wide enough to reach
     // the tip and gift fields above it, narrow enough to ignore the rest of the page.
@@ -520,6 +559,7 @@ export const Checkout = ({
                     isGift={isGift}
                     buyerCurrencyDisplay={localCurrency}
                     presentmentPriceCents={localAmounts?.linePriceCents[index] ?? null}
+                    noCentsIfWhole={noCentsIfWhole}
                     updateCart={updateCart}
                   />
                 ))}
@@ -536,15 +576,13 @@ export const Checkout = ({
                       buyerCurrencyDisplay={localCurrency}
                       presentmentTipCents={localAmounts?.tipCents ?? null}
                       isListedCurrency={listedCurrency != null}
+                      noCentsIfWhole={noCentsIfWhole}
+                      isRequoting={isRequoting}
                     />
                   </div>
                 ) : null}
                 <div
-                  className={classNames(
-                    "grid gap-4 p-4 transition-opacity sm:px-5",
-                    displayTipSelector && "border-t border-border",
-                    isRequoting && "opacity-50",
-                  )}
+                  className={classNames("grid gap-4 p-4 sm:px-5", displayTipSelector && "border-t border-border")}
                   data-checkout-price-rows="true"
                   aria-busy={isRequoting}
                 >
@@ -554,18 +592,24 @@ export const Checkout = ({
                         title="Subtotal"
                         price={
                           localAmounts && localCurrency
-                            ? formatPresentmentCents(localAmounts.subtotalCents, localCurrency)
-                            : formatCheckoutPrice(subtotal, localCurrency)
+                            ? formatPresentmentCents(localAmounts.subtotalCents, localCurrency, { noCentsIfWhole })
+                            : formatCheckoutPrice(subtotal, localCurrency, { noCentsIfWhole })
                         }
+                        isRequoting={isRequoting}
                       />
                       {summarySurcharges.tax_included_cents ? (
                         <CartPriceItem
                           title={`${nameOfSalesTaxForCountry(state.country)} (included)`}
                           price={
                             listedAmounts && listedCurrency
-                              ? formatPresentmentCents(listedAmounts.taxIncludedCents, listedCurrency)
-                              : formatCheckoutPrice(summarySurcharges.tax_included_cents, localCurrency)
+                              ? formatPresentmentCents(listedAmounts.taxIncludedCents, listedCurrency, {
+                                  noCentsIfWhole,
+                                })
+                              : formatCheckoutPrice(summarySurcharges.tax_included_cents, localCurrency, {
+                                  noCentsIfWhole,
+                                })
                           }
+                          isRequoting={isRequoting}
                         />
                       ) : null}
                       {summarySurcharges.tax_cents ? (
@@ -573,9 +617,10 @@ export const Checkout = ({
                           title={nameOfSalesTaxForCountry(state.country)}
                           price={
                             localAmounts && localCurrency
-                              ? formatPresentmentCents(localAmounts.taxCents, localCurrency)
-                              : formatCheckoutPrice(summarySurcharges.tax_cents, localCurrency)
+                              ? formatPresentmentCents(localAmounts.taxCents, localCurrency, { noCentsIfWhole })
+                              : formatCheckoutPrice(summarySurcharges.tax_cents, localCurrency, { noCentsIfWhole })
                           }
+                          isRequoting={isRequoting}
                         />
                       ) : null}
                       {summarySurcharges.shipping_rate_cents ? (
@@ -583,9 +628,12 @@ export const Checkout = ({
                           title="Shipping rate"
                           price={
                             localAmounts && localCurrency
-                              ? formatPresentmentCents(localAmounts.shippingCents, localCurrency)
-                              : formatCheckoutPrice(summarySurcharges.shipping_rate_cents, localCurrency)
+                              ? formatPresentmentCents(localAmounts.shippingCents, localCurrency, { noCentsIfWhole })
+                              : formatCheckoutPrice(summarySurcharges.shipping_rate_cents, localCurrency, {
+                                  noCentsIfWhole,
+                                })
                           }
+                          isRequoting={isRequoting}
                         />
                       ) : null}
                     </>
@@ -628,9 +676,13 @@ export const Checkout = ({
                       </h4>
                       {discount > 0 ? (
                         <div>
-                          {localAmounts && localCurrency
-                            ? formatPresentmentCents(-localAmounts.discountCents, localCurrency)
-                            : formatCheckoutPrice(-discount, localCurrency)}
+                          {isRequoting ? (
+                            <PendingAmount />
+                          ) : localAmounts && localCurrency ? (
+                            formatPresentmentCents(-localAmounts.discountCents, localCurrency, { noCentsIfWhole })
+                          ) : (
+                            formatCheckoutPrice(-discount, localCurrency, { noCentsIfWhole })
+                          )}
                         </div>
                       ) : null}
                     </div>
@@ -658,21 +710,16 @@ export const Checkout = ({
                 </div>
                 {total != null ? (
                   <>
-                    <footer
-                      className={classNames(
-                        "grid gap-4 border-t border-border p-4 transition-opacity sm:px-5",
-                        isRequoting && "opacity-50",
-                      )}
-                      aria-busy={isRequoting}
-                    >
+                    <footer className="grid gap-4 border-t border-border p-4 sm:px-5" aria-busy={isRequoting}>
                       <CartPriceItem
                         title="Total"
                         price={
                           localAmounts && localCurrency
-                            ? formatPresentmentCents(localAmounts.totalCents, localCurrency)
-                            : formatCheckoutPrice(total, localCurrency)
+                            ? formatPresentmentCents(localAmounts.totalCents, localCurrency, { noCentsIfWhole })
+                            : formatCheckoutPrice(total, localCurrency, { noCentsIfWhole })
                         }
                         variant="large"
+                        isRequoting={isRequoting}
                       />
                     </footer>
                     <CurrencyPicker
@@ -692,17 +739,21 @@ export const Checkout = ({
                               ? formatPresentmentCents(
                                   buyerCurrencyDisplay.chargePresentmentTotalCents,
                                   buyerCurrencyDisplay,
+                                  { noCentsIfWhole },
                                 )
                               : formatCheckoutPrice(
                                   total - commissionCompletionTotal - futureInstallmentsWithoutTipsTotal,
                                   localCurrency,
+                                  { noCentsIfWhole },
                                 )
                           }
+                          isRequoting={isRequoting}
                         />
                         {commissionCompletionTotal > 0 ? (
                           <CartPriceItem
                             title="Payment after completion"
-                            price={formatCheckoutPrice(commissionCompletionTotal, localCurrency)}
+                            price={formatCheckoutPrice(commissionCompletionTotal, localCurrency, { noCentsIfWhole })}
+                            isRequoting={isRequoting}
                           />
                         ) : null}
                         {futureInstallmentsWithoutTipsTotal > 0 ? (
@@ -713,9 +764,13 @@ export const Checkout = ({
                                 ? formatPresentmentCents(
                                     buyerCurrencyDisplay.futureInstallmentsPresentmentTotalCents,
                                     buyerCurrencyDisplay,
+                                    { noCentsIfWhole },
                                   )
-                                : formatCheckoutPrice(futureInstallmentsWithoutTipsTotal, localCurrency)
+                                : formatCheckoutPrice(futureInstallmentsWithoutTipsTotal, localCurrency, {
+                                    noCentsIfWhole,
+                                  })
                             }
+                            isRequoting={isRequoting}
                           />
                         ) : null}
                       </div>
@@ -761,12 +816,16 @@ const TipSelector = ({
   buyerCurrencyDisplay,
   presentmentTipCents,
   isListedCurrency = false,
+  noCentsIfWhole = true,
+  isRequoting = false,
 }: {
   buyerCurrencyDisplay?: CheckoutLocalCurrencyFormat | null;
   presentmentTipCents?: number | null;
   // True while checkout displays the listed-currency lane. The listed lane preserves fixed tips
   // exactly as typed instead of round-tripping them through canonical USD cents.
   isListedCurrency?: boolean;
+  noCentsIfWhole?: boolean;
+  isRequoting?: boolean;
 }) => {
   const [state, dispatch] = useState();
   const errors = getErrors(state);
@@ -807,10 +866,11 @@ const TipSelector = ({
         title="Add a tip?"
         price={
           presentmentTipCents != null && buyerCurrencyDisplay
-            ? formatPresentmentCents(presentmentTipCents, buyerCurrencyDisplay)
-            : formatCheckoutPrice(computeTip(state), buyerCurrencyDisplay)
+            ? formatPresentmentCents(presentmentTipCents, buyerCurrencyDisplay, { noCentsIfWhole })
+            : formatCheckoutPrice(computeTip(state), buyerCurrencyDisplay, { noCentsIfWhole })
         }
         variant="tip"
+        isRequoting={isRequoting}
       />
       <div className="grid grid-cols-1 gap-4 @[52rem]:grid-cols-5">
         {showPercentageOptions ? (
@@ -881,14 +941,22 @@ const TipSelector = ({
   );
 };
 
+// A summary amount while its re-quote is in flight. The figure still on screen belongs to the
+// currency the buyer just left, and a dimmed wrong-currency number reads as the new price, so the
+// amount is replaced rather than faded (tastelint on #7600). Sized like a typical amount so the row
+// does not jump when the real one lands.
+const PendingAmount = () => <Skeleton className="h-5 w-16" aria-hidden="true" />;
+
 const CartPriceItem = ({
   title,
   price,
   variant = "default",
+  isRequoting = false,
 }: {
   title: React.ReactNode;
   price: string | number | null;
   variant?: "default" | "large" | "tip";
+  isRequoting?: boolean;
 }) => {
   const isLarge = variant === "large";
   const isDefault = variant === "default";
@@ -903,7 +971,9 @@ const CartPriceItem = ({
       >
         {title}
       </h4>
-      <div className={classNames("text-base sm:text-lg", !isDefault && "font-bold")}>{price}</div>
+      <div className={classNames("text-base sm:text-lg", !isDefault && "font-bold")}>
+        {isRequoting ? <PendingAmount /> : price}
+      </div>
     </div>
   );
 };
@@ -915,6 +985,7 @@ const CartItemComponent = ({
   isGift,
   buyerCurrencyDisplay,
   presentmentPriceCents,
+  noCentsIfWhole,
 }: {
   item: CartItemProps;
   cart: CartState;
@@ -926,6 +997,7 @@ const CartItemComponent = ({
   // amount later persisted for the receipt; converting the USD price here instead can be a
   // cent off from both.
   presentmentPriceCents?: number | null;
+  noCentsIfWhole: boolean;
 }) => {
   const [editPopoverOpen, setEditPopoverOpen] = React.useState(false);
   const [selection, setSelection] = React.useState<PriceSelection>({
@@ -1126,8 +1198,8 @@ const CartItemComponent = ({
       <CartItemEnd className="max-w-1/2 text-right">
         <span className="current-price text-base font-bold sm:text-lg" aria-label="Price">
           {presentmentPriceCents != null && buyerCurrencyDisplay
-            ? formatPresentmentCents(presentmentPriceCents, buyerCurrencyDisplay)
-            : formatCheckoutPrice(convertToUSD(item, price), buyerCurrencyDisplay)}
+            ? formatPresentmentCents(presentmentPriceCents, buyerCurrencyDisplay, { noCentsIfWhole })
+            : formatCheckoutPrice(convertToUSD(item, price), buyerCurrencyDisplay, { noCentsIfWhole })}
         </span>
         {hasFreeTrial(item, isGift) && item.product.free_trial ? (
           <>
@@ -1144,7 +1216,9 @@ const CartItemComponent = ({
                     always a canonical USD amount. */}
                 {formatAmountPerRecurrence(
                   item.recurrence,
-                  formatCheckoutPrice(convertToUSD(item, discount.price), buyerCurrencyDisplay),
+                  formatCheckoutPrice(convertToUSD(item, discount.price), buyerCurrencyDisplay, {
+                    noCentsIfWhole,
+                  }),
                 )}{" "}
                 after
               </span>

--- a/app/javascript/components/Checkout/index.tsx
+++ b/app/javascript/components/Checkout/index.tsx
@@ -508,6 +508,11 @@ export const Checkout = ({
       if (allocated != null) return allocated;
       return toDisplayedCents(convertToUSD(item, hasFreeTrial(item, isGift) ? 0 : item.price * item.quantity));
     }),
+    // A free trial's renewal price prints under its line price in this same column, so it counts
+    // toward the column's one cents decision even though it is not charged today.
+    ...cart.items
+      .filter((item) => hasFreeTrial(item, isGift) && item.recurrence)
+      .map((item) => toDisplayedCents(convertToUSD(item, getDiscountedPrice(cart, item).price))),
     localAmounts?.subtotalCents ?? toDisplayedCents(subtotal),
     listedAmounts?.taxIncludedCents ?? toDisplayedCents(summarySurcharges?.tax_included_cents ?? 0),
     localAmounts?.taxCents ?? toDisplayedCents(summarySurcharges?.tax_cents ?? 0),
@@ -527,9 +532,8 @@ export const Checkout = ({
         ]
       : []),
   ];
-  // The summary is one column of amounts, so a single line holding cents makes every whole line in
-  // it look truncated (US$10 next to US$2.10 — tastelint on #7602). One fractional line switches the
-  // whole column to cents; an all-whole cart keeps the compact US$10 look.
+  // The summary is one column of amounts, so one fractional line switches the whole column to cents;
+  // an all-whole cart keeps the compact US$10 look.
   const noCentsIfWhole = summaryAmountsAreAllWhole(summaryDisplayedCents, localCurrency?.subunitToUnit ?? 100);
 
   return (
@@ -943,8 +947,8 @@ const TipSelector = ({
 
 // A summary amount while its re-quote is in flight. The figure still on screen belongs to the
 // currency the buyer just left, and a dimmed wrong-currency number reads as the new price, so the
-// amount is replaced rather than faded (tastelint on #7600). Sized like a typical amount so the row
-// does not jump when the real one lands.
+// amount is replaced rather than faded. Sized like a typical amount so the row does not jump when
+// the real one lands.
 const PendingAmount = () => <Skeleton className="h-5 w-16" aria-hidden="true" />;
 
 const CartPriceItem = ({

--- a/app/javascript/utils/currency.test.ts
+++ b/app/javascript/utils/currency.test.ts
@@ -86,4 +86,13 @@ describe("formatMinorUnitPriceWithIntl", () => {
   it("uses the currency convention when an internal 100-subunit amount is fractional", () => {
     expect(formatMinorUnitPriceWithIntl("krw", 1_343_250, 100)).toBe("₩13,433");
   });
+
+  it("shows cents on a whole amount when the caller is matching a column that has them", () => {
+    expect(formatMinorUnitPriceWithIntl("usd", 1_000, 100, { noCentsIfWhole: false })).toBe("$10.00");
+    expect(formatMinorUnitPriceWithIntl("usd", 1_000, 100)).toBe("$10");
+  });
+
+  it("keeps a zero-decimal currency whole even when the caller asks for cents", () => {
+    expect(formatMinorUnitPriceWithIntl("krw", 1_000_000, 100, { noCentsIfWhole: false })).toBe("₩10,000");
+  });
 });

--- a/app/javascript/utils/currency.ts
+++ b/app/javascript/utils/currency.ts
@@ -86,8 +86,10 @@ export const formatPriceCentsWithCurrencySymbol = (
 
 // USD's long symbol is set to $, which is often what we want.
 // In some places, though, we want to be more explicit (like cart total), and for these, we want to use US$ as the symbol.
-export const formatUSDCentsWithExpandedCurrencySymbol = (amountCents: number): string =>
-  formatPrice("US$", priceCentsToUnit(amountCents, false), 2, { noCentsIfWhole: true });
+export const formatUSDCentsWithExpandedCurrencySymbol = (
+  amountCents: number,
+  { noCentsIfWhole = true }: { noCentsIfWhole?: boolean } = {},
+) => formatPrice("US$", priceCentsToUnit(amountCents, false), 2, { noCentsIfWhole });
 
 export const formatPriceCentsWithoutCurrencySymbol = (code: CurrencyCode, amountCents: number): string => {
   const currency = findCurrencyByCode(code);
@@ -111,6 +113,7 @@ export const formatMinorUnitPriceWithIntl = (
   currencyCode: string,
   amountMinorUnits: number,
   subunitToUnit?: number | null,
+  { noCentsIfWhole = true }: { noCentsIfWhole?: boolean } = {},
 ): string => {
   const currency = currencyCode.toUpperCase();
   // Prefer the backend's authoritative subunit_to_unit (the Money gem's value, which is
@@ -128,9 +131,11 @@ export const formatMinorUnitPriceWithIntl = (
   const units = amountMinorUnits / resolvedSubunitToUnit;
   // Match USD checkout amounts by dropping .00 on whole units. Fractional values
   // use the currency's own convention, so KRW stays whole even though Gumroad stores it in 100 subunits.
+  // Callers rendering a column of amounts together pass noCentsIfWhole: false, so one line holding
+  // cents doesn't leave its neighbours looking truncated.
   const currencyFractionDigits = new Intl.NumberFormat("en-US", { style: "currency", currency }).resolvedOptions()
     .maximumFractionDigits;
-  const fractionDigits = Number.isInteger(units) ? 0 : currencyFractionDigits;
+  const fractionDigits = Number.isInteger(units) && noCentsIfWhole ? 0 : currencyFractionDigits;
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency,

--- a/spec/requests/purchases/product/installment_plan_spec.rb
+++ b/spec/requests/purchases/product/installment_plan_spec.rb
@@ -14,7 +14,7 @@ describe "Product with installment plan", type: :system, js: true do
     click_on "Pay in 3 installments"
 
     within_cart_item product.name do
-      expect(page).to have_text("US$10 in 3 installments", normalize_ws: true)
+      expect(page).to have_text("US$10.00 in 3 installments", normalize_ws: true)
 
       select_disclosure "Edit" do
         choose "Pay in full"
@@ -37,7 +37,7 @@ describe "Product with installment plan", type: :system, js: true do
     end
 
     within_cart_item product.name do
-      expect(page).to have_text("US$10 in 3 installments", normalize_ws: true)
+      expect(page).to have_text("US$10.00 in 3 installments", normalize_ws: true)
     end
 
     expect(page).to have_text("Subtotal US$10", normalize_ws: true)
@@ -89,7 +89,7 @@ describe "Product with installment plan", type: :system, js: true do
       click_on "Pay in 3 installments"
 
       within_cart_item product.name do
-        expect(page).to have_text("US$10 in 3 installments", normalize_ws: true)
+        expect(page).to have_text("US$10.00 in 3 installments", normalize_ws: true)
 
         select_disclosure "Edit" do
           choose "Pay in full"
@@ -112,7 +112,7 @@ describe "Product with installment plan", type: :system, js: true do
       end
 
       within_cart_item product.name do
-        expect(page).to have_text("US$10 in 3 installments", normalize_ws: true)
+        expect(page).to have_text("US$10.00 in 3 installments", normalize_ws: true)
       end
 
       expect(page).to have_text("Subtotal US$10", normalize_ws: true)
@@ -193,7 +193,7 @@ describe "Product with installment plan", type: :system, js: true do
       click_on "Pay in 3 installments"
 
       within_cart_item product.name do
-        expect(page).to have_text("US$10 in 3 installments", normalize_ws: true)
+        expect(page).to have_text("US$10.00 in 3 installments", normalize_ws: true)
       end
 
       expect(page).to have_text("Subtotal US$10", normalize_ws: true)
@@ -303,7 +303,7 @@ describe "Product with installment plan", type: :system, js: true do
       click_on "Pay in 3 installments"
 
       within_cart_item bundle.name do
-        expect(page).to have_text("US$10 in 3 installments", normalize_ws: true)
+        expect(page).to have_text("US$10.00 in 3 installments", normalize_ws: true)
       end
 
       expect(page).to have_text("Subtotal US$10", normalize_ws: true)


### PR DESCRIPTION
> CI note: the trimmed `Test Relevant` job maps this diff to all 78 money-path system specs but runs them on 4 nodes inside a 25-minute step cap (~3x over budget), so every head ended on the cap. The PR now carries the `run-all-specs` label, which runs the full suite on the standard node count instead. Numbers in Test Results.

Premerge review: clean @ 3b0921aae4a373409cc574650cc09fc6801229ca (autoreview panel — codex `gpt-6-astra` thinking=high + claude `claude-fable-5-1`, 0 findings)

## What

Two changes to the checkout order summary, both about the amounts that sit in one column.

**Decimals match across the column.** One fractional line made every other line look truncated — `US$10` next to `US$2.10`. The card now collects the amounts it is about to display (line prices, a free trial's renewal price, subtotal, tax, shipping, discounts, tip, total, payment today, future installments), decides once whether any of them is fractional, and passes that single `noCentsIfWhole` flag to every row: `US$10.00` / `US$2.10` / `US$12.10`. An all-whole cart keeps the compact `US$10`, and a zero-decimal currency (KRW) stays whole because it has no fractional unit to show. The formatter defaults are unchanged, so no other surface moves.

**The stale amount is replaced, not faded.** While a currency change is being re-quoted, the rows showed the previous currency's amounts at 50% opacity. A dimmed wrong-currency number reads as the new price, so each amount is now a skeleton bar of the same width: labels stay at full contrast, and `aria-busy` plus the existing "Updating total…" live region are unchanged.

## Why

Tastelint flagged the mixed precision three times (#7602 §3, #7607 §2, #7600-adjacent) and the faded stale total once (#7600 §2). For the decimals, the alternative — always showing two decimals — loses the compact look Sahil asked for on whole carts, and the alternative of formatting each row independently is what produced the mismatch. For the fade, skeletons are the standing rule.

A free trial's renewal price prints under its line price in this same column, so it feeds the same decision; the column only seeing the trial line's `0` read `US$10` beside `US$9.99 monthly after`. Regression test included.

Addresses:
- https://github.com/antiwork/gumroad/pull/7602#issuecomment-5647015574
- https://github.com/antiwork/gumroad/pull/7607#issuecomment-5647794593
- https://github.com/antiwork/gumroad/pull/7600#issuecomment-5645358841

## Before / After

Frames captured at `da57c4d`; the only change between that commit and the current head `3b0921aa` is six spec assertions, so the rendered summary is the same.

Before — the tip row prints `€0` while the column it sits in shows cents:

![Before: the tip row reads €0 next to Subtotal €9.19 and VAT €1.91](https://github.com/user-attachments/assets/e352cac9-a461-407c-a167-a264c1163973)

After — the same cart, the tip row joins the column's decimal style:

![After: the tip row reads €0.00 alongside Subtotal €9.19 and VAT €1.91](https://github.com/user-attachments/assets/8db09731-94d5-4012-991d-ee2c2cb1ad41)

After, mid re-quote — the amounts are skeleton bars with the labels at full contrast, and "Updating total…" stays in its live region:

![After: Subtotal, VAT and Total are skeleton bars during the re-quote](https://github.com/user-attachments/assets/8084d5d0-0ea7-4314-b354-bd2f85c97097)

## Test Results

- `npx vitest run app/javascript/components/Checkout app/javascript/utils/currency.test.ts` — 25 files, 565 passed, 0 failed.
- The new column-decision cases in `app/javascript/components/Checkout/index.test.tsx` cover the all-whole cart, the fractional-tax cart, KRW, and the free-trial renewal price. The trial case fails without the source change (mutation-checked: `expected [ 'US$0' ] to deeply equal [ 'US$0.00' ]`).
- `tsc --noEmit`, `eslint` and `prettier --check` clean on the touched files.
- `spec/requests/purchases/product/installment_plan_spec.rb:190` — the example the failed CI run reported — passes locally at this head: 1 example, 0 failures (12s). A live-page probe of the same flow reads `US$10.00 in 3 installments`, `Add a tip? US$2.00`, `Subtotal US$12.00`, `Total US$12.00`, `Payment today US$5.34`, `Future installments US$6.66`, and the page settles (mutation and fetch counters go to 0).
- CI on the failed runs: all four `Test Relevant` shards ended on the 25-minute step cap (28.2–30.0 min) on all three heads, with toast-only spec failures — `have_alert` on the purchase success message while the post-purchase page was already rendered, and `We sent a receipt to test@gumroad.com` reported as "found 1 time including non-visible text" (the toast's 5s auto-dismiss). `bin/branch-specs` maps `app/javascript/components/Checkout/**` to `spec/requests/{checkout,purchases,subscription}` — 78 files, under its `MAX_SELECTED_FILES = 120` cap — and 4 nodes cannot run that set in 25 minutes, which is why the job needs the full-suite label.

## Status

- [x] Scope — order-summary decimals match across one column; stale amounts become skeletons during a re-quote. No formatter defaults change, no other surface moves.
- [x] Design — one `noCentsIfWhole` decision per column, computed from the amounts actually rendered (including a free trial's renewal price); skeletons over faded amounts.
- [x] Build — `3b0921aa` on `gumclaw/ux-order-summary-decimals`
- [x] QA — before/after stills above
- [ ] Shipped
- [ ] Market — n/a
- [ ] Sell — n/a

---
AI disclosure: the application code, tests and this description were written by DeepSeek V4.1 Flash running as the gumclaw autonomous agent. Prompts: "make the order summary show one decimal style per column"; "replace the faded stale amounts during a re-quote with skeletons"; "resolve the Greptile findings on #7618".
