### PR TITLE
Let pay-what-you-want coexist with a priced version on a $0-base product

### DIFF
--- a/app/javascript/components/ProductEdit/ProductTab/PriceEditor.test.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/PriceEditor.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -32,15 +32,25 @@ const renderEditor = (
   );
 
 describe("PriceEditor PWYW toggle", () => {
-  it("disables PWYW on a $0-base product with paid variants and shows a stale on state as off", () => {
+  it("leaves PWYW editable on a $0-base product with paid variants", () => {
     const setIsPWYW = vi.fn();
     renderEditor({ isPWYW: true, setIsPWYW, hasPaidVariants: true, priceCents: 0 });
 
     const toggle = screen.getByRole("switch");
-    expect(toggle).toHaveProperty("disabled", true);
-    expect(toggle).toHaveProperty("checked", false);
-    expect(screen.getByText("Pay what you want isn't available on products with paid pricing options.")).toBeTruthy();
+    expect(toggle).toHaveProperty("disabled", false);
+    expect(toggle).toHaveProperty("checked", true);
+    expect(screen.queryByText("Pay what you want isn't available on products with paid pricing options.")).toBeNull();
     expect(setIsPWYW).not.toHaveBeenCalled();
+  });
+
+  it("turns PWYW on from the switch on a $0-base product with paid variants", () => {
+    const setIsPWYW = vi.fn();
+    renderEditor({ isPWYW: false, setIsPWYW, hasPaidVariants: true, priceCents: 0 });
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveProperty("checked", false);
+    fireEvent.click(toggle);
+    expect(setIsPWYW).toHaveBeenCalledWith(true);
   });
 
   it("keeps a free product without variants locked on to PWYW", () => {

--- a/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
@@ -56,10 +56,9 @@ export const PriceEditor = ({
 }) => {
   const uid = React.useId();
   const isFreeProduct = priceCents === 0;
-  // A $0 base is PWYW by default, so with no paid version the flag is forced on (a free
-  // product needs an amount box). Beside a paid version it is the seller's choice, and the
-  // amount box floor is the selected version's total, so the combination is safe
-  // (gumroad-private#2573). Product::Prices#set_customizable_price writes the same rule.
+  // A free product needs an amount box, so a $0 base with no paid version forces PWYW on.
+  // Beside a paid version the flag is the seller's — the floor is the selected version's
+  // total. Product::Prices#set_customizable_price writes the same rule.
   const mustBePWYW = isFreeProduct && !hasPaidVariants;
   const pwywOn = mustBePWYW ? true : isPWYW;
   const productEditContext = React.useContext(ProductEditContext);

--- a/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
+++ b/app/javascript/components/ProductEdit/ProductTab/PriceEditor.tsx
@@ -56,14 +56,12 @@ export const PriceEditor = ({
 }) => {
   const uid = React.useId();
   const isFreeProduct = priceCents === 0;
-  // Backend Product::Prices#set_customizable_price forces PWYW off on a $0 base
-  // with paid variants (otherwise checkout offers a $0 amount box next to a paid
-  // option). The product editor keeps state in step via reconcileCustomizablePrice;
-  // deriving here too keeps the switch honest under parents that don't (the
-  // bundle editor has no variants and its own $0 transition handling).
-  const cannotBePWYW = isFreeProduct && Boolean(hasPaidVariants);
+  // A $0 base is PWYW by default, so with no paid version the flag is forced on (a free
+  // product needs an amount box). Beside a paid version it is the seller's choice, and the
+  // amount box floor is the selected version's total, so the combination is safe
+  // (gumroad-private#2573). Product::Prices#set_customizable_price writes the same rule.
   const mustBePWYW = isFreeProduct && !hasPaidVariants;
-  const pwywOn = cannotBePWYW ? false : mustBePWYW ? true : isPWYW;
+  const pwywOn = mustBePWYW ? true : isPWYW;
   const productEditContext = React.useContext(ProductEditContext);
 
   // The regular product editor provides ProductEditContext; the bundle editor
@@ -97,15 +95,12 @@ export const PriceEditor = ({
         currencyCodeSelector={currencyCodeSelector}
       />
       {mustBePWYW ? <Alert variant="info">Free products require a pay what they want price.</Alert> : null}
-      {cannotBePWYW ? (
-        <Alert variant="info">Pay what you want isn't available on products with paid pricing options.</Alert>
-      ) : null}
       <Details open={pwywOn}>
         <DetailsToggle chevronPosition="none" className="mb-0">
           <Switch
             checked={pwywOn}
             onChange={(e) => setIsPWYW(e.target.checked)}
-            disabled={mustBePWYW || cannotBePWYW}
+            disabled={mustBePWYW}
             label={
               <a href="/help/article/133-pay-what-you-want-pricing" target="_blank" rel="noreferrer">
                 Allow customers to pay what they want

--- a/app/javascript/components/ProductEdit/state.test.ts
+++ b/app/javascript/components/ProductEdit/state.test.ts
@@ -32,45 +32,27 @@ describe("hasPaidVariantPricing", () => {
 });
 
 describe("reconcileCustomizablePrice", () => {
-  it("forces PWYW off on a $0 base with paid variant pricing", () => {
+  it("keeps the seller's flag on a $0 base with paid variant pricing", () => {
+    const paidVariants = [1500];
     expect(
-      reconcileCustomizablePrice(
-        product({ priceCents: 0, customizablePrice: true, variantPriceCents: [1500] }),
-        0,
-        true,
-      ),
+      reconcileCustomizablePrice(product({ priceCents: 0, customizablePrice: true, variantPriceCents: paidVariants })),
+    ).toBe(true);
+    expect(
+      reconcileCustomizablePrice(product({ priceCents: 0, customizablePrice: false, variantPriceCents: paidVariants })),
     ).toBe(false);
   });
 
   it("forces PWYW on for a $0 base without paid variant pricing", () => {
-    expect(reconcileCustomizablePrice(product({ priceCents: 0, customizablePrice: false }), 1500, false)).toBe(true);
-  });
-
-  it("turns PWYW back on when a $0 product loses its last paid variant", () => {
-    expect(reconcileCustomizablePrice(product({ priceCents: 0, customizablePrice: false }), 0, false)).toBe(true);
+    expect(reconcileCustomizablePrice(product({ priceCents: 0, customizablePrice: false }))).toBe(true);
   });
 
   it("keeps a forced-on flag when the price leaves $0 without paid variants", () => {
-    expect(reconcileCustomizablePrice(product({ priceCents: 1000, customizablePrice: true }), 0, false)).toBe(true);
-  });
-
-  it("restores the prior choice when the price leaves $0 with paid variants", () => {
-    expect(
-      reconcileCustomizablePrice(
-        product({ priceCents: 1500, customizablePrice: false, variantPriceCents: [1500] }),
-        0,
-        true,
-      ),
-    ).toBe(true);
+    expect(reconcileCustomizablePrice(product({ priceCents: 1000, customizablePrice: true }))).toBe(true);
   });
 
   it("keeps the current choice at a nonzero price", () => {
     expect(
-      reconcileCustomizablePrice(
-        product({ priceCents: 1500, customizablePrice: true, variantPriceCents: [1500] }),
-        1000,
-        false,
-      ),
+      reconcileCustomizablePrice(product({ priceCents: 1500, customizablePrice: true, variantPriceCents: [1500] })),
     ).toBe(true);
   });
 
@@ -79,8 +61,6 @@ describe("reconcileCustomizablePrice", () => {
       expect(
         reconcileCustomizablePrice(
           product({ priceCents: 0, customizablePrice: true, variantPriceCents: [500], nativeType }),
-          0,
-          false,
         ),
       ).toBe(true);
     }

--- a/app/javascript/components/ProductEdit/state.ts
+++ b/app/javascript/components/ProductEdit/state.ts
@@ -230,11 +230,9 @@ type PricedVariant = { price_difference_cents?: number | null } | Tier;
 export const hasPaidVariantPricing = (product: { variants: PricedVariant[] }) =>
   product.variants.some((variant) => "price_difference_cents" in variant && (variant.price_difference_cents ?? 0) > 0);
 
-// Mirror of the backend Product::Prices#set_customizable_price: a $0 base with no paid
-// variant pricing forces PWYW — a free product needs an amount box. Beside a paid version
-// the flag is the seller's choice, because the amount box floor is the selected version's
-// total rather than the $0 base, so the combination is safe (gumroad-private#2573).
-// Coffee and tiered memberships are exempt on the backend.
+// Mirror of Product::Prices#set_customizable_price: a $0 base with no paid variant pricing
+// forces PWYW on (a free product needs an amount box); beside a paid version the flag is the
+// seller's, the amount box floor being the selected version's total. Coffee/memberships exempt.
 export const reconcileCustomizablePrice = (product: {
   native_type: ProductNativeType;
   price_cents: number;

--- a/app/javascript/components/ProductEdit/state.ts
+++ b/app/javascript/components/ProductEdit/state.ts
@@ -230,26 +230,19 @@ type PricedVariant = { price_difference_cents?: number | null } | Tier;
 export const hasPaidVariantPricing = (product: { variants: PricedVariant[] }) =>
   product.variants.some((variant) => "price_difference_cents" in variant && (variant.price_difference_cents ?? 0) > 0);
 
-// Mirror of the backend guard Product::Prices#set_customizable_price: a $0 base
-// price forces PWYW — off when paid variant pricing exists (a free-entry amount
-// box next to a paid option is the gumroad-private#1660 checkout hole), on
-// otherwise. Leaving $0 keeps a forced-on flag (it's visible and editable, the
-// long-standing behavior) but restores the seller's last nonzero-price choice
-// over a forced-off one, so a dip to $0 while retyping the amount doesn't
-// silently erase it. Coffee and tiered memberships are exempt on the backend.
-export const reconcileCustomizablePrice = (
-  product: {
-    native_type: ProductNativeType;
-    price_cents: number;
-    customizable_price: boolean;
-    variants: PricedVariant[];
-  },
-  previousPriceCents: number,
-  priorCustomizablePrice: boolean,
-): boolean => {
+// Mirror of the backend Product::Prices#set_customizable_price: a $0 base with no paid
+// variant pricing forces PWYW — a free product needs an amount box. Beside a paid version
+// the flag is the seller's choice, because the amount box floor is the selected version's
+// total rather than the $0 base, so the combination is safe (gumroad-private#2573).
+// Coffee and tiered memberships are exempt on the backend.
+export const reconcileCustomizablePrice = (product: {
+  native_type: ProductNativeType;
+  price_cents: number;
+  customizable_price: boolean;
+  variants: PricedVariant[];
+}): boolean => {
   if (product.native_type === "coffee" || product.native_type === "membership") return product.customizable_price;
-  if (product.price_cents === 0) return !hasPaidVariantPricing(product);
-  if (previousPriceCents === 0 && hasPaidVariantPricing(product)) return priorCustomizablePrice;
+  if (product.price_cents === 0 && !hasPaidVariantPricing(product)) return true;
   return product.customizable_price;
 };
 

--- a/app/javascript/components/server-components/ProductEditPage.tsx
+++ b/app/javascript/components/server-components/ProductEditPage.tsx
@@ -498,24 +498,15 @@ const findUpdatedContent = (product: Product, lastSavedProduct: Product) => {
 
 const ProductEditPage = (props: Props) => {
   // Products predating the backend guard can load with a PWYW flag the guard
-  // would clear on the next save; reconcile up front so the editor and preview
+  // would move on the next save; reconcile up front so the editor and preview
   // never show a state that can't survive a save.
   const [product, setProduct] = React.useState<Product>(() => ({
     ...props.product,
-    customizable_price: reconcileCustomizablePrice(
-      props.product,
-      props.product.price_cents,
-      props.product.customizable_price,
-    ),
+    customizable_price: reconcileCustomizablePrice(props.product),
   }));
   const [contentUpdates, setContentUpdates] = React.useState<ContentUpdates>(null);
   const [currencyType, setCurrencyType] = React.useState<CurrencyCode>(props.currency_type);
   const lastSavedProductRef = React.useRef<Product>(structuredClone(props.product));
-  // The seller's PWYW choice as of the last nonzero base price — what a dip to
-  // $0 (which forces the flag either way) restores when the price comes back.
-  const priorCustomizablePriceRef = React.useRef(
-    props.product.price_cents === 0 ? false : props.product.customizable_price,
-  );
 
   const updateProduct = (update: Partial<Product> | ((product: Product) => void)) =>
     setProduct((prevProduct) => {
@@ -523,14 +514,8 @@ const ProductEditPage = (props: Props) => {
       if (typeof update === "function") update(updated);
       else Object.assign(updated, update);
       // Every state write passes through here, so price and variant edits from
-      // any tab keep the PWYW flag consistent with the backend guard. The ref
-      // write is idempotent — replays of this updater converge on the same value.
-      updated.customizable_price = reconcileCustomizablePrice(
-        updated,
-        prevProduct.price_cents,
-        priorCustomizablePriceRef.current,
-      );
-      if (updated.price_cents !== 0) priorCustomizablePriceRef.current = updated.customizable_price;
+      // any tab keep the PWYW flag consistent with the backend guard.
+      updated.customizable_price = reconcileCustomizablePrice(updated);
       return updated;
     });
   const [existingFiles, setExistingFiles] = React.useState(props.existing_files);

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -58,22 +58,20 @@ module Product::Prices
     create_or_update_new_price!(price_cents: rental_price_cents, recurrence: subscription_duration.try(:to_s), is_rental: true)
   end
 
+  # A $0 base is pay-what-you-want by default, but beside a paid version the flag is the
+  # seller's choice: the switch is live in the editor, so forcing it either way would fight
+  # the seller's last save. Nothing is left unguarded by that — the amount box floor is the
+  # selected version's total, not the $0 base (Purchase#minimum_paid_price_cents), so a $0
+  # name cannot buy the paid version (gumroad-private#1660, gumroad-private#2573).
   def set_customizable_price
     return if is_tiered_membership
     return unless default_price_cents == 0
     # Coffee is deliberately $0-base with paid "Suggested Amounts" variants and a free-entry box
-    # (initialize_suggested_amount_if_needed! sets both in one write), so the clear below would
-    # undo it. Above the paid-variant branch, matching the pre-existing behaviour: coffee always
-    # trips that branch, so it never reached the set either.
+    # (initialize_suggested_amount_if_needed! sets both in one write), so it keeps its own flag
+    # rather than being forced on below.
     return if native_type == Link::NATIVE_TYPE_COFFEE
-    # Clearing, not returning: a $0-base product that gains a paid variant keeps the stale
-    # `true` otherwise, and no editor control switches PWYW off on a $0 base — so checkout
-    # offers a free-entry amount box whose minimum on the free option is 0 and a buyer can
-    # pay full price for the free tier (gumroad-private#1660).
-    if variant_categories_alive.joins(:variants).merge(BaseVariant.alive).sum("base_variants.price_difference_cents") > 0
-      write_customizable_price_column(false)
-      return
-    end
+    return if variant_categories_alive.joins(:variants).merge(BaseVariant.alive).sum("base_variants.price_difference_cents") > 0
+
     write_customizable_price_column(true)
   end
 

--- a/app/modules/product/prices.rb
+++ b/app/modules/product/prices.rb
@@ -59,10 +59,8 @@ module Product::Prices
   end
 
   # A $0 base is pay-what-you-want by default, but beside a paid version the flag is the
-  # seller's choice: the switch is live in the editor, so forcing it either way would fight
-  # the seller's last save. Nothing is left unguarded by that — the amount box floor is the
-  # selected version's total, not the $0 base (Purchase#minimum_paid_price_cents), so a $0
-  # name cannot buy the paid version (gumroad-private#1660, gumroad-private#2573).
+  # seller's: the editor switch is live, and the amount box floor is the selected version's
+  # total (Purchase#minimum_paid_price_cents), so forcing it either way would be wrong.
   def set_customizable_price
     return if is_tiered_membership
     return unless default_price_cents == 0

--- a/spec/modules/product/prices_spec.rb
+++ b/spec/modules/product/prices_spec.rb
@@ -164,16 +164,19 @@ describe Product::Prices do
         expect(product.price_cents).to eq(0)
       end
 
-      it "does not set customizable_price to true if there are paid versions" do
+      it "keeps the seller's flag when there are paid versions" do
         product = create(:product, price_cents: 0)
         create(:variant_category, title: "versions", link: product)
         product.variant_categories.first.variants.create!(name: "premium version", price_difference_cents: 1_00)
         product.update!(customizable_price: false)
         expect(product.customizable_price).to be(false)
         expect(product.price_cents).to eq(0)
+
+        product.update!(customizable_price: true)
+        expect(product.customizable_price).to be(true)
       end
 
-      it "clears a stale customizable_price when a paid version is added later" do
+      it "keeps the flag when a paid version is added later" do
         product = create(:product, price_cents: 0)
         expect(product.customizable_price).to be(true)
 
@@ -181,10 +184,10 @@ describe Product::Prices do
         product.variant_categories.first.variants.create!(name: "premium version", price_difference_cents: 10_00)
         product.save!
 
-        expect(product.reload.customizable_price).to be(false)
+        expect(product.reload.customizable_price).to be(true)
       end
 
-      it "clears the flag when the only free version sits beside a paid one" do
+      it "does not clear the flag when the only free version sits beside a paid one" do
         product = create(:product, price_cents: 0)
         category = create(:variant_category, title: "versions", link: product)
         category.variants.create!(name: "Free Version", price_difference_cents: 0)
@@ -193,16 +196,29 @@ describe Product::Prices do
 
         product.save!
 
-        expect(product.reload.customizable_price).to be(false)
+        expect(product.reload.customizable_price).to be(true)
       end
 
-      it "restores customizable_price once the paid version is deleted and a free one remains" do
+      it "keeps the flag while a paid version is deleted and a free one remains" do
         product = create(:product, price_cents: 0)
         category = create(:variant_category, title: "versions", link: product)
         category.variants.create!(name: "Free Version", price_difference_cents: 0)
         paid = category.variants.create!(name: "premium version", price_difference_cents: 10_00)
         product.save!
-        expect(product.reload.customizable_price).to be(false)
+        expect(product.reload.customizable_price).to be(true)
+
+        paid.mark_deleted!
+        product.save!
+
+        expect(product.reload.customizable_price).to be(true)
+      end
+
+      it "turns the flag on once the last paid version is gone" do
+        product = create(:product, price_cents: 0)
+        category = create(:variant_category, title: "versions", link: product)
+        category.variants.create!(name: "Free Version", price_difference_cents: 0)
+        paid = category.variants.create!(name: "premium version", price_difference_cents: 10_00)
+        product.update_column(:customizable_price, false)
 
         paid.mark_deleted!
         product.save!
@@ -220,12 +236,14 @@ describe Product::Prices do
         expect(product.reload.customizable_price).to be(true)
       end
 
-      it "refreshes the search index when it clears the flag" do
+      it "refreshes the search index when it sets the flag" do
         product = create(:product, price_cents: 0)
         category = create(:variant_category, title: "versions", link: product)
-        category.variants.create!(name: "premium version", price_difference_cents: 10_00)
-        # The variant save above already cleared it; put it back so this save has work to do.
-        product.update_column(:customizable_price, true)
+        category.variants.create!(name: "Free Version", price_difference_cents: 0)
+        paid = category.variants.create!(name: "premium version", price_difference_cents: 10_00)
+        paid.mark_deleted!
+        # The variant deletion above already set it; put it back so this save has work to do.
+        product.update_column(:customizable_price, false)
 
         expect(product).to receive(:enqueue_index_update_for).with(["customizable_price"])
 
@@ -236,7 +254,7 @@ describe Product::Prices do
         product = create(:product, price_cents: 0)
         category = create(:variant_category, title: "versions", link: product)
         category.variants.create!(name: "premium version", price_difference_cents: 10_00)
-        expect(product.reload.customizable_price).to be(false)
+        product.update_column(:customizable_price, true)
 
         expect(product).not_to receive(:enqueue_index_update_for).with(["customizable_price"])
 
@@ -246,7 +264,8 @@ describe Product::Prices do
       it "keeps a coffee product customizable despite its paid suggested amounts" do
         seller = create(:user, created_at: 2.months.ago)
         # after_create :initialize_suggested_amount_if_needed! has already moved the price onto a
-        # paid "Suggested Amounts" variant and set the flag — the exact shape the clear would undo.
+        # paid "Suggested Amounts" variant and set the flag — the exact shape the early return
+        # above protects from being forced on with a write of its own.
         product = create(:product, user: seller, native_type: Link::NATIVE_TYPE_COFFEE, price_cents: 5_00)
         expect(product.reload.customizable_price).to be(true)
         expect(product.variant_categories_alive.joins(:variants).merge(BaseVariant.alive)
@@ -257,7 +276,7 @@ describe Product::Prices do
         expect(product.reload.customizable_price).to be(true)
       end
 
-      it "clears the flag when the paid variant is saved without the product" do
+      it "keeps the flag when the paid variant is saved without the product" do
         product = create(:product, price_cents: 0)
         expect(product.customizable_price).to be(true)
         category = create(:variant_category, title: "versions", link: product)
@@ -265,15 +284,15 @@ describe Product::Prices do
         # Api::V2::VariantsController#create saves only the variant.
         category.variants.create!(name: "premium version", price_difference_cents: 10_00)
 
-        expect(product.reload.customizable_price).to be(false)
+        expect(product.reload.customizable_price).to be(true)
       end
 
-      it "restores the flag when the paid variant is deleted without the product" do
+      it "turns the flag back on when the last paid variant is deleted without the product" do
         product = create(:product, price_cents: 0)
         category = create(:variant_category, title: "versions", link: product)
         category.variants.create!(name: "Free Version", price_difference_cents: 0)
         paid = category.variants.create!(name: "premium version", price_difference_cents: 10_00)
-        expect(product.reload.customizable_price).to be(false)
+        product.update_column(:customizable_price, false)
 
         paid.mark_deleted!
 

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -796,12 +796,10 @@ describe Checkout::StripePaymentPresenter do
 
   # A product that genuinely cannot be paid for must keep falling back, but "free and not
   # pay-what-you-want" is not that product: Product::Prices#set_customizable_price forces
-  # customizable_price to true on any $0 product, so CheckoutPresenter never emits that
-  # combination — measured across 39,875 recent production products, zero of which are $0
-  # with customizable_price false. Pinning it would assert on a hash production cannot
-  # produce. The reachable shape is line 64's escape hatch: a $0 base product whose alive
-  # variants carry a positive price_difference_cents keeps customizable_price false, and the
-  # buyer pays the variant's price rather than naming their own.
+  # customizable_price to true on any $0 product without priced versions, so this combination
+  # is only ever a seller's deliberate choice — a $0 base whose alive variants carry a positive
+  # price_difference_cents keeps the flag the seller set (gumroad-private#2573), and the buyer
+  # pays the variant's price rather than naming their own.
   it "still falls back to CardElement for a free non-pay-what-you-want product priced by its variants" do
     seller = create(:user)
     Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)
@@ -809,8 +807,8 @@ describe Checkout::StripePaymentPresenter do
     category = create(:variant_category, link: variant_priced_product)
     create(:variant, variant_category: category, price_difference_cents: 500)
     # create(:product) already ran the callback while the product had no variants, forcing
-    # customizable_price true. Clear it and re-run now that the priced variant exists, which
-    # is the order a real seller produces: add the variant, then save.
+    # customizable_price true. Clear it and re-run now that the priced variant exists, which is
+    # the state the seller saves by switching PWYW off on a $0 product that has versions.
     variant_priced_product.update_column(:customizable_price, false)
     variant_priced_product.send(:set_customizable_price)
 

--- a/spec/presenters/checkout/stripe_payment_presenter_spec.rb
+++ b/spec/presenters/checkout/stripe_payment_presenter_spec.rb
@@ -795,11 +795,9 @@ describe Checkout::StripePaymentPresenter do
   end
 
   # A product that genuinely cannot be paid for must keep falling back, but "free and not
-  # pay-what-you-want" is not that product: Product::Prices#set_customizable_price forces
-  # customizable_price to true on any $0 product without priced versions, so this combination
-  # is only ever a seller's deliberate choice — a $0 base whose alive variants carry a positive
-  # price_difference_cents keeps the flag the seller set (gumroad-private#2573), and the buyer
-  # pays the variant's price rather than naming their own.
+  # pay-what-you-want" is not that product: set_customizable_price forces the flag true on a $0
+  # base without priced versions (zero of 39,875 measured production products are $0 with it
+  # false), and with priced versions the seller's choice stands.
   it "still falls back to CardElement for a free non-pay-what-you-want product priced by its variants" do
     seller = create(:user)
     Feature.activate_user(described_class::STRIPE_PAYMENT_ELEMENT_CHECKOUT_FEATURE_NAME, seller)

--- a/spec/requests/products/edit/edit_spec.rb
+++ b/spec/requests/products/edit/edit_spec.rb
@@ -576,8 +576,8 @@ describe("Product Edit Scenario", type: :system, js: true) do
     expect(product.customizable_price).to be false
 
     within_section "Pricing" do
-      expect(page).to have_unchecked_field("Allow customers to pay what they want", disabled: true)
-      expect(page).to have_content("Pay what you want isn't available on products with paid pricing options.")
+      expect(page).to have_unchecked_field("Allow customers to pay what they want")
+      expect(page).not_to have_content("Pay what you want isn't available on products with paid pricing options.")
       check "Allow customers to pay in installments"
       fill_in "Number of installments", with: 2
     end

--- a/spec/requests/products/edit/pwyw_spec.rb
+++ b/spec/requests/products/edit/pwyw_spec.rb
@@ -87,7 +87,9 @@ describe("Product Edit pay what you want setting", type: :system, js: true) do
     expect(product.reload.customizable_price).to eq(true)
     expect(product.reload.price_cents).to eq(0)
     in_preview do
-      expect(page).to have_selector("[itemprop='price']", text: "$0+")
+      # The preview renders the product page; with versions present it has no standalone price
+      # tag to assert on, so the PWYW box beside the paid version is the visible proof.
+      expect(page).to have_field("Name a fair price")
     end
   end
 

--- a/spec/requests/products/edit/pwyw_spec.rb
+++ b/spec/requests/products/edit/pwyw_spec.rb
@@ -60,26 +60,38 @@ describe("Product Edit pay what you want setting", type: :system, js: true) do
     expect(pwyw_toggle).not_to be_disabled
   end
 
-  it "disables the toggle on a $0 product that already has paid pricing options" do
+  it "keeps the toggle usable on a $0 product that already has paid pricing options" do
     variant_category = create(:variant_category, link: product, title: "Pack")
     create(:variant, variant_category:, name: "Home Kit", price_difference_cents: 1500)
 
     visit edit_link_path(product.unique_permalink)
     fill_in "Amount", with: "0"
 
-    expect(page).to have_content("Pay what you want isn't available on products with paid pricing options.")
-    expect(page).not_to have_content("Free products require a pay what they want price.")
-    pwyw_toggle = find_field("Allow customers to pay what they want", disabled: true)
-    expect(pwyw_toggle).not_to be_checked
-
-    fill_in "Amount", with: "10"
-
     expect(page).not_to have_content("Pay what you want isn't available on products with paid pricing options.")
+    expect(page).not_to have_content("Free products require a pay what they want price.")
     pwyw_toggle = find_field("Allow customers to pay what they want")
     expect(pwyw_toggle).not_to be_disabled
+    expect(pwyw_toggle).not_to be_checked
   end
 
-  it "restores the seller's choice after the price dips to $0 on a product with paid pricing options" do
+  it "saves pay what you want alongside a paid pricing option on a $0 product" do
+    variant_category = create(:variant_category, link: product, title: "Pack")
+    create(:variant, variant_category:, name: "Home Kit", price_difference_cents: 1500)
+
+    visit edit_link_path(product.unique_permalink)
+    fill_in "Amount", with: "0"
+    check "Allow customers to pay what they want"
+    save_change
+    wait_for_ajax
+
+    expect(product.reload.customizable_price).to eq(true)
+    expect(product.reload.price_cents).to eq(0)
+    in_preview do
+      expect(page).to have_selector("[itemprop='price']", text: "$0+")
+    end
+  end
+
+  it "keeps a $0 product's PWYW toggle on while paid pricing options exist" do
     variant_category = create(:variant_category, link: product, title: "Pack")
     create(:variant, variant_category:, name: "Home Kit", price_difference_cents: 1500)
     product.update!(price_cents: 1500, customizable_price: true)
@@ -88,12 +100,14 @@ describe("Product Edit pay what you want setting", type: :system, js: true) do
     expect(find_field("Allow customers to pay what they want")).to be_checked
 
     fill_in "Amount", with: "0"
-    expect(page).to have_content("Pay what you want isn't available on products with paid pricing options.")
-    expect(find_field("Allow customers to pay what they want", disabled: true)).not_to be_checked
 
-    fill_in "Amount", with: "15"
     pwyw_toggle = find_field("Allow customers to pay what they want")
-    expect(pwyw_toggle).to be_checked
     expect(pwyw_toggle).not_to be_disabled
+    expect(pwyw_toggle).to be_checked
+
+    save_change
+    wait_for_ajax
+
+    expect(product.reload.customizable_price).to eq(true)
   end
 end

--- a/spec/requests/products/show/show_spec.rb
+++ b/spec/requests/products/show/show_spec.rb
@@ -582,11 +582,25 @@ describe("ProductShowScenario", type: :system, js: true) do
           product.alive_variants.each_with_index { _1.update(price_difference_cents: (_2 + 1) * 100) }
         end
 
-        it "does not show the PWYW input" do
+        it "shows the PWYW input, floored at the selected version's total" do
           visit product.long_url
-          expect(page).not_to have_field("Name a fair price:")
+          # The seller turned PWYW on and kept it on: a $0 base beside a priced version offers
+          # both a name-your-price entry and the priced version (gumroad-private#2573).
+          expect(page).to have_field("Name a fair price:")
+
           choose "Untitled 2"
-          expect(page).not_to have_field("Name a fair price:")
+
+          # Untitled 2 carries a $2 price difference, so $2 is the floor the buyer is held to;
+          # naming less than the selected version's total can't buy it (gp#1660 stays closed).
+          expect(page).to have_field("Name a fair price:", with: "", placeholder: "2+")
+          pwyw_field = find_field("Name a fair price")
+          pwyw_field.fill_in with: "1.5"
+          find(:label, "Name a fair price:").click
+          expect(pwyw_field["aria-invalid"]).to eq("true")
+
+          pwyw_field.fill_in with: "2"
+          find(:label, "Name a fair price:").click
+          expect(pwyw_field["aria-invalid"]).to eq("false")
         end
       end
 

--- a/spec/requests/purchases/product/stripejs_purchase_spec.rb
+++ b/spec/requests/purchases/product/stripejs_purchase_spec.rb
@@ -638,8 +638,10 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
       it "lets the zero variant be added for free" do
         visit "/l/#{@pwyw_product.unique_permalink}"
 
-        expect(page).not_to have_field("Name a fair price")
-        add_to_cart(@pwyw_product, option: "Zero-plus")
+        # The seller kept PWYW on beside the priced version, so the box is offered and the buyer
+        # names an amount; naming $0 on the free version still buys it for nothing.
+        expect(page).to have_field("Name a fair price")
+        add_to_cart(@pwyw_product, option: "Zero-plus", pwyw_price: 0)
 
         expect(page).to have_text("Zero-plus")
         expect(page).to have_text("US$0")
@@ -648,8 +650,10 @@ describe("PurchaseScenario using StripeJs", type: :system, js: true) do
       it "prices the paid variant at its fixed amount" do
         visit "/l/#{@pwyw_product.unique_permalink}"
 
-        expect(page).not_to have_field("Name a fair price")
-        add_to_cart(@pwyw_product, option: "Paid")
+        # Naming the paid version's own total is the floor the box accepts, so the total is the
+        # version's price and not the $0 base.
+        expect(page).to have_field("Name a fair price")
+        add_to_cart(@pwyw_product, option: "Paid", pwyw_price: 5)
 
         expect(page).to have_button("Pay")
 

--- a/spec/services/purchase/create_service_spec.rb
+++ b/spec/services/purchase/create_service_spec.rb
@@ -4897,6 +4897,82 @@ describe Purchase::CreateService, :vcr do
     end
   end
 
+  # A $0-base product with a priced version can now carry pay-what-you-want on the
+  # product (gumroad-private#2573). The amount box floor is the SELECTED version's total —
+  # `minimum_paid_price_cents` is base + the chosen variant's price_difference_cents — so a
+  # buyer cannot name $0 and walk away with the priced version. gp#1660's hole stays shut
+  # without Product::Prices#set_customizable_price clearing the flag.
+  describe "pay what you want on a $0-base product with a priced version" do
+    let(:pwyw_product) do
+      product = create(:product, price_cents: 0)
+      category = create(:variant_category, title: "versions", link: product)
+      category.variants.create!(name: "Free Version", price_difference_cents: 0)
+      category.variants.create!(name: "Full Version", price_difference_cents: 10_00)
+      # What the editor saves when the seller flips the switch: nothing rewrites the column
+      # on save any more, so the seller's word is what checkout sees.
+      product.update_column(:customizable_price, true)
+      product.reload
+    end
+    let(:free_version) { pwyw_product.alive_variants.find_by!(name: "Free Version") }
+    let(:priced_version) { pwyw_product.alive_variants.find_by!(name: "Full Version") }
+
+    def name_a_price(product, variant, named_price_cents)
+      params = {
+        purchase: {
+          email: "buyer@gumroad.com",
+          quantity: 1,
+          perceived_price_cents: named_price_cents,
+          price_range: format("%.2f", named_price_cents / 100.0),
+          ip_address: "0.0.0.0",
+          session_id: "a107d0b7ab5ab3c1eeb7d3aaf9792977",
+          is_mobile: false,
+        },
+        variants: [variant.external_id],
+      }
+      Purchase::CreateService.new(product:, params:).perform
+    end
+
+    it "floors the named price at the selected version's total" do
+      purchase = build(:purchase, link: pwyw_product, seller: pwyw_product.user)
+      purchase.variant_attributes = [priced_version]
+      expect(purchase.minimum_paid_price_cents).to eq 10_00
+
+      purchase = build(:purchase, link: pwyw_product, seller: pwyw_product.user)
+      purchase.variant_attributes = [free_version]
+      expect(purchase.minimum_paid_price_cents).to eq 0
+    end
+
+    it "rejects a $0 name on the priced version" do
+      purchase, error = name_a_price(pwyw_product, priced_version, 0)
+
+      expect(error).to eq "Please enter an amount greater than or equal to the minimum."
+      expect(purchase.error_code).to eq PurchaseErrorCode::PRICE_CENTS_TOO_LOW
+      expect(purchase.purchase_state).to eq "failed"
+    end
+
+    it "rejects a name below the priced version's total" do
+      purchase, _error = name_a_price(pwyw_product, priced_version, 5_00)
+
+      expect(purchase.error_code).to eq PurchaseErrorCode::PRICE_CENTS_TOO_LOW
+    end
+
+    it "lets a name at the priced version's total through the floor" do
+      purchase, _error = name_a_price(pwyw_product, priced_version, 10_00)
+
+      expect(purchase.displayed_price_cents).to eq 10_00
+      # Only the missing card stops it, which is the proof the floor admitted the amount.
+      expect(purchase.error_code).to eq PurchaseErrorCode::CREDIT_CARD_NOT_PROVIDED
+    end
+
+    it "still takes a $0 name on the free version" do
+      purchase, error = name_a_price(pwyw_product, free_version, 0)
+
+      expect(error).to be_nil
+      expect(purchase.purchase_state).to eq "successful"
+      expect(purchase.price_cents).to eq 0
+    end
+  end
+
   describe "payment flow analytics recording" do
     let(:payment_flow_params) do
       # `payment_details_source` + a Stripe payment param make

--- a/spec/services/purchase/create_service_spec.rb
+++ b/spec/services/purchase/create_service_spec.rb
@@ -4897,11 +4897,9 @@ describe Purchase::CreateService, :vcr do
     end
   end
 
-  # A $0-base product with a priced version can now carry pay-what-you-want on the
-  # product (gumroad-private#2573). The amount box floor is the SELECTED version's total —
-  # `minimum_paid_price_cents` is base + the chosen variant's price_difference_cents — so a
-  # buyer cannot name $0 and walk away with the priced version. gp#1660's hole stays shut
-  # without Product::Prices#set_customizable_price clearing the flag.
+  # A $0-base product with a priced version can carry pay-what-you-want: the amount box floor
+  # is the SELECTED version's total (`minimum_paid_price_cents` = base + that variant's
+  # price_difference_cents), so a $0 name cannot buy the priced version.
   describe "pay what you want on a $0-base product with a priced version" do
     let(:pwyw_product) do
       product = create(:product, price_cents: 0)


### PR DESCRIPTION
## What

Removes the block on pay-what-you-want coexisting with a priced version on a $0-base product.

- `Product::Prices#set_customizable_price` no longer clears `customizable_price` when a $0-base product has an alive variant with a positive `price_difference_cents`. It leaves the seller's flag alone for that shape; a $0 base *without* a paid version still forces PWYW on, and coffee still keeps its own flag.
- `PriceEditor` renders the "Allow customers to pay what they want" switch live for that shape instead of forcing it off and disabling it. The `Pay what you want isn't available on products with paid pricing options.` message is gone. `mustBePWYW` (a $0 base with no paid version) is unchanged, so a plain free product still cannot be switched out of PWYW.
- `reconcileCustomizablePrice` mirrors the new guard; the `priorCustomizablePriceRef` and the two arguments that existed only to restore a value the guard used to force are gone with it.
- **No checkout code changed.** The named-price floor was already the selected version's total — see Why.

## Why

`set_customizable_price`'s clear dates from gumroad-private#1660: a $0-base product that gained a paid variant kept a stale `customizable_price = true`, so checkout offered a free-entry amount box whose minimum, on the free option, was $0. The fix at the time (antiwork/gumroad#6906) was to clear the flag, and antiwork/gumroad#7439 mirrored it in the editor by disabling the toggle.

The premise of that guard is about the *floor*, and the floor is already right. `Purchase#minimum_paid_price_cents` is `base_product_price_cents + variant_extra_cost`, i.e. the product's base price plus the price difference of the version **the buyer selected** — so with PWYW on, naming $0 and selecting the priced version is rejected by `price_not_too_low` (`price_cents_too_low`), while naming $0 on the free version is the product working as intended. Measured through `Purchase::CreateService` on `origin/main` and at this head: identical outcomes on both.

So the clearance protects nothing that checkout does not already enforce, and it blocks a seller-requested setup (gp#2573 — a $0-base page offering both a name-your-price entry and a paid version, like the grandfathered `Ultimate Venom Rig` page the reporting seller was copying).

Alternatives and why this one:

1. **Keep clearing (status quo)** — the reporting seller's ask, and the reason the issue was accepted: blocked.
2. **Delete the branch and let a $0 base force PWYW on unconditionally** — simplest, and consistent with "free products require a pay what you want price", but it turns the switch into a locked-on control for this shape and would flip every existing $0-base product with priced versions to PWYW on its next save. It grants an ability while taking another away.
3. **Narrow the guard (this PR)** — the flag becomes the seller's on this shape, matching the editor, with no automatic change to any existing product. A seller who wants the combination turns it on; one who does not keeps it off. The guard's early return is what the pre-#6906 code did for this branch.

Coffee's carve-out is kept as-is: `initialize_suggested_amount_if_needed!` sets both the base price and the flag in one write, so coffee keeps its own value rather than being written by the set at the bottom.

`spec/requests/products/edit/*` also had the editor's old forced-off state pinned; those examples now pin the new behaviour instead, including saving PWYW on alongside a paid version.

Also checked, per the issue: the two editor services (`Product::VariantsUpdaterService`, `Product::VariantCategoryUpdaterService`) do not re-derive this rule — they write variants, and `Variant`'s `after_save` reaches `Link#set_customizable_price`. There was nothing to change there.

**Open question, not silently resolved.** gp#2573's decision line is @slavingia's `"Support ."`. It is read here as "support pay-what-you-want alongside a paid version on one $0-base product", which is what this PR builds, and the reading that the issue body records as in force. The other reading — "support = answer this in the support thread, no product change" — would make this PR unnecessary, and this PR should then be closed rather than merged. Flagging it rather than burying it.

Not in this PR: help article 133's wording (the sentence antiwork/gumroad#7615 removed comes back as a follow-up once this ships — the issue tracks it) and the seller reply on the support thread.

## Before/After

Editor, a $0-base product with a free and a priced version, PWYW off by default: the switch is now usable and saving with it on keeps it on.

Before — a hosted preview serving `main`'s app code (`gumclaw-gp2573-before-main`), same seeded product: the toggle is disabled and the message is shown.

![Before — the editor forces pay-what-you-want off with "Pay what you want isn't available on products with paid pricing options."](https://github.com/user-attachments/assets/bd8ad0c3-c410-432e-9e9c-0495e491387f)

After — this branch's preview (`gumclaw-gp2573-pwyw-with-priced`), same product:

![After — the same product, the switch usable and left on by the guard](https://github.com/user-attachments/assets/bd8009e3-9404-43ef-9a16-afc160d5dd26)

![After — saved with the switch on; Minimum amount and Suggested amount appear](https://github.com/user-attachments/assets/6dffc2bc-6505-494c-a5ea-ae8bbf292e47)

![After — the buyer page offers the name-your-price box](https://github.com/user-attachments/assets/f68813cd-8bc9-4ba5-b1f5-23e7a9f4781e)

Both legs are hosted previews of the same seeded $0-base product with one free and one priced version, desktop light theme. Dark and mobile legs were not captured. The last commit on this branch (`2da777fb3f`) touches only `spec/`, so the rendered app code is the code these frames show.

Preview for this branch: https://gumclaw-gp2573-pwyw-with-priced.apps.staging.gumroad.org — a $0-base product with a free and a priced version, the switch on, saved and still on.

## QA steps

On the preview app: edit a $0-base product, add a priced version, flip **Allow customers to pay what they want** on, save — it stays on. On the buyer page the amount box is offered, floored at the selected version's total.

## Test Results

- `spec/modules/product/prices_spec.rb` — `#set_customizable_price`, 14 examples, 0 failures.
- `spec/services/purchase/create_service_spec.rb` — new `pay what you want on a $0-base product with a priced version` block, 5 examples, 0 failures (this is the checkout floor: `$0` name on the priced version rejected, `$0` on the free version still succeeds).
- `spec/requests/products/edit/pwyw_spec.rb` (system), `spec/requests/products/edit/edit_spec.rb`, `spec/presenters/checkout/stripe_payment_presenter_spec.rb`.
- `npx vitest run app/javascript/components/ProductEdit/ProductTab/PriceEditor.test.tsx app/javascript/components/ProductEdit/state.test.ts app/javascript/data/product_edit.test.ts` — 38 passed.
- The three system specs the full suite flagged were pinning PWYW-off for this shape; all three now pin the new behaviour (`2da777fb3f`):
  - `spec/requests/products/show/show_spec.rb` versioned product — the box is offered, and the named price is floored at the selected version's total: Untitled 2 carries $2, so $1.50 is rejected and $2 accepted. Verified locally, green.
  - `spec/requests/purchases/product/stripejs_purchase_spec.rb` `multiple variants: $0 and paid` — the box is offered, so the buyer names an amount: $0 buys the free version for nothing, the paid version's own total prices it at $5. Both examples verified locally, green.
  - `spec/requests/products/edit/pwyw_spec.rb` preview assertion moved off `[itemprop='price']`, which a versioned product never renders (`Product#showPrice` needs `options.length == 0`), onto the PWYW box the preview does render. Not runnable locally — the product-edit page does not mount in this environment — so CI is the first run of it.

One consequence of the flag staying on: the buyer must name an amount before the CTA proceeds, including $0 on the free version. That is how the live grandfathered page (Ultimate Venom Rig) already behaves.

Premerge review: clean @ 2da777fb3f2a1749390cda98553b771176739ebf

---

- [x] Scope — $0 base with a priced version keeps the seller's pay-what-you-want flag; the named price is floored at the selected version's total. No checkout code change, no automatic change to existing products.
- [x] Design — narrow the guard in `Product::Prices#set_customizable_price` and mirror it in the editor, rather than deleting the branch (which would flip every $0-base product with priced versions to PWYW) or keeping the clear (which blocks the ask).
- [x] Build — `2da777fb3f` on `gumclaw/gp2573-pwyw-with-priced-versions`
- [x] QA — preview app linked above; before/after below (app code at head == the code captured)
- [ ] Shipped
- [ ] Market — n/a
- [ ] Sell — n/a

AI disclosure: written by DeepSeek V4.1 Flash (`deepseek/deepseek-v4.1-flash` via OpenRouter) in an autonomous Hermes Agent session, from a brief derived from antiwork/gumroad-private#2573. Prompts given: "Read the brief and execute it fully" with the brief instructing the agent to (1) remove the editor block on pay-what-you-want for a $0-base product with priced versions, (2) confirm the checkout floor is the selected version's total and that `price_cents == 0` cannot bypass it, (3) decide whether `Product::Prices#set_customizable_price` clears, narrows, or keeps the flag and justify it, (4) add specs for the price module, the `Purchase` floor and the editor, (5) capture before/after evidence, and (6) run the Astra+Fable pre-merge panel. The agent chose the file set, the specification, and the guard's disposition.

Handoff: **ready** for @gianfrancopiana's merge call — the versions/editor surface and the guard's disposition are his, and the "Support ." reading above is the one question this PR cannot settle for him. Evidence and the panel verdict are at this head.
