### PR TITLE
Give the shared select's value room before its chevron

### DIFF
--- a/app/javascript/components/ui/Select.tsx
+++ b/app/javascript/components/ui/Select.tsx
@@ -18,9 +18,7 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
           ref={ref}
           className={classNames(
             baseInputStyles,
-            // The chevron sits at `right-4` and is 20px wide, so the value needs 44px of right
-            // padding to clear it — otherwise a long value (a country name at 375px) runs into the
-            // icon. `truncate` keeps the overflow readable as an ellipsis instead of a hard cut.
+            // 44px clears the 20px chevron at `right-4`, with a gap before it.
             "appearance-none truncate bg-none pr-11",
             stateBorderStyles[state],
             className,

--- a/app/javascript/components/ui/Select.tsx
+++ b/app/javascript/components/ui/Select.tsx
@@ -16,7 +16,15 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
       <div className={classNames("relative inline-grid", wrapperClassName)}>
         <select
           ref={ref}
-          className={classNames(baseInputStyles, "appearance-none bg-none pr-10", stateBorderStyles[state], className)}
+          className={classNames(
+            baseInputStyles,
+            // The chevron sits at `right-4` and is 20px wide, so the value needs 44px of right
+            // padding to clear it — otherwise a long value (a country name at 375px) runs into the
+            // icon. `truncate` keeps the overflow readable as an ellipsis instead of a hard cut.
+            "appearance-none truncate bg-none pr-11",
+            stateBorderStyles[state],
+            className,
+          )}
           {...props}
         >
           {children}


### PR DESCRIPTION
## What

The shared `ui/Select` gives its value 44px of right padding instead of 40px, and truncates with an ellipsis. The chevron is 20px wide and sits at `right-4`, so the value needs 36px plus a gap to clear it; at 40px the last characters of a long value stopped 4px from the icon with no overflow cue.

Padding-only change to the primitive, so every consumer keeps its own classes and only gains the room.

## Why

Tastelint, at 375px on #7607: "United States" in the checkout Country select runs into the chevron and gets cut off, and longer names ("Saint Vincent and the Grenadines") look worse. The alternative — padding the one checkout field — leaves the same trap in the other 20-odd consumers of the shared select.

Addresses https://github.com/antiwork/gumroad/pull/7607#issuecomment-5647794625.

## Before / After

Local checkout harness (`:3006`), same worktree for both legs: `origin/main`'s `Select.tsx` swapped in for the before frames, the branch for the after frames. Country field measured directly (`getBoundingClientRect` + computed padding), desktop 1440px and mobile 375px.

| field | main (`pr-10`, no truncate) | branch (`pr-11`, `truncate`) |
| --- | --- | --- |
| 375px, longest name in the picker ("South Georgia and the South Sandwich Islands") | glyphs cut mid-word, 4px from the chevron, no ellipsis | `…` ellipsis, 8px from the chevron |
| 1440px, same name (Country sits beside ZIP, field is 179px) | cut mid-word, 4px from the chevron | `…` ellipsis, 8px from the chevron |
| 375px, "United States" | fits — 99px of text in a 309px field, byte-identical frame to the branch | fits — unchanged |
| 1440px, "United States" | fits (99px of 179px) | fits — unchanged |

The local harness draws the 375px field 309px wide, so "United States" itself clears the icon there; the overlap reproduces with the picker's longer names, and the desktop layout puts the same field at 179px.

Mobile 375px, picker's longest country name — before (hard cut, no ellipsis):

![375px country field on main with the longest country name selected: the glyphs are cut mid-word 4px before the chevron, with no ellipsis](https://github.com/user-attachments/assets/e0cc003c-f535-40a1-ba6c-3ca535558e4a)

Mobile 375px, same name — after (ellipsis, clear of the icon):

![375px country field on the branch with the same name: it ends in an ellipsis with an 8px gap before the chevron](https://github.com/user-attachments/assets/b8dc5c64-65be-4dc8-babb-509f8388170a)

Desktop 1440px, same name — before / after:

![Desktop country field on main, in place beside the ZIP field: text cut mid-word against the chevron](https://github.com/user-attachments/assets/a31a3a3e-e1e7-45ff-8c18-e00e95d9b9bb)

![Desktop country field on the branch: ellipsis with a gap before the chevron](https://github.com/user-attachments/assets/3e02ac16-0072-4a98-b965-325676005c70)

375px "United States" on the branch (fits; the main frame is byte-identical):

![375px country field showing United States with room to spare before the chevron](https://github.com/user-attachments/assets/29802b18-2c53-420c-8d3e-db3af6d398bf)

Widest-name frame on the branch, tight crop:

![Cropped country field on the branch showing the ellipsis ending clear of the chevron](https://github.com/user-attachments/assets/f8f5f394-a584-4a86-bc48-0872ae2ad7b2)

## Test results

- `vitest`: 153 files, 1661 passed.
- No spec pins the old padding class; the change is padding plus `truncate` on one shared primitive, and every consumer keeps its own classes.

Premerge review: clean @ dca46ec3a5c17b424d31ffc450c1c50f51045a29

---
AI assistance: DeepSeek V4.1 Flash, running as the gumclaw autonomous agent. Prompt: give the shared select's value room before its chevron so a long country name is not clipped at 375px.
